### PR TITLE
Uniformize the order of [Set]s at the top of files

### DIFF
--- a/theories/categories/Category/Dual.v
+++ b/theories/categories/Category/Dual.v
@@ -1,9 +1,9 @@
 Require Import Category.Core Category.Objects.
 
+Set Universe Polymorphism.
 Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
-Set Universe Polymorphism.
 
 Local Open Scope equiv_scope.
 Local Open Scope morphism_scope.

--- a/theories/categories/Category/Prod.v
+++ b/theories/categories/Category/Prod.v
@@ -1,10 +1,10 @@
 Require Import Category.Core Category.Strict.
 Require Import types.Prod.
 
+Set Universe Polymorphism.
 Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
-Set Universe Polymorphism.
 
 Local Open Scope category_scope.
 Local Open Scope morphism_scope.

--- a/theories/categories/Category/Sum.v
+++ b/theories/categories/Category/Sum.v
@@ -1,9 +1,9 @@
 Require Export Category.Core.
 
+Set Universe Polymorphism.
 Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
-Set Universe Polymorphism.
 
 Section internals.
   Variable C : PreCategory.

--- a/theories/categories/Functor/Composition/Core.v
+++ b/theories/categories/Functor/Composition/Core.v
@@ -1,9 +1,9 @@
 Require Import Category.Core Functor.Core.
 
+Set Universe Polymorphism.
 Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
-Set Universe Polymorphism.
 
 Local Open Scope morphism_scope.
 

--- a/theories/categories/Functor/Composition/Laws.v
+++ b/theories/categories/Functor/Composition/Laws.v
@@ -1,10 +1,10 @@
 Require Import Category.Core Functor.Core Functor.Composition.Core Functor.Identity.
 Require Import Functor.Paths.
 
+Set Universe Polymorphism.
 Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
-Set Universe Polymorphism.
 
 Local Open Scope morphism_scope.
 

--- a/theories/categories/Functor/Core.v
+++ b/theories/categories/Functor/Core.v
@@ -1,9 +1,9 @@
 Require Import Category.Core.
 
+Set Universe Polymorphism.
 Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
-Set Universe Polymorphism.
 
 Delimit Scope functor_scope with functor.
 

--- a/theories/categories/Functor/Dual.v
+++ b/theories/categories/Functor/Dual.v
@@ -2,10 +2,10 @@ Require Category.Dual.
 Import Category.Dual.CategoryDualNotations.
 Require Import Category.Core Functor.Core.
 
+Set Universe Polymorphism.
 Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
-Set Universe Polymorphism.
 
 Local Open Scope category_scope.
 

--- a/theories/categories/Functor/Identity.v
+++ b/theories/categories/Functor/Identity.v
@@ -1,9 +1,9 @@
 Require Import Category.Core Functor.Core.
 
+Set Universe Polymorphism.
 Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
-Set Universe Polymorphism.
 
 Section identity.
   (** There is an identity functor.  It does the obvious thing. *)

--- a/theories/categories/Functor/Paths.v
+++ b/theories/categories/Functor/Paths.v
@@ -1,10 +1,10 @@
 Require Import Category.Core Functor.Core.
 Require Import HProp HoTT.Tactics Equivalences PathGroupoids types.Sigma Trunc types.Record.
 
+Set Universe Polymorphism.
 Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
-Set Universe Polymorphism.
 
 Local Open Scope morphism_scope.
 Local Open Scope functor_scope.

--- a/theories/categories/Functor/Sum.v
+++ b/theories/categories/Functor/Sum.v
@@ -1,10 +1,10 @@
 Require Import Category.Sum Functor.Core Functor.Composition.Core Functor.Identity.
 Require Import Functor.Paths HoTT.Tactics types.Forall.
 
+Set Universe Polymorphism.
 Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
-Set Universe Polymorphism.
 
 (** We save [inl] and [inr] so we can use them to refer to the functors, too.  Outside of the [categories/] directory, they should always be referred to as [Functor.inl] and [Functor.inr], after a [Require Functor].  Outside of this file, but in the [categories/] directory, if you do not want to depend on all of [Functor] (for e.g., speed reasons), they should be referred to as [Functor.Sum.inl] and [Functor.Sum.inr] after a [Require Functor.Sum]. *)
 Local Notation type_inl := inl.

--- a/theories/categories/FunctorCategory/Core.v
+++ b/theories/categories/FunctorCategory/Core.v
@@ -2,10 +2,10 @@ Require Import Category.Core Category.Strict Functor.Core NaturalTransformation.
 (** These must come last, so that [identity], [compose], etc., refer to natural transformations. *)
 Require Import NaturalTransformation.Composition.Core NaturalTransformation.Identity NaturalTransformation.Composition.Laws.
 
+Set Universe Polymorphism.
 Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
-Set Universe Polymorphism.
 
 Section functor_category.
   Context `{Funext}.

--- a/theories/categories/NaturalTransformation/Composition/Core.v
+++ b/theories/categories/NaturalTransformation/Composition/Core.v
@@ -1,9 +1,9 @@
 Require Import Category.Core Functor.Core Functor.Composition.Core NaturalTransformation.Core.
 
+Set Universe Polymorphism.
 Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
-Set Universe Polymorphism.
 
 Local Open Scope morphism_scope.
 Local Open Scope natural_transformation_scope.

--- a/theories/categories/NaturalTransformation/Composition/Laws.v
+++ b/theories/categories/NaturalTransformation/Composition/Laws.v
@@ -1,9 +1,9 @@
 Require Import Category.Core Functor.Core Functor.Identity Functor.Composition.Core NaturalTransformation.Core NaturalTransformation.Identity NaturalTransformation.Composition.Core NaturalTransformation.Paths.
 
+Set Universe Polymorphism.
 Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
-Set Universe Polymorphism.
 
 Local Open Scope morphism_scope.
 Local Open Scope natural_transformation_scope.

--- a/theories/categories/NaturalTransformation/Core.v
+++ b/theories/categories/NaturalTransformation/Core.v
@@ -1,9 +1,9 @@
 Require Import Category.Core Functor.Core.
 
+Set Universe Polymorphism.
 Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
-Set Universe Polymorphism.
 
 Delimit Scope natural_transformation_scope with natural_transformation.
 

--- a/theories/categories/NaturalTransformation/Dual.v
+++ b/theories/categories/NaturalTransformation/Dual.v
@@ -2,10 +2,10 @@ Require Category.Dual Functor.Dual.
 Import Category.Dual.CategoryDualNotations Functor.Dual.FunctorDualNotations.
 Require Import Category.Core Functor.Core NaturalTransformation.Core.
 
+Set Universe Polymorphism.
 Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
-Set Universe Polymorphism.
 
 Local Open Scope category_scope.
 

--- a/theories/categories/NaturalTransformation/Identity.v
+++ b/theories/categories/NaturalTransformation/Identity.v
@@ -1,9 +1,9 @@
 Require Import Category.Core Functor.Core NaturalTransformation.Core NaturalTransformation.Paths.
 
+Set Universe Polymorphism.
 Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
-Set Universe Polymorphism.
 
 Local Open Scope morphism_scope.
 Local Open Scope path_scope.

--- a/theories/categories/NaturalTransformation/Paths.v
+++ b/theories/categories/NaturalTransformation/Paths.v
@@ -1,10 +1,10 @@
 Require Import Category.Core Functor.Core NaturalTransformation.Core.
 Require Import Equivalences types.Sigma Trunc.
 
+Set Universe Polymorphism.
 Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
-Set Universe Polymorphism.
 
 Local Open Scope morphism_scope.
 Local Open Scope natural_transformation_scope.

--- a/theories/categories/NaturalTransformation/Sum.v
+++ b/theories/categories/NaturalTransformation/Sum.v
@@ -1,9 +1,9 @@
 Require Import Category.Core Functor.Core Category.Sum Functor.Sum NaturalTransformation.Core.
 
+Set Universe Polymorphism.
 Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
-Set Universe Polymorphism.
 
 Section sum.
   Definition sum


### PR DESCRIPTION
Because I'm obsessive compulsive or something.  (It doesn't actually matter what order these come in, but I think it's nicer to use the same order in all the files.  Or perhaps I should find a way to only have to do it once, like setting the options in Overture.v or something.)
