### PR TITLE
Make autogen.sh use bash

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # don't fall back on git if you interrupt or kill this script
 trap "exit 1" SIGINT SIGTERM


### PR DESCRIPTION
Otherwise, on my Ubuntu machine, it complains about SIGINT being a bad trap.
