### PR TITLE
Use maintainer mode in configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,10 +7,8 @@ AC_PREREQ([2.67])
 AC_CONFIG_SRCDIR([theories/Overture.v])
 AC_CONFIG_AUX_DIR([etc])
 AC_CONFIG_MACRO_DIR([etc])
-# If we ever remove Makefile.in and configure from version control,
-# and depend on autoconf, we should replace "AM_MAINTAINER_MODE" with
-# "AM_MAINTAINER_MODE([enable])".  Possibly even before then.
-AM_MAINTAINER_MODE
+# Autoregenerate Makefile if needed
+AM_MAINTAINER_MODE([enable])
 AM_INIT_AUTOMAKE([foreign no-dependencies])
 
 # Check for programs


### PR DESCRIPTION
This will automatically rebuild Makefile and configure if needed,
preventing problems like the missing targets in
https://github.com/HoTT/HoTT/pull/286#issuecomment-30749614.  This means
that we now depend on having autobuild around to run ./configure and
make, though I think that systems without them will simply get warnings,
and not errors.
