### PR TITLE
Fix timing script to work with contrib/ prefixes

### DIFF
--- a/etc/timing/TimeFileMaker.py
+++ b/etc/timing/TimeFileMaker.py
@@ -9,7 +9,7 @@ import os, sys, re
 # mapping names of compiled files to the number of minutes and seconds
 # that they took to compile.
 
-STRIP_REG = re.compile('^(|coq/)theories/')
+STRIP_REG = re.compile('^(coq/|contrib/|)(?:theories/)?')
 STRIP_REP = r'\1'
 
 def get_times(file_name):


### PR DESCRIPTION
I'm going to merge this one immediately, because it's a small change that doesn't touch the library proper.
