### PR TITLE
/usr/bin/env bash -e doesn't work in some cygwins

### DIFF
--- a/etc/install_coq.sh
+++ b/etc/install_coq.sh
@@ -1,4 +1,7 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
+
+# exit immediately if any command fails
+set -e
 
 # in case we're run from out of git repo
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
It complains about not being able to find `bash -e`.
