### PR TITLE
Update readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -16,9 +16,8 @@ Installation details are explained in the file `INSTALL.txt`. You will need to c
 custom version of Coq which supports the `-indices-matter` flag, universe polymorphism, and
 private types. We hope to have these pushed into standard Coq, but in the meanwhile the
 Coq version is available at https://github.com/HoTT/coq/branches/trunk.  The particular
-version of Coq which the current version of this repository is compatible with can be
-found in the `.travis.yml` file, in the form of the commit message and SHA1 hash of the
-relevant commit to [HoTT/coq](https://github.com/HoTT/coq).
+version of Coq which the current version of this repository is compatible is bundled as
+a git submodule.
 
 If you are looking for an older version of HoTT which works with standard Coq, have a look
 at the one tagged as `pure-coq-8.3`. Note however that we do not support the old


### PR DESCRIPTION
We track Coq via git submodule, not .travis.yml
