### PR TITLE
Add image of current travis build status to readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,5 @@
+[![Build Status](https://api.travis-ci.org/HoTT/HoTT.png?branch=master)](https://travis-ci.org/HoTT/HoTT)
+
 [Homotopy Type Theory](http://homotopytypetheory.org/) is an interpretation of
 Martin-Löf’s intensional type theory into abstract homotopy theory. Propositional equality
 is interpreted as homotopy and type isomorphism as homotopy equivalence. Logical


### PR DESCRIPTION
This way we'll get to see the current build status from the
homepage (https://github.com/HoTT/HoTT).

It's small and fairly unobtrusive; scroll down on https://github.com/JasonGross/HoTT/tree/readme-build-status to preview.
