### PR TITLE
Add .travis.yml for a travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: c
+before_script:
+ - sudo apt-get update -q
+ - sudo apt-get install -q ocaml camlp5
+# change '--branch=stable' to '--branch=trunk' to use HoTT/coq trunk
+ - git clone --depth=5 --branch=stable git://github.com/HoTT/coq.git coq-HoTT
+ - pushd coq-HoTT
+ -   ./configure -prefix /usr/local -debug -no-native-compiler
+ -   make coqlight
+ -   sudo make install-coqlight
+ - popd
+script: "./configure && make"


### PR DESCRIPTION
This file will, if Travis CI is enabled for the repo by going to
https://travis-ci.org/profile/, add an automated build to check pull
requests for compatibility with HoTT/coq stable.  It is simple to modify
it to use trunk instead, should we desire.  Pull requests will be marked
with a green circle if they build, a yellow circle while they are
building, or a red circle if they fail, approximately 15-30 minutes
after they are submitted.
