### PR TITLE
Make symlinks to wrapper scripts work

### DIFF
--- a/hoq-config.in
+++ b/hoq-config.in
@@ -13,7 +13,7 @@ export COQTOP="@COQTOP@"
 # If there is a coq/theories directory in the parent directory of this
 # script, then use that one, otherwise use the global one. This trick
 # allows hoqc to work "in place" on the source files.
-mydir=`dirname $0`
+mydir="$(dirname "$(readlink -f "$0")")"
 if test -d "$mydir/coq/theories"
 then
   export COQLIB="$mydir/coq"

--- a/hoqc
+++ b/hoqc
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This is a wrapper around coqc which tricks Coq into using the HoTT
 # standard library and enables the HoTT-specific options.
-mydir=`dirname $0`
+mydir="$(dirname "$(readlink -f "$0")")"
 . "$mydir/hoq-config"
 # We could stick the arguments in hoq-config in COQ_ARGS, and then,
 # using (non-portable) bash arrays, do

--- a/hoqdep
+++ b/hoqdep
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This is a wrapper around coqdep which tricks Coq into using the HoTT
 # standard library and enables the HoTT-specific options.
-mydir=`dirname $0`
+mydir="$(dirname "$(readlink -f "$0")")"
 . "$mydir/hoq-config"
 # We could stick the arguments in hoq-config in COQ_ARGS, and then,
 # using (non-portable) bash arrays, do

--- a/hoqide
+++ b/hoqide
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This is a wrapper around coqide which tricks Coq into using the HoTT
 # standard library and enables the HoTT-specific options.
-mydir=`dirname $0`
+mydir="$(dirname "$(readlink -f "$0")")"
 . "$mydir/hoq-config"
 # We could stick the arguments in hoq-config in COQ_ARGS, and then,
 # using (non-portable) bash arrays, do

--- a/hoqtop
+++ b/hoqtop
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This is a wrapper around coqtop which tricks Coq into using the HoTT
 # standard library and enables the HoTT-specific options.
-mydir=`dirname $0`
+mydir="$(dirname "$(readlink -f "$0")")"
 . "$mydir/hoq-config"
 # We could stick the arguments in hoq-config in COQ_ARGS, and then,
 # using (non-portable) bash arrays, do

--- a/hoqtop.byte
+++ b/hoqtop.byte
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This is a wrapper around coqtop.byte which tricks Coq into using the HoTT
 # standard library and enables the HoTT-specific options.
-mydir=`dirname $0`
+mydir="$(dirname "$(readlink -f "$0")")"
 . "$mydir/hoq-config"
 # We could stick the arguments in hoq-config in COQ_ARGS, and then,
 # using (non-portable) bash arrays, do


### PR DESCRIPTION
If you symlink to the hoq\* scripts, the symlinks didn't work.  Now they
should; we need to recursively resolve symlinks before taking the directory
name.

Reported By: Thomas Braibant (@braibant)
