### PR TITLE
Make [sigT] an alias for [sig].

### DIFF
--- a/coq/theories/Init/Specif.v
+++ b/coq/theories/Init/Specif.v
@@ -91,20 +91,13 @@ Add Printing Let sig2.
 
 (** We make the parameters maximally inserted so that we can pass around [proj1] as a function and have it actually mean "first projection" in, e.g., [ap]. *)
 
-Definition proj1 {A} {P : A -> Type} (x : sig P) : A
+Definition proj1_sig {A} {P : A -> Type} (x : sig P) : A
   := let (a, _) := x in a.
-Definition proj2 {A} {P : A -> Type} (x : sig P) : P (proj1 x)
-  := let (a, h) return P (proj1 x) := x in h.
+Definition proj2_sig {A} {P : A -> Type} (x : sig P) : P (proj1_sig x)
+  := let (a, h) return P (proj1_sig x) := x in h.
 
-Notation proj1_sig := proj1.
-Notation proj2_sig := proj2.
-
-Notation projT1 := proj1.
-Notation projT2 := proj2.
-
-(** Because [proj1] and [proj2] were traditionally used for [and], we allow the coercion of a [prod] to a [sig] so that [proj1] and [proj2] still work for [and]. *)
-
-Coercion sig_of_prod A B (x : A * B) : { _ : A & B } := exist (fun _ => B) (fst x) (snd x).
+Notation projT1 := proj1_sig (only parsing).
+Notation projT2 := proj2_sig (only parsing).
 
 
 (** Various forms of the axiom of choice for specifications *)

--- a/theories/Overture.v
+++ b/theories/Overture.v
@@ -40,6 +40,10 @@ Notation idmap := (fun x => x).
 Notation "( x ; y )" := (existT _ x y) : fibration_scope.
 Open Scope fibration_scope.
 
+(** We have unified [sig] and [sigT] of the standard Coq, and so we introduce a new notation to not annoy newcomers with the [T] in [projT1] and [projT2] nor the [_sig] in [proj1_sig] and [proj2_sig], and to not confuse Coq veterans by stealing [proj1] and [proj2], which Coq uses for [and]. *)
+Notation pr1 := projT1.
+Notation pr2 := projT2.
+
 (** The following notation is very convenient, although it unfortunately clashes with Proof General's "electric period". *)
 Notation "x .1" := (projT1 x) (at level 3) : fibration_scope.
 Notation "x .2" := (projT2 x) (at level 3) : fibration_scope.


### PR DESCRIPTION
Now we only need to use [sig], [exist], and can choose either [proj1],
[proj1_sig], or [projT1] for its first projection (and similarly for its
second projection).  Because [proj1] used to be for [and], which is now
a notation for [prod], I've added a coercion [prod >-> sig] which allows
us to use [proj1] in place of [fst] and [proj2] in place of [snd].
Additionally, I've made the parameters for [proj1] and [proj2] implicit
and maximally inserted, so that we can do things like [ap proj1] and
have it mean what we want it to (that is, [ap proj1] is [ap (@proj1 _
_)]).  It would be nice to unify [Coq.Init.Specif] and
[Coq.Init.Datatypes], and make [fst] and [snd] just puns of [proj1] and
[proj2], maybe, but I think Coq will complain if I move identifiers
between files.
