### PR TITLE
Fix theories/Functorish.v

### DIFF
--- a/theories/Functorish.v
+++ b/theories/Functorish.v
@@ -51,8 +51,8 @@ Proposition isequiv_fmap {A B} (f : A -> B) `{IsEquiv _ _ f}
   : IsEquiv (fmap F f).
 Proof.
   refine (equiv_rect (fun A' e => IsEquiv (fmap F e)) _ _ (BuildEquiv _ _ f _)).
-  refine (transport _ (fmap_idmap F)^ _).
-  apply isequiv_idmap. (* This line may not be needed in a new enough coq. *)
+  refine (transport _ (fmap_idmap F)^ _);
+    try apply isequiv_idmap. (* This line may not be needed in a new enough coq. *)
 Defined.
 
 Proposition fmap_agrees_with_univalence {A B} (f : A -> B) `{IsEquiv _ _ f}


### PR DESCRIPTION
I'm not sure whether or not the last line in that proof is needed in an
old version of HoTT/coq, but I'm pretty sure it's not needed in the
newest version.  Chaining it with the previous command and adding a
[try] permits it to be run only if necessary.
