### PR TITLE
Strip out uses of [Set]/[Type0]

### DIFF
--- a/theories/Overture.v
+++ b/theories/Overture.v
@@ -39,6 +39,10 @@ But this gives "Error: in Tacinterp.add_tacdef: Reserved Ltac name symmetry.".  
 
 (** Define an alias for [Set], which is really [Type₀]. *)
 Notation Type0 := Set.
+(** Define [Type₁] (really, [Type_i] for any [i > 0]) so that we can enforce having universes that are not [Set].  In trunk, universes will not be unified with [Set] in most places, so we want to never use [Set] at all. *)
+Definition Type1 := Eval hnf in let U := Type in let gt := (Set : U) in U.
+Arguments Type1 / .
+Identity Coercion unfold_Type1 : Type1 >-> Sortclass.
 
 (** We make the identity map a notation so we do not have to unfold it,
     or complicate matters with its type. *)
@@ -376,7 +380,13 @@ Ltac path_via mid :=
   apply @concat with (y := mid); auto with path_hints.
 
 (** We put [Empty] here, instead of in [Empty.v], because [Ltac done] uses it. *)
-Inductive Empty : Type0 := .
+(** HoTT/coq is broken and somehow interprets [Type1] as [Prop] with regard to elimination schemes. *)
+Unset Elimination Schemes.
+Inductive Empty : Type1 := .
+Scheme Empty_rect := Induction for Empty Sort Type.
+Scheme Empty_rec := Induction for Empty Sort Set.
+Scheme Empty_ind := Induction for Empty Sort Prop.
+Set Elimination Schemes.
 
 Definition not (A:Type) : Type := A -> Empty.
 Notation "~ x" := (not x) : type_scope.

--- a/theories/categories/NatCategory.v
+++ b/theories/categories/NatCategory.v
@@ -10,14 +10,14 @@ Set Asymmetric Patterns.
 Module Export Core.
   (** ** [Fin n] types, or [CardinalityRepresentative] *)
   (** We use [Empty] for [0] and [Unit] for [1] so that we get nice judgmental behavior with opposites *)
-  Fixpoint CardinalityRepresentative (n : nat) : Type0 :=
+  Fixpoint CardinalityRepresentative (n : nat) : Type1 :=
     match n with
       | 0 => Empty
       | 1 => Unit
       | S n' => (CardinalityRepresentative n' + Unit)%type
     end.
 
-  Coercion CardinalityRepresentative : nat >-> Sortclass.
+  Coercion CardinalityRepresentative : nat >-> Type1.
 
   (** ** [Fin n] is an hSet *)
   Instance trunc_cardinality_representative (n : nat)

--- a/theories/hit/Circle.v
+++ b/theories/hit/Circle.v
@@ -12,7 +12,7 @@ Generalizable Variables X A B f g n.
 
 Module Export Circle.
 
-Local Inductive S1 : Type0 :=
+Local Inductive S1 : Type1 :=
 | base : S1.
 
 Axiom loop : base = base.
@@ -46,7 +46,7 @@ Defined.
 
 (* First we define the appropriate integers. *)
 
-Inductive Pos : Type :=
+Inductive Pos : Type1 :=
 | one : Pos
 | succ_pos : Pos -> Pos.
 
@@ -56,7 +56,7 @@ Definition one_neq_succ_pos (z : Pos) : ~ (one = succ_pos z)
 Definition succ_pos_injective {z w : Pos} (p : succ_pos z = succ_pos w) : z = w
   := transport (fun s => z = (match s with one => w | succ_pos a => a end)) p (idpath z).
 
-Inductive Int : Type :=
+Inductive Int : Type1 :=
 | neg : Pos -> Int
 | zero : Int
 | pos : Pos -> Int.

--- a/theories/hit/Interval.v
+++ b/theories/hit/Interval.v
@@ -10,7 +10,7 @@ Local Open Scope equiv_scope.
 
 Module Export Interval.
 
-Local Inductive interval : Type0 :=
+Local Inductive interval : Type1 :=
   | zero : interval
   | one : interval.
 

--- a/theories/hit/Spheres.v
+++ b/theories/hit/Spheres.v
@@ -10,8 +10,8 @@ Generalizable Variables X A B f g n.
 (** ** Definition, by iterated suspension. *)
 
 (** To match the usual indexing for spheres, we have to pad the sequence with a dummy term [Sphere minus_two]. *)
-Fixpoint Sphere (n : trunc_index) : Type0
-  := match n with
+Fixpoint Sphere (n : trunc_index)
+  := match n return Type with
        | minus_two => Empty
        | minus_one => Empty
        | trunc_S n' => Susp (Sphere (n'))

--- a/theories/hit/TwoSphere.v
+++ b/theories/hit/TwoSphere.v
@@ -12,7 +12,7 @@ Generalizable Variables X A B f g n.
 
 Module Export TwoSphere.
 
-Local Inductive S2 : Type0 :=
+Local Inductive S2 : Type1 :=
 | base : S2.
 
 Axiom surf : idpath base = idpath base.

--- a/theories/types/Unit.v
+++ b/theories/types/Unit.v
@@ -7,8 +7,14 @@ Local Open Scope equiv_scope.
 Generalizable Variables A.
 
 (** coq calls it "unit", we call it "Unit" *)
-Inductive Unit : Type0 :=
+(** HoTT/coq is broken and somehow interprets [Type1] as [Prop] with regard to elimination schemes. *)
+Unset Elimination Schemes.
+Inductive Unit : Type1 :=
     tt : Unit.
+Scheme Unit_rect := Induction for Unit Sort Type.
+Scheme Unit_rec := Induction for Unit Sort Set.
+Scheme Unit_ind := Induction for Unit Sort Prop.
+Set Elimination Schemes.
 
 (** ** Eta conversion *)
 


### PR DESCRIPTION
In trunk, rigid polymorphic universes are not lowered to [Set], so
things work out better if we don't use [Set] anywhere.  There's a bug in
HoTT/coq that forces us to manually choose the elimination schemes for
Unit and Empty, but it seems to be fixed in trunk.
