### PR TITLE
Fix the implicit arguments to [point]

### DIFF
--- a/theories/Overture.v
+++ b/theories/Overture.v
@@ -384,6 +384,7 @@ Hint Unfold not: core.
 (** A space is pointed if that space has a point. *)
 Class IsPointed (A : Type) := point : A.
 Definition pointedType := { u : Type & IsPointed u }.
+Arguments point A {_}.
 
 (** Ssreflect tactics, adapted by Robbert Krebbers *)
 Ltac done :=

--- a/theories/Pointed.v
+++ b/theories/Pointed.v
@@ -13,10 +13,9 @@ Generalizable Variables A B f.
 Instance ispointed_contr `{Contr A} : IsPointed A := center A.
 
 (** A pi type with a pointed target is pointed. *)
-(** I'm not sure why I need to explicitly pass the instance to [point] here. -Jason Gross *)
 Instance ispointed_forall `{H : forall a : A, IsPointed (B a)}
 : IsPointed (forall a, B a)
-  := fun a => @point (B a) (H a).
+  := fun a => point (B a).
 
 (** A sigma type of pointed components is pointed. *)
 Instance ispointed_sigma `{IsPointed A} `{IsPointed (B (point A))}


### PR DESCRIPTION
Now it takes the type as an argument, rather than taking no arguments.
For bonus points, figure out how [point A] used to work.
