### PR TITLE
Make the library work with the current version of HoTT/coq trunk

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -755,7 +755,7 @@ install-data-local:
 stdlib: $(STDVOFILES)
 
 $(STDVOFILES) : %.vo : %.v
-	$(COQTOP) -indices-matter -boot -nois -coqlib $(SRCCOQLIB) -R $(SRCCOQLIB)/theories Coq -compile $(basename $<)
+	$(COQTOP) -no-native-compiler -indices-matter -boot -nois -coqlib $(SRCCOQLIB) -R $(SRCCOQLIB)/theories Coq -compile $(basename $<)
 
 # The HoTT library as a single target
 hottlib: $(VOFILES)

--- a/hoqc.in
+++ b/hoqc.in
@@ -26,7 +26,7 @@ else
 fi
 if test "$ssr" = "yes"
 then
-  exec "$COQC" -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -R "$SSRLIB" Ssreflect -indices-matter $@
+  exec "$COQC" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -R "$SSRLIB" Ssreflect -indices-matter $@
 else
-  exec "$COQC" -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -indices-matter $@
+  exec "$COQC" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -indices-matter $@
 fi

--- a/hoqide.in
+++ b/hoqide.in
@@ -27,7 +27,7 @@ else
 fi
 if test "$ssr" = "yes"
 then
-  exec "$COQIDE" -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -R "$SSRLIB" Ssreflect -indices-matter $@
+  exec "$COQIDE" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -R "$SSRLIB" Ssreflect -indices-matter $@
 else
-  exec "$COQIDE" -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -indices-matter $@
+  exec "$COQIDE" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -indices-matter $@
 fi

--- a/hoqtop.byte.in
+++ b/hoqtop.byte.in
@@ -27,7 +27,7 @@ else
 fi
 if test "$ssr" = "yes"
 then
-  exec "$COQTOP" -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -R "$SSRLIB" Ssreflect -indices-matter $@
+  exec "$COQTOP" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -R "$SSRLIB" Ssreflect -indices-matter $@
 else
-  exec "$COQTOP" -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -indices-matter $@
+  exec "$COQTOP" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -indices-matter $@
 fi

--- a/hoqtop.in
+++ b/hoqtop.in
@@ -27,7 +27,7 @@ else
 fi
 if test "$ssr" = "yes"
 then
-  exec "$COQTOP" -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -R "$SSRLIB" Ssreflect -indices-matter $@
+  exec "$COQTOP" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -R "$SSRLIB" Ssreflect -indices-matter $@
 else
-  exec "$COQTOP" -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -indices-matter $@
+  exec "$COQTOP" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -indices-matter $@
 fi

--- a/theories/types/Universe.v
+++ b/theories/types/Universe.v
@@ -15,7 +15,11 @@ Instance isequiv_path {A B : Type} (p : A = B)
   := BuildIsEquiv _ _ _ (transport (fun X:Type => X) p^)
   (fun b => ((transport_pp idmap p^ p b)^ @ transport2 idmap (concat_Vp p) b))
   (fun a => ((transport_pp idmap p p^ a)^ @ transport2 idmap (concat_pV p) a))
-  (fun a => match p with idpath => 1 end).
+  (fun a => match p in _ = C return
+              (transport_pp idmap p^ p (transport idmap p a))^ @
+                 transport2 idmap (concat_Vp p) (transport idmap p a) =
+              ap (transport idmap p) ((transport_pp idmap p p^ a) ^ @
+                transport2 idmap (concat_pV p) a) with idpath => 1 end).
 
 Definition equiv_path (A B : Type) (p : A = B) : A <~> B
   := BuildEquiv _ _ (transport (fun X:Type => X) p) _.


### PR DESCRIPTION
The library needs to be modified for two reasons
- In file Universe.v , there is a definition that does not go through.  It used to be written as non-dependent pattern matching, but it is in fact dependent, and therefore it should have a "return" clause.
- The new version of Coq has a native compiler, but it does not react well to empty files.  New options need to be added to the packaging scripts (hoqtop, hoqtop.byte, etc) and to the Makefile to deactivate this native compiler.
