### PR TITLE
Add priorities to typeclass instances

### DIFF
--- a/theories/Contractible.v
+++ b/theories/Contractible.v
@@ -23,18 +23,19 @@ Proof.
 Defined.
 
 (** It follows that any space of paths in a contractible space is contractible. *)
-Instance contr_paths_contr `{Contr A} (x y : A) : Contr (x = y) := {
+(** Because [Contr] is a notation, and [Contr_internal] is the record, we need to iota expand to fool Coq's typeclass machinery into accepting supposedly "mismatched" contexts. *)
+Instance contr_paths_contr `{Contr A} (x y : A) : Contr (x = y) | 10000 := let c := {|
   center := (contr x)^ @ contr y;
   contr := path2_contr ((contr x)^ @ contr y)
-}.
+|} in c.
 
 (** Also, the total space of any based path space is contractible. *)
-Instance contr_basedpaths {X : Type} (x : X) : Contr {y : X & x = y}.
+Instance contr_basedpaths {X : Type} (x : X) : Contr {y : X & x = y} | 100.
   exists (x ; 1).
   intros [y []]; reflexivity.
 Defined.
 
-Instance contr_basedpaths' {X : Type} (x : X) : Contr {y : X & y = x}.
+Instance contr_basedpaths' {X : Type} (x : X) : Contr {y : X & y = x} | 100.
   exists (existT (fun y => y = x) x 1).
   intros [y []]; reflexivity.
 Defined.

--- a/theories/EquivalenceVarieties.v
+++ b/theories/EquivalenceVarieties.v
@@ -71,7 +71,7 @@ Defined.
 
 (** Using this, we can prove that [IsEquiv f] is an h-proposition. *)
 
-Global Instance hprop_isequiv `(f : A -> B) : IsHProp (IsEquiv f).
+Global Instance hprop_isequiv `(f : A -> B) : IsHProp (IsEquiv f) | 0.
 Proof.
   apply hprop_inhabited_contr; intros ?.
   (* Get rid of that pesky record. *)
@@ -195,7 +195,7 @@ Proof.
     s).
 Defined.
 
-Global Instance isprop_biinv `(f : A -> B) : IsHProp (BiInv f).
+Global Instance isprop_biinv `(f : A -> B) : IsHProp (BiInv f) | 0.
 Proof.
   apply hprop_inhabited_contr.
   intros bif; pose (fe := equiv_biinv f bif).

--- a/theories/Equivalences.v
+++ b/theories/Equivalences.v
@@ -11,16 +11,16 @@ Local Open Scope equiv_scope.
 Generalizable Variables A B C f g.
 
 (** The identity map is an equivalence. *)
-Instance isequiv_idmap (A : Type) : IsEquiv idmap :=
+Instance isequiv_idmap (A : Type) : IsEquiv idmap | 0 :=
   BuildIsEquiv A A idmap idmap (fun _ => 1) (fun _ => 1) (fun _ => 1).
 
 Definition equiv_idmap (A : Type) : A <~> A := BuildEquiv A A idmap _.
 
-Instance reflexive_equiv : Reflexive Equiv := equiv_idmap.
+Instance reflexive_equiv : Reflexive Equiv | 0 := equiv_idmap.
 
 (** The composition of equivalences is an equivalence. *)
 Instance isequiv_compose `{IsEquiv A B f} `{IsEquiv B C g}
-  : IsEquiv (compose g f)
+  : IsEquiv (compose g f) | 1000
   := BuildIsEquiv A C (compose g f)
     (compose f^-1 g^-1)
     (fun c => ap g (eisretr f (g^-1 c)) @ eisretr g c)
@@ -36,7 +36,7 @@ Instance isequiv_compose `{IsEquiv A B f} `{IsEquiv B C g}
       (ap_compose f g _)^
     ).
 
-(* An alias of [isequiv_compose], with some arguments explicit; often convenient when type class search fails. *) 
+(* An alias of [isequiv_compose], with some arguments explicit; often convenient when type class search fails. *)
 Definition isequiv_compose'
   {A B : Type} (f : A -> B) (_ : IsEquiv f)
   {C : Type} (g : B -> C) (_ : IsEquiv g)
@@ -53,7 +53,7 @@ Definition equiv_compose' {A B C : Type} (g : B <~> C) (f : A <~> B)
   := equiv_compose g f.
 
 (* The TypeClass [Transitive] has a different order of parameters than [equiv_compose].  Thus in declaring the instance we have to switch the order of arguments. *)
-Instance transitive_equiv : Transitive Equiv :=
+Instance transitive_equiv : Transitive Equiv | 0 :=
   fun _ _ _ f g => equiv_compose g f.
 
 
@@ -78,8 +78,8 @@ Section IsEquivHomotopic.
     apply whiskerR, eisadj.
   Qed.
 
-  (* It's unclear to me whether this should be a declared instance.  Will it cause the unifier to spin forever searching for homotopies? *)
-  Global Instance isequiv_homotopic : IsEquiv g
+  (* It's unclear to me whether this should be a declared instance.  Will it cause the unifier to spin forever searching for homotopies?  For now, we give it a very large priority number, which means that other instances will be preferred over this one. *)
+  Global Instance isequiv_homotopic : IsEquiv g | 10000
     := BuildIsEquiv _ _ g (f ^-1) sect retr adj.
 
   Definition equiv_homotopic : A <~> B
@@ -125,7 +125,7 @@ Section EquivInverse.
     rewrite concat_pV_p; apply concat_Vp.
   Qed.
 
-  Global Instance isequiv_inverse : IsEquiv f^-1
+  Global Instance isequiv_inverse : IsEquiv f^-1 | 1000
     := BuildIsEquiv B A f^-1 f (eissect f) (eisretr f) other_adj.
 End EquivInverse.
 
@@ -137,11 +137,11 @@ Proof.
   apply isequiv_inverse.
 Defined.
 
-Instance symmetric_equiv : Symmetric Equiv := @equiv_inverse.
+Instance symmetric_equiv : Symmetric Equiv | 0 := @equiv_inverse.
 
 (** If [g \o f] and [f] are equivalences, so is [g]. *)
 Instance cancelR_isequiv `{IsEquiv A B f} `{IsEquiv A C (g o f)}
-  : IsEquiv g
+  : IsEquiv g | 10000
 := isequiv_homotopic (compose (compose g f) f^-1) g
        (fun b => ap g (eisretr f b)).
 
@@ -153,7 +153,7 @@ Definition cancelR_equiv `{IsEquiv A B f} `{IsEquiv A C (g o f)}
 
 (** If [g \o f] and [g] are equivalences, so is [f]. *)
 Instance cancelL_isequiv `{IsEquiv B C g} `{IsEquiv A C (g o f)}
-  : IsEquiv f
+  : IsEquiv f | 10000
 := isequiv_homotopic (compose g^-1 (compose g f)) f
        (fun a => eissect g (f a)).
 
@@ -168,7 +168,7 @@ Section EquivTransport.
 
   Context {A : Type} (P : A -> Type) (x y : A) (p : x = y).
 
-  Global Instance isequiv_transport : IsEquiv (transport P p)
+  Global Instance isequiv_transport : IsEquiv (transport P p) | 0
     := BuildIsEquiv (P x) (P y) (transport P p) (transport P p^)
     (transport_pV P p) (transport_Vp P p) (transport_pVp P p).
 
@@ -212,7 +212,7 @@ Section Adjointify.
     := BuildEquiv A B f isequiv_adjointify.
 
 End Adjointify.
-  
+
 (** Several lemmas useful for rewriting. *)
 Definition moveR_E `{IsEquiv A B f} (x : A) (y : B) (p : x = f^-1 y)
   : (f x = y)
@@ -240,7 +240,7 @@ Definition contr_equiv' `(f : A <~> B) `{Contr A}
 
 Instance isequiv_precompose `{Funext} {A B C : Type}
   (f : A -> B) `{IsEquiv A B f}
-  : IsEquiv (fun g => @compose A B C g f)
+  : IsEquiv (fun g => @compose A B C g f) | 1000
   := isequiv_adjointify (fun g => @compose A B C g f)
     (fun h => @compose B A C h f^-1)
     (fun h => path_forall _ _ (fun x => ap h (eissect f x)))
@@ -257,7 +257,7 @@ Definition equiv_precompose' `{Funext} {A B C : Type} (f : A <~> B)
 
 Instance isequiv_postcompose `{Funext} {A B C : Type}
   (f : B -> C) `{IsEquiv B C f}
-  : IsEquiv (fun g => @compose A B C f g)
+  : IsEquiv (fun g => @compose A B C f g) | 1000
   := isequiv_adjointify (fun g => @compose A B C f g)
     (fun h => @compose A C B f^-1 h)
     (fun h => path_forall _ _ (fun x => eisretr f (h x)))

--- a/theories/FunextVarieties.v
+++ b/theories/FunextVarieties.v
@@ -51,7 +51,7 @@ Section Homotopies.
   Let idhtpy : f == f := fun x => idpath (f x).
 
   (** Weak funext implies that the "based homotopy space" of the Pi-type is contractible, just like the based path space. *)
-  Global Instance contr_basedhtpy : Contr {g : forall x, B x & f == g }.
+  Global Instance contr_basedhtpy : Contr {g : forall x, B x & f == g } | 0.
   Proof.
     exists (f;idhtpy). intros [g h].
     (* The trick is to show that the type [{g : forall x, B x & f == g }] is a retract of [forall x, {y : B x & f x = y}], which is contractible due to J and weak funext.  Here are the retraction and its section. *)
@@ -71,15 +71,13 @@ Section Homotopies.
 
   Definition htpy_rect g h : Q g h
     := @transport _ (fun gh => Q gh.1 gh.2) (f;idhtpy) (g;h)
-         (* Why can't it find the Instance? *)
-         (@path_contr _ contr_basedhtpy _ _) d.
+         (@path_contr _ _ _ _) d.
 
   (** The computation rule, of course, is only propositional. *)
   Definition htpy_rect_beta : htpy_rect f idhtpy = d
     := transport (fun p : (f;idhtpy) = (f;idhtpy) =>
                     transport (fun gh => Q gh.1 gh.2) p d = d)
-         (* Why can't it find the Instance? *)
-         (@path2_contr _ contr_basedhtpy _ _
+         (@path2_contr _ _ _ _
            (path_contr (f;idhtpy) (f;idhtpy)) (idpath _))^
          (idpath _).
 

--- a/theories/HProp.v
+++ b/theories/HProp.v
@@ -23,8 +23,8 @@ Proof.
   apply center, H.
 Defined.
 
-(** If inhabitation implies contractibility, then we have an h-proposition. *)
-Instance hprop_inhabited_contr (A : Type) : (A -> Contr A) -> IsHProp A.
+(** If inhabitation implies contractibility, then we have an h-proposition.  We probably won't often have a hypothesis of the form [A -> Contr A], so we make sure we give priority to other instances. *)
+Instance hprop_inhabited_contr (A : Type) : (A -> Contr A) -> IsHProp A | 10000.
 Proof.
   intro H.
   intros x y.
@@ -35,7 +35,7 @@ Defined.
 (** If a type is contractible, then so is its type of contractions.
     Using [issig_contr] and the [equiv_intro] tactic, we can transfer this to the equivalent problem of contractibility of a certain Sigma-type, in which case we can apply the general path-construction functions. *)
 Instance contr_contr `{Funext} (A : Type)
-  : Contr A -> Contr (Contr A).
+  : Contr A -> Contr (Contr A) | 100.
 Proof.
   intros c; exists c; generalize c.
   equiv_intro (issig_contr A) c'.
@@ -48,7 +48,7 @@ Qed.
 
 (** This provides the base case in a proof that truncatedness is a proposition. *)
 Instance hprop_trunc `{Funext} (n : trunc_index) (A : Type)
-  : IsHProp (IsTrunc n A).
+  : IsHProp (IsTrunc n A) | 0.
 Proof.
   apply hprop_inhabited_contr.
   revert A.
@@ -105,22 +105,9 @@ Proof.
 Defined.
 
 
-(** [IsHProp] is closed under [forall].  This should really be a theorem in types/Forall that all truncation levels are closed under [forall]. *)
-  
-Instance hprop_forall `{E : Funext} (A : Type) (P : A -> Type) :
-  (forall x, IsHProp (P x)) -> IsHProp (forall x, P x).
-Proof.
-  intro.
-  apply hprop_allpath.
-  intros f g.
-  apply path_forall; intro.
-  apply allpath_hprop.
-Defined.
-
-
 (** Being a contractible space is a proposition. *)
 
-Instance hprop_contr `{Funext} (A : Type) : IsHProp (Contr A).
+Instance hprop_contr `{Funext} (A : Type) : IsHProp (Contr A) | 0.
 Proof.
   apply hprop_inhabited_contr.
   intro cA.
@@ -129,13 +116,13 @@ Defined.
 
 (** Here is an alternate characterization of propositions. *)
 
-Instance HProp_HProp `{Funext} A : IsHProp (IsHProp A) 
+Instance HProp_HProp `{Funext} A : IsHProp (IsHProp A) | 0
   := hprop_trunc minus_one A.
 
 Theorem equiv_hprop_inhabited_contr `{Funext} {A}
   : IsHProp A <~> (A -> Contr A).
 Proof.
-  apply (equiv_adjointify (@contr_inhabited_hprop A) (@hprop_inhabited_contr A)). 
+  apply (equiv_adjointify (@contr_inhabited_hprop A) (@hprop_inhabited_contr A)).
   - intro ic. by_extensionality x.
     apply @path_contr. apply contr_contr. exact (ic x).
   - intro hp. by_extensionality x. by_extensionality y.

--- a/theories/HSet.v
+++ b/theories/HSet.v
@@ -39,7 +39,7 @@ Proof.
     eapply allpath_hprop.
 Defined.
 
-Global Instance axiomK_isprop A : IsHProp (axiomK A).
+Global Instance axiomK_isprop A : IsHProp (axiomK A) | 0.
 Proof.
   apply (trunc_equiv equiv_hset_axiomK).
 Defined.

--- a/theories/Trunc.v
+++ b/theories/Trunc.v
@@ -28,12 +28,12 @@ Notation "m <= n" := (trunc_index_leq m n) (at level 70, no associativity) : tru
 
 (** ** Truncatedness proper. *)
 
-(** A contractible space is (-2)-truncated, of course. *)
-Instance contr_trunc_minus_two `{IsTrunc minus_two A} : Contr A
-  := Trunc_is_trunc.
+(** A contractible space is (-2)-truncated, by definition. *)
+Definition contr_trunc_minus_two `{H : IsTrunc minus_two A} : Contr A
+  := H.
 
 (** Truncation levels are cumulative. *)
-Instance trunc_succ `{IsTrunc n A} : IsTrunc (trunc_S n) A.
+Instance trunc_succ `{IsTrunc n A} : IsTrunc (trunc_S n) A | 1000.
 Proof.
   generalize dependent A.
   induction n as [| n I]; simpl; intros A H x y.
@@ -41,14 +41,16 @@ Proof.
   - apply I, H.
 Qed.
 
-Instance trunc_leq {m n} (Hmn : m <= n) `{IsTrunc m A} : IsTrunc n A.
+Instance trunc_leq {m n} (Hmn : m <= n) `{IsTrunc m A} : IsTrunc n A | 1000.
 Proof.
   generalize dependent A; generalize dependent m.
-  induction n as [ | n' IH]; intros [ | m'] Hmn A ?.
-  (* -2, -2 *) assumption.
-  (* S m', -2 *) destruct Hmn.
-  (* -2, S n' *) apply @trunc_succ, (IH minus_two); auto.
-  (* S m', S n' *) intros x y; apply (IH m'); auto.
+  induction n as [ | n' IH];
+    intros [ | m'] Hmn A ? .
+  - (* -2, -2 *) assumption.
+  - (* S m', -2 *) destruct Hmn.
+  - (* -2, S n' *) apply @trunc_succ, (IH minus_two); auto.
+  - (* S m', S n' *) intros x y; apply (IH m');
+                     auto with typeclass_instances.
 Qed.
 
 (** Equivalence preserves truncation (this is, of course, trivial with univalence).
@@ -62,7 +64,9 @@ Proof.
   induction n as [| n I]; simpl; intros A ? B f ?.
   - refine (contr_equiv f).
   - intros x y.
-    refine (I (f^-1 x = f^-1 y) _ (x = y) ((ap (f^-1))^-1) _).
+    pose proof (fun X Y => I (f^-1 x = f^-1 y) X (x = y) ((ap (f^-1))^-1) Y).
+    clear I.
+    typeclasses eauto.
 Qed.
 
 Definition trunc_equiv' `(f : A <~> B) `{IsTrunc n A}

--- a/theories/TruncType.v
+++ b/theories/TruncType.v
@@ -49,7 +49,7 @@ Definition path_trunctype {n : trunc_index} {A B : TruncType n}
 := equiv_path_trunctype A B.
 
 Global Instance istrunc_trunctype {n : trunc_index}
-  : IsTrunc (trunc_S n) (TruncType n).
+  : IsTrunc (trunc_S n) (TruncType n) | 0.
 Proof.
   intros A B.
   apply (@trunc_equiv _ _ (equiv_path_trunctype A B)).

--- a/theories/hit/Circle.v
+++ b/theories/hit/Circle.v
@@ -78,7 +78,7 @@ Definition neg_neq_pos {z w : Pos} : ~ (neg z = pos w)
 
 (* And prove that they are a set. *)
 
-Instance hset_int : IsHSet Int.
+Instance hset_int : IsHSet Int | 0.
 Proof.
   apply hset_decidable.
   intros [n | | n] [m | | m].
@@ -123,7 +123,7 @@ Definition pred_int (z : Int) : Int
        | pos (succ_pos n) => pos n
      end.
 
-Instance isequiv_succ_int : IsEquiv succ_int
+Instance isequiv_succ_int : IsEquiv succ_int | 0
   := isequiv_adjointify succ_int pred_int _ _.
 Proof.
   intros [[|n] | | [|n]]; reflexivity.

--- a/theories/hit/Connectedness.v
+++ b/theories/hit/Connectedness.v
@@ -40,7 +40,7 @@ Proof.
 Defined.
 
 Global Instance isconnected_from_iscontr_truncation {n} {A} `{Contr (Truncation n A)}
-  : IsConnected n A.
+  : IsConnected n A | 1000.
 Proof.
   intros C ? f.
   set (ff := Truncation_rect_nondep f).
@@ -131,7 +131,7 @@ Defined.
 Global Instance isequiv_path_extension {A B : Type} {f : A -> B}
   {P : B -> Type} {d : forall x:A, P (f x)}
   (ext ext' : ExtensionAlong f P d)
-: IsEquiv (path_extension ext ext').
+: IsEquiv (path_extension ext ext') | 0.
 Proof.
   apply @isequiv_compose.
     2: apply @isequiv_path_sigma.
@@ -226,7 +226,7 @@ Defined.
 (** The connectivity of a pointed type and (the inclusion of) its point are intimately connected. *)
 
 Global Instance conn_pointed_type {n : trunc_index} {A : Type} (a0:A)
- `{IsConnMap n _ _ (unit_name a0)} : IsConnected (trunc_S n) A.
+ `{IsConnMap n _ _ (unit_name a0)} : IsConnected (trunc_S n) A | 1000.
 Proof.
   intros C HC f. exists (f a0).
 (* TODO: try to use [refine] or similar to get more concise? *)
@@ -236,7 +236,7 @@ Proof.
 Defined.
 
 Global Instance conn_point_incl `{Univalence} {n : trunc_index} {A : Type} (a0:A)
- `{IsConnected (trunc_S n) A} : IsConnMap n (unit_name a0).
+ `{IsConnected (trunc_S n) A} : IsConnMap n (unit_name a0) | 1000.
 Proof.
   apply conn_map_from_extension_elim.
   intros P ?. set (PP := fun a => BuildTruncType n (P a) _).

--- a/theories/hit/Interval.v
+++ b/theories/hit/Interval.v
@@ -10,7 +10,7 @@ Local Open Scope equiv_scope.
 
 Module Export Interval.
 
-Local Inductive interval : Type := 
+Local Inductive interval : Type :=
   | zero : interval
   | one : interval.
 
@@ -19,7 +19,7 @@ Axiom seg : zero = one.
 Definition interval_rect (P : interval -> Type)
   (a : P zero) (b : P one) (p : seg # a = b)
   : forall x:interval, P x
-  := fun x => match x return P x with 
+  := fun x => match x return P x with
                 | zero => a
                 | one  => b
               end.
@@ -44,7 +44,7 @@ Defined.
 
 (** *** From an interval type, we can prove function extensionality. *)
 
-Instance funext_from_interval : Funext
+Instance funext_from_interval : Funext | 0
   := WeakFunext_implies_Funext (NaiveFunext_implies_WeakFunext
     (fun A P f g p =>
       let h := fun (x:interval) (a:A) =>
@@ -53,7 +53,7 @@ Instance funext_from_interval : Funext
 
 (** *** The interval is contractible. *)
 
-Instance contr_interval : Contr interval.
+Instance contr_interval : Contr interval | 0.
 Proof.
   exists zero.
   refine (interval_rect _ 1 seg _).

--- a/theories/hit/Spheres.v
+++ b/theories/hit/Spheres.v
@@ -24,7 +24,7 @@ Proof.
   simpl. apply (Susp_rect_nd true false). intros [].
 Defined.
 
-Instance isequiv_Sph0_to_Bool : IsEquiv (Sph0_to_Bool).
+Instance isequiv_Sph0_to_Bool : IsEquiv (Sph0_to_Bool) | 0.
 Proof.
   apply isequiv_adjointify with (fun b : Bool => if b then North else South).
   intros [ | ]; exact 1.
@@ -75,9 +75,9 @@ Fixpoint allnullhomot_trunc {n : trunc_index} {X : Type} `{IsTrunc n X}
 : NullHomotopy f.
 Proof.
   destruct n as [ | n'].
-    simpl in *. exists (center X). intros [ ].
-  apply nullhomot_susp_from_paths.
-  apply allnullhomot_trunc; auto.
+  - simpl in *. exists (center X). intros [ ].
+  - apply nullhomot_susp_from_paths.
+    apply allnullhomot_trunc; auto with typeclass_instances.
 Defined.
 
 Fixpoint trunc_allnullhomot {n : trunc_index} {X : Type} 

--- a/theories/hit/Truncations.v
+++ b/theories/hit/Truncations.v
@@ -9,14 +9,14 @@ Generalizable Variables A X n.
 
 (** ** Definition. *)
 
-(** The definition of [Trunc n], the n-truncation of a type.  
+(** The definition of [Trunc n], the n-truncation of a type.
 
 If Coq supported higher inductive types natively, we would construct this as somthing like:
 
    Inductive Truncation n (A : Type) : Type :=
    | truncation_incl : A -> Truncation n A
    | istrunc_truncation : forall (f : Sphere (trunc_S n) -> Truncation n A)
-       (x : Sphere (trunc_S n)), f x = f North. 
+       (x : Sphere (trunc_S n)), f x = f North.
 
 However, while we are faking our higher-inductives anyway, we can take some shortcuts, rather than translating the definition above.  Firstly, we directly posit a “constructor” giving truncatedness, rather than rephrasing it in terms of maps of spheres.  Secondly, we omit the “computation rule” for this constructor, since it is implied by truncatedness of the result type (and, for essentially that reason, is never wanted in practice anyway).
 *)
@@ -27,7 +27,7 @@ Local Inductive Truncation (n : trunc_index) (A :Type) : Type :=
   truncation_incl : A -> Truncation n A.
 Arguments truncation_incl {n A} a.
 Axiom istrunc_truncation : forall n A, IsTrunc n (Truncation n A).
-Existing Instance istrunc_truncation.
+Global Existing Instance istrunc_truncation.
 
 Definition Truncation_rect {n A}
   (P : Truncation n A -> Type) `{forall aa, IsTrunc n (P aa)}
@@ -38,7 +38,7 @@ End Truncation.
 
 (** The non-dependent version of the eliminator. *)
 
-Definition Truncation_rect_nondep {n A X} `{IsTrunc n X} 
+Definition Truncation_rect_nondep {n A X} `{IsTrunc n X}
   : (A -> X) -> (Truncation n A -> X)
 := Truncation_rect (fun _ => X).
 

--- a/theories/hit/epi.v
+++ b/theories/hit/epi.v
@@ -8,7 +8,7 @@ Record hSet := BuildhSet {setT:> Type; iss :> IsHSet setT}.
 Canonical Structure default_HSet:= fun T P => (@BuildhSet T P).
 Hint Resolve isp iss.
 
-Instance hProp_is_hSet : (IsHSet hProp).
+Instance hProp_is_hSet : (IsHSet hProp) | 0.
 intros [p p1] [q q1].
 Admitted. (* We need some lemmas about records *)
 
@@ -26,8 +26,6 @@ Definition epi {X Y} `(f:X->Y) := forall Z: hSet,
 
 Definition hexists {X} (P:X->Type):Type:= minus1Trunc (sigT  P).
 Definition surj {X Y} (f:X->Y) := forall y:Y , hexists (fun x => (f x) = y).
-
-Existing Instances minus1Trunc_is_prop contr_unit.
 
 Lemma epi_surj `{fs:Funext} `{Univalence} {X Y} (f:X->Y): epi f -> surj f.
 intros epif y.

--- a/theories/hit/minus1Trunc.v
+++ b/theories/hit/minus1Trunc.v
@@ -70,13 +70,13 @@ Proof.
 Defined.
 (** [minus1Trunc A] is always a proposition. *)
 
-Theorem minus1Trunc_is_prop {A : Type} : IsHProp (minus1Trunc A).
+Instance minus1Trunc_is_prop {A : Type} : IsHProp (minus1Trunc A) | 0.
 Proof.
   apply hprop_allpath, min1_path.
 Defined.
 
 (** And if [A] was already a proposition, then [minus1Trunc A] is equivalent to [A]. *)
-Instance IsEquivmin1 {A} `{IsHProp A} : IsEquiv (@min1 A).
+Instance IsEquivmin1 {A} `{IsHProp A} : IsEquiv (@min1 A) | 1000.
 Proof.
   apply (@isequiv_adjointify _ _ (@min1 A) (minus1Trunc_rect_nondep (fun x:A => x) allpath_hprop )).
    intro x. apply hprop_allpath, min1_path.

--- a/theories/types/Arrow.v
+++ b/theories/types/Arrow.v
@@ -32,7 +32,7 @@ Definition path_arrow_1 {A B : Type} (f : A -> B)
   := eta_path_arrow f f 1.
 
 Global Instance isequiv_path_arrow {A B : Type} (f g : A -> B)
-  : IsEquiv (path_arrow f g)
+  : IsEquiv (path_arrow f g) | 0
   := isequiv_path_forall f g.
 
 Definition equiv_path_arrow {A B : Type} (f g : A -> B)
@@ -125,17 +125,17 @@ Definition ap_functor_arrow `(f : B -> A) `(g : C -> D)
 (** *** Truncatedness: functions into an n-type is an n-type *)
 
 Global Instance contr_arrow {A B : Type} `{Contr B}
-  : Contr (A -> B)
+  : Contr (A -> B) | 100
 := contr_forall.
 
 Global Instance trunc_arrow {A B : Type} `{IsTrunc n B}
-  : IsTrunc n (A -> B)
+  : IsTrunc n (A -> B) | 100
 := trunc_forall.
 
 (** *** Equivalences *)
 
 Global Instance isequiv_functor_arrow `{IsEquiv B A f} `{IsEquiv C D g}
-  : IsEquiv (functor_arrow f g)
+  : IsEquiv (functor_arrow f g) | 1000
   := @isequiv_functor_forall _ A (fun _ => C) B (fun _ => D)
      _ _ _ _.
 

--- a/theories/types/Bool.v
+++ b/theories/types/Bool.v
@@ -43,7 +43,7 @@ Section BoolDecidable.
                     | false, true => inr false_ne_true
                   end.
 
-  Global Instance trunc_bool : IsHSet Bool
+  Global Instance trunc_bool : IsHSet Bool | 0
     := hset_decidable decidable_paths_bool.
 End BoolDecidable.
 

--- a/theories/types/Forall.v
+++ b/theories/types/Forall.v
@@ -37,7 +37,7 @@ Definition path_forall_1 `{P : A -> Type} (f : forall x, P x)
 (** The identification of the path space of a dependent function space, up to equivalence, is of course just funext. *)
 
 Global Instance isequiv_path_forall `{P : A -> Type} (f g : forall x, P x)
-  : IsEquiv (path_forall f g)
+  : IsEquiv (path_forall f g) | 0
   := @isequiv_inverse _ _ (@apD10 A P f g) _.
 
 Definition equiv_path_forall `{P : A -> Type} (f g : forall x, P x)
@@ -118,7 +118,7 @@ Defined.
 
 Global Instance isequiv_functor_forall `{P : A -> Type} `{Q : B -> Type}
   `{IsEquiv B A f} `{forall b, @IsEquiv (P (f b)) (Q b) (g b)}
-  : IsEquiv (functor_forall f g).
+  : IsEquiv (functor_forall f g) | 1000.
 Proof.
   refine (isequiv_adjointify (functor_forall f g)
     (functor_forall (f^-1)
@@ -156,14 +156,14 @@ Definition equiv_functor_forall_id `{P : A -> Type} `{Q : A -> Type}
 (** *** Truncatedness: any dependent product of n-types is an n-type *)
 
 Global Instance contr_forall `{P : A -> Type} `{forall a, Contr (P a)}
-  : Contr (forall a, P a).
+  : Contr (forall a, P a) | 100.
 Proof.
   exists (fun a => center (P a)).
   intro f.  apply path_forall.  intro a.  apply contr.
 Defined.
 
 Global Instance trunc_forall `{P : A -> Type} `{forall a, IsTrunc n (P a)}
-  : IsTrunc n (forall a, P a).
+  : IsTrunc n (forall a, P a) | 100.
 Proof.
   generalize dependent P.
   induction n as [ | n' IH]; simpl; intros P ?.
@@ -184,7 +184,7 @@ Definition flip `{P : A -> B -> Type}
   := fun f b a => f a b.
 
 Global Instance isequiv_flip `{P : A -> B -> Type}
-  : IsEquiv (@flip _ _ P).
+  : IsEquiv (@flip _ _ P) | 0.
 Proof.
   set (flip_P := @flip _ _ P).
   set (flip_P_inv := @flip _ _ (flip P)).

--- a/theories/types/Paths.v
+++ b/theories/types/Paths.v
@@ -96,7 +96,7 @@ Defined.
 
 (** If [f] is an equivalence, then so is [ap f].  We are lazy and use [adjointify]. *)
 Instance isequiv_ap `{IsEquiv A B f} (x y : A)
-  : IsEquiv (@ap A B f x y)
+  : IsEquiv (@ap A B f x y) | 1000
   := isequiv_adjointify (ap f)
   (fun q => (eissect f x)^  @  ap f^-1 q  @  eissect f y)
   (fun q =>
@@ -126,7 +126,7 @@ Definition equiv_inj `{IsEquiv A B f} {x y : A}
 (** ** Path operations are equivalences *)
 
 Instance isequiv_path_inverse {A : Type} (x y : A)
-  : IsEquiv (@inverse A x y)
+  : IsEquiv (@inverse A x y) | 0
   := BuildIsEquiv _ _ _ (@inverse A y x) (@inv_V A y x) (@inv_V A x y) _.
 Proof.
   intros p; destruct p; reflexivity.
@@ -137,7 +137,7 @@ Definition equiv_path_inverse {A : Type} (x y : A)
   := BuildEquiv _ _ (@inverse A x y) _.
 
 Instance isequiv_concat_l {A : Type} `(p : x = y) (z : A)
-  : IsEquiv (@concat A x y z p)
+  : IsEquiv (@concat A x y z p) | 0
   := BuildIsEquiv _ _ _ (@concat A y x z p^)
      (concat_p_Vp p) (concat_V_pp p) _.
 Proof.
@@ -149,7 +149,7 @@ Definition equiv_concat_l {A : Type} `(p : x = y) (z : A)
   := BuildEquiv _ _ (concat p) _.
 
 Instance isequiv_concat_r {A : Type} `(p : y = z) (x : A)
-  : IsEquiv (fun q:x=y => q @ p)
+  : IsEquiv (fun q:x=y => q @ p) | 0
   := BuildIsEquiv _ _ (fun q => q @ p) (fun q => q @ p^)
      (fun q => concat_pV_p q p) (fun q => concat_pp_V q p) _.
 Proof.
@@ -161,14 +161,14 @@ Definition equiv_concat_r {A : Type} `(p : y = z) (x : A)
   := BuildEquiv _ _ (fun q => q @ p) _.
 
 Instance isequiv_concat_lr {A : Type} {x x' y y' : A} (p : x' = x) (q : y = y')
-  : IsEquiv (fun r:x=y => p @ r @ q)
+  : IsEquiv (fun r:x=y => p @ r @ q) | 0
   := @isequiv_compose _ _ (fun r => p @ r) _ _ (fun r => r @ q) _.
 
 Definition equiv_concat_lr {A : Type} {x x' y y' : A} (p : x' = x) (q : y = y')
   : (x = y) <~> (x' = y')
   := BuildEquiv _ _ (fun r:x=y => p @ r @ q) _.
 
-(** We can use these to build up more complicated equivalences. 
+(** We can use these to build up more complicated equivalences.
 
 In particular, all of the [move] family are equivalences.
 
@@ -179,21 +179,21 @@ Definition isequiv_moveR_Mp
 : IsEquiv (moveR_Mp p q r).
 Proof.
   destruct r.
-  apply (isequiv_compose' _ (isequiv_concat_l _ _) _ (isequiv_concat_r _ _)). 
+  apply (isequiv_compose' _ (isequiv_concat_l _ _) _ (isequiv_concat_r _ _)).
 Defined.
 
-Definition isequiv_moveR_pM 
+Definition isequiv_moveR_pM
   {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : y = x)
 : IsEquiv (moveR_pM p q r).
-Proof. 
+Proof.
   destruct p.
-  apply (isequiv_compose' _ (isequiv_concat_l _ _) _ (isequiv_concat_r _ _)). 
+  apply (isequiv_compose' _ (isequiv_concat_l _ _) _ (isequiv_concat_r _ _)).
 Defined.
 
 Definition isequiv_moveR_Vp
   {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : x = y)
 : IsEquiv (moveR_Vp p q r).
-Proof. 
+Proof.
   destruct r.
   apply (isequiv_compose' _ (isequiv_concat_l _ _) _ (isequiv_concat_r _ _)).
 Defined.
@@ -206,7 +206,7 @@ Definition equiv_moveR_Vp
 Definition isequiv_moveR_pV
   {A : Type} {x y z : A} (p : z = x) (q : y = z) (r : y = x)
 : IsEquiv (moveR_pV p q r).
-Proof. 
+Proof.
   destruct p.
   apply (isequiv_compose' _ (isequiv_concat_l _ _) _ (isequiv_concat_r _ _)).
 Defined.
@@ -214,7 +214,7 @@ Defined.
 Definition isequiv_moveL_Mp
   {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : y = x)
 : IsEquiv (moveL_Mp p q r).
-Proof. 
+Proof.
   destruct r.
   apply (isequiv_compose' _ (isequiv_concat_l _ _) _ (isequiv_concat_r _ _)).
 Defined.
@@ -222,7 +222,7 @@ Defined.
 Definition isequiv_moveL_pM
   {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : y = x)
 : IsEquiv (moveL_pM p q r).
-Proof. 
+Proof.
   destruct p.
   apply (isequiv_compose' _ (isequiv_concat_l _ _) _ (isequiv_concat_r _ _)).
 Defined.
@@ -235,7 +235,7 @@ Definition equiv_moveL_pM
 Definition isequiv_moveL_Vp
   {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : x = y)
 : IsEquiv (moveL_Vp p q r).
-Proof. 
+Proof.
   destruct r.
   apply (isequiv_compose' _ (isequiv_concat_l _ _) _ (isequiv_concat_r _ _)).
 Defined.
@@ -243,14 +243,14 @@ Defined.
 Definition isequiv_moveL_pV
   {A : Type} {x y z : A} (p : z = x) (q : y = z) (r : y = x)
 : IsEquiv (moveL_pV p q r).
-Proof. 
+Proof.
   destruct p.
   apply (isequiv_compose' _ (isequiv_concat_l _ _) _ (isequiv_concat_r _ _)).
 Defined.
 
 Definition isequiv_moveL_1M {A : Type} {x y : A} (p q : x = y)
 : IsEquiv (moveL_1M p q).
-Proof. 
+Proof.
   destruct q. apply isequiv_concat_l.
 Defined.
 
@@ -268,13 +268,13 @@ Defined.
 
 Definition isequiv_moveL_V1 {A : Type} {x y : A} (p : x = y) (q : y = x)
 : IsEquiv (moveL_V1 p q).
-Proof. 
+Proof.
   destruct q. apply isequiv_concat_l.
 Defined.
 
 Definition isequiv_moveR_M1 {A : Type} {x y : A} (p q : x = y)
 : IsEquiv (moveR_M1 p q).
-Proof. 
+Proof.
   destruct p. apply isequiv_concat_r.
 Defined.
 
@@ -338,7 +338,7 @@ Defined.
 
 Definition equiv_ap_l `(f : A -> B) `{IsEquiv A B f} (x : A) (z : B)
   : (f x = z) <~> (x = f^-1 z).
-Proof. 
+Proof.
   apply transitivity with (f x = f (f^-1 z)).
   apply equiv_concat_r.
   apply symmetry.
@@ -447,7 +447,7 @@ Defined.
 
 Instance isequiv_paths_rect `{Funext} {A : Type} (a : A)
   (P : forall x, (a = x) -> Type)
-  : IsEquiv (paths_rect a P)
+  : IsEquiv (paths_rect a P) | 0
   := isequiv_adjointify (paths_rect a P) (fun f => f a 1) _ _.
 Proof.
   - intros f.

--- a/theories/types/Prod.v
+++ b/theories/types/Prod.v
@@ -26,7 +26,7 @@ Definition eta_prod `(z : A * B) : (fst z, snd z) = z
 Definition path_prod_uncurried {A B : Type} (z z' : A * B)
   (pq : (fst z = fst z') * (snd z = snd z'))
   : (z = z')
-  := match pq with (p,q) => 
+  := match pq with (p,q) =>
        match z, z' return
          (fst z = fst z') -> (snd z = snd z') -> (z = z') with
          | (a,b), (a',b') => fun p q =>
@@ -71,12 +71,12 @@ Defined.
 (** This lets us identify the path space of a product type, up to equivalence. *)
 
 Instance isequiv_path_prod {A B : Type} {z z' : A * B}
-  : IsEquiv (path_prod_uncurried z z').
+  : IsEquiv (path_prod_uncurried z z') | 0.
   refine (BuildIsEquiv _ _ _
     (fun r => (ap fst r, ap snd r))
     eta_path_prod
     (fun pq => match pq with
-                 | (p,q) => path_prod' 
+                 | (p,q) => path_prod'
                    (ap_fst_path_prod p q) (ap_snd_path_prod p q)
                end) _).
   destruct z as [x y], z' as [x' y'].
@@ -113,7 +113,7 @@ Defined.
 (** *** Equivalences *)
 
 Instance isequiv_functor_prod `{IsEquiv A A' f} `{IsEquiv B B' g}
-  : IsEquiv (functor_prod f g).
+  : IsEquiv (functor_prod f g) | 1000.
   refine (BuildIsEquiv _ _ (functor_prod f g) (functor_prod f^-1 g^-1)
     (fun z => path_prod' (eisretr f (fst z)) (eisretr g (snd z)) @ eta_prod z)
     (fun w => path_prod' (eissect f (fst w)) (eissect g (snd w)) @ eta_prod w)
@@ -181,7 +181,7 @@ Defined.
 (* First the positive universal property.
    Doing this sort of thing without adjointifying will require very careful use of funext. *)
 Instance isequiv_prod_rect `{Funext} `(P : A * B -> Type)
-  : IsEquiv (prod_rect P)
+  : IsEquiv (prod_rect P) | 0
   := isequiv_adjointify _
   (fun f x y => f (x,y))
   (fun f => path_forall
@@ -210,7 +210,7 @@ Definition prod_corect `(f : forall x:X, A x) `(g : forall x:X, B x)
   := prod_corect_uncurried (f,g).
 
 Instance isequiv_prod_corect `{Funext} `(A : X -> Type) (B : X -> Type)
-  : IsEquiv (@prod_corect_uncurried X A B)
+  : IsEquiv (@prod_corect_uncurried X A B) | 0
   := isequiv_adjointify _
   (fun h => (fun x => fst (h x), fun x => snd (h x)))
   _ _.
@@ -228,7 +228,7 @@ Definition equiv_prod_corect `{Funext} `(A : X -> Type) (B : X -> Type)
 
 (** *** Products preserve truncation *)
 
-Instance trunc_prod `{IsTrunc n A} `{IsTrunc n B} : IsTrunc n (A * B).
+Instance trunc_prod `{IsTrunc n A} `{IsTrunc n B} : IsTrunc n (A * B) | 100.
 Proof.
   generalize dependent B; generalize dependent A.
   induction n as [| n I]; simpl; intros A ? B ?.
@@ -238,5 +238,5 @@ Proof.
     exact (trunc_equiv (equiv_path_prod x y)).
 Defined.
 
-Instance contr_prod `{CA : Contr A} `{CB : Contr B} : Contr (A * B)
+Instance contr_prod `{CA : Contr A} `{CB : Contr B} : Contr (A * B) | 100
   := @trunc_prod minus_two A CA B CB.

--- a/theories/types/Sigma.v
+++ b/theories/types/Sigma.v
@@ -109,7 +109,7 @@ Defined.
 (** This lets us identify the path space of a sigma-type, up to equivalence. *)
 
 Instance isequiv_path_sigma `{P : A -> Type} {u v : sigT P}
-  : IsEquiv (path_sigma_uncurried P u v).
+  : IsEquiv (path_sigma_uncurried P u v) | 0.
   refine (isequiv_adjointify _
     (fun r => (existT (fun p : u.1 = v.1 => p # u.2 = v.2) r..1 r..2))
     eta_path_sigma
@@ -258,7 +258,7 @@ Defined.
 
 Instance isequiv_functor_sigma `{P : A -> Type} `{Q : B -> Type}
   `{IsEquiv A B f} `{forall a, @IsEquiv (P a) (Q (f a)) (g a)}
-  : IsEquiv (functor_sigma f g).
+  : IsEquiv (functor_sigma f g) | 1000.
 Proof.
   refine (isequiv_adjointify (functor_sigma f g)
     (functor_sigma (f^-1)
@@ -336,7 +336,7 @@ Defined.
 (* The positive universal property. *)
 Instance isequiv_sigT_rect `{Funext} `{P : A -> Type}
   (Q : sigT P -> Type)
-  : IsEquiv (sigT_rect Q)
+  : IsEquiv (sigT_rect Q) | 0
   := isequiv_adjointify (sigT_rect Q)
   (fun f x y => f (x;y))
   _ _.
@@ -368,7 +368,7 @@ Definition sigT_corect
 
 Instance isequiv_sigT_corect `{Funext}
   `{A : X -> Type} {P : forall x, A x -> Type}
-  : IsEquiv (sigT_corect_uncurried P)
+  : IsEquiv (sigT_corect_uncurried P) | 0
   := isequiv_adjointify (sigT_corect_uncurried P)
   (fun h => existT (fun f => forall x, P x (f x))
     (fun x => (h x).1) (fun x => (h x).2))
@@ -389,7 +389,7 @@ Definition equiv_sigT_corect `{Funext}
 
 Instance trunc_sigma `{P : A -> Type}
   `{IsTrunc n A} `{forall a, IsTrunc n (P a)}
-  : IsTrunc n (sigT P).
+  : IsTrunc n (sigT P) | 100.
 Proof.
   generalize dependent A.
   induction n; simpl; intros A P ac Pc.

--- a/theories/types/Unit.v
+++ b/theories/types/Unit.v
@@ -31,7 +31,7 @@ Proof.
   destruct p. destruct z. reflexivity.
 Defined.
 
-Instance isequiv_path_unit (z z' : Unit) : IsEquiv (path_unit_uncurried z z').
+Instance isequiv_path_unit (z z' : Unit) : IsEquiv (path_unit_uncurried z z') | 0.
   refine (BuildIsEquiv _ _ (path_unit_uncurried z z') (fun _ => tt)
     (fun p:z=z' =>
       match p in (_ = z') return (path_unit_uncurried z z' tt = p) with
@@ -55,7 +55,7 @@ Definition equiv_path_unit (z z' : Unit) : Unit <~> (z = z')
 (* The positive universal property *)
 Arguments Unit_rect [A] a u : rename.
 
-Instance isequiv_unit_rect `{Funext} (A : Type) : IsEquiv (@Unit_rect A)
+Instance isequiv_unit_rect `{Funext} (A : Type) : IsEquiv (@Unit_rect A) | 0
   := isequiv_adjointify _
   (fun f : Unit -> A => f tt)
   (fun f : Unit -> A => path_forall (Unit_rect (f tt)) f
@@ -69,7 +69,7 @@ Notation unit_name x := (fun (_ : Unit) => x).
 Definition unit_corect {A : Type} : Unit -> (A -> Unit)
   := fun _ _ => tt.
 
-Instance isequiv_unit_corect `{Funext} (A : Type) : IsEquiv (@unit_corect A)
+Instance isequiv_unit_corect `{Funext} (A : Type) : IsEquiv (@unit_corect A) | 0
   := isequiv_adjointify _
   (fun f => tt)
   _ _.
@@ -85,10 +85,11 @@ Definition equiv_unit_corect `{Funext} (A : Type)
 (** *** Truncation *)
 
 (* The Unit type is contractible *)
-Instance contr_unit : Contr Unit := {
+(** Because [Contr] is a notation, and [Contr_internal] is the record, we need to iota expand to fool Coq's typeclass machinery into accepting supposedly "mismatched" contexts. *)
+Instance contr_unit : Contr Unit | 0 := let x := {|
   center := tt;
   contr := fun t : Unit => match t with tt => 1 end
-}.
+|} in x.
 
 (** *** Equivalences *)
 
@@ -105,6 +106,6 @@ Proof.
 Defined.
 
 (* Conversely, a type equivalent to [Unit] is contractible. *)
-Instance contr_equiv_unit (A : Type) (f : A <~> Unit) : Contr A
+Instance contr_equiv_unit (A : Type) (f : A <~> Unit) : Contr A | 10000
   := BuildContr A (f^-1 tt)
   (fun a => ap f^-1 (contr (f a)) @ eissect f a).

--- a/theories/types/Universe.v
+++ b/theories/types/Universe.v
@@ -11,7 +11,7 @@ Generalizable Variables A B f.
 (** *** Paths *)
 
 Instance isequiv_path {A B : Type} (p : A = B)
-  : IsEquiv (transport (fun X:Type => X) p)
+  : IsEquiv (transport (fun X:Type => X) p) | 0
   := BuildIsEquiv _ _ _ (transport (fun X:Type => X) p^)
   (fun b => ((transport_pp idmap p^ p b)^ @ transport2 idmap (concat_Vp p) b))
   (fun a => ((transport_pp idmap p p^ a)^ @ transport2 idmap (concat_pV p) a))


### PR DESCRIPTION
The default priorities are rediculously high (small numbers), equal to
the number of (typeclass?) arguments to the instance.  Instead, I've
defaulted to 1000 for most instances, 10000 for the instances that are
likely to lead to cycles or information flow in the wrong direction, 100
for instances which I think are likely to lead to speedy resolution, and
0 for instances which have no typeclass arguments (and thus discharge
their goals immediately).  (Smaller numbers are higher priority.)

Additionally, I have renamed [Contr] to [Contr_internal] and made
[Contr] a notation for [IsTrunc minus_two].  This, combined with the
fact that [IsTrunc] is now [Opaque] in typeclass search, breaks [Contr]
-> [IsTrunc] -> [Contr] cycles.  We now only do typeclass search on
[IsTrunc].  This requires iota-expanding a few instance declarations of
[Contr], to get around deficiencies in Coq's typeclass machinery; I've
submitted a bug report at
https://coq.inria.fr/bugs/show_bug.cgi?id=3101.

Now that all the instances are global, we pick up some instances in
FunextVarieties.v; I've removed the confused comments and explicit
instances.

I remove [hprop_forall] and the associated comment, because we have
[trunc_forall].

I've added some [Hint]s to typeclass search which trigger early and set
up the goal.  It seems to me that we generally want to reason about
[IsTrunc (S n) A] rather than [IsTrunc n (a = b)]; the opaqueness of
[IsTrunc](only to typeclass resolution), [istrunc_paths], and the [Hint
Extern]s I've added to [Overture.v], implement this.

The instance [contr_trunc_minus_two] is no longer; it's not useful,
because we instead want to use [progress change].  If we don't then we
can get into infinite loops because [contr_trunc_minus_two] can, up to
unificiation, be applied an arbitrary number of times.

There are a few proofs where I've changed [auto] to [auto with
typeclass_instances]; [auto] doesn't always work any more, though I
haven't looked into it very closely.  I think it's reasonable to need to
inform Coq that you're doing typeclass resolution.

The proof of [trunc_equiv] needed to be modified so we don't loop
infinitely on [eapply I].  I'm annoyed that the context seems to take
precedence over cost 0 hints.  However, this is a fairly foundational
proof, and I don't anticipate this kind of problem popping up in
typeclass search often.

This makes my category theory library compile twice as fast, and doesn't
significantly effect the total compile time of the HoTT library.
