### PR TITLE
Use ${BASH_SOURCE[0]} instead of $0

### DIFF
--- a/hoq-config.in
+++ b/hoq-config.in
@@ -37,7 +37,7 @@ function readlink_f() {
 # If there is a coq/theories directory in the parent directory of this
 # script, then use that one, otherwise use the global one. This trick
 # allows hoqc to work "in place" on the source files.
-mydir="$(dirname "$(readlink_f "$0")")"
+mydir="$(dirname "$(readlink_f "${BASH_SOURCE[0]}")")"
 if test -d "$mydir/coq/theories"
 then
   export COQLIB="$mydir/coq"
@@ -47,4 +47,3 @@ else
   export HOTTLIB="@hottdir@/theories"
 fi
 #export COQ_ARGS=(-no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -indices-matter)
-

--- a/hoqc
+++ b/hoqc
@@ -26,7 +26,7 @@ function readlink_f() {
     echo "$RESULT"
 }
 
-mydir="$(dirname "$(readlink_f "$0")")"
+mydir="$(dirname "$(readlink_f "${BASH_SOURCE[0]}")")"
 if [ ! -f "$mydir/hoq-config" ]
 then
   echo "Could not find hoq-config. Did you run ./configure?"
@@ -47,5 +47,3 @@ fi
 # $ eval 'exec "$COQC" '"$COQ_ARGS"' "$@"'
 # Instead, we duplicate code, because it's simpler.
 exec "$COQC" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -indices-matter "$@"
-
-

--- a/hoqdep
+++ b/hoqdep
@@ -26,7 +26,7 @@ function readlink_f() {
     echo "$RESULT"
 }
 
-mydir="$(dirname "$(readlink_f "$0")")"
+mydir="$(dirname "$(readlink_f "${BASH_SOURCE[0]}")")"
 if [ ! -f "$mydir/hoq-config" ]
 then
   echo "Could not find hoq-config. Did you run ./configure?"
@@ -47,4 +47,3 @@ fi
 # $ eval 'exec "$COQDEP" '"$COQ_ARGS"' "$@"'
 # Instead, we duplicate code, because it's simpler.
 exec "$COQDEP" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -indices-matter "$@"
-

--- a/hoqide
+++ b/hoqide
@@ -26,7 +26,7 @@ function readlink_f() {
     echo "$RESULT"
 }
 
-mydir="$(dirname "$(readlink_f "$0")")"
+mydir="$(dirname "$(readlink_f "${BASH_SOURCE[0]}")")"
 if [ ! -f "$mydir/hoq-config" ]
 then
   echo "Could not find hoq-config. Did you run ./configure?"
@@ -47,5 +47,3 @@ fi
 # $ eval 'exec "$COQIDE" '"$COQ_ARGS"' "$@"'
 # Instead, we duplicate code, because it's simpler.
 exec "$COQIDE" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -indices-matter "$@"
-
-

--- a/hoqtop
+++ b/hoqtop
@@ -26,7 +26,7 @@ function readlink_f() {
     echo "$RESULT"
 }
 
-mydir="$(dirname "$(readlink_f "$0")")"
+mydir="$(dirname "$(readlink_f "${BASH_SOURCE[0]}")")"
 if [ ! -f "$mydir/hoq-config" ]
 then
   echo "Could not find hoq-config. Did you run ./configure?"
@@ -47,5 +47,3 @@ fi
 # $ eval 'exec "$COQTOP" '"$COQ_ARGS"' "$@"'
 # Instead, we duplicate code, because it's simpler.
 exec "$COQTOP" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -indices-matter "$@"
-
-

--- a/hoqtop.byte
+++ b/hoqtop.byte
@@ -26,7 +26,7 @@ function readlink_f() {
     echo "$RESULT"
 }
 
-mydir="$(dirname "$(readlink_f "$0")")"
+mydir="$(dirname "$(readlink_f "${BASH_SOURCE[0]}")")"
 if [ ! -f "$mydir/hoq-config" ]
 then
   echo "Could not find hoq-config. Did you run ./configure?"
@@ -47,4 +47,3 @@ fi
 # $ eval 'exec "$COQTOP.byte" '"$COQ_ARGS"' "$@"'
 # Instead, we duplicate code, because it's simpler.
 exec "$COQTOP.byte" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -indices-matter "$@"
-


### PR DESCRIPTION
Now we have better behavior when we use `source`; before we got the
parent's name, but now, we get the actual script's name.

Maybe we should also use the shorter version at http://stackoverflow.com/a/246128/377022 rather than the long `readlink -f` replacement we use now?

Anyway, I'm going to merge this once travis runs, because it's small and doesn't touch the actual library.
