### PR TITLE
Mark which version of HoTT/coq we use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,30 @@
 language: c
 env:
- - BRANCH=trunk
- - BRANCH=stable
+# If you want to mark that the current tip of this repository should
+# compile with a different version of HoTT/coq (trunk), you should
+# update the SHA1 hash in the following line to match that of the
+# version given by `git log`, and update the comment with the commit
+# message.
+ - BRANCH=trunk   COMMITISH=e88e47ca76200a5e52bd0f9397fe4900fa9b241b
+# commit e88e47ca76200a5e52bd0f9397fe4900fa9b241b
+# Author: Matthieu Sozeau <mattam@mattam.org>
+# Date:   Thu Aug 1 02:01:08 2013 +0200
+#
+#     - Relax identification of metas in Ltac to not compare universes syntactically.
+#     - add constr_eq_nounivs tactic to compare constrs without comparing universes.
+ - BRANCH=trunk   COMMITISH=HEAD
+ - BRANCH=stable  COMMITISH=HEAD
 matrix:
  allow_failures:
 # we're on trunk, so allow stable to fail
-  - env: BRANCH=stable
+  - env: BRANCH=stable  COMMITISH=HEAD
 before_script:
  - sudo apt-get update -q
  - sudo apt-get install -q ocaml camlp5
  - git clone --depth=5 --branch=$BRANCH git://github.com/HoTT/coq.git coq-HoTT
  - pushd coq-HoTT
+ -   git remote update
+ -   git checkout $COMMITISH
  -   ./configure -prefix /usr/local -debug -no-native-compiler
  -   make coqlight
  -   sudo make install-coqlight

--- a/README.markdown
+++ b/README.markdown
@@ -15,7 +15,10 @@ It draws many ideas from Vladimir Voevodsky's
 Installation details are explained in the file `INSTALL.txt`. You will need to compile a
 custom version of Coq which supports the `-indices-matter` flag, universe polymorphism, and
 private types. We hope to have these pushed into standard Coq, but in the meanwhile the
-Coq version is available at https://github.com/HoTT/HoTT/branches/stable.
+Coq version is available at https://github.com/HoTT/coq/branches/trunk.  The particular
+version of Coq which the current version of this repository is compatible with can be
+found in the `.travis.yml` file, in the form of the commit message and SHA1 hash of the
+relevant commit to [HoTT/coq](https://github.com/HoTT/coq).
 
 If you are looking for an older version of HoTT which works with standard Coq, have a look
 at the one tagged as `pure-coq-8.3`. Note however that we do not support the old
@@ -26,7 +29,7 @@ library anymore.
 It is possible to use the HoTT library directly on the command line with the `hoqtop`
 script, but who does that?
 
-It is probably better o use [Proof General](http://proofgeneral.inf.ed.ac.uk) and
+It is probably better to use [Proof General](http://proofgeneral.inf.ed.ac.uk) and
 [Emacs](http://www.gnu.org/software/emacs/). When Proof General asks you where to find the
 `coqtop` executable, just point it to the `hoqtop` script. If Emacs runs a `coqtop`
 without asking, you should probably customize set the variable `proof-prog-name-ask` to


### PR DESCRIPTION
Mark this in .travis.yml, and note it in README.markdown, as described
by https://github.com/HoTT/HoTT/pull/166#issuecomment-22460613.
