### PR TITLE
Qualify the import of the Tactics module.

### DIFF
--- a/theories/HoTT.v
+++ b/theories/HoTT.v
@@ -25,4 +25,4 @@ Require Export types.Sigma.
 Require Export types.Sum.
 Require Export types.Universe.
 
-Require Export Tactics.
+Require Export HoTT.Tactics.


### PR DESCRIPTION
This way, we don't get a warning about ambiguous imports
