### PR TITLE
Equiv as total space

### DIFF
--- a/theories/Equivalences.v
+++ b/theories/Equivalences.v
@@ -31,15 +31,10 @@ Definition is_equiv {A B} (e : A -> B) := forall y : B, is_contr (hfiber e y).
 
    The disadvantage of using a structure is that various theorems about
    total spaces cannot be used directly on the structure.
+  
+   So let's use the total space.
 *)
 
-
-(*
-Structure equiv (A B : Type) := {
-  equiv_map :> A -> B ;
-  equiv_is_equiv : is_equiv equiv_map
-}.
-*)
 
 Definition equiv (A B : Type) := sigT (fun e : A -> B => is_equiv e).
 
@@ -514,9 +509,7 @@ Definition equiv_cancel_right {A B C} (f : A <~> B) (g : B -> C) :
   is_equiv (g o f) -> B <~> C.
 Proof.
   intros H.
-  Print equiv_is_equiv.
   pose (gof := make_equiv _ H).
-  (*  pose (gof := {| equiv_map := g o f; equiv_is_equiv := H |}). *)
   apply (equiv_from_hequiv g (f o gof^-1)).
   intro y.
   expand_inverse_trg gof y.
@@ -533,7 +526,6 @@ Definition equiv_cancel_left {A B C} (f : A -> B) (g : B <~> C) :
 Proof.
   intros H.
   pose (gof := make_equiv _ H).
-  (*  pose (gof := {| equiv_map := g o f; equiv_is_equiv := H |}). *)
   apply (equiv_from_hequiv f (gof^-1 o g)).
   intros y.
   expand_inverse_trg g y.
@@ -566,7 +558,6 @@ Definition is_hiso_from_is_equiv {A B} (f : A -> B) : is_equiv f -> is_hiso f.
 Proof.
   intro feq.
   pose (e := make_equiv _ feq).
-  (*  pose (e := {| equiv_map := f; equiv_is_equiv := feq |}). *)
   rewrite (idpath _ : f = equiv_map e).
   refine {| hiso_section := e^-1; hiso_retraction := e^-1|}.
   apply inverse_is_section.

--- a/theories/FiberEquivalences.v
+++ b/theories/FiberEquivalences.v
@@ -274,7 +274,6 @@ Section FibrationMap.
     Proof.
       apply total_equiv.
       intro x.
-(*      exact {| equiv_map := g x; equiv_is_equiv := is_equiv_g x |}. *)
      exact (make_equiv _ (is_equiv_g x)).
     Defined.
 
@@ -282,7 +281,6 @@ Section FibrationMap.
     Theorem fibseq_total_equiv : total P <~> total Q.
     Proof.
        exists eg.
-  (*      refine {| equiv_map := eg |}. *)
       apply (equiv_is_equiv (equiv_compose he ke)).
     Defined.
   End FiberFibseq.

--- a/theories/Funext.v
+++ b/theories/Funext.v
@@ -80,7 +80,6 @@ Theorem strong_to_naive_funext_dep {X} (P : fibration X):
 Proof.
   intros H f g.  
    exact ((make_equiv _ (H f g))^-1).
-(*  exact ({| equiv_map := @happly_dep X P f g ; equiv_is_equiv := H f g |} ^-1). *)
 Defined.
 
 Theorem strong_funext_dep_compute {X} (P : fibration X)

--- a/theories/Univalence.v
+++ b/theories/Univalence.v
@@ -72,9 +72,6 @@ Section Univalence.
 
   Definition path_to_equiv_equiv (U V : Type) := 
      make_equiv _ (univalence U V).
-(*    {| equiv_map := @path_to_equiv U V ;
-       equiv_is_equiv := univalence U V |}.
-*)
 
   (** Assuming univalence, every equivalence yields a path. *)
 


### PR DESCRIPTION
Equiv as total space rather than record.
I suggest this change even though people might be even less convinced that this is necessary than they are for direct products...
Anyway, so far the mentioned reasons for preferring records over sigmas are not convincing, as show these patches. This might change when things grow, however.
