### PR TITLE
Make lift and lower transparent

### DIFF
--- a/theories/types/UniverseLevel.v
+++ b/theories/types/UniverseLevel.v
@@ -33,7 +33,6 @@ Definition lower {A} := (@equiv_inv _ _ (@lift A) _).
 
 (** We make [lift] and [lower] opaque so that typeclass resolution doesn't pick up [isequiv_lift] as an instance of [IsEquiv idmap] and wreck havok. *)
 Typeclasses Opaque lift lower.
-Global Opaque lift lower.
 
 
 (*Fail Check Lift nat : Type0.


### PR DESCRIPTION
The reason to make them opaque was purely for typeclasses.  They will
need to be transparent when we move to trunk-polyproj, to get an
alternate version of Funext_downward_closed to work correctly.
