### PR TITLE
Added lemma [forall_hlevel], that h-levels are closed under arbitrary products.

### DIFF
--- a/theories/HLevel.v
+++ b/theories/HLevel.v
@@ -249,22 +249,13 @@ Defined.
 Definition sum_isprop X (P : X -> Type) :
   is_prop X -> (forall x, is_prop (P x)) -> is_prop (sigT P).
 Proof.
-  intros Xp Pp.
-  apply allpath_prop.
-  intros [x p] [y q].
-  apply @total_path with (prop_path Xp x y).
-  apply prop_path, Pp.
+  apply total_hlevel.
 Defined.
 
 Definition forall_isprop {X} (P : X -> Type) :
   (forall x, is_prop (P x)) -> is_prop (forall x, P x).
 Proof.
-  intros H.
-  apply allpath_prop.
-  intros f g.
-  apply funext_dep. intros x.
-  apply prop_path.
-  apply H.
+  apply forall_hlevel.
 Defined.
 
 (** Being an equivalence is a prop. *)


### PR DESCRIPTION
Added the useful lemma that h-levels are closed under dependent products over arbitrary bases; also made minor changes in a couple of nearby proofs, giving lemmas about h-props as instances of lemmas about h-levels rather than re-proving them directly.
