### PR TITLE
Don't abstract inside of Qed; also another change that speeds things up in trunk

### DIFF
--- a/theories/categories/Comma/ProjectionFunctors.v
+++ b/theories/categories/Comma/ProjectionFunctors.v
@@ -92,7 +92,7 @@ Section comma.
     apply CommaCategory.path_morphism; simpl; [ | reflexivity ].
     path_functor.
     exists (path_forall _ _ (comma_category_induced_functor_object_of_identity _)).
-    abstract comma_laws_t.
+    comma_laws_t.
   Qed.
 
   Lemma comma_category_projection_functor_composition_of s d d' m m'
@@ -105,7 +105,7 @@ Section comma.
     path_functor.
     simpl.
     exists (path_forall _ _ (comma_category_induced_functor_object_of_compose m' m)).
-    abstract comma_laws_t.
+    comma_laws_t.
   Qed.
 
   Definition comma_category_projection_functor

--- a/theories/categories/Functor/Prod/Functorial.v
+++ b/theories/categories/Functor/Prod/Functorial.v
@@ -34,14 +34,14 @@ Section functorial.
   : functor_morphism_of (m2 o m1)
     = functor_morphism_of m2 o functor_morphism_of m1.
   Proof.
-    abstract (path_natural_transformation; reflexivity).
+    path_natural_transformation; reflexivity.
   Qed.
 
   Definition functor_identity_of
              (x : object ((C -> D) * (C -> D')))
   : functor_morphism_of (identity x) = identity _.
   Proof.
-    abstract (path_natural_transformation; reflexivity).
+    path_natural_transformation; reflexivity.
   Qed.
 
   Definition functor

--- a/theories/categories/FunctorCategory/Dual.v
+++ b/theories/categories/FunctorCategory/Dual.v
@@ -71,13 +71,13 @@ Section opposite.
   : opposite_functor o opposite_functor_inv = 1
     /\ opposite_functor_inv o opposite_functor = 1.
   Proof.
-    abstract op_t.
+    op_t.
   Qed.
 
   Definition opposite_functor'_law
   : opposite_functor' o opposite_functor_inv' = 1
     /\ opposite_functor_inv' o opposite_functor' = 1.
   Proof.
-    abstract op_t.
+    op_t.
   Qed.
 End opposite.

--- a/theories/categories/Grothendieck/PseudofunctorToCat.v
+++ b/theories/categories/Grothendieck/PseudofunctorToCat.v
@@ -224,7 +224,7 @@ intros a b c d [f f'] [g g'] [h h']; simpl.
              (x x3 o (f1 _1 f' o x0 x4))
       = (f; f').
   Proof.
-    abstract helper_t idtac.
+    helper_t idtac.
   Qed.
 
   Lemma pseudofunctor_to_cat_right_identity_helper
@@ -244,7 +244,7 @@ intros a b c d [f f'] [g g'] [h h']; simpl.
                (f' o ((f0 f) _1 (x x4) o x0 x4))
         = (f; f').
   Proof.
-    abstract helper_t idtac.
+    helper_t idtac.
   Qed.
 
   (** ** Category of elements *)

--- a/theories/categories/ProductLaws.v
+++ b/theories/categories/ProductLaws.v
@@ -118,7 +118,7 @@ Module Law1.
       /\ inverse o functor = 1.
     Proof.
       unfold functor, inverse.
-      abstract t_prod.
+      t_prod.
     Qed.
 
     (** *** [1 × C ≅ C] *)
@@ -127,7 +127,7 @@ Module Law1.
       /\ inverse' o functor' = 1.
     Proof.
       unfold functor', inverse'.
-      abstract t_prod.
+      t_prod.
     Qed.
   End law1.
 End Law1.

--- a/theories/categories/Pseudofunctor/FromFunctor.v
+++ b/theories/categories/Pseudofunctor/FromFunctor.v
@@ -111,7 +111,7 @@ intros.
               o (idtoiso (x0 -> x1) x12 : morphism _ _ _)))%natural_transformation.
   Proof.
     clear F.
-    abstract (apply symmetry; simpl; pseudofunctor_t).
+    apply symmetry; simpl; pseudofunctor_t.
   Qed.
 
   Lemma pseudofunctor_of_functor__left_identity_of
@@ -126,7 +126,7 @@ intros.
          o (Category.Morphisms.idtoiso (x0 -> x) x6 : morphism _ _ _))%natural_transformation.
   Proof.
     clear F.
-    abstract (simpl; pseudofunctor_t).
+    simpl; pseudofunctor_t.
   Qed.
 
   Lemma pseudofunctor_of_functor__right_identity_of
@@ -141,7 +141,7 @@ intros.
          o (Category.Morphisms.idtoiso (x0 -> x) x6 : morphism _ _ _))%natural_transformation.
   Proof.
     clear F.
-    abstract (simpl; pseudofunctor_t).
+    simpl; pseudofunctor_t.
   Qed.
 
   Definition pseudofunctor_of_functor : Pseudofunctor C

--- a/theories/categories/Pseudofunctor/RewriteLaws.v
+++ b/theories/categories/Pseudofunctor/RewriteLaws.v
@@ -85,8 +85,11 @@ Section lemmas.
     Definition p_composition_of_coherent_iso_for_rewrite__isisomorphism_helper__to_inverse
           X
           (H' : X = @Build_Isomorphic (_ -> _) _ _ _ p_composition_of_coherent_iso_for_rewrite__isisomorphism_helper)
-    : @morphism_inverse _ _ _ _ X = inv
-      := ap (fun i => @morphism_inverse _ _ _ _ (@isisomorphism_isomorphic _ _ _ i)) H'.
+    : @morphism_inverse _ _ _ _ X = inv.
+    Proof.
+      refine (ap (fun i => @morphism_inverse _ _ _ _ (@isisomorphism_isomorphic _ _ _ i)) H' @ _)%path.
+      reflexivity. (** Why is [exact idpath] slow? *)
+    Defined.
   End helper.
 
   Lemma p_composition_of_coherent_iso_for_rewrite w x y z
@@ -168,9 +171,12 @@ Section lemmas.
     := Eval simpl in typeof (ap (fun i => @morphism_inverse _ _ _ _ (@isisomorphism_isomorphic _ _ _ i))
                                 (@p_left_identity_of_coherent_iso_for_rewrite x y f)).
   Definition p_left_identity_of_coherent_inverse_for_rewrite x y f
-  : p_left_identity_of_coherent_inverse_for_rewrite_type x y f
-    := ap (fun i => @morphism_inverse _ _ _ _ (@isisomorphism_isomorphic _ _ _ i))
-          (@p_left_identity_of_coherent_iso_for_rewrite x y f).
+  : p_left_identity_of_coherent_inverse_for_rewrite_type x y f.
+  Proof.
+    refine (ap (fun i => @morphism_inverse _ _ _ _ (@isisomorphism_isomorphic _ _ _ i))
+               (@p_left_identity_of_coherent_iso_for_rewrite x y f) @ _)%path.
+    reflexivity.
+  Defined.
 
   Let p_right_identity_of_coherent_for_rewrite_type x y f
     := Eval simpl in typeof (ap (@morphism_isomorphic _ _ _)
@@ -184,7 +190,10 @@ Section lemmas.
     := Eval simpl in typeof (ap (fun i => @morphism_inverse _ _ _ _ (@isisomorphism_isomorphic _ _ _ i))
                                 (@p_right_identity_of_coherent_iso_for_rewrite x y f)).
   Definition p_right_identity_of_coherent_inverse_for_rewrite x y f
-  : p_right_identity_of_coherent_inverse_for_rewrite_type x y f
-    := ap (fun i => @morphism_inverse _ _ _ _ (@isisomorphism_isomorphic _ _ _ i))
-          (@p_right_identity_of_coherent_iso_for_rewrite x y f).
+  : p_right_identity_of_coherent_inverse_for_rewrite_type x y f.
+  Proof.
+    refine (ap (fun i => @morphism_inverse _ _ _ _ (@isisomorphism_isomorphic _ _ _ i))
+               (@p_right_identity_of_coherent_iso_for_rewrite x y f) @ _)%path.
+    reflexivity.
+  Defined.
 End lemmas.


### PR DESCRIPTION
Trunk inlines [abstract] in [Qed]ed proofs, so we might as well not
[abstract] things in the first place.

No idea why this change speeds up
theories/categories/Pseudofunctor/RewriteLaws.v in trunk (though not
HoTT/coq); why are [constructor] and [reflexivity] fast while [exact
idpath] is slow...?
