### PR TITLE
Add a .dir-locals.el to theories subdirectories

### DIFF
--- a/theories/.dir-locals.el
+++ b/theories/.dir-locals.el
@@ -1,0 +1,3 @@
+((coq-mode . ((eval . (let ((default-directory (locate-dominating-file
+						buffer-file-name ".dir-locals.el")))
+			(setq coq-prog-name (expand-file-name "../hoqtop")))))))


### PR DESCRIPTION
This tells emacs to default to using the local hoqtop for editing the
files in theories.  There might be a fancier way to only need one
.dir-locals.el, which uses paths relative to it, or uses absolute paths,
but I don't know enough elisp to or emacs to do it.
