### PR TITLE
Fix install script for Make >= 4.0

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -15,7 +15,9 @@ minimal fuss, you should try your luck by following these instructions:
    * OSX: we recommend that you install the Opam package manager for Ocaml
      (http://opam.ocamlpro.com/) and go from there.
 
-   * MS Windows: we we wish you good luck.
+   * MS Windows: we wish you good luck.  Note that you may have to run
+     the `dos2unix` command on various scripts to prevent cygwin's
+     shell from complaining about unrecognized `\r` commands.
 
 2. Get the HoTT library (skip this step if you already have it):
 

--- a/etc/install_coq.sh
+++ b/etc/install_coq.sh
@@ -21,6 +21,11 @@ echo '$ git submodule update --init --recursive'
 git submodule update --init --recursive
 
 pushd coq-HoTT
+echo '$ Patching configure'
+if [ ! -z "$(grep '\[ "$MAKEVERSIONMAJOR" -eq 3 -a "$MAKEVERSIONMINOR" -ge 81 \]' configure)" ]
+then
+    sed -i s'/\[ "$MAKEVERSIONMAJOR" -eq 3 -a "$MAKEVERSIONMINOR" -ge 81 \]/[ "$MAKEVERSIONMAJOR" -eq 3 -a "$MAKEVERSIONMINOR" -ge 81 -o "$MAKEVERSIONMAJOR" -gt 3 ]/g' configure
+fi
 echo '$ ./configure -local '"$@"
 ./configure -local "$@"
 echo '$ make coqlight coqide'


### PR DESCRIPTION
This works around https://github.com/HoTT/coq/issues/69.  For the time being (until we get a better version of
Coq), we simply patch Coq's configure script.

Also add a note about running scripts on Windows.
