### PR TITLE
Don't remove .travis.yml from the autogoo branch

### DIFF
--- a/etc/ci/autogen_and_push.sh
+++ b/etc/ci/autogen_and_push.sh
@@ -37,7 +37,6 @@ FILES=`cat etc/autoreconf-files`
 BRANCH=`cat etc/autoreconf-branch`
 echo '$ git checkout -b '"$BRANCH"
 git checkout -b $BRANCH
-git rm -f .travis.yml
 git add -f $FILES
 echo '$ git commit -am "'"$MESSAGE"'"'
 git commit -m "$MESSAGE"


### PR DESCRIPTION
It seems that travis only respects our blacklist if we have a
.travis.yml on the relevant branch (I think).  And we don't want to be
compiling this branch, especially without a .travis.yml.
