### PR TITLE
Prepare for moving to trunk with some minor workarounds for known changes

### DIFF
--- a/theories/categories/Functor/Paths.v
+++ b/theories/categories/Functor/Paths.v
@@ -94,7 +94,7 @@ Section path_functor.
   Definition path_functor'_sig_inv (F G : Functor C D) : F = G -> path_functor'_T F G
     := fun H'
        => (ap object_of H';
-           (transport_compose _ _ _ _) ^ @ apD (@morphism_of _ _) H')%path.
+           (transport_compose _ object_of _ _) ^ @ apD (@morphism_of _ _) H')%path.
 
   (** ** Curried version of path classifying lemma *)
   Lemma path_functor' (F G : Functor C D)

--- a/theories/categories/Pseudofunctor/FromFunctor.v
+++ b/theories/categories/Pseudofunctor/FromFunctor.v
@@ -110,7 +110,7 @@ intros.
          o ((idtoiso (x0 -> x1) x14 : morphism _ _ _)
               o (idtoiso (x0 -> x1) x12 : morphism _ _ _)))%natural_transformation.
   Proof.
-    clear HP F.
+    clear F.
     abstract (apply symmetry; simpl; pseudofunctor_t).
   Qed.
 
@@ -125,7 +125,7 @@ intros.
     = ((NaturalTransformation.Composition.Laws.left_identity_natural_transformation_2 x5)
          o (Category.Morphisms.idtoiso (x0 -> x) x6 : morphism _ _ _))%natural_transformation.
   Proof.
-    clear HP F.
+    clear F.
     abstract (simpl; pseudofunctor_t).
   Qed.
 
@@ -140,7 +140,7 @@ intros.
     = ((NaturalTransformation.Composition.Laws.right_identity_natural_transformation_2 x3)
          o (Category.Morphisms.idtoiso (x0 -> x) x6 : morphism _ _ _))%natural_transformation.
   Proof.
-    clear HP F.
+    clear F.
     abstract (simpl; pseudofunctor_t).
   Qed.
 

--- a/theories/hit/Flattening.v
+++ b/theories/hit/Flattening.v
@@ -42,7 +42,8 @@ Definition W_rectnd_beta_pp {A B f g} (P : Type) (cc' : A -> P)
   : ap (W_rectnd P cc' pp') (pp b) = pp' b.
 Proof.
   unfold W_rectnd.
-  refine (cancelL (transport_const (pp b) _) _ _ _).
+  (** Use [eapply] rather than [refine] so that we don't get evars as goals, and don't have to shelve any goals with [shelve_unifiable]. *)
+  eapply (cancelL (transport_const (pp b) _)).
   refine ((apD_const (@W_rect A B f g (fun _ => P) cc' _) (pp b))^ @ _).
   refine (W_rect_beta_pp (fun _ => P) _ _ _).
 Defined.
@@ -92,7 +93,7 @@ Definition Wtil_rectnd_beta_ppt
   : ap (@Wtil_rectnd A B f g C D Q cct' ppt') (ppt b y) = ppt' b y.
 Proof.
   unfold Wtil_rectnd.
-  refine (cancelL (transport_const (ppt b y) _) _ _ _).
+  eapply (cancelL (transport_const (ppt (C:=C) b y) _)).
   refine ((apD_const
     (@Wtil_rect A B f g C D (fun _ => Q) cct' _) (ppt b y))^ @ _).
   refine (Wtil_rect_beta_ppt (fun _ => Q) _ _ _ _).

--- a/theories/types/Arrow.v
+++ b/theories/types/Arrow.v
@@ -102,7 +102,7 @@ Definition ap_apply_Fl {A B C : Type} {x y : A} (p : x = y) (M : A -> B -> C) (z
 
 Definition ap_apply_Fr {A B C : Type} {x y : A} (p : x = y) (z : B -> C) (N : A -> B) :
   ap (fun a => z (N a)) p = ap01 z (ap N p)
-:= (ap_compose _ _ _).
+:= (ap_compose N _ _).
 
 Definition ap_apply_FlFr {A B C : Type} {x y : A} (p : x = y) (M : A -> B -> C) (N : A -> B) :
   ap (fun a => (M a) (N a)) p = ap11 (ap M p) (ap N p)


### PR DESCRIPTION
These are work-arounds for minor known changes:
- [refine] will now permit dependent goals, so we need to use [eapply]
  to get the same resulting goals
- We need to not clear section variables when the proof depends on them
  (https://coq.inria.fr/bugs/show_bug.cgi?id=3418)
- Higher order unification has changed, so we need to give more things
  explicitly now (https://coq.inria.fr/bugs/show_bug.cgi?id=3269).  In
  particular, Coq had to use a heuristic to decide [f b = ?X b] by
  instantiating [X] to [f], and not e.g. [λ x, f b]([b] is in [?X]'s
  context).
