### PR TITLE
make constructions compile again

### DIFF
--- a/theories/FiberSequences.v
+++ b/theories/FiberSequences.v
@@ -82,7 +82,12 @@ Section ThreeByThree.
     undo_opposite_concat.
     associate_right.
     apply map, opposite.
-    apply @map_trans with (P := fun d' => d' = g c).
+    rewrite opposite_opposite.
+    hott_simpl. (* finishes a subgoal *)
+    rewrite opposite_opposite.
+    apply map.
+    rewrite <- map_trans.
+    reflexivity.
   Defined.
 
   Let fibfibmap (x : A) (p : f x = b) :

--- a/theories/UsefulEquivalences.v
+++ b/theories/UsefulEquivalences.v
@@ -58,6 +58,8 @@ Proof.
   moveright_onleft.
   moveright_onright.
   rewrite inverse_triangle.
+  transitivity ((inverse_is_section e (e x) @ p) @ opposite (inverse_is_section e (e y))).
+  apply opposite, concat_associativity.
   apply whisker_left.
   apply map.
   apply opposite.
@@ -65,6 +67,7 @@ Proof.
   intro p.
   unfold equiv_map_inv.
   moveright_onleft.
+  associate_left.
 Defined.
 
 (** Path-concatenation is an equivalence. *)


### PR DESCRIPTION
fixed two constructions which had not worked any more after some mods (which ones? triangle thingy? ssreflect? perhaps some rewrite working differently?)

Suggestion: restrict use of automation to _finish_ a construction -- otherwise if automation behaviour changes, proof script breaks in the middle -> difficult to fix
This is particularly bad since we are following trunk and should expect frequent change in behaviour of Coq tactics.
