### PR TITLE
Remove trailing slashes from the `ln` invocation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -177,7 +177,7 @@ AC_MSG_NOTICE([Creating symbolic links into Coq standard library])
 # directory, because the replacement standard library lives in the source
 # directory, and these links are required to make Coq accept it.
 rm -f "$srcdir/coq/dev" "$srcdir/coq/kernel" "$srcdir/coq/library" "$srcdir/coq/plugins"
-ln -s "$COQLIB/dev/" "$COQLIB/kernel/" "$COQLIB/library/" "$COQLIB/plugins/" "$srcdir/coq/"
+ln -s "$COQLIB/dev" "$COQLIB/kernel" "$COQLIB/library" "$COQLIB/plugins" "$srcdir/coq"
 # TODO(jgross): Should we use AC_CONFIG_LINKS?  But $COQLIB/dev
 # doesn't exist in my installation, and that would make configure
 # error...


### PR DESCRIPTION
While it worked fine with GNU tools, it doesn't work correctly with BSD
tools, which is what Mac OSX uses.  This closes #201 (again).
Conceptually, the reason to not have the trailing slashes is so that,
e.g., `coq/dev` resolves to `coq-HoTT/dev`, and `coq/dev/` resolves to
`coq-HoTT/dev/`, rather than having `coq/dev` resolve to `coq-HoTT/dev/`
and `coq/dev/` resolve to `coq-HoTT/dev//`.
