### PR TITLE
Added axiom export files.

### DIFF
--- a/theories/FunextAxiom.v
+++ b/theories/FunextAxiom.v
@@ -1,0 +1,8 @@
+(** To assume the Funext axiom outright, import this file.
+    (Doing this instead of simply positing Funext directly
+    avoids creating multiple witnesses for the axiom in
+    different developments.) *)
+
+Require Import Overture.
+
+Context `{funext_axiom : Funext}.

--- a/theories/UnivalenceAxiom.v
+++ b/theories/UnivalenceAxiom.v
@@ -1,0 +1,8 @@
+(** To assume the Univalence axiom outright, import this file.
+    (Doing this instead of simply positing Univalence directly
+    avoids creating multiple witnesses for the axiom in
+    different developments.) *)
+
+Require Import types.Universe.
+
+Context `{univalence_axiom : Univalence}.


### PR DESCRIPTION
Added files exporting witnesses for the axioms [Funext] and [Univalence], as per recent mailing list discussion.  Also (not in this commit request, but) provided documentation go with them on the HoTT/HoTT wiki: https://github.com/HoTT/HoTT/wiki/Using-the-HoTT-library .

Question: as we go on, providing/maintaining documentation for the library is fairly important.  Is it better to provide this on the HoTT/HoTT wiki (as above), or on the univalent-foundations wiki, or as extra files within the repo?
