### PR TITLE
naming and arguments for contr_equiv and trunc_equiv

### DIFF
--- a/theories/EquivalenceVarieties.v
+++ b/theories/EquivalenceVarieties.v
@@ -88,7 +88,7 @@ Definition fcontr_equiv `(f : A -> B) `{IsEquiv A B f}
 
 Instance hprop_isequiv `(f : A -> B) : IsHProp (IsEquiv f).
 Proof.
-  refine (@trunc_equiv _ _ (equiv_fcontr_isequiv f) _ _ _).
+  refine (trunc_equiv (equiv_fcontr_isequiv f)).
 Defined.
 
 
@@ -121,14 +121,14 @@ Proof.
   (* Now we can split into the two halves. *)
   apply @contr_prod.
   (* For the first half, we change homotopies into paths. *)
-  - refine (@contr_equiv_contr' { g : B -> A & g o f = idmap } _ _ _).
+  - refine (@contr_equiv' { g : B -> A & g o f = idmap } _ _ _).
     + apply symmetry.
       (* Then we use the fact that precomposing with an equivalence is an equivalence. *)
       refine (equiv_functor_sigma' (equiv_idmap _) _); intros g.
       exact (equiv_path_forall (g o f) idmap).
     + apply equiv_fcontr_isequiv; exact _.
   (* The other half is similar. *)
-  - refine (@contr_equiv_contr' { h : B -> A & f o h = idmap } _ _ _).
+  - refine (@contr_equiv' { h : B -> A & f o h = idmap } _ _ _).
     + apply symmetry.
       refine (equiv_functor_sigma' (equiv_idmap _) _); intros h.
       exact (equiv_path_forall (f o h) idmap).

--- a/theories/Equivalences.v
+++ b/theories/Equivalences.v
@@ -213,7 +213,7 @@ Definition moveL_E `{IsEquiv A B f} (x : A) (y : B) (p : f^-1 y = x)
   := (eisretr f y)^ @ ap f p.
 
 (** Equivalence preserves contractibility (which of course is trivial under univalence). *)
-Lemma contr_equiv_contr `(f : A -> B) `{IsEquiv A B f} `{Contr A}
+Lemma contr_equiv `(f : A -> B) `{IsEquiv A B f} `{Contr A}
   : Contr B.
 Proof.
   exists (f (center A)).
@@ -222,9 +222,9 @@ Proof.
   apply contr.
 Qed.
 
-Definition contr_equiv_contr' `(f : A <~> B) `{Contr A}
+Definition contr_equiv' `(f : A <~> B) `{Contr A}
   : Contr B
-  := contr_equiv_contr f.
+  := contr_equiv f.
 
 (** Assuming function extensionality, composing with an equivalence is itself an equivalence *)
 

--- a/theories/HSet.v
+++ b/theories/HSet.v
@@ -41,7 +41,7 @@ Defined.
 
 Instance axiomK_isprop A : IsHProp (axiomK A).
 Proof.
-  apply (trunc_equiv _ _ equiv_hset_axiomK). 
+  apply (trunc_equiv equiv_hset_axiomK). 
 Defined.
 
 Theorem set_path2 {A} `{IsHSet A} {x y : A} (p q : x = y):

--- a/theories/Trunc.v
+++ b/theories/Trunc.v
@@ -22,13 +22,17 @@ Qed.
 (** Equivalence preserves truncation (this is, of course, trivial with univalence).
    This is not an [Instance] because it causes infinite loops.
    *)
-Definition trunc_equiv (A B : Type) (f : A -> B)
+Definition trunc_equiv `(f : A -> B)
   `{IsTrunc n A} `{IsEquiv A B f}
   : IsTrunc n B.
 Proof.
   generalize dependent f; revert B; generalize dependent A.
   induction n as [| n I]; simpl; intros A ? B f ?.
-  - refine (contr_equiv_contr f).
+  - refine (contr_equiv f).
   - intros x y.
     refine (I (f^-1 x = f^-1 y) _ (x = y) ((ap (f^-1))^-1) _).
 Qed.
+
+Definition trunc_equiv' `(f : A <~> B) `{IsTrunc n A}
+  : IsTrunc n B
+  := trunc_equiv f.

--- a/theories/types/Forall.v
+++ b/theories/types/Forall.v
@@ -130,7 +130,7 @@ Proof.
   (* case [n = -2], i.e. contractibility *)
   - exact _.
   (* case n = trunc_S n' *)
-  - intros f g; apply (trunc_equiv _ _ (apD10 ^-1)).
+  - intros f g; apply (trunc_equiv (apD10 ^-1)).
 Defined.
 
 

--- a/theories/types/Prod.v
+++ b/theories/types/Prod.v
@@ -214,7 +214,7 @@ Proof.
   exists (center A, center B).
     intros z; apply path_prod; apply contr.
   intros x y.
-    exact (trunc_equiv _ _ (equiv_path_prod x y)).
+    exact (trunc_equiv (equiv_path_prod x y)).
 Defined.
 
 Instance contr_prod `{CA : Contr A} `{CB : Contr B} : Contr (A * B)

--- a/theories/types/Sigma.v
+++ b/theories/types/Sigma.v
@@ -283,5 +283,5 @@ Proof.
     intros [a ?].
     refine (path_sigma' P (contr a) (path_contr _ _)).
   - intros u v.
-    refine (trunc_equiv _ _ (path_sigma_uncurried P u v)).
+    refine (trunc_equiv (path_sigma_uncurried P u v)).
 Defined.


### PR DESCRIPTION
The lemmas `contr_equiv_contr` and `trunc_equiv' were inconsistently named, and also inconsistent about which arguments were implicit.  I made them consistent, which necessitated changing a number of invocations throughout the library.
