### PR TITLE
Removed Unicode, total, and tpair; used == for paths.

### DIFF
--- a/Coq/Contractible.v
+++ b/Coq/Contractible.v
@@ -9,12 +9,12 @@ Unset Automatic Introduction.
    first component is a point [x] and the second component is a
    pointwise retraction of [A] to [x]. *)
 
-Definition is_contr A := {x : A & forall y : A, y ~~> x}.
+Definition is_contr A := {x : A & forall y : A, y == x}.
 
 (** If a space is contractible, then any two points in it are
    connected by a path in a canonical way. *)
 
-Lemma contr_path {A} (x y : A) : (is_contr A) -> (x ~~> y).
+Lemma contr_path {A} (x y : A) : (is_contr A) -> (x == y).
 Proof.
   intros A x y.
   intro H.
@@ -24,7 +24,7 @@ Defined.
 
 (** Similarly, any two parallel paths in a contractible space are homotopic.  *)
 
-Lemma contr_path2 {A} {x y : A} (p q : x ~~> y) : (is_contr A) -> (p ~~> q).
+Lemma contr_path2 {A} {x y : A} (p q : x == y) : (is_contr A) -> (p == q).
 Proof.
   intros X x y p q.
   intro ctr.
@@ -41,7 +41,7 @@ Defined.
 
 (** It follows that any space of paths in a contractible space is contractible. *)
 
-Lemma contr_pathcontr {A} (x y : A) : is_contr A -> is_contr (x ~~> y).
+Lemma contr_pathcontr {A} (x y : A) : is_contr A -> is_contr (x == y).
 Proof.
   intros A x y.
   intro ctr.
@@ -56,15 +56,15 @@ Defined.
 Lemma pathspace_contr {X} (x:X) : is_contr (sigT (paths x)).
 Proof.
   intros X x.
-  exists (tpair x (idpath x)).
+  exists (x ; idpath x).
   intros [y p].
   path_induction.
 Defined.
 
-Lemma pathspace_contr' {X} (x:X) : is_contr { y:X  &  x ~~> y }.
+Lemma pathspace_contr' {X} (x:X) : is_contr { y:X  &  x == y }.
 Proof.
   intros X x.
-  exists (existT (fun y => x ~~> y) x (idpath x)).
+  exists (existT (fun y => x == y) x (idpath x)).
   intros [y p].
   path_induction.
 Defined.

--- a/Coq/Equivalences.v
+++ b/Coq/Equivalences.v
@@ -11,17 +11,17 @@ Definition is_equiv {A B} (f : A -> B) := forall y : B, is_contr (hfiber f y).
 
 Definition equiv A B := { w : A -> B & is_equiv w }.
 
-Notation "A ≃> B" := (equiv A B) (at level 55).
+Notation "A <~> B" := (equiv A B) (at level 55).
 
-(** printing ≃> $\overset{\sim}{\longrightarrow}$ *)
+(** printing <~> $\overset{\sim}{\longrightarrow}$ *)
 
-(** Strictly speaking, an element [w] of [A ≃> B] is a _pair_
+(** Strictly speaking, an element [w] of [A <~> B] is a _pair_
    consisting of a map [projT1 w] and the proof [projT2 w] that it is
    an equivalence. Thus, in order to apply [w] to [x] we must write
    [projT1 w x]. Coq is able to do this automatically if we declare
    that [projT1] is a _coercion_ from [equiv A B] to [A -> B]. *)
 
-Definition equiv_coerce_to_function A B (w : A ≃> B) : (A -> B)
+Definition equiv_coerce_to_function A B (w : A <~> B) : (A -> B)
   := projT1 w.
 
 Coercion equiv_coerce_to_function : equiv >-> Funclass.
@@ -33,7 +33,7 @@ Coercion equiv_coerce_to_function : equiv >-> Funclass.
 Ltac contract_hfiber y p :=
   match goal with
     | [ |- is_contr (@hfiber _ _ ?f ?x) ] =>
-      eexists (existT (fun z => f z ~~> x) y p);
+      eexists (existT (fun z => f z == x) y p);
         let z := fresh "z" in
         let q := fresh "q" in
           intros [z q]
@@ -50,7 +50,7 @@ Ltac contract_hfiber y p :=
 
 (** The identity map is an equivalence. *)
 
-Definition idequiv A : A ≃> A.
+Definition idequiv A : A <~> A.
 Proof.
   intro A.
   exists (idmap A).
@@ -65,31 +65,31 @@ Defined.
 (** From an equivalence from [U] to [V] we can extract a map in the
    inverse direction. *)
 
-Definition inverse {U V} (w : U ≃> V) : (V -> U) :=
+Definition inverse {U V} (w : U <~> V) : (V -> U) :=
   fun y => pr1 (pr1 ((pr2 w) y)).
 
-Notation "w ⁻¹" := (inverse w) (at level 40).
+Notation "w ^-1" := (inverse w) (at level 40).
 
-(** printing ⁻¹ $^{-1}$ *)
+(** printing ^-1 $^{-1}$ *)
 
 (** The extracted map in the inverse direction is actually an inverse
    (up to homotopy, of course). *)
 
-Definition inverse_is_section {U V} (w : U ≃> V) y : w (w⁻¹ y) ~~> y :=
+Definition inverse_is_section {U V} (w : U <~> V) y : w (w^-1 y) == y :=
   pr2 (pr1 ((pr2 w) y)).
 
-Definition inverse_is_retraction {U V} (w : U ≃> V) x : (w⁻¹ (w x)) ~~> x :=
-  !base_path (pr2 ((pr2 w) (w x)) (tpair x (idpath (w x)))).
+Definition inverse_is_retraction {U V} (w : U <~> V) x : (w^-1 (w x)) == x :=
+  !base_path (pr2 ((pr2 w) (w x)) (x ; idpath (w x))).
 
 (** Here are some tactics to use for canceling inverses, and for
    introducing them. *)
 
 Ltac cancel_inverses_in s :=
   match s with
-    | context cxt [ equiv_coerce_to_function _ _ ?w (?w ⁻¹ ?x) ] =>
+    | context cxt [ equiv_coerce_to_function _ _ ?w (?w ^-1 ?x) ] =>
       let mid := context cxt [ x ] in
         path_using mid inverse_is_section
-    | context cxt [ ?w ⁻¹ (equiv_coerce_to_function _ _ ?w ?x) ] =>
+    | context cxt [ ?w ^-1 (equiv_coerce_to_function _ _ ?w ?x) ] =>
       let mid := context cxt [ x ] in
         path_using mid inverse_is_retraction
   end.
@@ -97,21 +97,21 @@ Ltac cancel_inverses_in s :=
 Ltac cancel_inverses :=
   repeat progress (
     match goal with
-      | |- ?s ~~> ?t => first [ cancel_inverses_in s | cancel_inverses_in t ]
+      | |- ?s == ?t => first [ cancel_inverses_in s | cancel_inverses_in t ]
     end
   ).
 
 Ltac expand_inverse_src w x :=
   match goal with
-    | |- ?s ~~> ?t =>
+    | |- ?s == ?t =>
       match s with
         | context cxt [ x ] =>
           first [
-            let mid := context cxt [ w (w⁻¹ x) ] in
+            let mid := context cxt [ w (w^-1 x) ] in
               path_via' mid;
               [ path_simplify' inverse_is_section | ]
             |
-            let mid := context cxt [ w⁻¹ (w x) ] in
+            let mid := context cxt [ w^-1 (w x) ] in
               path_via' mid;
               [ path_simplify' inverse_is_retraction | ]
           ]
@@ -120,41 +120,41 @@ Ltac expand_inverse_src w x :=
 
 Ltac expand_inverse_trg w x :=
   match goal with
-    | |- ?s ~~> ?t =>
+    | |- ?s == ?t =>
       match t with
         | context cxt [ x ] =>
           first [
-            let mid := context cxt [ w (w⁻¹ x) ] in
+            let mid := context cxt [ w (w^-1 x) ] in
               path_via' mid;
               [ | path_simplify' inverse_is_section ]
             |
-            let mid := context cxt [ w⁻¹ (w x) ] in
+            let mid := context cxt [ w^-1 (w x) ] in
               path_via' mid;
               [ | path_simplify' inverse_is_retraction ]
           ]
       end
   end.
 
-(** These tactics change between goals of the form [w x ~~> y] and the
-   form [x ~~> w⁻¹ y], and dually. *)
+(** These tactics change between goals of the form [w x == y] and the
+   form [x == w^-1 y], and dually. *)
 
 Ltac equiv_moveright :=
   match goal with
-    | |- equiv_coerce_to_function _ _ ?w ?a ~~> ?b =>
-      apply @concat with (y := w (w⁻¹ b));
+    | |- equiv_coerce_to_function _ _ ?w ?a == ?b =>
+      apply @concat with (y := w (w^-1 b));
         [ apply map | apply inverse_is_section ]
-    | |- (?w ⁻¹) ?a ~~> ?b =>
-      apply @concat with (y := w⁻¹ (w b));
+    | |- (?w ^-1) ?a == ?b =>
+      apply @concat with (y := w^-1 (w b));
         [ apply map | apply inverse_is_retraction ]
   end.
 
 Ltac equiv_moveleft :=
   match goal with
-    | |- ?a ~~> equiv_coerce_to_function _ _ ?w ?b =>
-      apply @concat with (y := w (w⁻¹ a));
+    | |- ?a == equiv_coerce_to_function _ _ ?w ?b =>
+      apply @concat with (y := w (w^-1 a));
         [ apply opposite, inverse_is_section | apply map ]
-    | |- ?a ~~> (?w ⁻¹) ?b =>
-      apply @concat with (y := w⁻¹ (w a));
+    | |- ?a == (?w ^-1) ?b =>
+      apply @concat with (y := w^-1 (w a));
         [ apply opposite, inverse_is_retraction | apply map ]
   end.
 
@@ -162,8 +162,8 @@ Ltac equiv_moveleft :=
    homotopies.  (It doesn't look like a triangle since we've inverted
    one of the homotopies.) *)
 
-Definition inverse_triangle {A B} (w : A ≃> B) x :
-  (map w (inverse_is_retraction w x)) ~~> (inverse_is_section w (w x)).
+Definition inverse_triangle {A B} (w : A <~> B) x :
+  (map w (inverse_is_retraction w x)) == (inverse_is_section w (w x)).
 Proof.
   intros.
   unfold inverse_is_retraction.
@@ -171,13 +171,13 @@ Proof.
   apply (concat (!idpath_right_unit _ _ _ _)).
   moveright_onleft.
   apply opposite.
-  exact (hfiber_triangle (pr2 (pr2 w (w x)) (tpair x (idpath _)))).
+  exact (hfiber_triangle (pr2 (pr2 w (w x)) (x ; idpath _))).
 Defined.
 
 
 (** Equivalences are "injective on paths". *)
 
-Lemma equiv_injective U V (w : U ≃> V) x y : (w x ~~> w y) -> (x ~~> y).
+Lemma equiv_injective U V (w : U <~> V) x y : (w x == w y) -> (x == y).
 Proof.
   intros U V w x y.
   intro p.
@@ -189,7 +189,7 @@ Defined.
 (** Anything contractible is equivalent to the unit type. *)
 
 Lemma contr_equiv_unit (A : Type) :
-  is_contr A -> (A ≃> unit).
+  is_contr A -> (A <~> unit).
 Proof.
   intros A H.
   exists (fun x => tt).
@@ -204,7 +204,7 @@ Defined.
    contractible. *)
 
 Lemma contr_equiv_contr (A B : Type) :
-  A ≃> B -> is_contr A -> is_contr B.
+  A <~> B -> is_contr A -> is_contr B.
 Proof.
   intros A B f Acontr.
   destruct Acontr.
@@ -216,14 +216,14 @@ Defined.
 
 (** The free path space of a type is equivalent to the type itself. *)
 
-Definition free_path_space A := {xy : A * A & fst xy ~~> snd xy}.
+Definition free_path_space A := {xy : A * A & fst xy == snd xy}.
 
-Definition free_path_source A : free_path_space A ≃> A.
+Definition free_path_source A : free_path_space A <~> A.
 Proof.
   intro A.
   exists (fun p => fst (projT1 p)).
   intros x.
-  eexists (existT _ (existT (fun (xy : A * A) => fst xy ~~> snd xy) (x,x) (idpath x)) _).
+  eexists (existT _ (existT (fun (xy : A * A) => fst xy == snd xy) (x,x) (idpath x)) _).
   intros [[[u v] p] q].
   simpl in * |- *.
   induction q as [a].
@@ -231,12 +231,12 @@ Proof.
   apply idpath.
 Defined.
 
-Definition free_path_target A : free_path_space A ≃> A.
+Definition free_path_target A : free_path_space A <~> A.
 Proof.
   intro A.
   exists (fun p => snd (projT1 p)).
   intros x.
-  eexists (existT _ (existT (fun (xy : A * A) => fst xy ~~> snd xy) (x,x) (idpath x)) _).
+  eexists (existT _ (existT (fun (xy : A * A) => fst xy == snd xy) (x,x) (idpath x)) _).
   intros [[[u v] p] q].
   simpl in * |- *.
   induction q as [a].
@@ -254,14 +254,14 @@ Defined.
 
 Definition is_adjoint_equiv {A B} (f : A -> B) :=
   { g : B -> A &
-    { is_section : forall y, (f (g y)) ~~> y &
-      { is_retraction : forall x, (g (f x)) ~~> x &
-        forall x, (map f (is_retraction x)) ~~> (is_section (f x))
+    { is_section : forall y, (f (g y)) == y &
+      { is_retraction : forall x, (g (f x)) == x &
+        forall x, (map f (is_retraction x)) == (is_section (f x))
           }}}.
 
 Definition is_equiv_to_adjoint {A B} (f: A -> B) (E : is_equiv f) : is_adjoint_equiv f :=
-  let w := (tpair f E) in
-    tpair (w⁻¹) (tpair (inverse_is_section w) (tpair (inverse_is_retraction w) (inverse_triangle w))).
+  let w := (f ; E) in
+    (w^-1 ; (inverse_is_section w; (inverse_is_retraction w ; inverse_triangle w))).
 
 Definition adjoint_equiv (A B : Type) := { f: A -> B  &  is_adjoint_equiv f }.
 
@@ -271,7 +271,7 @@ Proof.
   intro y.
   contract_hfiber (g y) (is_section y).
   apply (total_path _
-    (fun x => f x ~~> y)
+    (fun x => f x == y)
     (existT _ z q)
     (existT _ (g y) (is_section y))
     (!is_retraction z @ (map g q))).
@@ -287,14 +287,14 @@ Proof.
   associate_right.
   moveright_onleft.
   undo_compose_map.
-  apply opposite, homotopy_naturality_toid with (f := f ○ g).
+  apply opposite, homotopy_naturality_toid with (f := f o g).
 Defined.
 
 (** Probably equiv_to_adjoint and adjoint_to_equiv are actually
    inverse equivalences, at least if we assume function
    extensionality. *)
 
-Lemma equiv_pointwise_idmap A (f : A -> A) (p : forall x, f x ~~> x) : is_equiv f.
+Lemma equiv_pointwise_idmap A (f : A -> A) (p : forall x, f x == x) : is_equiv f.
 Proof.
   intros.
   apply is_adjoint_to_equiv.
@@ -311,7 +311,7 @@ Defined.
    the usual proof for adjoint equivalences in 2-category theory.  *)
 
 Definition adjointify {A B} (f : A -> B) (g : B -> A) :
-  (forall y, f (g y) ~~> y) -> (forall x, g (f x) ~~> x ) ->
+  (forall y, f (g y) == y) -> (forall x, g (f x) == x ) ->
   is_adjoint_equiv f.
 Proof.
   intros A B f g is_section is_retraction.
@@ -330,12 +330,12 @@ Proof.
   undo_compose_map.
   moveleft_onleft.
   associate_left.
-  path_via ((!is_section (f x)  @  map (f ○ g) (map f (!is_retraction x))
-    @  map (f ○ g) (is_section (f x)))  @  map f (is_retraction x)).
+  path_via ((!is_section (f x)  @  map (f o g) (map f (!is_retraction x))
+    @  map (f o g) (is_section (f x)))  @  map f (is_retraction x)).
   unwhisker.
   do_compose_map; auto.
   path_via (map f (!is_retraction x)  @  (!is_section (f (g (f x))))
-    @  map (f ○ g) (is_section (f x))  @  map f (is_retraction x)).
+    @  map (f o g) (is_section (f x))  @  map f (is_retraction x)).
   unwhisker.
   apply opposite, (homotopy_naturality_fromid B _ (fun y => !is_section y)).
   path_via (map f (!is_retraction x)  @  (is_section (f x) @ (!is_section (f x)))
@@ -349,14 +349,14 @@ Defined.
 (** Therefore, "any homotopy equivalence is an equivalence." *)
 
 Definition hequiv_is_equiv {A B} (f : A -> B) (g : B -> A)
-  (is_section : forall y, f (g y) ~~> y) (is_retraction : forall x, g (f x) ~~> x) :
+  (is_section : forall y, f (g y) == y) (is_retraction : forall x, g (f x) == x) :
   is_equiv f := is_adjoint_to_equiv f (adjointify f g is_section is_retraction).
 
 (** All sorts of nice things follow from this theorem. *)
 
 (** The inverse of an equivalence is an equivalence. *)
 
-Lemma equiv_inverse {A B} (f : A ≃> B) : B ≃> A.
+Lemma equiv_inverse {A B} (f : A <~> B) : B <~> A.
 Proof.
   intros.
   destruct (is_equiv_to_adjoint f (pr2 f)) as [g [is_section [is_retraction triangle]]].
@@ -367,12 +367,11 @@ Defined.
 (** Anything homotopic to an equivalence is an equivalence. *)
 
 Lemma equiv_homotopic {A B} (f g : A -> B) :
-  (forall x, f x ~~> g x) -> is_equiv g -> is_equiv f.
+  (forall x, f x == g x) -> is_equiv g -> is_equiv f.
 Proof.
   intros A B f g' p geq.
-  set (g := existT is_equiv g' geq : A ≃> B).
-  eapply hequiv_is_equiv.
-  instantiate (1 := g⁻¹).
+  set (g := existT is_equiv g' geq : A <~> B).
+  apply @hequiv_is_equiv with (g := g^-1).
   intro y.
   expand_inverse_trg g y; auto.
   intro x.
@@ -381,15 +380,14 @@ Defined.
 
 (** And the 2-out-of-3 property for equivalences. *)
 
-Definition equiv_compose {A B C} (f : A ≃> B) (g : B ≃> C) : (A ≃> C).
+Definition equiv_compose {A B C} (f : A <~> B) (g : B <~> C) : (A <~> C).
 Proof.
   intros.
-  exists (g ○ f).
-  eapply hequiv_is_equiv.
-  instantiate (1 := (f⁻¹) ○ (g⁻¹)).
+  exists (g o f).
+  apply @hequiv_is_equiv with (g := (f^-1) o (g^-1)).
   intro y.
   expand_inverse_trg g y.
-  expand_inverse_trg f (g⁻¹ y).
+  expand_inverse_trg f (g^-1 y).
   apply idpath.
   intro x.
   expand_inverse_trg f x.
@@ -397,38 +395,36 @@ Proof.
   apply idpath.
 Defined.
 
-Definition equiv_cancel_right {A B C} (f : A ≃> B) (g : B -> C) :
-  is_equiv (g ○ f) -> is_equiv g.
+Definition equiv_cancel_right {A B C} (f : A <~> B) (g : B -> C) :
+  is_equiv (g o f) -> is_equiv g.
 Proof.
   intros A B C f g H.
-  set (gof := (existT _ (g ○ f) H) : A ≃> C).
-  eapply hequiv_is_equiv.
-  instantiate (1 := f ○ (gof⁻¹)).
+  set (gof := (existT _ (g o f) H) : A <~> C).
+  apply @hequiv_is_equiv with (g := f o (gof^-1)).
   intro y.
   expand_inverse_trg gof y.
   apply idpath.
   intro x.
-  change (f (gof⁻¹ (g x)) ~~> x).
+  change (f (gof^-1 (g x)) == x).
   equiv_moveright; equiv_moveright.
-  change (g x ~~> g (f (f⁻¹ x))).
+  change (g x == g (f (f^-1 x))).
   cancel_inverses.
 Defined.
 
-Definition equiv_cancel_left {A B C} (f : A -> B) (g : B ≃> C) :
-  is_equiv (g ○ f) -> is_equiv f.
+Definition equiv_cancel_left {A B C} (f : A -> B) (g : B <~> C) :
+  is_equiv (g o f) -> is_equiv f.
 Proof.
   intros A B C f g H.
-  set (gof := existT _ (g ○ f) H : A ≃> C).
-  eapply hequiv_is_equiv. 
-  instantiate (1 := gof⁻¹ ○ g).
+  set (gof := existT _ (g o f) H : A <~> C).
+  apply @hequiv_is_equiv with (g := gof^-1 o g).
   intros y.
   expand_inverse_trg g y.
-  expand_inverse_src g (f (((gof ⁻¹) ○ g) y)).
+  expand_inverse_src g (f (((gof ^-1) o g) y)).
   apply map.
-  path_via (gof ((gof⁻¹ (g y)))).
+  path_via (gof ((gof^-1 (g y)))).
   apply inverse_is_section.
   intros x.
-  path_via (gof⁻¹ (gof x)).
+  path_via (gof^-1 (gof x)).
   apply inverse_is_retraction.
 Defined.
 
@@ -445,18 +441,18 @@ Defined.
 
 (** The action of an equivalence on paths is an equivalence. *)
 
-Theorem equiv_map_inv {A B} {x y : A} (f : A ≃> B) :
-  (f x ~~> f y) -> (x ~~> y).
+Theorem equiv_map_inv {A B} {x y : A} (f : A <~> B) :
+  (f x == f y) -> (x == y).
 Proof.
   intros A B x y f p.
-  path_via (f⁻¹ (f x)).
+  path_via (f^-1 (f x)).
   apply opposite, inverse_is_retraction.
-  path_via' (f⁻¹ (f y)).
+  path_via' (f^-1 (f y)).
   apply map. assumption.
   apply inverse_is_retraction.
 Defined.
 
-Theorem equiv_map_is_equiv {A B} {x y : A} (f : A ≃> B) :
+Theorem equiv_map_is_equiv {A B} {x y : A} (f : A <~> B) :
   is_equiv (@map A B x y f).
 Proof.
   intros A B x y f.
@@ -467,26 +463,26 @@ Proof.
   do_opposite_map.
   moveright_onleft.
   undo_compose_map.
-  path_via (map (f ○ (f ⁻¹)) p @ inverse_is_section f (f y)).
+  path_via (map (f o (f ^-1)) p @ inverse_is_section f (f y)).
   apply inverse_triangle.
   path_via (inverse_is_section f (f x) @ p).
-  apply homotopy_naturality_toid with (f := f ○ (f⁻¹)).
+  apply homotopy_naturality_toid with (f := f o (f^-1)).
   apply opposite, inverse_triangle.
   intro p.
   unfold equiv_map_inv.
   moveright_onleft.
   undo_compose_map.
-  apply homotopy_naturality_toid with (f := (f⁻¹) ○ f).
+  apply homotopy_naturality_toid with (f := (f^-1) o f).
 Defined.
 
-Definition equiv_map_equiv {A B} {x y : A} (f : A ≃> B) :
-  (x ~~> y) ≃> (f x ~~> f y) :=
-  tpair (@map A B x y f) (equiv_map_is_equiv f).
+Definition equiv_map_equiv {A B} {x y : A} (f : A <~> B) :
+  (x == y) <~> (f x == f y) :=
+  (@map A B x y f ; equiv_map_is_equiv f).
 
 (** Path-concatenation is an equivalence. *)
 
-Lemma concat_is_equiv_left {A} (x y z : A) (p : x ~~> y) :
-  is_equiv (fun q: y ~~> z => p @ q).
+Lemma concat_is_equiv_left {A} (x y z : A) (p : x == y) :
+  is_equiv (fun q: y == z => p @ q).
 Proof.
   intros A x y z p.
   apply @hequiv_is_equiv with (g := @concat A y x z (!p)).
@@ -496,33 +492,33 @@ Proof.
   associate_left.
 Defined.
 
-Definition concat_equiv_left {A} (x y z : A) (p : x ~~> y) :
-  (y ~~> z) ≃> (x ~~> z) :=
-  tpair (fun q: y ~~> z => p @ q) (concat_is_equiv_left x y z p).
+Definition concat_equiv_left {A} (x y z : A) (p : x == y) :
+  (y == z) <~> (x == z) :=
+  (fun q: y == z => p @ q  ;  concat_is_equiv_left x y z p).
 
-Lemma concat_is_equiv_right {A} (x y z : A) (p : y ~~> z) :
-  is_equiv (fun q : x ~~> y => q @ p).
+Lemma concat_is_equiv_right {A} (x y z : A) (p : y == z) :
+  is_equiv (fun q : x == y => q @ p).
 Proof.
   intros A x y z p.
-  apply @hequiv_is_equiv with (g := fun r : x ~~> z => r @ !p).
+  apply @hequiv_is_equiv with (g := fun r : x == z => r @ !p).
   intro q.
   associate_right.
   intro q.
   associate_right.
 Defined.
 
-Definition concat_equiv_right {A} (x y z : A) (p : y ~~> z) :
-  (x ~~> y) ≃> (x ~~> z) :=
-  tpair (fun q: x ~~> y => q @ p) (concat_is_equiv_right x y z p).
+Definition concat_equiv_right {A} (x y z : A) (p : y == z) :
+  (x == y) <~> (x == z) :=
+  (fun q: x == y => q @ p  ;  concat_is_equiv_right x y z p).
 
 (** And we can characterize the path types of the total space of a
    fibration, up to equivalence. *)
 
-Theorem total_paths_equiv (A : Type) (P : A -> Type) (x y : total P) :
-  (x ~~> y) ≃> { p : pr1 x ~~> pr1 y & transport p (pr2 x) ~~> pr2 y }.
+Theorem total_paths_equiv (A : Type) (P : A -> Type) (x y : sigT P) :
+  (x == y) <~> { p : pr1 x == pr1 y & transport p (pr2 x) == pr2 y }.
 Proof.
   intros A P x y.
-  exists (fun r => existT (fun p => transport p (pr2 x) ~~> pr2 y) (base_path r) (fiber_path r)).
+  exists (fun r => existT (fun p => transport p (pr2 x) == pr2 y) (base_path r) (fiber_path r)).
   eapply @hequiv_is_equiv.
   instantiate (1 := fun pq => let (p,q) := pq in total_path A P x y p q).
   intros [p q].
@@ -539,16 +535,16 @@ Defined.
    and to call it "h-isomorphism". *)
 
 Definition is_hiso {A B} (f : A -> B) :=
-  ( { g : B->A  &  forall x, g (f x) ~~> x } *
-    { h : B->A  &  forall y, f (h y) ~~> y } )%type.
+  ( { g : B->A  &  forall x, g (f x) == x } *
+    { h : B->A  &  forall y, f (h y) == y } )%type.
 
 Theorem equiv_to_hiso {A B} (f : equiv A B) : is_hiso f.
 Proof.
   intros A B f.
   split.
-  exists (f⁻¹).
+  exists (f^-1).
   apply inverse_is_retraction.
-  exists (f⁻¹).
+  exists (f^-1).
   apply inverse_is_section.
 Defined.
 

--- a/Coq/FiberEquivalences.v
+++ b/Coq/FiberEquivalences.v
@@ -7,7 +7,7 @@ Unset Automatic Introduction.
 
 Definition total_map {A B : Type} {P : A -> Type} {Q : B -> Type}
   (f : A -> B) (g : forall x:A, P x -> Q (f x)) :
-  total P -> total Q.
+  sigT P -> sigT Q.
 Proof.
   intros A B P Q f g.
   intros [x y].
@@ -28,15 +28,15 @@ Section FiberMap.
   Let tg := total_map (idmap A) g.
 
   (* There is a subtlety here that is easy to get confused about.  The
-     type [total P] is *inductively generated* by elements of the form
-     [tpair x y].  This does *not* mean that every element of [total
+     type [sigT P] is *inductively generated* by elements of the form
+     [(x ; y)].  This does *not* mean that every element of [total
      P] is *definitionally* equal to one of that form.  In particular,
      although it appears that [total_map f g] "acts as [f] on the base
      space," we cannot assert that *definitionally* except for
-     arguments of the form [tpair x y].  Hence we need the following
+     arguments of the form [(x ; y)].  Hence we need the following
      lemma.  *)
 
-  Let tg_is_fiberwise (z : total P) : pr1 z ~~> pr1 (tg z).
+  Let tg_is_fiberwise (z : sigT P) : pr1 z == pr1 (tg z).
     intros [x y].
     auto.
   Defined.
@@ -46,8 +46,8 @@ Section FiberMap.
      fiber component of [z], modulo the previously defined path in the
      base.  *)
 
-  Let tg_isg_onfibers (z : total P) :
-    g _ (transport (tg_is_fiberwise z) (pr2 z)) ~~> pr2 (tg z).
+  Let tg_isg_onfibers (z : sigT P) :
+    g _ (transport (tg_is_fiberwise z) (pr2 z)) == pr2 (tg z).
   Proof.
     intros [x y].
     auto.
@@ -56,8 +56,8 @@ Section FiberMap.
   (* And the following lemma tells us that the same is true for its
      action on paths. *)
 
-  Let tg_isfib_onpaths (z w : total P) (p : z ~~> w) :
-    (tg_is_fiberwise z @ base_path (map tg p) @ !tg_is_fiberwise w) ~~> base_path p.
+  Let tg_isfib_onpaths (z w : sigT P) (p : z == w) :
+    (tg_is_fiberwise z @ base_path (map tg p) @ !tg_is_fiberwise w) == base_path p.
   Proof.
     path_induction.
     destruct x. simpl. auto.
@@ -69,7 +69,7 @@ Section FiberMap.
 
     Hypothesis tot_iseqv : is_equiv tg.
 
-    Let tot_eqv : (total P) ≃> (total Q) := (tpair tg tot_iseqv).
+    Let tot_eqv : (sigT P) <~> (sigT Q) := (tg ; tot_iseqv).
 
     (* We want to show that each function [g x] is an equivalence, so we
        start by defining its inverse. *)
@@ -78,16 +78,16 @@ Section FiberMap.
     Proof.
       intros x y.
       (* The obvious thing to look at first is this. *)
-      set (inv1 := pr2 ((tot_eqv⁻¹) (tpair x y))).
+      set (inv1 := pr2 ((tot_eqv^-1) (x ; y))).
       (* Unfortunately, this does not live in the fiber over [x], but
          rather in some other fiber.  We need to transport it along some
          path.  Our first guess at such a path might be this. *)
-      apply (transport (base_path (inverse_is_section tot_eqv (tpair x y)))).
+      apply (transport (base_path (inverse_is_section tot_eqv (x ; y)))).
       simpl.
       (* This type is not quite the type of [inv1] yet; it involves
          knowing something about the base component of an image under
          [tg].  This is what [tg_is_fiberwise] is for.   *)
-      apply (transport (tg_is_fiberwise ((tot_eqv⁻¹) (tpair x y)))).
+      apply (transport (tg_is_fiberwise ((tot_eqv^-1) (x ; y)))).
       (* Now we are back to the type of [inv1]. *)
       assumption.
     Defined.
@@ -105,45 +105,45 @@ Section FiberMap.
       (* First we have to show it is a section of [f x]. *)
       intro y.
       path_via (transport (P := Q)
-        (base_path (is_section (tpair x y)))
-        (pr2 (tot_eqv (tot_eqv⁻¹ (tpair x y))))).
+        (base_path (is_section (x ; y)))
+        (pr2 (tot_eqv (tot_eqv^-1 (x ; y))))).
       path_via (transport
-        (base_path (is_section (tpair x y)))
-        (g _ (transport (tg_is_fiberwise (tot_eqv⁻¹ (tpair x y)))
-          (pr2 (tot_eqv⁻¹ (tpair x y)))))).
+        (base_path (is_section (x ; y)))
+        (g _ (transport (tg_is_fiberwise (tot_eqv^-1 (x ; y)))
+          (pr2 (tot_eqv^-1 (x ; y)))))).
       apply trans_map.
       exact (fiber_path (is_section (existT _ x y))).
       (* And now that it is a retraction. *)
       intro y.
-      path_via (transport (base_path (map tg (is_retraction (tpair x y))))
-      (transport (tg_is_fiberwise (tot_eqv⁻¹ (tpair x (g x y))))
-        (pr2 (tot_eqv⁻¹ (tpair x (g x y)))))).
+      path_via (transport (base_path (map tg (is_retraction (x ; y))))
+      (transport (tg_is_fiberwise (tot_eqv^-1 (x ; (g x y))))
+        (pr2 (tot_eqv^-1 (x ; (g x y)))))).
       unfold ginv.
       apply happly, map, map.
       apply opposite, triangle.
       path_via (transport
-        (base_path (is_retraction (tpair x y)))
-        (pr2 (tot_eqv⁻¹ (tpair x (g x y))))).
+        (base_path (is_retraction (x ; y)))
+        (pr2 (tot_eqv^-1 (x ; (g x y))))).
       path_via (transport
-        ((tg_is_fiberwise (tot_eqv⁻¹ (tpair x (g x y))))
-          @ (base_path (map tg (is_retraction (tpair x y)))))
-        (pr2 ((tot_eqv⁻¹) (tpair x (g x y))))).
+        ((tg_is_fiberwise (tot_eqv^-1 (x ; (g x y))))
+          @ (base_path (map tg (is_retraction (x ; y)))))
+        (pr2 ((tot_eqv^-1) (x ; (g x y))))).
       apply opposite, trans_concat.
       apply happly, map.
       (* Here is where we need [tg_isfib_onpaths], but it is easy to
          get confused because the second copy of [tg_is_fiberwise]
          appears to be missing.  The reason is that it would be
-         instantiated at an element of the form [tpair x y], in which
+         instantiated at an element of the form [(x ; y)], in which
          case it happens to be an identity.  Thus, we can just add it
          back in. *)
-      path_via (tg_is_fiberwise (tot_eqv⁻¹ (tpair x (g x y))) @
-        base_path (map tg (is_retraction (tpair x y))) @
-        !tg_is_fiberwise (tpair x y)).
+      path_via (tg_is_fiberwise (tot_eqv^-1 (x ; (g x y))) @
+        base_path (map tg (is_retraction (x ; y))) @
+        !tg_is_fiberwise (x ; y)).
       exact (fiber_path (is_retraction (existT _ x y))).
     Defined.
 
-    Definition fiber_equiv (x:A) : P x ≃> Q x :=
-      tpair (g x) (fiber_is_equiv x).
+    Definition fiber_equiv (x:A) : P x <~> Q x :=
+      (g x ; fiber_is_equiv x).
 
   End TotalIsEquiv.
 
@@ -153,13 +153,13 @@ Section FiberMap.
 
     Hypothesis fiber_iseqv : forall x, is_equiv (g x).
 
-    Let fiber_eqv x : P x ≃> Q x := tpair (g x) (fiber_iseqv x).
+    Let fiber_eqv x : P x <~> Q x := (g x ; fiber_iseqv x).
 
-    Let total_inv : total Q -> total P.
+    Let total_inv : sigT Q -> sigT P.
     Proof.
       intros [x y].
       exists x.
-      apply ((fiber_eqv x)⁻¹).
+      apply ((fiber_eqv x)^-1).
       assumption.
     Defined.
 
@@ -170,17 +170,17 @@ Section FiberMap.
       intros [x y].
       eapply total_path.
       instantiate (1 := idpath x).
-      path_via (fiber_eqv x ((fiber_eqv x ⁻¹) y)).
+      path_via (fiber_eqv x ((fiber_eqv x ^-1) y)).
       apply inverse_is_section.
       intros [x y].
       eapply total_path.
       instantiate (1 := idpath x).
-      path_via (fiber_eqv x ⁻¹ (fiber_eqv x y)).
+      path_via (fiber_eqv x ^-1 (fiber_eqv x y)).
       apply inverse_is_retraction.
     Defined.
 
-    Definition total_equiv : total P ≃> total Q :=
-      tpair tg (total_is_equiv).
+    Definition total_equiv : sigT P <~> sigT Q :=
+      (tg ; total_is_equiv).
 
   End FiberIsEquiv.
 
@@ -200,18 +200,18 @@ Section PullbackMap.
 
   Variables A B : Type.
   Variable Q : B -> Type.
-  Variable f : A ≃> B.
+  Variable f : A <~> B.
 
-  Let pbQ : A -> Type := Q ○ f.
+  Let pbQ : A -> Type := Q o f.
 
   Let g (x:A) : pbQ x -> Q (f x) := idmap (Q (f x)).
 
   Let tg := total_map f g.
 
-  Let tginv : total Q -> total pbQ.
+  Let tginv : sigT Q -> sigT pbQ.
   Proof.
     intros [x z].
-    exists (f⁻¹ x).
+    exists (f^-1 x).
     apply (transport (! inverse_is_section f x)).
     assumption.
   Defined.
@@ -236,7 +236,7 @@ Section PullbackMap.
     path_via (transport (!inverse_is_section f (f x) @ map f (inverse_is_retraction f x)) z).
     apply opposite, trans_concat.
     path_via (transport (idpath (f x)) z).
-    assert (p : (!inverse_is_section f (f x) @ map f (inverse_is_retraction f x)) ~~> idpath (f x)).
+    assert (p : (!inverse_is_section f (f x) @ map f (inverse_is_retraction f x)) == idpath (f x)).
     moveright_onleft.
     cancel_units.
     apply inverse_triangle.
@@ -245,7 +245,7 @@ Section PullbackMap.
       (fun p => transport p z) p).
   Defined.
 
-  Definition pullback_total_equiv : total pbQ ≃> total Q :=
+  Definition pullback_total_equiv : sigT pbQ <~> sigT Q :=
     existT _ tg pullback_total_is_equiv.
 
 End PullbackMap.
@@ -264,12 +264,12 @@ Section FibrationMap.
   Variable P : A -> Type.
   Variable Q : B -> Type.
 
-  Variable f : A ≃> B.
+  Variable f : A <~> B.
   Variable g : forall x:A, P x -> Q (f x).
 
   Let tg := total_map f g.
 
-  Let pbQ := Q ○ f.
+  Let pbQ := Q o f.
 
   Let pbg (x : A) : P x -> pbQ x := g x.
 
@@ -279,7 +279,7 @@ Section FibrationMap.
     intro H.
     set (pbmap_equiv := pullback_total_is_equiv Q f).
     apply fiber_is_equiv.
-    apply @equiv_cancel_left with (C := total Q) (g := pullback_total_equiv Q f).
+    apply @equiv_cancel_left with (C := sigT Q) (g := pullback_total_equiv Q f).
     apply @equiv_homotopic with (g := tg).
     intros [x y].
     auto.
@@ -287,18 +287,18 @@ Section FibrationMap.
   Defined.
 
   Definition fibseq_fiber_equiv :
-    is_equiv tg -> forall x, P x ≃> Q (f x) :=
-      fun H x => tpair (g x) (fibseq_fiber_is_equiv H x).
+    is_equiv tg -> forall x, P x <~> Q (f x) :=
+      fun H x => (g x ; fibseq_fiber_is_equiv H x).
 
   (* Instead of proving directly that [tg] is an equivalence, we'll
-  prove first that a different map from [total P] to [total Q] is an
+  prove first that a different map from [sigT P] to [sigT Q] is an
   equivalence, then that [tg] is homotopic to that map. *)
 
   Let fibseq_a_totalequiv :
-    (forall x, is_equiv (g x)) -> (total P ≃> total Q).
+    (forall x, is_equiv (g x)) -> (sigT P <~> sigT Q).
   Proof.
     intro H.
-    apply @equiv_compose with (B := total pbQ).
+    apply @equiv_compose with (B := sigT pbQ).
     exists (total_map (idmap A) pbg).
     apply @total_is_equiv.
     apply H.
@@ -316,8 +316,8 @@ Section FibrationMap.
   Defined.
 
   Definition fibseq_total_equiv :
-    (forall x, is_equiv (g x)) -> (total P ≃> total Q) :=
-    fun H => tpair tg (fibseq_total_is_equiv H).
+    (forall x, is_equiv (g x)) -> (sigT P <~> sigT Q) :=
+    fun H => (tg ; fibseq_total_is_equiv H).
 
 End FibrationMap.
 

--- a/Coq/Fibrations.v
+++ b/Coq/Fibrations.v
@@ -24,8 +24,7 @@ Unset Automatic Introduction.
 (** We can also define more familiar homotopy-looking aliases for all
    of these functions. *)
 
-Notation total := sigT.
-Notation tpair := (@existT _ _).
+Notation "( x  ; y )" := (existT _ x y).
 Notation pr1 := (@projT1 _ _).
 Notation pr2 := (@projT2 _ _).
 
@@ -40,22 +39,22 @@ Definition section {A} (P : A -> Type) := forall x : A, P x.
    not depend on paths in the base space but rather just on points of
    the base space. *)
 
-Theorem transport {A} {P : A -> Type} {x y : A} (p : x ~~> y) : P x -> P y.
+Theorem transport {A} {P : A -> Type} {x y : A} (p : x == y) : P x -> P y.
 Proof.
   path_induction.
 Defined.
 
 (** A homotopy fiber for a map [f] at [y] is the space of paths of the
-   form [f x ~~> y].
+   form [f x == y].
    *)
 
-Definition hfiber {A B} (f : A -> B) (y : B) := {x : A & f x ~~> y}.
+Definition hfiber {A B} (f : A -> B) (y : B) := {x : A & f x == y}.
 
 (** We prove a lemma that explains how to transport a point in the
    homotopy fiber along a path in the domain of the map. *)
 
-Lemma transport_hfiber A B (f : A -> B) (x y : A) (z : B) (p : x ~~> y) (q : f x ~~> z) :
-  transport (P := fun x => f x ~~> z) p q ~~> !(map f p) @ q.
+Lemma transport_hfiber A B (f : A -> B) (x y : A) (z : B) (p : x == y) (q : f x == z) :
+  transport (P := fun x => f x == z) p q == !(map f p) @ q.
 Proof.
   intros A B f x y z p q.
   induction p.
@@ -65,8 +64,8 @@ Defined.
 (** The following lemma tells us how to construct a path in the total space from
    a path in the base space and a path in the fiber. *)
 
-Lemma total_path (A : Type) (P : A -> Type) (x y : sigT P) (p : projT1 x ~~> projT1 y) :
-  (transport p (projT2 x) ~~> projT2 y) -> (x ~~> y).
+Lemma total_path (A : Type) (P : A -> Type) (x y : sigT P) (p : projT1 x == projT1 y) :
+  (transport p (projT2 x) == projT2 y) -> (x == y).
 Proof.
   intros A P x y p.
   intros q.
@@ -81,13 +80,13 @@ Defined.
 (** Conversely, a path in the total space can be projected down to the base. *)
 
 Definition base_path {A} {P : A -> Type} {u v : sigT P} :
-  (u ~~> v) -> (projT1 u ~~> projT1 v) :=
+  (u == v) -> (projT1 u == projT1 v) :=
   map pr1.
 
 (** And similarly to the fiber.  *)
 
 Definition fiber_path {A} {P : A -> Type} {u v : sigT P}
-  (p : u ~~> v) : (transport (map pr1 p) (projT2 u) ~~> projT2 v).
+  (p : u == v) : (transport (map pr1 p) (projT2 u) == projT2 v).
 Proof.
   path_induction.
 Defined.
@@ -95,8 +94,8 @@ Defined.
 (** And these operations are inverses.  See [total_paths_equiv], later
    on, for a more precise statement. *)
 
-Lemma total_path_reconstruction (A : Type) (P : A -> Type) (x y : sigT P) (p : x ~~> y) :
-  total_path A P x y (base_path p) (fiber_path p) ~~> p.
+Lemma total_path_reconstruction (A : Type) (P : A -> Type) (x y : sigT P) (p : x == y) :
+  total_path A P x y (base_path p) (fiber_path p) == p.
 Proof.
   intros A P x y p.
   induction p.
@@ -105,8 +104,8 @@ Proof.
 Defined.
 
 Lemma base_total_path (A : Type) (P : A -> Type) (x y : sigT P)
-  (p : projT1 x ~~> projT1 y) (q : transport p (projT2 x) ~~> projT2 y) :
-  (base_path (total_path A P x y p q)) ~~> p.
+  (p : projT1 x == projT1 y) (q : transport p (projT2 x) == projT2 y) :
+  (base_path (total_path A P x y p q)) == p.
 Proof.
   destruct x as [x H]. destruct y as [y K]. intros p q.
   simpl in p. induction p. simpl in q. induction q.
@@ -114,10 +113,10 @@ Proof.
 Defined.
 
 Lemma fiber_total_path (A : Type) (P : A -> Type) (x y : sigT P)
-  (p : projT1 x ~~> projT1 y) (q : transport p (projT2 x) ~~> projT2 y) :
-  transport (P := fun p' : pr1 x ~~> pr1 y => transport p' (pr2 x) ~~> pr2 y)
+  (p : projT1 x == projT1 y) (q : transport p (projT2 x) == projT2 y) :
+  transport (P := fun p' : pr1 x == pr1 y => transport p' (pr2 x) == pr2 y)
   (base_total_path A P x y p q) (fiber_path (total_path A P x y p q))
-  ~~> q.
+  == q.
 Proof.
   destruct x as [x H]. destruct y as [y K]. intros p q.
   simpl in p. induction p. simpl in q. induction q.
@@ -127,8 +126,8 @@ Defined.
 (** This lemma tells us how to extract a commutative triangle in the
    base from a path in the homotopy fiber. *)
 
-Lemma hfiber_triangle {A B} {f : A -> B} {z : B} {x y : hfiber f z} (p : x ~~> y) :
-  (map f (base_path p)) @ (projT2 y) ~~> (projT2 x).
+Lemma hfiber_triangle {A B} {f : A -> B} {z : B} {x y : hfiber f z} (p : x == y) :
+  (map f (base_path p)) @ (projT2 y) == (projT2 x).
 Proof.
   intros. induction p.
   unfold base_path.
@@ -138,63 +137,63 @@ Defined.
 (** Transporting a path along another path is equivalent to
    concatenating the two paths. *)
 
-Lemma trans_is_concat {A} {x y z : A} (p : x ~~> y) (q : y ~~> z) :
-  (transport q p) ~~> p @ q.
+Lemma trans_is_concat {A} {x y z : A} (p : x == y) (q : y == z) :
+  (transport q p) == p @ q.
 Proof.
   path_induction.
 Defined.
 
 (* This is also a special case of [transport_hfiber]. *)
-Lemma trans_is_concat_opp {A} {x y z : A} (p : x ~~> y) (q : x ~~> z) :
-  (transport (P := fun x' => (x' ~~> z)) p q) ~~> !p @ q.
+Lemma trans_is_concat_opp {A} {x y z : A} (p : x == y) (q : x == z) :
+  (transport (P := fun x' => (x' == z)) p q) == !p @ q.
 Proof.
   path_induction.
 Defined.
 
 (** Transporting along a concatenation is transporting twice. *)
 
-Lemma trans_concat {A} {P : A -> Type} {x y z : A} (p : x ~~> y) (q : y ~~> z) (z : P x) :
-  transport (p @ q) z ~~> transport q (transport p z).
+Lemma trans_concat {A} {P : A -> Type} {x y z : A} (p : x == y) (q : y == z) (z : P x) :
+  transport (p @ q) z == transport q (transport p z).
 Proof.
   path_induction.
 Defined.
 
 (** Transporting commutes with pulling back along a map. *)
 
-Lemma map_trans {A B} {x y : A} (P : B -> Type) (f : A -> B) (p : x ~~> y) (z : P (f x)) :
- (transport (P := (fun x => P (f x))) p z) ~~> (transport (map f p) z).
+Lemma map_trans {A B} {x y : A} (P : B -> Type) (f : A -> B) (p : x == y) (z : P (f x)) :
+ (transport (P := (fun x => P (f x))) p z) == (transport (map f p) z).
 Proof.
   path_induction.
 Defined.
 
 (** And also with applying fiberwise functions. *)
 
-Lemma trans_map {A} {P Q : A -> Type} {x y : A} (p : x ~~> y) (f : forall x, P x -> Q x) (z : P x) :
-  f y (transport p z) ~~> (transport p (f x z)).
+Lemma trans_map {A} {P Q : A -> Type} {x y : A} (p : x == y) (f : forall x, P x -> Q x) (z : P x) :
+  f y (transport p z) == (transport p (f x z)).
 Proof.
   path_induction.
 Defined.
 
 (** A version of [map] for dependent functions. *)
 
-Lemma map_dep {A} {P : A -> Type} {x y : A} (f : forall x, P x) (p: x ~~> y) :
-  transport p (f x) ~~> f y.
+Lemma map_dep {A} {P : A -> Type} {x y : A} (f : forall x, P x) (p: x == y) :
+  transport p (f x) == f y.
 Proof.
   path_induction.
 Defined.
 
 (* Transporting in a non-dependent type does nothing. *)
 
-Lemma trans_trivial {A B : Type} {x y : A} (p : x ~~> y) (z : B) :
-  transport (P := fun x => B) p z ~~> z.
+Lemma trans_trivial {A B : Type} {x y : A} (p : x == y) (z : B) :
+  transport (P := fun x => B) p z == z.
 Proof.
   path_induction.
 Defined.
 
 (* And for a non-dependent type, [map_dep] reduces to [map], modulo [trans_trivial]. *)
 
-Lemma map_dep_trivial {A B} {x y : A} (f : A -> B) (p: x ~~> y):
-  map_dep f p ~~> trans_trivial p (f x) @ map f p. 
+Lemma map_dep_trivial {A B} {x y : A} (f : A -> B) (p: x == y):
+  map_dep f p == trans_trivial p (f x) @ map f p. 
 Proof.
   path_induction.
 Defined.
@@ -202,8 +201,8 @@ Defined.
 (* 2-Paths in a total space. *)
 
 Lemma map_twovar {A : Type} {P : A -> Type} {B : Type} {x y : A} {a : P x} {b : P y}
-  (f : forall x : A, P x -> B) (p : x ~~> y) (q : transport p a ~~> b) :
-  f x a ~~> f y b.
+  (f : forall x : A, P x -> B) (p : x == y) (q : transport p a == b) :
+  f x a == f y b.
 Proof.
   intros A P B x y a b f p q.
   induction p.
@@ -213,8 +212,8 @@ Proof.
 Defined.
 
 Lemma total_path2 (A : Type) (P : A -> Type) (x y : sigT P)
-  (p q : x ~~> y) (r : base_path p ~~> base_path q) :
-  (transport (P := fun s => transport s (pr2 x) ~~> (pr2 y)) r (fiber_path p) ~~> fiber_path q) -> (p ~~> q).
+  (p q : x == y) (r : base_path p == base_path q) :
+  (transport (P := fun s => transport s (pr2 x) == (pr2 y)) r (fiber_path p) == fiber_path q) -> (p == q).
 Proof.
   intros A P x y p q r H.
   path_via (total_path A P x y (base_path p) (fiber_path p)) ;

--- a/Coq/Functions.v
+++ b/Coq/Functions.v
@@ -4,7 +4,6 @@ Definition idmap A := fun x : A => x.
 
 Definition compose {A B C} (g : B -> C) (f : A -> B) (x : A) := g (f x).
 
-(** printing ○ $\circ$ *)
+(** printing o $\circ$ *)
 
-Notation "g ○ f" := (compose g f) (left associativity, at level 37).
-(* Notation "g 'o' f" := (compose g f) (left associativity, at level 37). *)
+Notation "g 'o' f" := (compose g f) (left associativity, at level 37).

--- a/Coq/HIT/Circle.v
+++ b/Coq/HIT/Circle.v
@@ -9,28 +9,28 @@ Unset Automatic Introduction.
 Axiom circle : Type.
 
 Axiom base : circle.
-Axiom loop : base ~~> base.
+Axiom loop : base == base.
  
 Axiom circle_rect :
-  forall (P : circle -> Type) (pt : P base) (lp : transport loop pt ~~> pt), 
+  forall (P : circle -> Type) (pt : P base) (lp : transport loop pt == pt), 
     forall x : circle, P x.
 
 Axiom compute_base :
-  forall (P : circle -> Type) (pt : P base) (lp : transport loop pt ~~> pt), 
-    circle_rect P pt lp base ~~> pt.
+  forall (P : circle -> Type) (pt : P base) (lp : transport loop pt == pt), 
+    circle_rect P pt lp base == pt.
 
 Axiom compute_loop :
-  forall (P : circle -> Type) (pt : P base) (lp : transport loop pt ~~> pt), 
+  forall (P : circle -> Type) (pt : P base) (lp : transport loop pt == pt), 
     (! map (transport loop) (compute_base P pt lp)
       @ (map_dep (circle_rect P pt lp) loop)
       @ (compute_base P pt lp))
-    ~~> lp.
+    == lp.
 
 (** From this we can derive the non-dependent version of the
    eliminator, with its propositional computation rules. *)
 
 Definition circle_rect' :
-  forall (B : Type) (pt : B) (lp : pt ~~> pt), circle -> B.
+  forall (B : Type) (pt : B) (lp : pt == pt), circle -> B.
 Proof.
   intros B pt lp.
   apply circle_rect with (P := fun x => B) (pt := pt).
@@ -48,8 +48,8 @@ Proof.
 Defined.
 
 Definition compute_base' :
-  forall (B : Type) (pt : B) (lp : pt ~~> pt),
-    circle_rect' B pt lp base ~~> pt.
+  forall (B : Type) (pt : B) (lp : pt == pt),
+    circle_rect' B pt lp base == pt.
 Proof.
   intros B pt lp.
   unfold circle_rect'.
@@ -57,11 +57,11 @@ Proof.
 Defined.
 
 Definition compute_loop' :
-  forall (B : Type) (pt : B) (lp : pt ~~> pt),
+  forall (B : Type) (pt : B) (lp : pt == pt),
     (! (compute_base' B pt lp)
       @ map (circle_rect' B pt lp) loop
       @ (compute_base' B pt lp))
-    ~~> lp.
+    == lp.
 Proof.
   intros B pt lp.
   set (P := fun x : circle => B).
@@ -87,15 +87,15 @@ Defined.
 (** If the circle is contractible, then UIP holds. *)
 
 Theorem circle_contr_implies_UIP : is_contr (circle) ->
-  forall (A : Type) (x y : A) (p q : x ~~> y), p ~~> q.
+  forall (A : Type) (x y : A) (p q : x == y), p == q.
 Proof.
   intros H A x y p q.
   induction p.
   set (cq := circle_rect' A x q).
   set (cqb := cq base).
-  set (cqcb := compute_base' A x q : cqb ~~> x).
-  set (cql := map cq loop : cqb ~~> cqb).
-  set (cqcl := compute_loop' A x q : (!cqcb @ cql @ cqcb ~~> q)).
+  set (cqcb := compute_base' A x q : cqb == x).
+  set (cql := map cq loop : cqb == cqb).
+  set (cqcl := compute_loop' A x q : (!cqcb @ cql @ cqcb == q)).
   path_via (!cqcb @ cql @ cqcb).
   moveleft_onright.
   moveleft_onleft.

--- a/Coq/HIT/Integers.v
+++ b/Coq/HIT/Integers.v
@@ -19,7 +19,7 @@ Proof.
   destruct (IHn m) as [p | e].
   left; apply map; assumption.
   right. intro H. apply e.
-  exact (transport (P := fun k => n ~~> match k with 0 => n | S l => l end) H (idpath n)).
+  exact (transport (P := fun k => n == match k with 0 => n | S l => l end) H (idpath n)).
 Defined.
 
 Theorem nat_is_set : is_set nat.
@@ -43,7 +43,7 @@ Proof.
   destruct ndec as [p | f].
   left; apply map; assumption.
   right. intro H. apply f.
-  exact (transport (P := fun z => n ~~> match z with pos a => a | _ => n end) H (idpath n)).
+  exact (transport (P := fun z => n == match z with pos a => a | _ => n end) H (idpath n)).
   right. intro H.
   exact (transport (P := fun z => match z with zero => Empty_set | _ => unit end) H tt).
   right. intro H.
@@ -63,7 +63,7 @@ Proof.
   destruct ndec as [p | f].
   left; apply map; assumption.
   right. intro H. apply f.
-  exact (transport (P := fun z => n ~~> match z with neg a => a | _ => n end) H (idpath n)).
+  exact (transport (P := fun z => n == match z with neg a => a | _ => n end) H (idpath n)).
 Defined.
 
 Theorem int_is_set : is_set int.
@@ -91,7 +91,7 @@ Definition pred (z : int) : int :=
   end.
 
 Definition succ_pred (z : int) :
-  succ (pred z) ~~> z.
+  succ (pred z) == z.
 Proof.
   intro z.
   induction z.
@@ -99,14 +99,14 @@ Proof.
 Defined.  
 
 Definition pred_succ (z : int) :
-  pred (succ z) ~~> z.
+  pred (succ z) == z.
 Proof.
   intro z.
   induction z.
   auto. auto. induction n; auto.
 Defined.  
 
-Definition succ_equiv : int ≃> int.
+Definition succ_equiv : int <~> int.
 Proof.
   exists succ.
   apply hequiv_is_equiv with (g := pred).
@@ -137,7 +137,7 @@ Proof.
 Defined.
 
 Lemma zero_right_unit (z : int) :
-  zadd z zero ~~> z.
+  zadd z zero == z.
 Proof.
   intro z.
   induction z.

--- a/Coq/HIT/IsInhab.v
+++ b/Coq/HIT/IsInhab.v
@@ -9,7 +9,7 @@ Unset Automatic Introduction.
 
    Inductive is_inhab (A : Type) : Type :=
    | inhab : A -> is_inhab A
-   | inhab_path : forall (x y: is_inhab A), x ~~> y
+   | inhab_path : forall (x y: is_inhab A), x == y
 
    Instead we have to assume axioms that amount ot the same thing.
 *)
@@ -18,7 +18,7 @@ Axiom is_inhab : forall (A : Type), Type.
 
 Axiom inhab : forall {A : Type}, A -> is_inhab A.
 
-Axiom inhab_path : forall {A : Type} (x y : is_inhab A), x ~~> y.
+Axiom inhab_path : forall {A : Type} (x y : is_inhab A), x == y.
 
 (** By adding the following [Hint Resolve] we can simply use the [auto] tactic
    to resolve any path involving [is_inhab]. *)
@@ -28,25 +28,25 @@ Axiom is_inhab_rect :
   forall
     {A : Type} {P : is_inhab A -> Type}
     (dinhab : forall a : A, P (inhab a))
-    (dpath : forall (x y : is_inhab A) (z : P x) (w : P y), transport (inhab_path x y) z ~~> w)
+    (dpath : forall (x y : is_inhab A) (z : P x) (w : P y), transport (inhab_path x y) z == w)
     (x : is_inhab A), P x.
 
 Axiom is_inhab_compute_inhab : forall {A : Type} {P : is_inhab A -> Type}
   (dinhab : forall (a : A), P (inhab a))
-  (dpath : forall (x y : is_inhab A) (z : P x) (w : P y), transport (inhab_path x y) z ~~> w),
-  forall (a : A), is_inhab_rect dinhab dpath (inhab a) ~~> dinhab a.
+  (dpath : forall (x y : is_inhab A) (z : P x) (w : P y), transport (inhab_path x y) z == w),
+  forall (a : A), is_inhab_rect dinhab dpath (inhab a) == dinhab a.
 
 Axiom is_inhab_compute_path : forall {A : Type} {P : is_inhab A -> Type}
   (dinhab : forall (a : A), P (inhab a))
-  (dpath : forall (x y : is_inhab A) (z : P x) (w : P y), transport (inhab_path x y) z ~~> w),
+  (dpath : forall (x y : is_inhab A) (z : P x) (w : P y), transport (inhab_path x y) z == w),
   forall (x y : is_inhab A),
     map_dep (is_inhab_rect dinhab dpath) (inhab_path x y)
-    ~~> dpath x y (is_inhab_rect dinhab dpath x) (is_inhab_rect dinhab dpath y).
+    == dpath x y (is_inhab_rect dinhab dpath x) (is_inhab_rect dinhab dpath y).
 
 (** The non-dependent version of the eliminator. *)
 
 Definition is_inhab_rect_nondep {A B : Type} :
-  (A -> B) -> (forall (z w : B), z ~~> w) -> (is_inhab A -> B).
+  (A -> B) -> (forall (z w : B), z == w) -> (is_inhab A -> B).
 Proof.
   intros A B dinhab' dpath'.
   apply is_inhab_rect.
@@ -58,18 +58,18 @@ Proof.
 Defined.
 
 Definition is_inhab_compute_inhab_nondep {A B : Type}
-  (dinhab' : A -> B) (dpath' : forall (z w : B), z ~~> w) (a : A) :
-  is_inhab_rect_nondep dinhab' dpath' (inhab a) ~~> (dinhab' a).
+  (dinhab' : A -> B) (dpath' : forall (z w : B), z == w) (a : A) :
+  is_inhab_rect_nondep dinhab' dpath' (inhab a) == (dinhab' a).
 Proof.
   intros A B dinhab' dpath' a.
   apply @is_inhab_compute_inhab with (P := fun a => B).
 Defined.
 
 Definition is_inhab_compute_path_nondep {A B : Type}
-  (dinhab' : A -> B) (dpath' : forall (z w : B), z ~~> w)
+  (dinhab' : A -> B) (dpath' : forall (z w : B), z == w)
   (x y : is_inhab A) :
   map (is_inhab_rect_nondep dinhab' dpath') (inhab_path x y)
-  ~~> dpath' (is_inhab_rect_nondep dinhab' dpath' x) (is_inhab_rect_nondep dinhab' dpath' y).
+  == dpath' (is_inhab_rect_nondep dinhab' dpath' x) (is_inhab_rect_nondep dinhab' dpath' y).
 Proof.
   intros A B dinhab' dpath' x y.
   (* Here is a "cheating" proof which just uses the assumption that [B] is a prop:
@@ -153,13 +153,13 @@ Defined.
   
 (** Functoriality of [is_inhab_map]. *)
 Lemma is_inhab_map_id {A : Type} :
-  forall (p : is_inhab A), is_inhab_map (fun x => x) p ~~> p.
+  forall (p : is_inhab A), is_inhab_map (fun x => x) p == p.
 Proof.
   auto.
 Defined.
 
 Lemma is_inhab_map_compose {A B C : Type} (f : A -> B) (g : B -> C):
-  forall (p : is_inhab A), is_inhab_map (compose g f) p ~~> is_inhab_map g (is_inhab_map f p).
+  forall (p : is_inhab A), is_inhab_map (compose g f) p == is_inhab_map g (is_inhab_map f p).
 Proof.
   auto.
 Defined.
@@ -169,7 +169,7 @@ Definition eta := @inhab.
 
   (** Naturality of unit. *)
 Lemma eta_natural {A B : Type} (f : A -> B) :
-  forall a : A, eta B (f a) ~~> is_inhab_map f (eta A a).
+  forall a : A, eta B (f a) == is_inhab_map f (eta A a).
 Proof.
   auto.
 Defined.
@@ -184,27 +184,27 @@ Defined.
   (** Naturality of multiplication. *)
 Lemma mu_natural {A B : Type} (f : A -> B) :
   forall p : is_inhab (is_inhab A),
-    mu B (is_inhab_map (is_inhab_map f) p) ~~> is_inhab_map f (mu A p).
+    mu B (is_inhab_map (is_inhab_map f) p) == is_inhab_map f (mu A p).
 Proof.
   auto.
 Qed.
 
   (** Unit laws. *)
 Lemma eta_1 (A : Type) :
-  forall p : is_inhab A, mu A (eta (is_inhab A) p) ~~> p.
+  forall p : is_inhab A, mu A (eta (is_inhab A) p) == p.
 Proof.
   auto.
 Qed.
 
 Lemma eta_2 (A : Type) :
-  forall p : is_inhab A, mu A (is_inhab_map (eta A) p) ~~> p.
+  forall p : is_inhab A, mu A (is_inhab_map (eta A) p) == p.
 Proof.
   auto.
 Qed.
 
 Lemma mu_1 (A : Type) :
   forall p : is_inhab (is_inhab (is_inhab A)),
-    mu A (is_inhab_map (mu A) p) ~~> mu A (mu (is_inhab A) p).
+    mu A (is_inhab_map (mu A) p) == mu A (mu (is_inhab A) p).
 Proof.
   auto.
 Qed.
@@ -221,7 +221,7 @@ Defined.
   (* Naturality of strength. *)
 Lemma t_natural (A A' B B' : Type) (f : A -> A') (g : B -> B') :
   forall (a : A) (q : is_inhab B),
-    is_inhab_map (fun xy => (f (fst xy), g (snd xy))) (t A B (a,q)) ~~> t A' B' (f a, is_inhab_map g q).
+    is_inhab_map (fun xy => (f (fst xy), g (snd xy))) (t A B (a,q)) == t A' B' (f a, is_inhab_map g q).
 Proof.
   auto.
 Qed.
@@ -230,14 +230,14 @@ Qed.
 
 Lemma strength_unit (A : Type) :
   forall p : unit * is_inhab A,
-    is_inhab_map (@snd unit A) (t unit A p) ~~> snd p.
+    is_inhab_map (@snd unit A) (t unit A p) == snd p.
 Proof.
   auto.
 Qed.
 
 Lemma strength_eta (A B : Type) :
   forall (a : A) (b : B),
-    t A B (a, eta B b) ~~> eta (A * B) (a,b).
+    t A B (a, eta B b) == eta (A * B) (a,b).
 Proof.
   auto.
 Qed.
@@ -246,7 +246,7 @@ Definition alpha A B C (u : (A * B) * C) := (fst (fst u), (snd (fst u), snd u)).
 
 Lemma strength_pentagon_1 (A B C : Type) :
   forall (a : A) (b : B) (r : is_inhab C),
-    is_inhab_map (alpha A B C) (t (A * B) C ((a,b),r)) ~~>
+    is_inhab_map (alpha A B C) (t (A * B) C ((a,b),r)) ==
     t A (B * C) (a, t B C (b, r)).
 Proof.
   auto.
@@ -254,7 +254,7 @@ Qed.
 
 Lemma strength_pentagon_2 (A B : Type) :
   forall (a : A) (p : is_inhab (is_inhab B)),
-    mu (A * B) (is_inhab_map (t A B) (t A (is_inhab B) (a, p))) ~~> t A B (a, mu B p).
+    mu (A * B) (is_inhab_map (t A B) (t A (is_inhab B) (a, p))) == t A B (a, mu B p).
 Proof.
   auto.
 Qed.

--- a/Coq/HIT/Pi1S1.v
+++ b/Coq/HIT/Pi1S1.v
@@ -4,14 +4,14 @@ Require Import Homotopy Integers Circle.
 (** For compatibility with Coq 8.2. *)
 Unset Automatic Introduction.
 
-(** In this file we prove that the loop space [base ~~> base] of
+(** In this file we prove that the loop space [base == base] of
    [circle] is equivalent to the integers [int]. *)
 
 (** It is easy to define a map in one direction.  We call the function
    [wind] because [wind z] is the path that winds around the circle
    [z] times.  *)
 
-Definition wind (z : int) : (base ~~> base) :=
+Definition wind (z : int) : (base == base) :=
   match z with
     | zero => idpath base
     | pos n => (fix F (n : nat) :=
@@ -30,7 +30,7 @@ Definition wind (z : int) : (base ~~> base) :=
    with [loop], and dually. *)
 
 Lemma wind_succ (z : int) :
-  wind z @ loop ~~> wind (succ z).
+  wind z @ loop == wind (succ z).
 Proof.
   intro z.
   induction z.
@@ -45,7 +45,7 @@ Proof.
 Defined.
 
 Lemma wind_pred (z : int) :
-  wind z @ !loop ~~> wind (pred z).
+  wind z @ !loop == wind (pred z).
 Proof.
   intro z.
   induction z.
@@ -66,7 +66,7 @@ Definition circle_cover : circle -> Type :=
 
 (** Of course, the fiber over [base] is equivalent to [int]. *)
 
-Definition fiber_toint : (circle_cover base) ≃> int.
+Definition fiber_toint : (circle_cover base) <~> int.
 Proof.
   apply path_to_equiv.
   apply compute_base'.
@@ -78,8 +78,8 @@ Defined.
    the fact that [int] is a set. *)
 
 Lemma circle_cover_dfib (c c' : circle) (z : circle_cover c) (z' : circle_cover c')
-  (p q : tpair c z ~~> tpair c' z') :
-  (base_path p ~~> base_path q) -> (p ~~> q).
+  (p q : (c ; z) == (c' ; z')) :
+  (base_path p == base_path q) -> (p == q).
 Proof.
   intros c c' z z' p q s.
   apply total_path2 with (r := s).
@@ -93,7 +93,7 @@ Proof.
   apply contr_path.
   apply hlevel_inhabited_contr.
   assumption.
-  apply (S' c' (pr2 (tpair c' z'))).
+  apply (S' c' (pr2 (c' ; z'))).
 Defined.
 
 (** The next two lemmas say that modulo [fiber_toint], the paths
@@ -101,14 +101,14 @@ Defined.
    [succ] and [pred], respectively. *)
 
 Lemma fiber_loop_action (x : circle_cover base) :
-  fiber_toint (transport loop x) ~~> succ (fiber_toint x).
+  fiber_toint (transport loop x) == succ (fiber_toint x).
 Proof.
   intro x.
   expand_inverse_src fiber_toint x.
-  change ((fiber_toint ○ transport loop ○ (fiber_toint⁻¹)) (fiber_toint x) ~~> succ (fiber_toint x)).
+  change ((fiber_toint o transport loop o (fiber_toint^-1)) (fiber_toint x) == succ (fiber_toint x)).
   apply happly.
   path_via succ_equiv.
-  path_via (fiber_toint ○ path_to_equiv (map circle_cover loop) ○ (fiber_toint ⁻¹)).
+  path_via (fiber_toint o path_to_equiv (map circle_cover loop) o (fiber_toint ^-1)).
   apply happly; apply map; apply map.
   apply opposite, path_to_equiv_map.
   unfold fiber_toint.
@@ -121,20 +121,20 @@ Proof.
 Defined.
 
 Lemma fiber_opploop_action (x : circle_cover base) :
-  fiber_toint (transport (!loop) x) ~~> pred (fiber_toint x).
+  fiber_toint (transport (!loop) x) == pred (fiber_toint x).
 Proof.
   intro x.
   expand_inverse_src fiber_toint x.
-  change ((fiber_toint ○ transport (!loop) ○ (fiber_toint⁻¹)) (fiber_toint x) ~~> pred (fiber_toint x)).
+  change ((fiber_toint o transport (!loop) o (fiber_toint^-1)) (fiber_toint x) == pred (fiber_toint x)).
   apply happly.
-  path_via (succ_equiv ⁻¹).
-  path_via (fiber_toint ○ path_to_equiv (map circle_cover (!loop)) ○ (fiber_toint ⁻¹)).
+  path_via (succ_equiv ^-1).
+  path_via (fiber_toint o path_to_equiv (map circle_cover (!loop)) o (fiber_toint ^-1)).
   apply happly; apply map; apply map.
   apply opposite, path_to_equiv_map.
   unfold fiber_toint.
   undo_opposite_to_inverse.
   undo_concat_to_compose.
-  path_via ((path_to_equiv (equiv_to_path succ_equiv))⁻¹).
+  path_via ((path_to_equiv (equiv_to_path succ_equiv))^-1).
   path_via (path_to_equiv (! equiv_to_path succ_equiv)).
   do_opposite_map.
   path_via (!compute_base' Type int (equiv_to_path succ_equiv) @
@@ -149,7 +149,7 @@ Defined.
 (** More generally, [wind z] acts on the fiber by addition of [z]. *)
 
 Lemma fiber_wind_action (z : int) (x : circle_cover base) :
-  fiber_toint (transport (wind z) x) ~~> zadd z (fiber_toint x).
+  fiber_toint (transport (wind z) x) == zadd z (fiber_toint x).
 Proof.
   intros z x.
   induction z.
@@ -182,17 +182,17 @@ Proof.
 Defined.
   
 (** We will need the following lemma, which says that if we transport
-   a function [f : P x -> Q x] along a path [p : x ~~> y], the
+   a function [f : P x -> Q x] along a path [p : x == y], the
    resulting function [P y -> Q y] can be computed by transporting
    along [! p], applying [f], then transporting back along [p]. *)
 
-Lemma trans_function {A} (P Q : A -> Type) (x y : A) (p : x ~~> y) (f : P x -> Q x) :
-  transport (P := fun x => P x -> Q x) p f ~~> transport p ○ f ○ transport (!p).
+Lemma trans_function {A} (P Q : A -> Type) (x y : A) (p : x == y) (f : P x -> Q x) :
+  transport (P := fun x => P x -> Q x) p f == transport p o f o transport (!p).
 Proof.
   intros A P Q x y p f.
   induction p.
   simpl.
-  path_via (idmap _ ○ f ○ idmap _).
+  path_via (idmap _ o f o idmap _).
   apply funext.
   intro z.
   auto.
@@ -207,17 +207,17 @@ Defined.
    not just its component at [base]. *)
 
 Definition cover_to_pathcirc : forall (x : circle),
-  circle_cover x -> (base ~~> x).
+  circle_cover x -> (base == x).
 Proof.
-  set (P := fun x => circle_cover x -> base ~~> x).
-  set (d := wind ○ fiber_toint : P base).
+  set (P := fun x => circle_cover x -> base == x).
+  set (d := wind o fiber_toint : P base).
   apply (circle_rect P d).
   unfold d.
   apply funext.
   intro x.
   path_via (wind (fiber_toint x)).
   
-  path_via ((transport loop ○ wind ○ fiber_toint ○ transport (!loop)) x).
+  path_via ((transport loop o wind o fiber_toint o transport (!loop)) x).
   apply happly.
   apply trans_function.
   path_via (transport loop (wind (fiber_toint (transport (!loop) x)))).
@@ -237,12 +237,12 @@ Defined.
    the total path space, this is a standard fact, so we only need to
    deal with the universal cover.
 
-   We will contract the universal cover to [fiber_toint⁻¹ zero] in the
+   We will contract the universal cover to [fiber_toint^-1 zero] in the
    fiber over [base].  Thus we will need to produce a path to this
    point from every point of the universal cover. *)
 
 Lemma circle_cover_contrbase_opp (z : circle_cover base) :
-  tpair base (fiber_toint ⁻¹ zero) ~~> tpair base z.
+  (base ; fiber_toint ^-1 zero) == (base ; z).
 Proof.
   intro z.
   apply total_path with (p := wind (fiber_toint z)).
@@ -256,7 +256,7 @@ Proof.
 Defined.
 
 Definition circle_cover_contrbase (z : circle_cover base) :
-  tpair base z ~~> tpair base (fiber_toint ⁻¹ zero) :=
+  (base ; z) == (base ; fiber_toint ^-1 zero) :=
   ! circle_cover_contrbase_opp z.
 
 (** You might naively think that we're done.  But actually we need to
@@ -273,12 +273,12 @@ Definition circle_cover_contrbase (z : circle_cover base) :
    every point in the fiber over [c] to the basepoint. *)
 
 Definition circle_cover_contraction (c : circle) :=
-  forall z, tpair c z ~~> tpair base (fiber_toint ⁻¹ zero).
+  forall z, (c ; z) == (base ; fiber_toint ^-1 zero).
 
 (** The following lemma is easy but subtle and important.  It says
    that if [cb] is *any* way to contract every point in the fiber over
    [c] to the basepoint, as above, and we transport [cb] along any
-   path [p : c ~~> c'], then for any point [z] in the fiber over [c'],
+   path [p : c == c'], then for any point [z] in the fiber over [c'],
    the contraction of [z] to the basepoint obtained thereby is the
    concatenation of the tautological path from [z] to its
    transportation back along [!p] to the fiber over [c], followed by
@@ -287,10 +287,10 @@ Definition circle_cover_contraction (c : circle) :=
    But I'm not sure if that description in words is actually any
    clearer than just reading the statement of the lemma.  *)
 
-Lemma circle_cover_contr_action (c c' : circle) (l : c ~~> c')
+Lemma circle_cover_contr_action (c c' : circle) (l : c == c')
   (z : circle_cover c') (cb : circle_cover_contraction c) :
-  transport l cb z ~~>
-  total_path _ _ (tpair c' z) (tpair c (transport (!l) z)) (!l) (idpath _)
+  transport l cb z ==
+  total_path _ _ (c' ; z) (c ; transport (!l) z) (!l) (idpath _)
   @ cb (transport (!l) z).
 Proof.
   intros c c' l z cb.
@@ -305,12 +305,12 @@ Defined.
    unchanged. *)
 
 Lemma trans_basecontr_fixed :
-  transport (P := circle_cover_contraction) loop circle_cover_contrbase ~~> circle_cover_contrbase.
+  transport (P := circle_cover_contraction) loop circle_cover_contrbase == circle_cover_contrbase.
 Proof.
   apply funext_dep.
   intro x.
-  path_via (total_path _ _ (tpair _ x)
-    (tpair _ (transport (!loop) x)) (!loop) (idpath _)
+  path_via (total_path _ _ (_ ; x)
+    (_ ; transport (!loop) x) (!loop) (idpath _)
     @ circle_cover_contrbase (transport (!loop) x)).
   apply circle_cover_contr_action.
   apply circle_cover_dfib.
@@ -318,8 +318,8 @@ Proof.
   do_concat_map.
   path_via (!loop @ map pr1 (circle_cover_contrbase (transport (!loop) x))).
   apply @base_total_path with
-    (x := tpair base x)
-    (y := tpair base (transport (!loop) x)).
+    (x := (base ; x))
+    (y := (base ; transport (!loop) x)).
   path_via (!wind (fiber_toint x)).
   path_via (!loop @ !wind (fiber_toint (transport (!loop) x))).
   unfold circle_cover_contrbase.
@@ -342,13 +342,13 @@ Defined.
 (** Finally, we can prove that the total space of the universal cover
    is contractible. *)
 
-Theorem circle_cover_contr: is_contr (total circle_cover).
+Theorem circle_cover_contr: is_contr (sigT circle_cover).
 Proof.
-  exists (tpair base (fiber_toint ⁻¹ zero)).
+  exists (base ; fiber_toint ^-1 zero).
   intros [c z].
   generalize z. generalize c.
   exact (circle_rect
-    (fun c => forall z, tpair c z ~~> tpair base (fiber_toint ⁻¹ zero))
+    (fun c => forall z, (c ; z) == (base ; fiber_toint ^-1 zero))
     circle_cover_contrbase
     trans_basecontr_fixed).
 Defined.
@@ -357,7 +357,7 @@ Defined.
    contractible total space, so [cover_to_pathcirc] induces an
    equivalence between total spaces.  By the theorem about fibrations,
    it follows that it is an equivalence itself, hence it is equivalent
-   to [base ~~> base]. *)
+   to [base == base]. *)
 
 Theorem cover_to_pathcirc_is_equiv (x : circle) : is_equiv (cover_to_pathcirc x).
 Proof.
@@ -369,7 +369,7 @@ Defined.
 
 (** Here is the main theorem. *)
 
-Theorem int_equiv_loopcirc : int ≃> (base ~~> base).
+Theorem int_equiv_loopcirc : int <~> (base == base).
 Proof.
   apply @equiv_compose with (B := circle_cover base).
   apply path_to_equiv.

--- a/Coq/HLevel.v
+++ b/Coq/HLevel.v
@@ -36,7 +36,7 @@ Defined.
 Fixpoint is_hlevel (n : nat) : Type -> Type :=
   match n with
     | 0 => is_contr
-    | S n' => fun X => forall (x y:X), is_hlevel n' (x ~~> y)
+    | S n' => fun X => forall (x y:X), is_hlevel n' (x == y)
   end.
 
 Theorem hlevel_inhabited_contr {n X} : is_hlevel n X -> is_contr (is_hlevel n X).
@@ -72,7 +72,7 @@ Defined.
 
 (** H-level is preserved under equivalence. *)
 
-Theorem hlevel_equiv {n A B} : (A ≃> B) -> is_hlevel n A -> is_hlevel n B.
+Theorem hlevel_equiv {n A B} : (A <~> B) -> is_hlevel n A -> is_hlevel n B.
 Proof.
   intro n.
   induction n.
@@ -80,13 +80,13 @@ Proof.
   apply @contr_equiv_contr.
   simpl.
   intros A B f H x y.
-  apply IHn with (A := f (f⁻¹ x) ~~> y).
+  apply IHn with (A := f (f^-1 x) == y).
   apply concat_equiv_left.
   apply opposite, inverse_is_section.
-  apply IHn with (A := f (f⁻¹ x) ~~> f (f⁻¹ y)).
+  apply IHn with (A := f (f^-1 x) == f (f^-1 y)).
   apply concat_equiv_right.
   apply inverse_is_section.
-  apply IHn with (A := (f⁻¹ x) ~~> (f⁻¹ y)).
+  apply IHn with (A := (f^-1 x) == (f^-1 y)).
   apply equiv_map_equiv.
   apply H.
 Defined.
@@ -122,7 +122,7 @@ Defined.
 
 Definition isprop_isprop {A} : is_prop (is_prop A) := hlevel_isprop.
 
-Theorem prop_equiv_inhabited_contr {A} : is_prop A ≃> (A -> is_contr A).
+Theorem prop_equiv_inhabited_contr {A} : is_prop A <~> (A -> is_contr A).
 Proof.
   intros A.
   exists prop_inhabited_contr.
@@ -148,7 +148,7 @@ Defined.
 
 (** And another one. *)
 
-Theorem prop_path {A} : is_prop A -> forall (x y : A), x ~~> y.
+Theorem prop_path {A} : is_prop A -> forall (x y : A), x == y.
 Proof.
   intro A.
   unfold is_prop. simpl.
@@ -156,7 +156,7 @@ Proof.
   exact (pr1 (H x y)).
 Defined.
 
-Theorem allpath_prop {A} : (forall (x y : A), x ~~> y) -> is_prop A.
+Theorem allpath_prop {A} : (forall (x y : A), x == y) -> is_prop A.
   intro A.
   intros H x y.
   assert (K : is_contr A).
@@ -164,7 +164,7 @@ Theorem allpath_prop {A} : (forall (x y : A), x ~~> y) -> is_prop A.
   apply contr_pathcontr. assumption.
 Defined.
 
-Theorem prop_equiv_allpath {A} : is_prop A ≃> (forall (x y : A), x ~~> y).
+Theorem prop_equiv_allpath {A} : is_prop A <~> (forall (x y : A), x == y).
 Proof.
   intro A.
   exists prop_path.
@@ -192,7 +192,7 @@ Definition is_set := is_hlevel 2.
 
 (** A type is a set if and only if it satisfies Axiom K. *)
 
-Definition axiomK A := forall (x : A) (p : x ~~> x), p ~~> idpath x.
+Definition axiomK A := forall (x : A) (p : x == x), p == idpath x.
 
 Definition isset_implies_axiomK {A} : is_set A -> axiomK A.
 Proof.
@@ -210,7 +210,7 @@ Proof.
 Defined.
 
 Theorem isset_equiv_axiomK {A} :
-  is_set A ≃> (forall (x : A) (p : x ~~> x), p ~~> idpath x).
+  is_set A <~> (forall (x : A) (p : x == x), p == idpath x).
 Proof.
   intro A.
   exists isset_implies_axiomK.
@@ -241,8 +241,8 @@ Proof.
   apply hlevel_isprop.
 Defined.
 
-Theorem set_path2 (A : Type) (x y : A) (p q : x ~~> y) :
-  is_set A -> (p ~~> q).
+Theorem set_path2 (A : Type) (x y : A) (p q : x == y) :
+  is_set A -> (p == q).
 Proof.
   intros A x y p q.
   intro H.
@@ -260,7 +260,7 @@ Defined.
    homotopy (whew!).  *)
 
 Lemma axiomK_idpath (A : Type) (x : A) (K : axiomK A) :
-  K x (idpath x) ~~> idpath (idpath x).
+  K x (idpath x) == idpath (idpath x).
 Proof.
   intros.
   set (qq := map_dep (K x) (K x (idpath x))).
@@ -274,13 +274,13 @@ Defined.
 (** Any type with "decidable equality" is a set. *)
 
 Definition decidable_paths (A : Type) :=
-  forall (x y : A), (x ~~> y) + ((x ~~> y) -> Empty_set).
+  forall (x y : A), (x == y) + ((x == y) -> Empty_set).
 
 (* Classically, this lemma would be proved with [discriminate], but
    unfortunately that tactic is hardcoded to work only with Coq's
    Prop-valued equality. *)
-Definition inl_injective (A B : Type) (x y : A) (p : inl B x ~~> inl B y) : (x ~~> y) :=
-  transport (P := fun (s:A+B) => x ~~> match s with inl a => a | inr b => x end) p (idpath x).
+Definition inl_injective (A B : Type) (x y : A) (p : inl B x == inl B y) : (x == y) :=
+  transport (P := fun (s:A+B) => x == match s with inl a => a | inr b => x end) p (idpath x).
 
 Theorem decidable_isset (A : Type) :
   decidable_paths A -> is_set A.
@@ -299,8 +299,8 @@ Proof.
   path_via (transport p q).
   apply opposite, trans_is_concat.
   path_via q.
-  set (qp1 := trans_map p (fun (x0:A) => inl  (x ~~> x0 -> Empty_set)) q).
-  apply inl_injective with (B := (x ~~> x -> Empty_set)).
+  set (qp1 := trans_map p (fun (x0:A) => inl  (x == x0 -> Empty_set)) q).
+  apply inl_injective with (B := (x == x -> Empty_set)).
   exact (qp1 @ qp0).
   induction (q' p).
 Defined.

--- a/Coq/Paths.v
+++ b/Coq/Paths.v
@@ -7,19 +7,19 @@ Unset Automatic Introduction.
 
 Inductive paths {A} : A -> A -> Type := idpath : forall x, paths x x.
 
-(* The next line tells [coqdoc] to print [paths] as a wiggly arrow LaTeX. *)
-(** printing ~~> $\leadsto$ *)
+(* The next line tells [coqdoc] to print [paths] as an equals sign in LaTeX. *)
+(** printing == $=$ *)
 
-(** We introduce notation [x ~~> y] for the space [paths x y] of paths
-   from [x] to [y]. We can then write [p : x ~~> y] to indicate that
+(** We introduce notation [x == y] for the space [paths x y] of paths
+   from [x] to [y]. We can then write [p : x == y] to indicate that
    [p] is a path from [x] to [y]. *)
 
-Notation "x ~~> y" := (paths x y) (at level 70).
+Notation "x == y" := (paths x y) (at level 70).
 
 (** The [Hint Resolve @idpath] line below means that Coq's [auto]
    tactic will automatically perform [apply idpath] if that leads to a
    successful solution of the current goal. For example if we ask it
-   to construct a path [x ~~> x], [auto] will find the identity path
+   to construct a path [x == x], [auto] will find the identity path
    [idpath x], thanks to the [Hint Resolve].
 
    In general we should declare [Hint Resolve] on those theorems which
@@ -36,7 +36,7 @@ Hint Resolve @idpath.
 Ltac path_induction :=
   intros; repeat progress (
     match goal with
-      | [ p : _ ~~> _  |- _ ] => induction p
+      | [ p : _ == _  |- _ ] => induction p
       | _ => idtac
     end
   ); auto.
@@ -58,7 +58,7 @@ Ltac path_induction :=
 (** We now define the basic operations on paths, starting with
    concatenation. *)
 
-Definition concat {A} {x y z : A} : (x ~~> y) -> (y ~~> z) -> (x ~~> z).
+Definition concat {A} {x y z : A} : (x == y) -> (y == z) -> (x == z).
 Proof.
   intros A x y z p q.
   induction p.
@@ -73,14 +73,14 @@ Notation "p @ q" := (concat p q) (at level 60).
 (** A definition like [concat] can be used in two ways. The first and
    obvious way is as an operation which concatenates together two
    paths. The second use is a proof tactic when we want to construct a
-   path [x ~~> z] as a concatenation of paths [x ~~> y ~~> z]. This is
+   path [x == z] as a concatenation of paths [x == y == z]. This is
    done with [apply @concat], see examples below. We will actually
    define a tactic [path_via] which uses [concat] but is much smarter
    than just the direct application [apply @concat]. *)
 
 (** Paths can be reversed. *)
 
-Definition opposite {A} {x y : A} : (x ~~> y) -> (y ~~> x).
+Definition opposite {A} {x y : A} : (x == y) -> (y == x).
 Proof.
   intros A x y p.
   induction p.
@@ -99,43 +99,43 @@ Notation "! p" := (opposite p) (at level 50).
 (** The following lemmas say that up to higher paths, the paths form a
    1-groupoid. *)
 
-Lemma idpath_left_unit A (x y : A) (p : x ~~> y) : idpath x @ p ~~> p.
+Lemma idpath_left_unit A (x y : A) (p : x == y) : idpath x @ p == p.
 Proof.
   path_induction.
 Defined.
 
-Lemma idpath_right_unit A (x y : A) (p : x ~~> y) : (p @ idpath y) ~~> p.
+Lemma idpath_right_unit A (x y : A) (p : x == y) : (p @ idpath y) == p.
 Proof.
   path_induction.
 Defined.
 
-Lemma opposite_right_inverse A (x y : A) (p : x ~~> y) : (p @ !p) ~~> idpath x.
+Lemma opposite_right_inverse A (x y : A) (p : x == y) : (p @ !p) == idpath x.
 Proof.
  path_induction.
 Defined.
 
-Lemma opposite_left_inverse A (x y : A) (p : x ~~> y) : (!p @ p) ~~> idpath y.
+Lemma opposite_left_inverse A (x y : A) (p : x == y) : (!p @ p) == idpath y.
 Proof.
   path_induction.
 Defined.
 
-Lemma opposite_concat A (x y z : A) (p : x ~~> y) (q : y ~~> z) : !(p @ q) ~~> !q @ !p.
+Lemma opposite_concat A (x y z : A) (p : x == y) (q : y == z) : !(p @ q) == !q @ !p.
 Proof.
   path_induction.
 Defined.
 
-Lemma opposite_idpath A (x : A) : !(idpath x) ~~> idpath x.
+Lemma opposite_idpath A (x : A) : !(idpath x) == idpath x.
 Proof.
   path_induction.
 Defined.
 
-Lemma opposite_opposite A (x y : A) (p : x ~~> y) : !(! p) ~~> p.
+Lemma opposite_opposite A (x y : A) (p : x == y) : !(! p) == p.
 Proof.
   path_induction.
 Defined.
 
-Lemma concat_associativity A (w x y z : A) (p : w ~~> x) (q : x ~~> y) (r : y ~~> z) :
-  (p @ q) @ r ~~> p @ (q @ r).
+Lemma concat_associativity A (w x y z : A) (p : w == x) (q : x == y) (r : y == z) :
+  (p @ q) @ r == p @ (q @ r).
 Proof.
   path_induction.
 Defined.
@@ -145,8 +145,8 @@ Defined.
    concatenation in a path type, but we need a new name and notation
    for concatenation of 2-paths along points. *)
 
-Definition concat2 {A} {x y z : A} {p p' : x ~~> y} {q q' : y ~~> z} :
-  (p ~~> p') -> (q ~~> q') -> (p @ q ~~> p' @ q').
+Definition concat2 {A} {x y z : A} {p p' : x == y} {q q' : y == z} :
+  (p == p') -> (q == q') -> (p @ q == p' @ q').
 Proof.
   path_induction.
 Defined.
@@ -155,20 +155,20 @@ Notation "p @@ q" := (concat2 p q) (at level 60).
 
 (** We also have whiskering operations. *)
 
-Definition whisker_right {A} {x y z : A} {p p' : x ~~> y} (q : y ~~> z) :
-  (p ~~> p') -> (p @ q ~~> p' @ q).
+Definition whisker_right {A} {x y z : A} {p p' : x == y} (q : y == z) :
+  (p == p') -> (p @ q == p' @ q).
 Proof.
   path_induction.
 Defined.
 
-Definition whisker_left {A} {x y z : A} {q q' : y ~~> z} (p : x ~~> y) :
-  (q ~~> q') -> (p @ q ~~> p @ q').
+Definition whisker_left {A} {x y z : A} {q q' : y == z} (p : x == y) :
+  (q == q') -> (p @ q == p @ q').
 Proof.
   path_induction.
 Defined.
 
-Definition whisker_right_toid {A} {x y : A} {p : x ~~> x} (q : x ~~> y) :
-  (p ~~> idpath x) -> (p @ q ~~> q).
+Definition whisker_right_toid {A} {x y : A} {p : x == x} (q : x == y) :
+  (p == idpath x) -> (p @ q == q).
 Proof.
   intros A x y p q a.
   apply @concat with (y := idpath x @ q).
@@ -176,8 +176,8 @@ Proof.
   apply idpath_left_unit.
 Defined.
 
-Definition whisker_right_fromid {A} {x y : A} {p : x ~~> x} (q : x ~~> y) :
-  (idpath x ~~> p) -> (q ~~> p @ q).
+Definition whisker_right_fromid {A} {x y : A} {p : x == x} (q : x == y) :
+  (idpath x == p) -> (q == p @ q).
 Proof.
   intros A x y p q a.
   apply @concat with (y := idpath x @ q).
@@ -185,8 +185,8 @@ Proof.
   apply whisker_right. assumption.
 Defined.
 
-Definition whisker_left_toid {A} {x y : A} {p : y ~~> y} (q : x ~~> y) :
-  (p ~~> idpath y) -> (q @ p ~~> q).
+Definition whisker_left_toid {A} {x y : A} {p : y == y} (q : x == y) :
+  (p == idpath y) -> (q @ p == q).
 Proof.
   intros A x y p q a.
   apply @concat with (y := q @ idpath y).
@@ -194,8 +194,8 @@ Proof.
   apply idpath_right_unit.
 Defined.
 
-Definition whisker_left_fromid {A} {x y : A} {p : y ~~> y} (q : x ~~> y) :
-  (idpath y ~~> p) -> (q ~~> q @ p).
+Definition whisker_left_fromid {A} {x y : A} {p : y == y} (q : x == y) :
+  (idpath y == p) -> (q == q @ p).
 Proof.
   intros A x y p q a.
   apply @concat with (y := q @ idpath y).
@@ -205,88 +205,88 @@ Defined.
 
 (** The interchange law for whiskering. *)
 
-Definition whisker_interchange A (x y z : A) (p p' : x ~~> y) (q q' : y ~~> z)
-  (a : p ~~> p') (b : q ~~> q') :
-  (whisker_right q a) @ (whisker_left p' b) ~~> (whisker_left p b) @ (whisker_right q' a).
+Definition whisker_interchange A (x y z : A) (p p' : x == y) (q q' : y == z)
+  (a : p == p') (b : q == q') :
+  (whisker_right q a) @ (whisker_left p' b) == (whisker_left p b) @ (whisker_right q' a).
 Proof.
   path_induction.
 Defined.
 
 (** The interchange law for concatenation. *)
 
-Definition concat2_interchange A (x y z : A) (p p' p'' : x ~~> y) (q q' q'' : y ~~> z)
-  (a : p ~~> p') (b : p' ~~> p'') (c : q ~~> q') (d : q' ~~> q'') :
-  (a @@ c) @ (b @@ d) ~~> (a @ b) @@ (c @ d).
+Definition concat2_interchange A (x y z : A) (p p' p'' : x == y) (q q' q'' : y == z)
+  (a : p == p') (b : p' == p'') (c : q == q') (d : q' == q'') :
+  (a @@ c) @ (b @@ d) == (a @ b) @@ (c @ d).
 Proof.
   path_induction.
 Defined.
 
 (** Taking opposites of 1-paths is functorial on 2-paths. *)
 
-Definition opposite2 A {x y : A} (p q : x ~~> y) (a : p ~~> q) : (!p ~~> !q).
+Definition opposite2 A {x y : A} (p q : x == y) (a : p == q) : (!p == !q).
 Proof.
   path_induction.
 Defined.
 
 (** Now we consider the application of functions to paths. *)
 
-(** A path [p : x ~~> y] in a space [A] is mapped by [f : A -> B] to a
-   path [map f p : f x ~~> f y] in [B]. *)
+(** A path [p : x == y] in a space [A] is mapped by [f : A -> B] to a
+   path [map f p : f x == f y] in [B]. *)
 
-Lemma map {A B} {x y : A} (f : A -> B) : (x ~~> y) -> (f x ~~> f y).
+Lemma map {A B} {x y : A} (f : A -> B) : (x == y) -> (f x == f y).
 Proof.
   path_induction.
 Defined.
 
 (** The next two lemmas state that [map f p] is "functorial" in the path [p]. *)
 
-Lemma idpath_map A B (x : A) (f : A -> B) : map f (idpath x) ~~> idpath (f x).
+Lemma idpath_map A B (x : A) (f : A -> B) : map f (idpath x) == idpath (f x).
 Proof.
   path_induction.
 Defined.
 
-Lemma concat_map A B (x y z : A) (f : A -> B) (p : x ~~> y) (q : y ~~> z) :
-  map f (p @ q) ~~> (map f p) @ (map f q).
+Lemma concat_map A B (x y z : A) (f : A -> B) (p : x == y) (q : y == z) :
+  map f (p @ q) == (map f p) @ (map f q).
 Proof.
   path_induction.
 Defined.
 
-Lemma opposite_map A B (f : A -> B) (x y : A) (p : x ~~> y) :
-  map f (! p) ~~> ! map f p.
+Lemma opposite_map A B (f : A -> B) (x y : A) (p : x == y) :
+  map f (! p) == ! map f p.
 Proof.
   path_induction.
 Defined.
 
 (** It is also the case that [map f p] is functorial in [f].  *)
 
-Lemma idmap_map A (x y : A) (p : x ~~> y) : map (idmap A) p ~~> p.
+Lemma idmap_map A (x y : A) (p : x == y) : map (idmap A) p == p.
 Proof.
   path_induction.
 Defined.
 
-Lemma compose_map A B C (f : A -> B) (g : B -> C) (x y : A) (p : x ~~> y) :
-  map (g ○ f) p ~~> map g (map f p).
+Lemma compose_map A B C (f : A -> B) (g : B -> C) (x y : A) (p : x == y) :
+  map (g o f) p == map g (map f p).
 Proof.
   path_induction.
 Defined.
 
 (** We can also map paths between paths. *)
 
-Definition map2 {A B} {x y : A} {p q : x ~~> y} (f : A -> B) :
-  p ~~> q -> (map f p ~~> map f q)
+Definition map2 {A B} {x y : A} {p q : x == y} (f : A -> B) :
+  p == q -> (map f p == map f q)
   := map (map f).
 
 (** The type of "homotopies" between two functions [f] and [g] is
-   [forall x, f x ~~> g x].  These can be derived from "paths" between
-   functions [f ~~> g]; the converse is function extensionality. *)
+   [forall x, f x == g x].  These can be derived from "paths" between
+   functions [f == g]; the converse is function extensionality. *)
 
-Definition happly {A B} {f g : A -> B} : (f ~~> g) -> (forall x, f x ~~> g x) :=
+Definition happly {A B} {f g : A -> B} : (f == g) -> (forall x, f x == g x) :=
   fun p x => map (fun h => h x) p.
 
 (** Similarly, [happly] for dependent functions. *)
 
 Definition happly_dep {A} {P : A -> Type} {f g : forall x, P x} :
-  (f ~~> g) -> (forall x, f x ~~> g x) :=
+  (f == g) -> (forall x, f x == g x) :=
   fun p x => map (fun h => h x) p.
 
 
@@ -321,7 +321,7 @@ Hint Resolve
 
 Ltac apply_happly :=
   match goal with
-    | |- ?f' ?x ~~> ?g' ?x =>
+    | |- ?f' ?x == ?g' ?x =>
       first [
           apply @happly with (f := f') (g := g')
         | apply @happly_dep with (f := f') (g := g')
@@ -355,8 +355,8 @@ Ltac path_simplify' lem :=
     | apply opposite; apply lem
     ]; auto with path_hints.
 
-(** These tactics are used to construct a path [a ~~> b] as a
-   composition of paths [a ~~> x] and [x ~~> b].  They then apply
+(** These tactics are used to construct a path [a == b] as a
+   composition of paths [a == x] and [x == b].  They then apply
    [path_simplify] to both paths, along with possibly an additional
    lemma supplied by the user. *)
 
@@ -385,7 +385,7 @@ Ltac associate_right_in s :=
 Ltac associate_right :=
   repeat progress (
     match goal with
-      |- ?s ~~> ?t => first [ associate_right_in s | associate_right_in t ]
+      |- ?s == ?t => first [ associate_right_in s | associate_right_in t ]
     end
   ).
 
@@ -399,7 +399,7 @@ Ltac associate_left_in s :=
 Ltac associate_left :=
   repeat progress (
     match goal with
-      |- ?s ~~> ?t => first [ associate_left_in s | associate_left_in t ]
+      |- ?s == ?t => first [ associate_left_in s | associate_left_in t ]
     end
   ).
 
@@ -433,7 +433,7 @@ Ltac cancel_units_in s :=
 Ltac cancel_units :=
   repeat (
     match goal with
-      |- ?s ~~> ?t => first [ cancel_units_in s | cancel_units_in t ]
+      |- ?s == ?t => first [ cancel_units_in s | cancel_units_in t ]
     end
   ).
 
@@ -470,7 +470,7 @@ Ltac partly_cancel_left_opposite_of_in p s :=
 Ltac cancel_left_opposite_of p := 
   repeat progress (
     match goal with
-      |- ?s ~~> ?t => first [
+      |- ?s == ?t => first [
           partly_cancel_left_opposite_of_in p s
         | partly_cancel_left_opposite_of_in p t
       ]
@@ -496,7 +496,7 @@ Ltac partly_cancel_right_opposite_of_in p s :=
 Ltac cancel_right_opposite_of p := 
   repeat progress (
     match goal with
-      |- ?s ~~> ?t => first [
+      |- ?s == ?t => first [
           partly_cancel_right_opposite_of_in p s
         | partly_cancel_right_opposite_of_in p t
       ]
@@ -530,7 +530,7 @@ Ltac cancel_opposites_in s :=
 Ltac cancel_opposites :=
   repeat progress (
     match goal with
-      |- ?s ~~> ?t => first [ cancel_opposites_in s | cancel_opposites_in t ]
+      |- ?s == ?t => first [ cancel_opposites_in s | cancel_opposites_in t ]
     end
   ).
 
@@ -555,7 +555,7 @@ Ltac do_opposite_opposite_in s :=
 Ltac do_opposite_opposite :=
   repeat progress (
     match goal with
-      |- ?s ~~> ?t => first [ do_opposite_opposite_in s | do_opposite_opposite_in t ]
+      |- ?s == ?t => first [ do_opposite_opposite_in s | do_opposite_opposite_in t ]
     end
   ).
 
@@ -563,9 +563,9 @@ Ltac do_opposite_opposite :=
 
 Ltac apply_opposite_map :=
   match goal with
-    | |- map ?f' (! ?p') ~~> ! map ?f' ?p' =>
+    | |- map ?f' (! ?p') == ! map ?f' ?p' =>
       apply opposite_map with (f := f') (p := p')
-    | |- ! map ?f' ?p' ~~> map ?f' (! ?p') =>
+    | |- ! map ?f' ?p' == map ?f' (! ?p') =>
       apply opposite, opposite_map with (f := f') (p := p')
   end.
 
@@ -578,7 +578,7 @@ Ltac do_opposite_map_in s :=
 Ltac do_opposite_map :=
   repeat progress (
     match goal with
-      |- ?s ~~> ?t => first [ do_opposite_map_in s | do_opposite_map_in t ]
+      |- ?s == ?t => first [ do_opposite_map_in s | do_opposite_map_in t ]
     end
   ); do_opposite_opposite.
 
@@ -591,7 +591,7 @@ Ltac undo_opposite_map_in s :=
 Ltac undo_opposite_map :=
   repeat progress (
     match goal with
-      |- ?s ~~> ?t => first [ undo_opposite_map_in s | undo_opposite_map_in t ]
+      |- ?s == ?t => first [ undo_opposite_map_in s | undo_opposite_map_in t ]
     end
   ); do_opposite_opposite.
 
@@ -606,7 +606,7 @@ Ltac do_opposite_concat_in s :=
 Ltac do_opposite_concat :=
   repeat progress (
     match goal with
-      |- ?s ~~> ?t => first [ do_opposite_concat_in s | do_opposite_concat_in t ]
+      |- ?s == ?t => first [ do_opposite_concat_in s | do_opposite_concat_in t ]
     end
   ); do_opposite_opposite.
 
@@ -619,7 +619,7 @@ Ltac undo_opposite_concat_in s :=
 Ltac undo_opposite_concat :=
   repeat progress (
     match goal with
-      |- ?s ~~> ?t => first [ undo_opposite_concat_in s | undo_opposite_concat_in t ]
+      |- ?s == ?t => first [ undo_opposite_concat_in s | undo_opposite_concat_in t ]
     end
   ); do_opposite_opposite.
 
@@ -628,15 +628,15 @@ Ltac undo_opposite_concat :=
 
 Ltac apply_compose_map :=
   match goal with
-    | |- map (?g' ○ ?f') ?p' ~~> map ?g' (map ?f' ?p') =>
+    | |- map (?g' o ?f') ?p' == map ?g' (map ?f' ?p') =>
       apply compose_map with (g := g') (f := f') (p := p')
-    | |- map ?g' (map ?f' ?p') ~~> map (?g' ○ ?f') ?p' =>
+    | |- map ?g' (map ?f' ?p') == map (?g' o ?f') ?p' =>
       apply opposite; apply compose_map with (g := g') (f := f') (p := p')
   end.
 
 Ltac do_compose_map_in s :=
   match s with
-    | context cxt [ map (?f ○ ?g) ?p ] =>
+    | context cxt [ map (?f o ?g) ?p ] =>
       let mid := context cxt [ map f (map g p) ] in
         path_via mid; try apply_compose_map
   end.
@@ -644,21 +644,21 @@ Ltac do_compose_map_in s :=
 Ltac do_compose_map :=
   repeat progress (
     match goal with
-      |- ?s ~~> ?t => first [ do_compose_map_in s | do_compose_map_in t ]
+      |- ?s == ?t => first [ do_compose_map_in s | do_compose_map_in t ]
     end
   ).
 
 Ltac undo_compose_map_in s :=
   match s with
     | context cxt [ map ?f (map ?g ?p) ] =>
-      let mid := context cxt [ map (f ○ g) p ] in
+      let mid := context cxt [ map (f o g) p ] in
         path_via mid; try apply_compose_map
   end.
 
 Ltac undo_compose_map :=
   repeat progress (
     match goal with
-      |- ?s ~~> ?t => first [ undo_compose_map_in s | undo_compose_map_in t ]
+      |- ?s == ?t => first [ undo_compose_map_in s | undo_compose_map_in t ]
     end
   ).
 
@@ -673,7 +673,7 @@ Ltac do_concat_map_in s :=
 Ltac do_concat_map :=
   repeat progress (
     match goal with
-      |- ?s ~~> ?t => first [ do_concat_map_in s | do_concat_map_in t ]
+      |- ?s == ?t => first [ do_concat_map_in s | do_concat_map_in t ]
     end
   ).
 
@@ -686,15 +686,15 @@ Ltac undo_concat_map_in s :=
 Ltac undo_concat_map :=
   repeat progress (
     match goal with
-      |- ?s ~~> ?t => first [ undo_concat_map_in s | undo_concat_map_in t ]
+      |- ?s == ?t => first [ undo_concat_map_in s | undo_concat_map_in t ]
     end
   ).
 
 (** Now we return to proving lemmas about paths.
    We show that homotopies are natural with respect to paths in the domain. *) 
 
-Lemma homotopy_naturality A B (f g : A -> B) (p : forall x, f x ~~> g x) (x y : A) (q : x ~~> y) :
-  map f q @ p y ~~> p x @ map g q.
+Lemma homotopy_naturality A B (f g : A -> B) (p : forall x, f x == g x) (x y : A) (q : x == y) :
+  map f q @ p y == p x @ map g q.
 Proof.
   induction q.
   cancel_units.
@@ -702,8 +702,8 @@ Defined.
 
 Hint Resolve homotopy_naturality : path_hints.
 
-Lemma homotopy_naturality_toid A (f : A -> A) (p : forall x, f x ~~> x) (x y : A) (q : x ~~> y) :
-  map f q @ p y ~~> p x @ q.
+Lemma homotopy_naturality_toid A (f : A -> A) (p : forall x, f x == x) (x y : A) (q : x == y) :
+  map f q @ p y == p x @ q.
 Proof.
   induction q.
   cancel_units.
@@ -711,8 +711,8 @@ Defined.
 
 Hint Resolve homotopy_naturality_toid : path_hints.
 
-Lemma homotopy_naturality_fromid A (f : A -> A) (p : forall x, x ~~> f x) (x y : A) (q : x ~~> y) :
-  q @ p y ~~> p x @ map f q.
+Lemma homotopy_naturality_fromid A (f : A -> A) (p : forall x, x == f x) (x y : A) (q : x == y) :
+  q @ p y == p x @ map f q.
 Proof.
   induction q.
   cancel_units.
@@ -722,7 +722,7 @@ Hint Resolve homotopy_naturality_fromid : path_hints.
 
 (** Cancellability of concatenation on both sides. *)
 
-Lemma concat_cancel_right A (x y z : A) (p q : x ~~> y) (r : y ~~> z) : (p @ r ~~> q @ r) -> (p ~~> q).
+Lemma concat_cancel_right A (x y z : A) (p q : x == y) (r : y == z) : (p @ r == q @ r) -> (p == q).
 Proof.
   intros A x y z p q r.
   intro a.
@@ -731,7 +731,7 @@ Proof.
   path_via (q @ idpath x).
 Defined.
 
-Lemma concat_cancel_left A (x y z : A) (p : x ~~> y) (q r : y ~~> z) : (p @ q ~~> p @ r) -> (q ~~> r).
+Lemma concat_cancel_left A (x y z : A) (p : x == y) (q r : y == z) : (p @ q == p @ r) -> (q == r).
 Proof.
   intros A x y z p q r.
   intro a.
@@ -743,8 +743,8 @@ Defined.
 (** If a function is homotopic to the identity, then that homotopy
    makes it a "well-pointed" endofunctor in the following sense. *)
 
-Lemma htoid_well_pointed A (f : A -> A) (p : forall x, f x ~~> x) (x : A) :
-  map f (p x) ~~> p (f x).
+Lemma htoid_well_pointed A (f : A -> A) (p : forall x, f x == x) (x : A) :
+  map f (p x) == p (f x).
 Proof.
   intros A f p x.
   apply concat_cancel_right with (r := p x).
@@ -753,8 +753,8 @@ Defined.
 
 (** Mates *)
 
-Lemma concat_moveright_onright A (x y z : A) (p : x ~~> z) (q : x ~~> y) (r : z ~~> y) :
-  (p ~~> q @ !r) -> (p @ r ~~> q).
+Lemma concat_moveright_onright A (x y z : A) (p : x == z) (q : x == y) (r : z == y) :
+  (p == q @ !r) -> (p @ r == q).
 Proof.
   intros A x y z p q r.
   intro a.
@@ -764,14 +764,14 @@ Defined.
 
 Ltac moveright_onright :=
   match goal with
-    | |- (?p @ ?r ~~> ?q) =>
+    | |- (?p @ ?r == ?q) =>
       apply concat_moveright_onright
-    | |- (?r ~~> ?q) =>
+    | |- (?r == ?q) =>
       path_via (idpath _ @ r); apply concat_moveright_onright
   end; do_opposite_opposite.
 
-Lemma concat_moveleft_onright A (x y z : A) (p : x ~~> y) (q : x ~~> z) (r : z ~~> y) :
-  (p @ !r ~~> q) -> (p ~~> q @ r).
+Lemma concat_moveleft_onright A (x y z : A) (p : x == y) (q : x == z) (r : z == y) :
+  (p @ !r == q) -> (p == q @ r).
 Proof.
   intros A x y z p q r.
   intro a.
@@ -781,14 +781,14 @@ Defined.
 
 Ltac moveleft_onright :=
   match goal with
-    | |- (?p ~~> ?q @ ?r) =>
+    | |- (?p == ?q @ ?r) =>
       apply concat_moveleft_onright
-    | |- (?p ~~> ?r) =>
+    | |- (?p == ?r) =>
       path_via (idpath _ @ r); apply concat_moveleft_onright
   end; do_opposite_opposite.
 
-Lemma concat_moveleft_onleft A (x y z : A) (p : y ~~> z) (q : x ~~> z) (r : y ~~> x) :
-  (!r @ p ~~> q) -> (p ~~> r @ q).
+Lemma concat_moveleft_onleft A (x y z : A) (p : y == z) (q : x == z) (r : y == x) :
+  (!r @ p == q) -> (p == r @ q).
 Proof.
   intros A x y z p q r.
   intro a.
@@ -798,14 +798,14 @@ Defined.
 
 Ltac moveleft_onleft :=
   match goal with
-    | |- (?p ~~> ?r @ ?q) =>
+    | |- (?p == ?r @ ?q) =>
       apply concat_moveleft_onleft
-    | |- (?p ~~> ?r) =>
+    | |- (?p == ?r) =>
       path_via (r @ idpath _); apply concat_moveleft_onleft
   end; do_opposite_opposite.
 
-Lemma concat_moveright_onleft A (x y z : A) (p : x ~~> z) (q : y ~~> z) (r : y ~~> x) :
-  (p ~~> !r @ q) -> (r @ p ~~> q).
+Lemma concat_moveright_onleft A (x y z : A) (p : x == z) (q : y == z) (r : y == x) :
+  (p == !r @ q) -> (r @ p == q).
 Proof.
   intros A x y z p q r.
   intro a.
@@ -815,8 +815,8 @@ Defined.
 
 Ltac moveright_onleft :=
   match goal with
-    | |- (?r @ ?p ~~> ?q) =>
+    | |- (?r @ ?p == ?q) =>
       apply concat_moveright_onleft
-    | |- (?r ~~> ?q) =>
+    | |- (?r == ?q) =>
       path_via (r @ idpath _); apply concat_moveright_onleft
   end; do_opposite_opposite.

--- a/Coq/Univalence.v
+++ b/Coq/Univalence.v
@@ -5,7 +5,7 @@ Unset Automatic Introduction.
 
 (** Every path between spaces gives an equivalence. *)
 
-Definition path_to_equiv {U V} : (U ~~> V) -> (U ≃> V).
+Definition path_to_equiv {U V} : (U == V) -> (U <~> V).
 Proof.
   intros U V.
   path_induction.
@@ -14,21 +14,21 @@ Defined.
 
 (** This is functorial in the appropriate sense. *)
 
-Lemma path_to_equiv_map {A} (P : A -> Type) (x y : A) (p : x ~~> y) :
-  projT1 (path_to_equiv (map P p)) ~~> transport (P := P) p.
+Lemma path_to_equiv_map {A} (P : A -> Type) (x y : A) (p : x == y) :
+  projT1 (path_to_equiv (map P p)) == transport (P := P) p.
 Proof.
   path_induction.
 Defined.
 
-Lemma concat_to_compose {A B C} (p : A ~~> B) (q : B ~~> C) :
-  path_to_equiv q ○ path_to_equiv p ~~> projT1 (path_to_equiv (p @ q)).
+Lemma concat_to_compose {A B C} (p : A == B) (q : B == C) :
+  path_to_equiv q o path_to_equiv p == projT1 (path_to_equiv (p @ q)).
 Proof.
   path_induction.
 Defined.
 
 Ltac undo_concat_to_compose_in s :=
   match s with  
-    | context cxt [ equiv_coerce_to_function _ _ (path_to_equiv ?p) ○ equiv_coerce_to_function _ _ (path_to_equiv ?q) ] =>
+    | context cxt [ equiv_coerce_to_function _ _ (path_to_equiv ?p) o equiv_coerce_to_function _ _ (path_to_equiv ?q) ] =>
       let mid := context cxt [ equiv_coerce_to_function _ _ (path_to_equiv (q @ p)) ] in
         path_via mid;
         [ repeat first [ apply happly | apply map | apply concat_to_compose ] | ] 
@@ -37,20 +37,20 @@ Ltac undo_concat_to_compose_in s :=
 Ltac undo_concat_to_compose :=
   repeat progress (
     match goal with
-      | |- ?s ~~> ?t =>
+      | |- ?s == ?t =>
         first [ undo_concat_to_compose_in s | undo_concat_to_compose_in t ]
     end
   ).
 
-Lemma opposite_to_inverse {A B} (p : A ~~> B) :
-  (path_to_equiv p)⁻¹ ~~> path_to_equiv (!p).
+Lemma opposite_to_inverse {A B} (p : A == B) :
+  (path_to_equiv p)^-1 == path_to_equiv (!p).
 Proof.
   path_induction.
 Defined.
 
 Ltac undo_opposite_to_inverse_in s :=
   match s with  
-    | context cxt [ (path_to_equiv ?p) ⁻¹ ] =>
+    | context cxt [ (path_to_equiv ?p) ^-1 ] =>
       let mid := context cxt [ equiv_coerce_to_function _ _ (path_to_equiv (! p)) ] in
         path_via mid;
         [ repeat apply map; apply opposite_to_inverse | ]
@@ -59,7 +59,7 @@ Ltac undo_opposite_to_inverse_in s :=
 Ltac undo_opposite_to_inverse :=
   repeat progress (
     match goal with
-      | |- ?s ~~> ?t =>
+      | |- ?s == ?t =>
         first [ undo_opposite_to_inverse_in s | undo_opposite_to_inverse_in t ]
     end
   ).
@@ -72,31 +72,31 @@ Section Univalence.
 
   Hypothesis univalence : univalence_statement.
 
-  Definition path_to_equiv_equiv (U V : Type) := (tpair (@path_to_equiv U V) (univalence U V)).
+  Definition path_to_equiv_equiv (U V : Type) := (@path_to_equiv U V ; univalence U V).
 
   (** Assuming univalence, every equivalence yields a path. *)
 
-  Definition equiv_to_path {U V} : U ≃> V -> U ~~> V :=
+  Definition equiv_to_path {U V} : U <~> V -> U == V :=
     inverse (path_to_equiv_equiv U V).
 
   (** The map [equiv_to_path] is a section of [path_to_equiv]. *)
 
   Definition equiv_to_path_section U V :
-    forall (w : U ≃> V), path_to_equiv (equiv_to_path w) ~~> w :=
+    forall (w : U <~> V), path_to_equiv (equiv_to_path w) == w :=
     inverse_is_section (path_to_equiv_equiv U V).
 
   Definition equiv_to_path_retraction U V :
-    forall (p : U ~~> V), equiv_to_path (path_to_equiv p) ~~> p :=
+    forall (p : U == V), equiv_to_path (path_to_equiv p) == p :=
     inverse_is_retraction (path_to_equiv_equiv U V).
 
-  Definition equiv_to_path_triangle U V : forall (p : U ~~> V),
-      map path_to_equiv (equiv_to_path_retraction U V p) ~~> equiv_to_path_section U V (path_to_equiv p) :=
+  Definition equiv_to_path_triangle U V : forall (p : U == V),
+      map path_to_equiv (equiv_to_path_retraction U V p) == equiv_to_path_section U V (path_to_equiv p) :=
     inverse_triangle (path_to_equiv_equiv U V).
 
   (** We can do better than [equiv_to_path]: we can turn a fibration
      fibered over equivalences to one fiberered over paths. *)
 
-  Definition pred_equiv_to_path U V : (U ≃> V -> Type) -> (U ~~> V -> Type).
+  Definition pred_equiv_to_path U V : (U <~> V -> Type) -> (U == V -> Type).
   Proof.
     intros U V.
     intros Q p.
@@ -111,8 +111,8 @@ Section Univalence.
      transport the predicate [P] of equivalences to a predicate [P']
      on paths. Then we use path induction and transport back to [P]. *)
 
-  Theorem equiv_induction (P : forall U V, U ≃> V -> Type) :
-    (forall T, P T T (idequiv T)) -> (forall U V (w : U ≃> V), P U V w).
+  Theorem equiv_induction (P : forall U V, U <~> V -> Type) :
+    (forall T, P T T (idequiv T)) -> (forall U V (w : U <~> V), P U V w).
   Proof.
     intros P.
     intro r.

--- a/Coq/UnivalenceImpliesFunext.v
+++ b/Coq/UnivalenceImpliesFunext.v
@@ -23,11 +23,11 @@ Section UnivalenceImpliesFunext.
   (** Exponentiation preserves equivalences, i.e., if [w] is an
      equivalence then so is post-composition by [w]. *)
 
-  Theorem equiv_exponential : forall {A B} (w : A ≃> B) C,
-    (C -> A) ≃> (C -> B).
+  Theorem equiv_exponential : forall {A B} (w : A <~> B) C,
+    (C -> A) <~> (C -> B).
   Proof.
     intros A B w C.
-    exists (fun h => w ○ h).
+    exists (fun h => w o h).
     generalize A B w.
     apply equiv_induction.
     assumption.
@@ -41,12 +41,12 @@ Section UnivalenceImpliesFunext.
   Theorem univalence_implies_funext : funext_statement.
   Proof.
     intros A B f g p.
-    (* It suffices to find a path [eta f ~~> eta g]. *)
+    (* It suffices to find a path [eta f == eta g]. *)
     apply equiv_injective with (w := eta_equiv eta_rule A B).
     simpl.
     (* Consider the following maps. *)
-    pose (d := fun x : A => existT (fun xy => fst xy ~~> snd xy) (f x, f x) (idpath (f x))).
-    pose (e := fun x : A => existT (fun xy => fst xy ~~> snd xy) (f x, g x) (p x)).
+    pose (d := fun x : A => existT (fun xy => fst xy == snd xy) (f x, f x) (idpath (f x))).
+    pose (e := fun x : A => existT (fun xy => fst xy == snd xy) (f x, g x) (p x)).
     (* If we compose [d] and [e] with [free_path_target], we get [eta
        f] and [eta g], respectively. So, if we had a path from [d] to
        [e], we would get one from [eta f] to [eta g]. *)
@@ -76,7 +76,7 @@ Section UnivalenceImpliesFunext.
     intro f.
     apply univalence_implies_funext.
     intro x.
-    assert (alltt : forall y:unit, y ~~> tt).
+    assert (alltt : forall y:unit, y == tt).
     induction y; apply idpath.
     apply alltt.
     exact (transport (P := fun Q: X -> Type => is_contr (forall x, Q x)) eqpt contrunit). 


### PR DESCRIPTION
I went ahead and implemented the notation changes discussed on the mailing list: specifically, removing all Unicode, and using == for paths and <~> for equivalences (which nobody has objected to so far...).
