### PR TITLE
Added exploit for polymorphic axioms

### DIFF
--- a/theories/FunextAxiom.v
+++ b/theories/FunextAxiom.v
@@ -5,4 +5,6 @@
 
 Require Import Overture.
 
-Context `{funext_axiom : Funext}.
+Instance funext_axiom : Funext.
+  admit.
+Defined.

--- a/theories/UnivalenceAxiom.v
+++ b/theories/UnivalenceAxiom.v
@@ -5,4 +5,6 @@
 
 Require Import types.Universe.
 
-Context `{univalence_axiom : Univalence}.
+Instance univalence_axiom : Univalence.
+  admit.
+Defined.


### PR DESCRIPTION
As per recent discussions, working with monomorphic axioms is quite cumbersome; so am adding (until true polymorphic axioms are available) the exploit that seems (so far, at least) to fake them.  So: if you want polymorphic axioms in your development, use `Require Import FunextAxiom`, and so on.

The preferred library style is still to restrict axioms within sections (since a global assumption irrevocably pollutes any development importing the library).  However, Bas argues strongly that in some of his contributions (e.g. on the object classifier), it’s very cumbersome to do this, because of the monomorphism problem; so he would like to import `FunextAxiom` within a few specific library files.  My feeling is that this is OK, provided it’s clearly documented in those files (and I guess that we keep them out of the `HoTT.v` export list for now).  Another option would be to say: for now, files doing this should stay in `/contrib`.  Thoughts?
