### PR TITLE
More notation fixes

### DIFF
--- a/theories/Overture.v
+++ b/theories/Overture.v
@@ -236,6 +236,11 @@ Inductive trunc_index : Type :=
 | minus_two : trunc_index
 | trunc_S : trunc_index -> trunc_index.
 
+(* We will use [Notation] for [trunc_index]es, so define a scope for them here. *)
+Delimit Scope trunc_scope with trunc.
+Bind Scope trunc_scope with trunc_index.
+Arguments trunc_S _%trunc_scope.
+
 Fixpoint nat_to_trunc_index (n : nat) : trunc_index
   := match n with
        | 0 => trunc_S (trunc_S minus_two)

--- a/theories/Trunc.v
+++ b/theories/Trunc.v
@@ -4,6 +4,7 @@
 
 Require Import Overture Contractible Equivalences Paths Unit.
 Local Open Scope equiv_scope.
+Local Open Scope trunc_scope.
 
 Generalizable Variables A B m n f.
 
@@ -14,7 +15,7 @@ Fixpoint trunc_index_add (m n : trunc_index) : trunc_index
        | trunc_S m' => trunc_S (trunc_index_add m' n)
      end.
 
-Notation "m -2+ n" := (trunc_index_add m n) (at level 50, left associativity).
+Notation "m -2+ n" := (trunc_index_add m n) (at level 50, left associativity) : trunc_scope.
 
 Fixpoint trunc_index_leq (m n : trunc_index) : Type
   := match m, n with
@@ -23,7 +24,7 @@ Fixpoint trunc_index_leq (m n : trunc_index) : Type
        | trunc_S m', trunc_S n' => trunc_index_leq m' n'
      end.
 
-Notation "m <= n" := (trunc_index_leq m n) (at level 70, no associativity).
+Notation "m <= n" := (trunc_index_leq m n) (at level 70, no associativity) : trunc_scope.
 
 (** ** Truncatedness proper. *)
 


### PR DESCRIPTION
The main reason for this pull request is to put `'o'` inside of a scope; when trying to port my category theory library to be built on top of HoTT, I discovered that I couldn't effectively use `'o'` as a notation after importing HoTT because it got stuck in the default scope.  I figured I'd also put the other notations in scopes while I was at it; it's much easier to overwrite a notation or hide it, should you want to, if it's in a scope.

I've checked to make sure that the library still compiles.  One backwards-incompatible change is that we'll now need to `Open trunc_scope` to use the `<=` notation for truncation.  This can be remedied by opening it globally in `Overture.v`, if that's desirable.

If you want, I can remove the churn caused by emacs removing trailing spaces, but I figured I'd leave it in unless told otherwise.
