### PR TITLE
Added a convenience file theories/HoTT.v which exports the rest of the librarary

### DIFF
--- a/theories/HoTT.v
+++ b/theories/HoTT.v
@@ -1,0 +1,26 @@
+(** A convenience file that loads most of the HoTT library.
+    You can use it with "Require Import HoTT" in your files.
+    But please do not use it in the HoTT library itself, or
+    you are likely going to create a dependency loop. *)
+
+Require Export Overture.
+Require Export PathGroupoids.
+Require Export Contractible.
+Require Export Fibrations.
+Require Export Equivalences.
+Require Export types.Paths.
+Require Export types.Forall.
+Require Export HLevel.
+Require Export HProp.
+Require Export HLevel.
+
+Require Export types.Empty_set.
+Require Export types.Unit.
+Require Export types.Bool.
+Require Export types.Arrow.
+Require Export types.Prod.
+Require Export types.Record.
+Require Export types.Sigma.
+Require Export types.Universe.
+
+


### PR DESCRIPTION
A development based on the HoTT library can now import most, if not all of it
by "Require Import HoTT".
