### PR TITLE
Various fixes for cygwin/MSWin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -40,14 +40,14 @@ SILENCE_COQDEP_1 :=
 SILENCE_COQDEP = $(SILENCE_COQDEP_$(V))
 
 # The list of files that comprise the HoTT library
-VFILES=$(shell find $(srcdir)/theories -name "*.v")
+VFILES=$(shell find "$(srcdir)/theories" -name "*.v")
 VOFILES:=$(VFILES:.v=.vo)
 GLOBFILES:=$(VFILES:.v=.glob)
 DEPFILES:=$(VFILES:.v=.d)
 HTMLFILES:=$(VFILES:.v=.html)
 
 # The list of files that comprise the alternative standard library
-STDVFILES=$(shell find $(SRCCOQLIB) -name "*.v")
+STDVFILES=$(shell find "$(SRCCOQLIB)/theories" -name "*.v")
 STDVOFILES:=$(STDVFILES:.v=.vo)
 STDGLOBFILES:=$(STDVFILES:.v=.glob)
 STDDEPFILES:=$(STDVFILES:.v=.d)
@@ -57,13 +57,13 @@ if make_ssreflect
 # The list of Coq files that comprise ssreflect
 SSRMAKEFILE=$(srcdir)/Makefile_ssrplugin
 ssrdir=$(srcdir)/ssrplugin
-SSRVFILES=$(shell find $(ssrdir)/theories -name "*.v")
+SSRVFILES=$(shell find "$(ssrdir)/theories" -name "*.v")
 SSRVOFILES=$(SSRVFILES:.v=.vo)
 SSRGLOBFILES=$(SSRVFILES:.v=.glob)
 SSRHTMLFILES:=$(SSRVFILES:.v=.html)
-SSRMLIFILES=$(shell find $(ssrdir)/src -name "*.mli")
-SSRMLFILES=$(shell find $(ssrdir)/src -name "*.ml4" -o -name "*.ml")
-SSRMLLIBFILES=$(shell find $(ssrdir)/theories -name "*.mllib")
+SSRMLIFILES=$(shell find "$(ssrdir)/src" -name "*.mli")
+SSRMLFILES=$(shell find "$(ssrdir)/src" -name "*.ml4" -o -name "*.ml")
+SSRMLLIBFILES=$(shell find "$(ssrdir)/theories" -name "*.mllib")
 SSRCMXSFILES=$(SSRMLLIBFILES:.mllib=.cmxs)
 SSRCMAFILES=$(SSRMLLIBFILES:.mllib=.cma)
 endif
@@ -72,7 +72,7 @@ endif
 nobase_hott_DATA = \
 	$(VOFILES) \
 	$(STDVOFILES) \
-	$(shell find $(SRCCOQLIB)/theories -name "README.txt") \
+	$(shell find "$(SRCCOQLIB)/theories" -name "README.txt") \
 	$(SSRVOFILES) \
 	$(SSRCMXSFILES) \
 	$(SSRCMAFILES)
@@ -89,11 +89,12 @@ else
 .PHONY: stdlib hottlib
 endif
 
+# TODO(JasonGross): Get this to work on Windows, where symlinks are unreliable
 install-data-local:
-	$(MKDIR_P) $(hottdir)/coq
-	rm -f $(hottdir)/coq/dev $(hottdir)/coq/plugins
-	$(LN_S) $(COQLIB)/dev $(hottdir)/coq
-	$(LN_S) $(COQLIB)/plugins $(hottdir)/coq
+	$(MKDIR_P) "$(hottdir)/coq"
+	rm -f "$(hottdir)/coq/dev" "$(hottdir)/coq/plugins"
+	$(LN_S) "$(COQLIB)/dev" "$(hottdir)/coq"
+	$(LN_S) "$(COQLIB)/plugins" "$(hottdir)/coq"
 
 if make_ssreflect
 clean-local: $(SSRMAKEFILE)
@@ -106,7 +107,7 @@ stdlib: $(STDVOFILES)
 
 $(STDVOFILES) : %.vo : %.v
 	$(VECHO) COQTOP $(basename $<)
-	$(Q) $(TIMER) $(COQTOP) -indices-matter -boot -nois -coqlib $(SRCCOQLIB) -R $(SRCCOQLIB)/theories Coq -compile $(basename $<)
+	$(Q) $(TIMER) "$(COQTOP)" -indices-matter -boot -nois -coqlib "$(SRCCOQLIB)" -R "$(SRCCOQLIB)/theories" Coq -compile "$(basename $<)"
 
 
 # The HoTT library as a single target
@@ -152,7 +153,7 @@ endif
 # The HTML files
 html: $(GLOBFILES) $(VFILES) $(STDGLOBFILES) $(STDVFILES)
 	- $(mkdir_p) html
-	$(COQDOC) -toc -interpolate -utf8 -html --coqlib_path $(SRCCOQLIB) --no-externals -R $(srcdir)/theories HoTT -R $(SRCCOQLIB)/theories Coq -d html $(VFILES) $(STDVFILES)
+	"$(COQDOC)" -toc -interpolate -utf8 -html --coqlib_path "$(SRCCOQLIB)" --no-externals -R "$(srcdir)/theories" HoTT -R "$(SRCCOQLIB)/theories" Coq -d html $(VFILES) $(STDVFILES)
 
 # The TAGS file
 TAGS_FILES = $(STDVFILES) $(VFILES)
@@ -165,10 +166,10 @@ TAGS : $(TAGS_FILES)
 # Dependency files
 $(DEPFILES) $(STDDEPFILES) : %.d : %.v
 	$(VECHO) COQDEP $<
-	$(Q) $(COQDEP) -nois -coqlib $(SRCCOQLIB) -R $(srcdir)/theories HoTT -R $(SRCCOQLIB)/theories Coq $< >$@
+	$(Q) "$(COQDEP)" -nois -coqlib "$(SRCCOQLIB)" -R "$(srcdir)/theories" HoTT -R "$(SRCCOQLIB)/theories" Coq $< | sed s'#\\#/#g' >$@
 
 clean:
 	rm -f $(CLEANFILES)
-	find $(SRCCOQLIB)/theories $(srcdir)/theories -name \*.vo -o -name \*.glob | xargs rm -f
+	find "$(SRCCOQLIB)/theories" $(srcdir)/theories -name \*.vo -o -name \*.glob | xargs rm -f
 
 -include $(DEPFILES) $(STDDEPFILES)

--- a/configure.ac
+++ b/configure.ac
@@ -41,15 +41,15 @@ AS_IF([test "x$COQTOP" != "x"],
 AS_IF([test "x$COQTOP" = "xno"],
       [AC_MSG_ERROR([Could not find coqtop])],
       [AC_MSG_CHECKING([coqtop version])
-       COQVERSION="`$COQTOP -v | sed -n -e 's|^.*version \(@<:@^ @:>@*\) .*$|\1|p'`"
+       COQVERSION="`"$COQTOP" -v | sed -n -e 's|^.*version \(@<:@^ @:>@*\) .*$|\1|p'`"
        AC_MSG_RESULT([$COQVERSION])
        AC_MSG_CHECKING([Coq library path])
-       COQLIB="`$COQTOP -where 2>/dev/null`"
+       COQLIB="`"$COQTOP" -where 2>/dev/null | tr -d '\r'`"
        AC_MSG_RESULT([$COQLIB])
        AC_SUBST([COQVERSION])
        AC_SUBST([COQLIB])
 
-       indicesmatter="`$COQTOP -help 2>&1 | grep -c -- -indices-matter`"
+       indicesmatter="`"$COQTOP" -help 2>&1 | grep -c -- -indices-matter`"
        AS_IF([test "$indicesmatter" = "0"],
              [AC_MSG_ERROR([You need a version of Coq which supports -indices-matter])
              ])
@@ -76,7 +76,7 @@ AS_IF([test "x$COQC" != "x"],
 AS_IF([test "x$COQC" = "xno"],
       [AC_MSG_ERROR([Could not find coqc])],
       [AC_MSG_CHECKING([coqc version])
-       COQCVERSION="`$COQC -v | sed -n -e 's|^.*version \(@<:@^ @:>@*\) .*$|\1|p'`"
+       COQCVERSION=`"$COQC" -v | sed -n -e 's|^.*version \(@<:@^ @:>@*\) .*$|\1|p'`
        AC_MSG_RESULT([$COQCVERSION])
        AC_SUBST([COQCVERSION])
        AS_IF([test "x$COQCVERSION" != "x$COQVERSION"],
@@ -176,13 +176,32 @@ AC_MSG_NOTICE([Creating symbolic links into Coq standard library])
 # We must have these links in the source directory, not in the build
 # directory, because the replacement standard library lives in the source
 # directory, and these links are required to make Coq accept it.
-rm -f "$srcdir/coq/dev" "$srcdir/coq/kernel" "$srcdir/coq/library" "$srcdir/coq/plugins"
+# First remove existing links.  If they are symlinks, use -f.  If they are
+# physical directories, use -rf.  This ensures that we don't delete the
+# contents of symlinked directories.
+AS_IF([test -h "$srcdir/coq/dev"], [rm -f "$srcdir/coq/dev"],
+      [test -d "$srcdir/coq/dev"], [rm -rf "$srcdir/coq/dev"])
+AS_IF([test -h "$srcdir/coq/kernel"], [rm -f "$srcdir/coq/kernel"],
+      [test -d "$srcdir/coq/kernel"], [rm -rf "$srcdir/coq/kernel"])
+AS_IF([test -h "$srcdir/coq/library"], [rm -f "$srcdir/coq/library"],
+      [test -d "$srcdir/coq/library"], [rm -rf "$srcdir/coq/library"])
+AS_IF([test -h "$srcdir/coq/plugins"], [rm -f "$srcdir/coq/plugins"],
+      [test -d "$srcdir/coq/plugins"], [rm -rf "$srcdir/coq/plugins"])
 ln -s "$COQLIB/dev" "$COQLIB/kernel" "$COQLIB/library" "$COQLIB/plugins" "$srcdir/coq"
 # TODO(jgross): Should we use AC_CONFIG_LINKS?  But $COQLIB/dev
 # doesn't exist in my installation, and that would make configure
 # error...
 #AC_CONFIG_LINKS([$srcdir/coq/plugins:$COQLIB/plugins
 #                 $srcdir/coq/dev:$COQLIB/dev])
+AC_MSG_CHECKING([whether your coqtop supports directory symlinks to the stdlib])
+coqtop_out="$("$COQTOP" -coqlib "$srcdir/coq" < /dev/null 2>&1 | grep -c 'Warning: Cannot open')"
+AS_IF([test "$coqtop_out" = 0],
+      [AC_MSG_RESULT([yes])],
+      [AC_MSG_RESULT([no])
+       AC_MSG_NOTICE([Falling back on making physical copies of the stdlib])
+       rm -f "$srcdir/coq/dev" "$srcdir/coq/kernel" "$srcdir/coq/library" "$srcdir/coq/plugins"
+       cp -R "$COQLIB/dev" "$COQLIB/kernel" "$COQLIB/library" "$COQLIB/plugins" "$srcdir/coq"])
+
 
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([hoq-config])


### PR DESCRIPTION
Quote more things so that it works even if COQBIN has spaces.

coq doesn't like cygwin symlinks, so fall back on physical copies

make doesn't like backslashes, so pipe coqdep through sed to fix that
(bug reported at https://coq.inria.fr/bugs/show_bug.cgi?id=3157,
and also to make)

hoq\* still doesn't work, but that's for the next commit.  I'm going to try recompiling ocaml, to see if that fixes the `Warning: Cannot open /cygdrive/d/Documents/GitHub/HoTT/coq\theories/*` warnings from getting cygwin-style paths from `readlink -f`.
