### PR TITLE
Fix a typo, FunExt -> Funext; now things compile

### DIFF
--- a/theories/hit/minus1Trunc.v
+++ b/theories/hit/minus1Trunc.v
@@ -83,7 +83,7 @@ Proof.
   intro a. apply allpath_hprop.
 Defined.
 
-Section AssumeFunExt.
+Section AssumeFunext.
 (** Inhabited propositions are contractible. *)
 Open Scope fibration_scope.
 Context `{Funext}.
@@ -237,4 +237,3 @@ Proof.
 Qed.
 
 End minus1TruncMonad.
-End AssumeFunExt.


### PR DESCRIPTION
I believe this was due to a merge conflict between
74fddcd8b492cfa92874d606c6e3d6b9629a28ad and
64dcc4f24a23ff532ff27f2e44980e9faf39e0da.  I think this was because
e4f905e4afbc55f6f0bc0011f00bd3c5885a2849 was a merge from HoTT/HoTT,
rather than a rebase on top of it.
