### PR TITLE
Revert part of 466ce5fc88546baf75dc9e9dead5e1d6af6fd721

### DIFF
--- a/theories/categories/Pseudofunctor/RewriteLaws.v
+++ b/theories/categories/Pseudofunctor/RewriteLaws.v
@@ -83,11 +83,8 @@ Section lemmas.
     Definition p_composition_of_coherent_iso_for_rewrite__isisomorphism_helper__to_inverse
           X
           (H' : X = @Build_Isomorphic (_ -> _) _ _ _ p_composition_of_coherent_iso_for_rewrite__isisomorphism_helper)
-    : @morphism_inverse _ _ _ _ X = inv.
-    Proof.
-      refine (ap (fun i => @morphism_inverse _ _ _ _ (@isisomorphism_isomorphic _ _ _ i)) H' @ _)%path.
-      reflexivity. (** Why is [exact idpath] slow? *)
-    Defined.
+    : @morphism_inverse _ _ _ _ X = inv
+      := ap (fun i => @morphism_inverse _ _ _ _ (@isisomorphism_isomorphic _ _ _ i)) H'.
   End helper.
 
   Lemma p_composition_of_coherent_iso_for_rewrite w x y z
@@ -169,12 +166,9 @@ Section lemmas.
     := Eval simpl in typeof (ap (fun i => @morphism_inverse _ _ _ _ (@isisomorphism_isomorphic _ _ _ i))
                                 (@p_left_identity_of_coherent_iso_for_rewrite x y f)).
   Definition p_left_identity_of_coherent_inverse_for_rewrite x y f
-  : p_left_identity_of_coherent_inverse_for_rewrite_type x y f.
-  Proof.
-    refine (ap (fun i => @morphism_inverse _ _ _ _ (@isisomorphism_isomorphic _ _ _ i))
-               (@p_left_identity_of_coherent_iso_for_rewrite x y f) @ _)%path.
-    reflexivity.
-  Defined.
+  : p_left_identity_of_coherent_inverse_for_rewrite_type x y f
+    := ap (fun i => @morphism_inverse _ _ _ _ (@isisomorphism_isomorphic _ _ _ i))
+          (@p_left_identity_of_coherent_iso_for_rewrite x y f).
 
   Let p_right_identity_of_coherent_for_rewrite_type x y f
     := Eval simpl in typeof (ap (@morphism_isomorphic _ _ _)
@@ -188,10 +182,7 @@ Section lemmas.
     := Eval simpl in typeof (ap (fun i => @morphism_inverse _ _ _ _ (@isisomorphism_isomorphic _ _ _ i))
                                 (@p_right_identity_of_coherent_iso_for_rewrite x y f)).
   Definition p_right_identity_of_coherent_inverse_for_rewrite x y f
-  : p_right_identity_of_coherent_inverse_for_rewrite_type x y f.
-  Proof.
-    refine (ap (fun i => @morphism_inverse _ _ _ _ (@isisomorphism_isomorphic _ _ _ i))
-               (@p_right_identity_of_coherent_iso_for_rewrite x y f) @ _)%path.
-    reflexivity.
-  Defined.
+  : p_right_identity_of_coherent_inverse_for_rewrite_type x y f
+    := ap (fun i => @morphism_inverse _ _ _ _ (@isisomorphism_isomorphic _ _ _ i))
+          (@p_right_identity_of_coherent_iso_for_rewrite x y f).
 End lemmas.


### PR DESCRIPTION
We no longer need it to speed things up in trunk, and this way is
actually a bit faster now.
