### PR TITLE
readlink -f doesn't work on Mac OS; don't use -f

### DIFF
--- a/hoq-config.in
+++ b/hoq-config.in
@@ -10,10 +10,35 @@ export COQDEP="@COQDEP@"
 export COQDOC="@COQDOC@"
 export COQIDE="@COQIDE@"
 export COQTOP="@COQTOP@"
+
+function readlink_f() {
+    # readlink -f doesn't work on Mac OS.  So we roll our own readlink
+    # -f, from
+    # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
+    TARGET_FILE="$1"
+
+    cd "$(dirname "$TARGET_FILE")"
+    TARGET_FILE=`basename "$TARGET_FILE"`
+
+    # Iterate down a (possible) chain of symlinks
+    while [ -L "$TARGET_FILE" ]
+    do
+	TARGET_FILE=`readlink "$TARGET_FILE"`
+	cd "$(dirname "$TARGET_FILE")"
+	TARGET_FILE=`basename "$TARGET_FILE"`
+    done
+
+    # Compute the canonicalized name by finding the physical path
+    # for the directory we're in and appending the target file.
+    PHYS_DIR=`pwd -P`
+    RESULT="$PHYS_DIR/$TARGET_FILE"
+    echo "$RESULT"
+}
+
 # If there is a coq/theories directory in the parent directory of this
 # script, then use that one, otherwise use the global one. This trick
 # allows hoqc to work "in place" on the source files.
-mydir="$(dirname "$(readlink -f "$0")")"
+mydir="$(dirname "$(readlink_f "$0")")"
 if test -d "$mydir/coq/theories"
 then
   export COQLIB="$mydir/coq"

--- a/hoqc
+++ b/hoqc
@@ -1,7 +1,32 @@
 #!/bin/bash
 # This is a wrapper around coqc which tricks Coq into using the HoTT
 # standard library and enables the HoTT-specific options.
-mydir="$(dirname "$(readlink -f "$0")")"
+
+function readlink_f() {
+    # readlink -f doesn't work on Mac OS.  So we roll our own readlink
+    # -f, from
+    # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
+    TARGET_FILE="$1"
+
+    cd "$(dirname "$TARGET_FILE")"
+    TARGET_FILE=`basename "$TARGET_FILE"`
+
+    # Iterate down a (possible) chain of symlinks
+    while [ -L "$TARGET_FILE" ]
+    do
+	TARGET_FILE=`readlink "$TARGET_FILE"`
+	cd "$(dirname "$TARGET_FILE")"
+	TARGET_FILE=`basename "$TARGET_FILE"`
+    done
+
+    # Compute the canonicalized name by finding the physical path
+    # for the directory we're in and appending the target file.
+    PHYS_DIR=`pwd -P`
+    RESULT="$PHYS_DIR/$TARGET_FILE"
+    echo "$RESULT"
+}
+
+mydir="$(dirname "$(readlink_f "$0")")"
 . "$mydir/hoq-config"
 # We could stick the arguments in hoq-config in COQ_ARGS, and then,
 # using (non-portable) bash arrays, do

--- a/hoqdep
+++ b/hoqdep
@@ -1,7 +1,32 @@
 #!/bin/bash
 # This is a wrapper around coqdep which tricks Coq into using the HoTT
 # standard library and enables the HoTT-specific options.
-mydir="$(dirname "$(readlink -f "$0")")"
+
+function readlink_f() {
+    # readlink -f doesn't work on Mac OS.  So we roll our own readlink
+    # -f, from
+    # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
+    TARGET_FILE="$1"
+
+    cd "$(dirname "$TARGET_FILE")"
+    TARGET_FILE=`basename "$TARGET_FILE"`
+
+    # Iterate down a (possible) chain of symlinks
+    while [ -L "$TARGET_FILE" ]
+    do
+	TARGET_FILE=`readlink "$TARGET_FILE"`
+	cd "$(dirname "$TARGET_FILE")"
+	TARGET_FILE=`basename "$TARGET_FILE"`
+    done
+
+    # Compute the canonicalized name by finding the physical path
+    # for the directory we're in and appending the target file.
+    PHYS_DIR=`pwd -P`
+    RESULT="$PHYS_DIR/$TARGET_FILE"
+    echo "$RESULT"
+}
+
+mydir="$(dirname "$(readlink_f "$0")")"
 . "$mydir/hoq-config"
 # We could stick the arguments in hoq-config in COQ_ARGS, and then,
 # using (non-portable) bash arrays, do

--- a/hoqide
+++ b/hoqide
@@ -1,7 +1,32 @@
 #!/bin/bash
 # This is a wrapper around coqide which tricks Coq into using the HoTT
 # standard library and enables the HoTT-specific options.
-mydir="$(dirname "$(readlink -f "$0")")"
+
+function readlink_f() {
+    # readlink -f doesn't work on Mac OS.  So we roll our own readlink
+    # -f, from
+    # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
+    TARGET_FILE="$1"
+
+    cd "$(dirname "$TARGET_FILE")"
+    TARGET_FILE=`basename "$TARGET_FILE"`
+
+    # Iterate down a (possible) chain of symlinks
+    while [ -L "$TARGET_FILE" ]
+    do
+	TARGET_FILE=`readlink "$TARGET_FILE"`
+	cd "$(dirname "$TARGET_FILE")"
+	TARGET_FILE=`basename "$TARGET_FILE"`
+    done
+
+    # Compute the canonicalized name by finding the physical path
+    # for the directory we're in and appending the target file.
+    PHYS_DIR=`pwd -P`
+    RESULT="$PHYS_DIR/$TARGET_FILE"
+    echo "$RESULT"
+}
+
+mydir="$(dirname "$(readlink_f "$0")")"
 . "$mydir/hoq-config"
 # We could stick the arguments in hoq-config in COQ_ARGS, and then,
 # using (non-portable) bash arrays, do

--- a/hoqtop
+++ b/hoqtop
@@ -1,7 +1,32 @@
 #!/bin/bash
 # This is a wrapper around coqtop which tricks Coq into using the HoTT
 # standard library and enables the HoTT-specific options.
-mydir="$(dirname "$(readlink -f "$0")")"
+
+function readlink_f() {
+    # readlink -f doesn't work on Mac OS.  So we roll our own readlink
+    # -f, from
+    # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
+    TARGET_FILE="$1"
+
+    cd "$(dirname "$TARGET_FILE")"
+    TARGET_FILE=`basename "$TARGET_FILE"`
+
+    # Iterate down a (possible) chain of symlinks
+    while [ -L "$TARGET_FILE" ]
+    do
+	TARGET_FILE=`readlink "$TARGET_FILE"`
+	cd "$(dirname "$TARGET_FILE")"
+	TARGET_FILE=`basename "$TARGET_FILE"`
+    done
+
+    # Compute the canonicalized name by finding the physical path
+    # for the directory we're in and appending the target file.
+    PHYS_DIR=`pwd -P`
+    RESULT="$PHYS_DIR/$TARGET_FILE"
+    echo "$RESULT"
+}
+
+mydir="$(dirname "$(readlink_f "$0")")"
 . "$mydir/hoq-config"
 # We could stick the arguments in hoq-config in COQ_ARGS, and then,
 # using (non-portable) bash arrays, do

--- a/hoqtop.byte
+++ b/hoqtop.byte
@@ -1,7 +1,32 @@
 #!/bin/bash
 # This is a wrapper around coqtop.byte which tricks Coq into using the HoTT
 # standard library and enables the HoTT-specific options.
-mydir="$(dirname "$(readlink -f "$0")")"
+
+function readlink_f() {
+    # readlink -f doesn't work on Mac OS.  So we roll our own readlink
+    # -f, from
+    # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
+    TARGET_FILE="$1"
+
+    cd "$(dirname "$TARGET_FILE")"
+    TARGET_FILE=`basename "$TARGET_FILE"`
+
+    # Iterate down a (possible) chain of symlinks
+    while [ -L "$TARGET_FILE" ]
+    do
+	TARGET_FILE=`readlink "$TARGET_FILE"`
+	cd "$(dirname "$TARGET_FILE")"
+	TARGET_FILE=`basename "$TARGET_FILE"`
+    done
+
+    # Compute the canonicalized name by finding the physical path
+    # for the directory we're in and appending the target file.
+    PHYS_DIR=`pwd -P`
+    RESULT="$PHYS_DIR/$TARGET_FILE"
+    echo "$RESULT"
+}
+
+mydir="$(dirname "$(readlink_f "$0")")"
 . "$mydir/hoq-config"
 # We could stick the arguments in hoq-config in COQ_ARGS, and then,
 # using (non-portable) bash arrays, do


### PR DESCRIPTION
I don't know any good cross-platform way to do this simply, so I inlined
the first solution from
http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac.
(I added quotes in appropriate places to make the script still work with
spaces or backslashes.)

This closes #243.

I don't like the fact that I've duplicated so much code, but I don't see a good way around it.  (I suppose I could make a bunch of .in files, one for each script, and do `@readlink_f@`, and put the definition of the function as a string in the `configure` file, but I think that might be even worse...)
