### PR TITLE
Define the functor (C -> D)^op -> (C^op -> D^op)

### DIFF
--- a/Makefile_targets.mk
+++ b/Makefile_targets.mk
@@ -144,6 +144,7 @@ CATEGORY_VFILES = \
 	$(srcdir)/theories/categories/NaturalTransformation/Sum.v \
 	$(srcdir)/theories/categories/NaturalTransformation/Pointwise.v \
 	\
+	$(srcdir)/theories/categories/FunctorCategory/Dual.v \
 	$(srcdir)/theories/categories/FunctorCategory/Morphisms.v \
 	$(srcdir)/theories/categories/FunctorCategory/Notations.v \
 	\

--- a/theories/categories/Functor/Dual.v
+++ b/theories/categories/Functor/Dual.v
@@ -34,18 +34,28 @@ Local Notation "F ^op" := (opposite F) : functor_scope.
 Local Notation "F ^op'" := (opposite_inv F) (at level 3) : functor_scope.
 
 Section opposite_involutive.
-  Variable C : PreCategory.
-  Variable D : PreCategory.
-  Variable F : Functor C D.
+  Local Open Scope functor_scope.
 
   Local Notation op_op_id := Category.Dual.opposite_involutive.
 
-  Lemma opposite_involutive
+  Lemma opposite_involutive C D (F : Functor C D)
   : match op_op_id C in (_ = C), op_op_id D in (_ = D) return Functor C D with
       | idpath, idpath => ((F^op)^op)%functor
     end = F.
   Proof.
     destruct F, C, D; reflexivity.
+  Defined.
+
+  Lemma opposite_law C D (F : Functor C D)
+  : F^op^op' = F.
+  Proof.
+    destruct F; reflexivity.
+  Defined.
+
+  Lemma opposite'_law C D (F : Functor C^op D^op)
+  : F^op'^op = F.
+  Proof.
+    destruct F; reflexivity.
   Defined.
 End opposite_involutive.
 

--- a/theories/categories/FunctorCategory/Dual.v
+++ b/theories/categories/FunctorCategory/Dual.v
@@ -1,0 +1,80 @@
+Require Import Category.Core Functor.Core NaturalTransformation.Core.
+Require Import Category.Dual Functor.Dual NaturalTransformation.Dual.
+Require Import Functor.Composition.Core Functor.Identity.
+Require Import FunctorCategory.Core.
+Require Import Functor.Paths.
+Require Import HoTT.Tactics types.Forall.
+
+Set Universe Polymorphism.
+Set Implicit Arguments.
+Generalizable All Variables.
+Set Asymmetric Patterns.
+
+Local Open Scope functor_scope.
+
+Section opposite.
+  Context `{Funext}.
+  Variable C : PreCategory.
+  Variable D : PreCategory.
+
+  Definition opposite_functor : Functor (C -> D) (C^op -> D^op)^op
+    := Build_Functor
+         (C -> D) ((C^op -> D^op)^op)
+         (fun F => F^op)%functor
+         (fun _ _ T => T^op)%natural_transformation
+         (fun _ _ _ _ _ => idpath)
+         (fun _ => idpath).
+
+
+  Definition opposite_functor_inv : Functor (C^op -> D^op)^op (C -> D)
+    := Build_Functor
+         ((C^op -> D^op)^op) (C -> D)
+         (fun F => F^op')%functor
+         (fun _ _ T => T^op')%natural_transformation
+         (fun _ _ _ _ _ => idpath)
+         (fun _ => idpath).
+
+  Definition opposite_functor' : Functor (C -> D)^op (C^op -> D^op)
+    := Build_Functor
+         ((C -> D)^op) (C^op -> D^op)
+         (fun F => F^op)%functor
+         (fun _ _ T => T^op)%natural_transformation
+         (fun _ _ _ _ _ => idpath)
+         (fun _ => idpath).
+
+
+  Definition opposite_functor_inv' : Functor (C^op -> D^op) (C -> D)^op
+    := Build_Functor
+         (C^op -> D^op) ((C -> D)^op)
+         (fun F => F^op')%functor
+         (fun _ _ T => T^op')%natural_transformation
+         (fun _ _ _ _ _ => idpath)
+         (fun _ => idpath).
+
+  Local Ltac op_t :=
+    split;
+    path_functor;
+    [ (exists (path_forall _ _ (@opposite'_law C D)))
+    | (exists (path_forall _ _ (@opposite_law C D))) ];
+    repeat (apply path_forall; intro);
+    simpl;
+    rewrite !transport_forall_constant;
+    transport_path_forall_hammer;
+    destruct_head NaturalTransformation;
+    destruct_head Functor;
+    exact idpath.
+
+  Definition opposite_functor_law
+  : opposite_functor o opposite_functor_inv = 1
+    /\ opposite_functor_inv o opposite_functor = 1.
+  Proof.
+    abstract op_t.
+  Qed.
+
+  Definition opposite_functor'_law
+  : opposite_functor' o opposite_functor_inv' = 1
+    /\ opposite_functor_inv' o opposite_functor' = 1.
+  Proof.
+    abstract op_t.
+  Qed.
+End opposite.

--- a/theories/categories/FunctorCategory/FunctorCategory.v
+++ b/theories/categories/FunctorCategory/FunctorCategory.v
@@ -4,8 +4,10 @@ Require Export FunctorCategory.Notations.
 Require FunctorCategory.Core.
 Require FunctorCategory.Morphisms.
 Require FunctorCategory.Functorial.
+Require FunctorCategory.Dual.
 
 Include FunctorCategory.Core.
 Include FunctorCategory.Morphisms.
 Include FunctorCategory.Functorial.
+Include FunctorCategory.Dual.
 (** We don't want to make utf-8 notations the default, so we don't export them. *)

--- a/theories/categories/FunctorCategory/Morphisms.v
+++ b/theories/categories/FunctorCategory/Morphisms.v
@@ -5,6 +5,7 @@ Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
 
+Local Open Scope path_scope.
 Local Open Scope category_scope.
 Local Open Scope morphism_scope.
 
@@ -70,14 +71,14 @@ Section idtoiso.
              (T : F = G)
   : NaturalTransformation F G.
   Proof.
-    refine (Build_NaturalTransformation
+    refine (Build_NaturalTransformation'
               F G
               (fun x => idtoiso _ (ap10 (ap object_of T) x))
-              _).
-    intros; case T; simpl.
-    etransitivity; [ | symmetry ];
-    first [ apply left_identity
-          | apply right_identity ].
+              _
+              _);
+    intros; case T; simpl;
+    [ exact (left_identity _ _ _ _ @ (right_identity _ _ _ _)^)
+    | exact (right_identity _ _ _ _ @ (left_identity _ _ _ _)^) ].
   Defined.
 
   Definition idtoiso

--- a/theories/categories/NaturalTransformation/Composition/Functorial.v
+++ b/theories/categories/NaturalTransformation/Composition/Functorial.v
@@ -31,6 +31,6 @@ Section functorial_composition.
          (D -> E) (C -> E)
          (fun F => F o G)%functor
          (fun _ _ T => T oR G)
-         (fun _ _ _ _ _ => inverse (composition_of_whisker_r _ _ _))
+         (fun _ _ _ _ _ => composition_of_whisker_r _ _ _)
          (fun _ => whisker_r_left_identity _ _).
 End functorial_composition.

--- a/theories/categories/NaturalTransformation/Composition/Laws.v
+++ b/theories/categories/NaturalTransformation/Composition/Laws.v
@@ -32,8 +32,10 @@ Section natural_transformation_identity.
 
   Definition whisker_r_left_identity E
              (G : Functor D E) (F : Functor C D)
-  : identity G oR F = 1
-    := idpath.
+  : identity G oR F = 1.
+  Proof.
+    path_natural_transformation; auto with morphism.
+  Qed.
 
   Definition whisker_l_right_identity E
              (G : Functor D E) (F : Functor C D)
@@ -83,8 +85,8 @@ Section whisker.
     Lemma composition_of_whisker_r B (I : Functor B C)
     : (T o T') oR I = (T oR I) o (T' oR I).
     Proof.
-      exact idpath.
-    Defined.
+      path_natural_transformation; apply idpath.
+    Qed.
   End whisker.
 End whisker.
 

--- a/theories/categories/NaturalTransformation/Identity.v
+++ b/theories/categories/NaturalTransformation/Identity.v
@@ -1,4 +1,5 @@
 Require Import Category.Core Functor.Core NaturalTransformation.Core NaturalTransformation.Paths.
+Require Import PathGroupoids.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.
@@ -12,12 +13,6 @@ Local Open Scope natural_transformation_scope.
 Section identity.
   Variable C : PreCategory.
   Variable D : PreCategory.
-
-  Local Ltac id_fin_t :=
-    intros;
-    etransitivity;
-    [ apply left_identity
-    | apply symmetry; apply right_identity ].
 
   (** There is an identity natrual transformation.  We create a number
       of variants, for various uses. *)
@@ -35,24 +30,31 @@ Section identity.
                                       HO
                                       (identity (F c))).
 
-    Definition generalized_identity_commutes
-               s d (m : morphism C s d)
-    : CO d o morphism_of F m
-      = morphism_of G m o CO s.
+    Definition generalized_identity_commutes s d (m : morphism C s d)
+    : CO d o morphism_of F m = morphism_of G m o CO s.
     Proof.
       case HM. case HO.
-      id_fin_t.
+      exact (left_identity _ _ _ _ @ (right_identity _ _ _ _)^).
+    Defined.
+
+    Definition generalized_identity_commutes_sym s d (m : morphism C s d)
+    : morphism_of G m o CO s = CO d o morphism_of F m.
+    Proof.
+      case HM. case HO.
+      exact (right_identity _ _ _ _ @ (left_identity _ _ _ _)^).
     Defined.
 
     Definition generalized_identity
     : NaturalTransformation F G
-      := Build_NaturalTransformation
+      := Build_NaturalTransformation'
            F G
            (fun c => CO c)
-           generalized_identity_commutes.
+           generalized_identity_commutes
+           generalized_identity_commutes_sym.
   End generalized.
 
   Global Arguments generalized_identity_commutes / .
+  Global Arguments generalized_identity_commutes_sym / .
   Global Arguments generalized_identity F G !HO !HM / .
 
   Section generalized'.
@@ -78,6 +80,7 @@ Section identity.
 End identity.
 
 Global Opaque commutes.
+Global Opaque commutes_sym.
 
 Module Export NaturalTransformationIdentityNotations.
   Notation "1" := (identity _) : natural_transformation_scope.


### PR DESCRIPTION
Unfortunately, it's a bit slow.  I'm not sure what to do to speed it up; over 50% of the time is spent figuring out that `idpath` has the right type.

Also, fine tune some other definitions so that we can get more proofs by convertibility.
