### PR TITLE
Makefile for Coq/IT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 *.out
 # Ignore the dependency file created by coqdep
 .depend
+# Ignore local settings
+Coq/IT/.dirlocals
+Coq/IT/coqidescript

--- a/Coq/IT/Makefile
+++ b/Coq/IT/Makefile
@@ -1,0 +1,65 @@
+# Edit the following parameter(s) if "make" fails to find the executables
+
+# The directory which contains the Coq executables (leave it empty if
+# coqc is in the PATH), for example on my Mac I would set
+# COQBIN=/Applications/CoqIdE_8.3.app/Contents/Resources/bin/
+# (note the trailing slash).
+#
+# alternatively you can pass these as arguments on the command line, e.g.
+# make COQBIN=~/w/htt/coq-8.3pl2-vv/bin/ COQC=coqc.opt
+#
+COQBIN=
+
+# Edit below at your own risk
+
+COQC:=coqc
+COQDEP:=coqdep
+
+# instead of Add LoadPath we pass them to coqc/coqide/coqtop
+COQINCLUDES:=-R "univalent_foundations/Generalities" "Foundations" \
+	-R "univalent_foundations/hlevel1" "Foundations" \
+	-R "univalent_foundations/hlevel2" "Foundations" \
+	-R "identity/" "IT" \
+	-R "inductive_types/" "IT" \
+	-R "nat_as_w_type/" "IT" \
+	-R "two_is_hinitial/" "IT" \
+	-R "w_is_hinitial/" "IT"
+
+# recursively find all .v files and compile them
+VFILES:=$(shell find . -name '*.v')
+VOFILES:=$(VFILES:.v=.vo)
+GLOBFILES:=$(VFILES:.v=.glob)
+
+.PHONY: all .depend clean
+
+all: .depend coqidescript .dirlocals $(VOFILES)
+
+.depend:
+	@$(COQBIN)$(COQDEP) $(COQINCLUDES) -I . $(VFILES) > .depend
+
+%.vo %.glob: %.v
+	@echo Compiling $<
+	$(COQBIN)$(COQC) $(COQINCLUDES) $<
+
+clean:
+	@rm -f coqidescript
+	@rm -f $(VOFILES)
+	@rm -f $(GLOBFILES)
+
+# script to start coq ide with proper arguments (-R ...)
+coqidescript:
+	@echo "#!/bin/sh" > $@
+	@echo 'exec $(COQBIN)coqide $(COQINCLUDES) $$@' >> $@
+	@chmod +x $@
+
+# similar script, but for proof general
+.dirlocals:
+	@echo ';; local settings for proof general' > $@
+	@echo '((coq-mode . (' >> $@
+	@echo '  (coq-prog-args . ("-emacs-U" $(COQINCLUDES)))' >> $@
+	@echo '  (coq-prog-name . "$(COQBIN)coqtop")' >> $@
+	@echo ')))' >> $@
+	@# we need to quote -R in elisp
+	@sed -e 's/-R/"-R"/g' --in-place $@
+
+-include .depend


### PR DESCRIPTION
Nothing spectacular, but this is a makefile that recursively compiles the file in Coq/IT (Bas requested me to write this).

Compilation is done by passing -R arguments to coqc/coqide/coqtop. Vladimir's code in place in the "Foundations" namespace and the inductive types code in the "IT" namespace. It generates a .dirlocals file for proofgeneral users and a coqidescript for coq IDE users. These files contain the appropriate -R settings and point to the right coq binary.

I've also slightly modified the way variables are assigned such that you can specifiy the Coq path and coqc binary on the commandline when calling make, like so (for example):

make COQBIN=~/w/htt/coq-8.3pl2/bin/ COQC=coqc.opt

This makefile uses find and sed, unix utilities not available under windows, so MINGW or Cygwin are required to run this under windows.

There is a slight problem with the .depends file (this problem also exists with the other Makefiles in the HoTT repo). The first call to make fails but generates .depends, the second invocation works.

Feel free to pull or not.

Cheers,
Jelle.
