### PR TITLE
Circle was in Prop.  Now it's not.

### DIFF
--- a/theories/hit/Circle.v
+++ b/theories/hit/Circle.v
@@ -12,14 +12,14 @@ Generalizable Variables X A B f g n.
 
 Module Export Circle.
 
-Local Inductive S1 : Type :=
+Local Inductive S1 : Set :=
 | base : S1.
 
 Axiom loop : base = base.
 
 Definition S1_rect (P : S1 -> Type) (b : P base) (l : loop # b = b)
   : forall (x:S1), P x
-  := fun x => match x with base => b end.
+  := fun x => match x with base => fun _ => b end l.
 
 Axiom S1_rect_beta_loop
   : forall (P : S1 -> Type) (b : P base) (l : loop # b = b),


### PR DESCRIPTION
Instead it's in Set, which is fine.  Also, fix definition of eliminator as per #122.

Since this is a very small change, and someone is waiting on the `Prop` -> `Set` fix, I'm going to push it directly.  
