### PR TITLE
Add a .dir-locals.el for dealing with the std lib

### DIFF
--- a/coq/theories/.dir-locals.el
+++ b/coq/theories/.dir-locals.el
@@ -1,0 +1,4 @@
+((coq-mode . ((eval . (let ((default-directory (locate-dominating-file
+                                                buffer-file-name ".dir-locals.el")))
+                        (make-local-variable 'coq-prog-args)
+                        (setq coq-prog-args `("-no-native-compiler" "-indices-matter" "-boot" "-nois" "-coqlib" ,(expand-file-name "..") "-R" ,(expand-file-name ".") "Coq" "-emacs-U")))))))


### PR DESCRIPTION
Thanks to @DanGrayson's trick of making variables local to a `.dir-locals.el` file, I now feel comfortable asking for this to be merged; it allows easier editing of files our replacement std-lib.

I think it's small enough that it probably only needs one other pair of eyes; I'm not sure if it's small enough for me to just merge without review.
