### PR TITLE
TypeClasses for Refl, Sym, Trans applied to Paths and Equiv.

### DIFF
--- a/theories/Conjugation.v
+++ b/theories/Conjugation.v
@@ -27,8 +27,8 @@ Lemma ap_to_conjp {A B : Type} {f g : A -> B} (p : forall x, f x = g x) {x y : A
   ap g q = conjp p (ap f q).
 Proof.
   destruct q.  unfold conjp.  simpl.
-  path_via ((p x)^ @ p x).  apply inverse ; apply concat_Vp.
-  apply whiskerR.  apply inverse, concat_p1.
+  path_via ((p x)^ @ p x).  apply symmetry; apply concat_Vp.
+  apply whiskerR.  apply symmetry, concat_p1.
 Qed.
 
 Lemma conjp_ap {A : Type} {f : A -> A} (p : forall x, f x = x) {x y : A} (q : x = y) :

--- a/theories/Contractible.v
+++ b/theories/Contractible.v
@@ -18,7 +18,7 @@ Definition path_contr `{Contr A} (x y : A) : x = y
 Definition path2_contr `{Contr A} {x y : A} (p q : x = y) : p = q.
 Proof.
   assert (K : forall (r : x = y), r = path_contr x y).
-    intro r; destruct r; apply inverse; now apply concat_Vp.
+    intro r; destruct r; apply symmetry; now apply concat_Vp.
   path_via (path_contr x y).
 Defined.
 

--- a/theories/Equivalences.v
+++ b/theories/Equivalences.v
@@ -16,6 +16,8 @@ Instance isequiv_idmap (A : Type) : IsEquiv idmap :=
 
 Definition equiv_idmap (A : Type) : A <~> A := BuildEquiv A A idmap _.
 
+Instance equiv_Reflexive : Reflexive Equiv := equiv_idmap.
+
 (** The composition of equivalences is an equivalence. *)
 Instance isequiv_compose `{IsEquiv A B f} `{IsEquiv B C g}
   : IsEquiv (compose g f)
@@ -37,6 +39,17 @@ Instance isequiv_compose `{IsEquiv A B f} `{IsEquiv B C g}
 Definition equiv_compose `{IsEquiv B C g} `{IsEquiv A B f}
   : A <~> C
   := BuildEquiv A C (compose g f) _.
+
+
+(* Note: Transitive TypeClass has a different order of parameters than equiv_compose. 
+   Note: This is "Let" definition and private to this file.  Use equiv_compose.*)
+Let equiv_transitivity (A B C : Type) (ab : A <~> B) (bc : B <~> C) : A <~> C
+  := 
+  match ab, bc with
+    | BuildEquiv ab_fun ab_isequiv, BuildEquiv bc_fun bc_isequiv 
+      => (@equiv_compose B C bc_fun bc_isequiv A ab_fun ab_isequiv)
+end.
+Instance equiv_Transitive : Transitive Equiv := equiv_transitivity.
 
 (** Anything homotopic to an equivalence is an equivalence. *)
 Section IsEquivHomotopic.
@@ -117,6 +130,9 @@ Proof.
   exists (e^-1).
   apply isequiv_inverse.
 Defined.
+
+Instance equiv_Symmetric : Symmetric Equiv := equiv_inverse.
+
 
 (** If [g \o f] and [f] are equivalences, so is [g]. *)
 Section EquivCancelR.
@@ -221,7 +237,7 @@ Lemma moveL_E (A B : Type) (e : A <~> B) (x : A) (y : B) :
 Proof.
   intro H.
   rewrite <- H.
-  apply inverse, eisretr.
+  apply symmetry, eisretr.
 Qed.
 
 (** Equivalence preserves contractibility (which of course is trivial under univalence). *)

--- a/theories/HLevel.v
+++ b/theories/HLevel.v
@@ -1,4 +1,4 @@
-(** * H-Levels *)
+ (** * H-Levels *)
 
 Require Import Overture Contractible Equivalences types.Paths.
 Local Open Scope equiv_scope.
@@ -30,7 +30,7 @@ Proof.
   - intros A B e H x y.
     fold is_hlevel.
     apply I with (A := (e^-1 x = e^-1 y)).
-    + apply equiv_inverse.
+    + apply symmetry.
       apply @equiv_ap.
       apply @isequiv_inverse.
     + apply H.

--- a/theories/Overture.v
+++ b/theories/Overture.v
@@ -1,6 +1,19 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 (** * Basic definitions of homotopy type theory, particularly the groupoid structure of identity types. *)
 
+(** ** Type classes *)
+Definition relation (A : Type) := A -> A -> Type.
+
+Class Reflexive {A} (R : relation A) :=
+  reflexivity : forall x : A, R x x.
+
+Class Symmetric {A} (R : relation A) :=
+  symmetry : forall x y, R x y -> R y x.
+
+Class Transitive {A} (R : relation A) :=
+  transitivity : forall x y z, R x y -> R y z -> R x z.
+
+
 (** ** Basic definitions *)
 
 (** We make the identity map a notation so we do not have to unfold it,
@@ -34,6 +47,8 @@ Arguments paths_rect [A] a P f y p.
 Notation "x = y :> A" := (@paths A x y) : type_scope.
 Notation "x = y" := (x = y :>_) : type_scope.
 
+Instance paths_Reflexive {A} : Reflexive (@paths A) := @idpath A.
+
 (** We declare a scope in which we shall place path notations. This way they can be turned on and off by the user. *)
 
 Delimit Scope path_scope with path.
@@ -47,6 +62,8 @@ Definition concat {A : Type} {x y z : A} (p : x = y) (q : y = z) : x = z :=
 (** See above for the meaning of [simpl nomatch]. *)
 Arguments concat {A x y z} p q : simpl nomatch.
 
+Instance paths_Transitive {A} : Transitive (@paths A) := @concat A.
+
 (** The inverse of a path. *)
 Definition inverse {A : Type} {x y : A} (p : x = y) : y = x
   := match p with idpath => idpath end.
@@ -54,7 +71,10 @@ Definition inverse {A : Type} {x y : A} (p : x = y) : y = x
 (** See above for the meaning of [simpl nomatch]. *)
 Arguments inverse {A x y} p : simpl nomatch.
 
-(** Note that you can use the built-in Coq tactics "reflexivity" and "transitivity" when working with paths, but not "symmetry", because it is too smart for its own good.  But you can say "apply inverse" instead.   *)
+Instance paths_Symmetric {A} : Symmetric (@paths A) := @inverse A.
+
+
+(** Note that you can use the built-in Coq tactics "reflexivity" and "transitivity" when working with paths, but not "symmetry", because it is too smart for its own good.  But you can say "apply symmetry" instead.   *)
 
 (** The identity path. *)
 Notation "1" := idpath : path_scope.
@@ -68,6 +88,7 @@ Notation "p ^" := (inverse p) (at level 3) : path_scope.
 (* An alternative notation which puts each path on its own line.  Useful as a temporary device during proofs of equalities between very long composites; to turn it on inside a section, say [Open Scope long_path_scope]. *)
 Notation "p @' q" := (concat p q) (at level 21, left associativity,
   format "'[v' p '/' '@''  q ']'") : long_path_scope.
+
 
 (** An important instance of [paths_rect] is that given any dependent type, one can _transport_ elements of instances of the type along equalities in the base.
 

--- a/theories/PathGroupoids.v
+++ b/theories/PathGroupoids.v
@@ -184,28 +184,28 @@ Definition moveL_Mp {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : y = x) :
   r^ @ q = p -> q = r @ p.
 Proof.
   intro h; rewrite <- h.
-  apply inverse, concat_p_Vp.
+  apply symmetry, concat_p_Vp.
 Defined.
 
 Definition moveL_pM {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : y = x) :
   q @ p^ = r -> q = r @ p.
 Proof.
   intro h; rewrite <- h.
-  apply inverse; apply concat_pV_p.
+  apply symmetry; apply concat_pV_p.
 Defined.
 
 Definition moveL_Vp {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : x = y) :
   r @ q = p -> q = r^ @ p.
 Proof.
   intro h; rewrite <- h.
-  apply inverse, concat_V_pp.
+  apply symmetry, concat_V_pp.
 Defined.
 
 Definition moveL_pV {A : Type} {x y z : A} (p : z = x) (q : y = z) (r : y = x) :
   q @ p = r -> q = r @ p^.
 Proof.
   intro h; rewrite <- h.
-  apply inverse; apply concat_pp_V.
+  apply symmetry; apply concat_pp_V.
 Defined.
 
 Definition moveL_1M {A : Type} {x y : A} (p q : x = y) :

--- a/theories/types/Forall.v
+++ b/theories/types/Forall.v
@@ -33,7 +33,7 @@ Definition equiv_path_forall `{E : Funext} {A : Type} {P : A -> Type}
     (f g : forall x, P x) :
   (forall x, f x = g x)  <~>  (f = g).
 Proof.
-  apply equiv_inverse.
+  apply symmetry.
   exists (@apD10 A P f g).
   apply E.
 Defined.

--- a/theories/types/Unit.v
+++ b/theories/types/Unit.v
@@ -68,7 +68,7 @@ Proof.
       (fun (_ : unit) => center A)
       (fun t : unit => match t with tt => 1 end)
       (fun x : A => contr x) _)).
-  intro x. apply inverse, ap_const.
+  intro x. apply symmetry, ap_const.
 Defined.
 
 (* Conversely, a type equivalent to [unit] is contractible. *)


### PR DESCRIPTION
The tactic "symmetry" was not working.  We figured the better long term solution was to use a TypeClass for symmetry and just use "apply symmetry".

This commit declare a relation and 3 TypeClasses on it:
  Reflexive
  Symmetric
  Transitive

Instances of all 3 exist for "paths" ("=") and "Equiv" ("<~>").

I changed "apply inverse" and "apply equiv_inverse" to "apply symmetry" where I found it.
