### PR TITLE
Improve the [symmetry] and [etransitivity] tactics

### DIFF
--- a/theories/Overture.v
+++ b/theories/Overture.v
@@ -18,11 +18,11 @@ Tactic Notation "etransitivity" open_constr(y) :=
   let R := match goal with |- ?R ?x ?z => constr:(R) end in
   let x := match goal with |- ?R ?x ?z => constr:(x) end in
   let z := match goal with |- ?R ?x ?z => constr:(z) end in
-  eapply (transitivity (R := R) x y z).
+  refine (@transitivity _ R _ x y z _ _).
 
 Tactic Notation "etransitivity" := etransitivity _.
 
-Tactic Notation "symmetry" := apply symmetry.
+Tactic Notation "symmetry" := refine (@symmetry _ _ _ _ _ _).
 
 (** ** Basic definitions *)
 


### PR DESCRIPTION
It seems that [apply] uses an inferior(?) unificiation engine.  That of
[refine] and [exact](and even [eapply], in some cases) are better, in
my experience.
