### PR TITLE
Dependency graph titles

### DIFF
--- a/etc/DepsToDot.hs
+++ b/etc/DepsToDot.hs
@@ -5,9 +5,7 @@
 import Data.Graph.Inductive
   (reachable, delEdge, mkGraph, nmap, Edge, Gr, DynGraph, UEdge, LEdge, efilter, LNode, labNodes, Graph, delNodes)
 import Data.GraphViz
-  (color, toLabel, printDotGraph, nonClusteredParams, graphToDot, fmtNode, X11Color(..))
-import Data.GraphViz.Attributes
-  (Attributes)
+  (Attributes, toGraphID, color, toLabel, printDotGraph, nonClusteredParams, graphToDot, fmtNode, setID, X11Color(..))
 import Data.GraphViz.Attributes.Complete
   (Attribute(URL))
 import Data.Text.Lazy (Text, pack, unpack)
@@ -92,6 +90,7 @@ label opts p' =
 
 makeGraph :: Options -> String -> Text
 makeGraph opts = printDotGraph .
+  setID (toGraphID $ optTitle opts) .
   graphToDot (nonClusteredParams {fmtNode = snd}) .
   nmap (label opts).
   untransitive .
@@ -100,6 +99,7 @@ makeGraph opts = printDotGraph .
 
 data Options = Options {
   optCoqDocBase :: Maybe String,
+  optTitle :: String,
   optInput :: IO String,
   optOutput :: String -> IO ()
 }
@@ -107,6 +107,7 @@ data Options = Options {
 defaultOptions :: Options
 defaultOptions = Options {
   optCoqDocBase = Nothing,
+  optTitle = "",
   optInput = getContents,
   optOutput = putStr
 }
@@ -119,6 +120,8 @@ options = [
     return opt { optInput = readFile arg }) "FILE") "input file, stdin if omitted",
   Option ['o'] ["output"] (ReqArg (\arg opt ->
     return opt { optOutput = writeFile arg }) "FILE") "output file, stdout if omitted",
+  Option ['t'] ["title"] (ReqArg (\arg opt ->
+    return opt { optTitle = arg }) "TITLE") "title of the graph page",
   Option ['h'] ["help"] (NoArg (\_ ->
     usage >> exitSuccess)) "display this help page"]
 

--- a/etc/ci/generate_and_push_quick_doc.sh
+++ b/etc/ci/generate_and_push_quick_doc.sh
@@ -30,9 +30,8 @@ git config --global user.email "Travis-CI-Bot@travis.fake"
 export MESSAGE="Autoupdate documentation with DepsToDot.hs"
 echo '$ make HoTT.deps HoTTCore.deps'
 make HoTT.deps HoTTCore.deps
-# There must be a better way to insert titles than sed...
-runhaskell etc/DepsToDot.hs --coqdocbase="http://hott.github.io/HoTT/proviola-html/" < HoTT.deps | sed s'/^digraph {/digraph "HoTT Library Dependency Graph" {/g' > HoTT.dot
-runhaskell etc/DepsToDot.hs --coqdocbase="http://hott.github.io/HoTT/proviola-html/" < HoTTCore.deps | sed s'/^digraph {/digraph "HoTT Core Library Dependency Graph" {/g' > HoTTCore.dot
+runhaskell etc/DepsToDot.hs --coqdocbase="http://hott.github.io/HoTT/proviola-html/" --title="HoTT Library Dependency Graph" < HoTT.deps > HoTT.dot
+runhaskell etc/DepsToDot.hs --coqdocbase="http://hott.github.io/HoTT/proviola-html/" --title="HoTT Core Library Dependency Graph" < HoTTCore.deps > HoTTCore.dot
 dot -Tsvg HoTT.dot -o HoTT.svg
 dot -Tsvg HoTTCore.dot -o HoTTCore.svg
 echo '$ git checkout -b gh-pages upstream/gh-pages'


### PR DESCRIPTION
Now the dependency graphs are no longer titled `_anonymous_0`.

Also, link to proviola, because I think people will be interested in stepping through the proofs from looking at the files.
