### PR TITLE
Fix dir locals

### DIFF
--- a/theories/.dir-locals.el
+++ b/theories/.dir-locals.el
@@ -1,6 +1,4 @@
-(
- (coq-mode 
-  . (
-     (coq-prog-name
-      . (let ((default-directory (locate-dominating-file buffer-file-name ".dir-locals.el")))
-	  (expand-file-name "../hoqtop"))))))
+((coq-mode . ((eval . (let ((default-directory (locate-dominating-file
+						buffer-file-name ".dir-locals.el")))
+			(make-local-variable 'coq-prog-name)
+			(setq coq-prog-name (expand-file-name "../hoqtop")))))))


### PR DESCRIPTION
This pull request fixes the .dir-locals.el file so that it sets coq-prog-name just locally in the current buffer. Otherwise its value can spoil coq projects in other buffers visiting files in other directories that must be used with another version of coqtop.
