### PR TITLE
Fix the universes of some HITs; add a check file

### DIFF
--- a/Makefile_targets.mk
+++ b/Makefile_targets.mk
@@ -46,8 +46,6 @@ CORE_VFILES = \
 	$(srcdir)/theories/UnivalenceImpliesFunext.v \
 	$(srcdir)/theories/Pointed.v \
 	$(srcdir)/theories/Tactics.v \
-	$(srcdir)/theories/HoTT.v \
-	$(srcdir)/theories/Misc.v \
 	$(srcdir)/theories/TruncType.v \
 	$(srcdir)/theories/Functorish.v \
 	$(srcdir)/theories/FunextAxiom.v \
@@ -66,7 +64,10 @@ CORE_VFILES = \
 	$(srcdir)/theories/hit/unique_choice.v \
 	$(srcdir)/theories/hit/quotient.v \
 	$(srcdir)/theories/hit/iso.v \
-	$(srcdir)/theories/types/ObjectClassifier.v
+	$(srcdir)/theories/types/ObjectClassifier.v \
+	$(srcdir)/theories/Misc.v \
+	$(srcdir)/theories/HoTT.v \
+	$(srcdir)/theories/Tests.v
 
 CATEGORY_VFILES = \
 	$(srcdir)/theories/categories/categories.v \

--- a/theories/Tests.v
+++ b/theories/Tests.v
@@ -1,0 +1,13 @@
+Require Import HoTT.
+
+Fail Check Type0 : Type0.
+Check Susp nat : Type0.
+Fail Check Susp Type0 : Type0.
+
+Fail Check (fun (P : interval -> Type) (a : P Interval.zero) (b : P Interval.one)
+                (p p' : seg # a = b)
+            => idpath : interval_rect P a b p = interval_rect P a b p').
+
+Local Open Scope nat_scope.
+Fail Check Lift nat : Type0.
+Check 1 : Lift nat.

--- a/theories/hit/Interval.v
+++ b/theories/hit/Interval.v
@@ -10,7 +10,7 @@ Local Open Scope equiv_scope.
 
 Module Export Interval.
 
-Local Inductive interval : Type :=
+Local Inductive interval : Type0 :=
   | zero : interval
   | one : interval.
 

--- a/theories/hit/Spheres.v
+++ b/theories/hit/Spheres.v
@@ -10,7 +10,7 @@ Generalizable Variables X A B f g n.
 (** ** Definition, by iterated suspension. *)
 
 (** To match the usual indexing for spheres, we have to pad the sequence with a dummy term [Sphere minus_two]. *)
-Fixpoint Sphere (n : trunc_index) : Type
+Fixpoint Sphere (n : trunc_index) : Type0
   := match n with
        | minus_two => Empty
        | minus_one => Empty

--- a/theories/hit/Suspension.v
+++ b/theories/hit/Suspension.v
@@ -11,9 +11,13 @@ Generalizable Variables X A B f g n.
 
 Module Export Suspension.
 
-Local Inductive Susp (X : Type) : Type :=
+(** We play games to ensure that [Susp X] does not live in a lower universe than [X] *)
+Section hack_my_types.
+Let U := Type.
+Local Inductive Susp (X : U) : U :=
   | North : Susp X
   | South : Susp X.
+End hack_my_types.
 
 Global Arguments North {X}.
 Global Arguments South {X}.


### PR DESCRIPTION
Susp X is now in the same universe as X.

This is verified in the Tests.v file.

This closes #369.

It's possible we should fix the universes of quotients, but this will be
trickier.  In trunk-polyproj, we can do it like this:

``` coq
Section Domain.
Let U := Type.
(** We need a universe level that is not lower than [U], but doesn't
need to be the same. *)
Let U' : Type.
Proof.
  let U' := constr:(Type) in
  let U_le_U' := constr:(fun x : U => (x : U')) in
  exact U'.
Defined.
Context {A : Type} {R:A -> A -> U} {sR:setrel R}.

Inductive quotient (sR:setrel R): U' :=
 | class_of : A -> quotient sR.
```

But in HoTT/coq, this gives "Error: No such section variable or
assumption: U'." at `End Domain.` (see
https://github.com/HoTT/coq/issues/116).
