### PR TITLE
Use [Admitted] rather than [admit] for axioms.

### DIFF
--- a/theories/FunextAxiom.v
+++ b/theories/FunextAxiom.v
@@ -5,6 +5,5 @@
 
 Require Import Overture.
 
-Instance funext_axiom : Funext.
-  admit.
-Defined.
+Axiom funext_axiom : Funext.
+Existing Instance funext_axiom.

--- a/theories/UnivalenceAxiom.v
+++ b/theories/UnivalenceAxiom.v
@@ -5,6 +5,5 @@
 
 Require Import types.Universe.
 
-Instance univalence_axiom : Univalence.
-  admit.
-Defined.
+Axiom univalence_axiom : Univalence.
+Existing Instance univalence_axiom.


### PR DESCRIPTION
The newer versions of HoTT/coq support polymorphic axioms, and no longer
require the [admit] exploit.  This way, we have two fewer top-level
constants floating around.
