### PR TITLE
Fix a name error

### DIFF
--- a/theories/types/ObjectClassifier.v
+++ b/theories/types/ObjectClassifier.v
@@ -56,9 +56,9 @@ Defined.
 Theorem equiv_induction (P : forall U V, U <~> V -> Type) :
   (forall T, P T T (equiv_idmap T)) -> (forall U V (w : U <~> V), P U V w).
 Proof.
-intros H???.
+intros H0???.
 apply (equiv_rect (equiv_path _ _)).
-intro x. case x. apply H.
+intro x. case x. apply H0.
 Defined.
 
 (* This is generalized in Functorish.v *)


### PR DESCRIPTION
Oops.  I neglected to check that a last-minute change I made to 8add452dbeb0b517a36708c07e11a2166ed2d952 worked.  Now it's fixed, and checked, and, with this patch, HoTT/HoTT compiles again.  Sorry about the mistake.
