### PR TITLE
Correct arguments to equiv_compose, and simplify equiv_Transitive.

### DIFF
--- a/STYLE.txt
+++ b/STYLE.txt
@@ -33,6 +33,13 @@ They are currently in several groups:
 See the introduction to PathGroupoids.v.
 [Should we move it to here?]
 
+In general, the name of a theorem (or definition, or instance, etc.)
+should begin with the property (or structure, or class, or record,
+etc.) being proven, and then state the object or construction it is
+being proven about.  For instance, "isequiv_idmap" proves "IsEquiv
+idmap", and "equiv_compose" constructs an "Equiv" record by composing
+two given equivalences.
+
 
 3. RECORDS, STRUCTURES, TYPECLASSES
 

--- a/theories/Equivalences.v
+++ b/theories/Equivalences.v
@@ -16,7 +16,7 @@ Instance isequiv_idmap (A : Type) : IsEquiv idmap :=
 
 Definition equiv_idmap (A : Type) : A <~> A := BuildEquiv A A idmap _.
 
-Instance equiv_Reflexive : Reflexive Equiv := equiv_idmap.
+Instance Reflexive_equiv : Reflexive Equiv := equiv_idmap.
 
 (** The composition of equivalences is an equivalence. *)
 Instance isequiv_compose `{IsEquiv A B f} `{IsEquiv B C g}
@@ -42,7 +42,7 @@ Definition equiv_compose {A B C : Type} (g : B -> C) (f : A -> B)
   := BuildEquiv A C (compose g f) _.
 
 (* The TypeClass [Transitive] has a different order of parameters than [equiv_compose].  Thus in declaring the instance we have to switch the order of arguments. *)
-Instance equiv_Transitive : Transitive Equiv :=
+Instance Transitive_equiv : Transitive Equiv :=
   fun _ _ _ f g => equiv_compose g f.
 
 
@@ -126,7 +126,7 @@ Proof.
   apply isequiv_inverse.
 Defined.
 
-Instance equiv_Symmetric : Symmetric Equiv := equiv_inverse.
+Instance Symmetric_equiv : Symmetric Equiv := equiv_inverse.
 
 
 (** If [g \o f] and [f] are equivalences, so is [g]. *)

--- a/theories/Overture.v
+++ b/theories/Overture.v
@@ -47,7 +47,7 @@ Arguments paths_rect [A] a P f y p.
 Notation "x = y :> A" := (@paths A x y) : type_scope.
 Notation "x = y" := (x = y :>_) : type_scope.
 
-Instance paths_Reflexive {A} : Reflexive (@paths A) := @idpath A.
+Instance Reflexive_paths {A} : Reflexive (@paths A) := @idpath A.
 
 (** We declare a scope in which we shall place path notations. This way they can be turned on and off by the user. *)
 
@@ -62,7 +62,7 @@ Definition concat {A : Type} {x y z : A} (p : x = y) (q : y = z) : x = z :=
 (** See above for the meaning of [simpl nomatch]. *)
 Arguments concat {A x y z} p q : simpl nomatch.
 
-Instance paths_Transitive {A} : Transitive (@paths A) := @concat A.
+Instance Transitive_paths {A} : Transitive (@paths A) := @concat A.
 
 (** The inverse of a path. *)
 Definition inverse {A : Type} {x y : A} (p : x = y) : y = x
@@ -71,7 +71,7 @@ Definition inverse {A : Type} {x y : A} (p : x = y) : y = x
 (** See above for the meaning of [simpl nomatch]. *)
 Arguments inverse {A x y} p : simpl nomatch.
 
-Instance paths_Symmetric {A} : Symmetric (@paths A) := @inverse A.
+Instance Symmetric_paths {A} : Symmetric (@paths A) := @inverse A.
 
 
 (** Note that you can use the built-in Coq tactics "reflexivity" and "transitivity" when working with paths, but not "symmetry", because it is too smart for its own good.  But you can say "apply symmetry" instead.   *)


### PR DESCRIPTION
The function arguments to equiv_compose should be explicit.  This makes it unnecessary to break down the arguments to equiv_Transitive, so we can eliminate the auxiliary lemma.
