### PR TITLE
Mark the arguments to Equiv projections implicit

### DIFF
--- a/theories/Overture.v
+++ b/theories/Overture.v
@@ -246,6 +246,9 @@ Record Equiv A B := BuildEquiv {
 
 Existing Instance equiv_isequiv.
 
+Arguments equiv_fun {A B} _ _.
+Arguments equiv_isequiv {A B} _.
+
 Delimit Scope equiv_scope with equiv.
 Local Open Scope equiv_scope.
 

--- a/theories/categories/Adjoint/HomCoercions.v
+++ b/theories/categories/Adjoint/HomCoercions.v
@@ -220,7 +220,6 @@ Section AdjunctionEquivalences'.
              @isiso_isequiv
                _ _ _ _
                (equiv_isequiv
-                  _ _
                   (equiv_inverse (equiv_hom_set_adjunction T (fst cd) (snd cd))))).
     Grab Existential Variables.
     simpl.

--- a/theories/types/Record.v
+++ b/theories/types/Record.v
@@ -78,7 +78,7 @@ Defined.
 Definition issig_equiv (A B : Type)
   : { f : A -> B & IsEquiv f } <~> Equiv A B.
 Proof.
-  issig (BuildEquiv A B) (equiv_fun A B) (equiv_isequiv A B).
+  issig (BuildEquiv A B) (@equiv_fun A B) (@equiv_isequiv A B).
 Defined.
 
 (** Here is a version of the [issig] tactic for three-component records, which proves goals that look like

--- a/theories/types/Universe.v
+++ b/theories/types/Universe.v
@@ -46,7 +46,7 @@ Definition path_universe {A B : Type} (f : A -> B) {feq : IsEquiv f} : (A = B)
 
 Definition transport_path_universe {A B : Type} (f : A -> B) {feq : IsEquiv f} (z : A)
   : transport (fun X:Type => X) (path_universe f) z = f z
-  := ap10 (ap (equiv_fun A B) (eisretr (equiv_path A B) (BuildEquiv _ _ f feq))) z.
+  := ap10 (ap equiv_fun (eisretr (equiv_path A B) (BuildEquiv _ _ f feq))) z.
 
 (* This somewhat fancier version is useful when working with HITs. *)
 Definition transport_path_universe'
@@ -91,12 +91,12 @@ Proof.
   intros pf1 pf2.
   rewrite <- (eta_path_universe pf1), <- (eta_path_universe pf2).
   lazymatch goal with
-    | [ |- @path_universe _ _ (equiv_fun _ _ ?f) ?Hf
-           = @path_universe _ _ (equiv_fun _ _ ?g) ?Hg ]
-      => change Hf with (equiv_isequiv _ _ f);
-        change Hg with (equiv_isequiv _ _ g);
-        generalize (equiv_isequiv _ _ f) (equiv_isequiv _ _ g);
-        generalize (equiv_fun _ _ f) (equiv_fun _ _ g)
+    | [ |- @path_universe _ _ (equiv_fun ?f) ?Hf
+           = @path_universe _ _ (equiv_fun ?g) ?Hg ]
+      => change Hf with (equiv_isequiv f);
+        change Hg with (equiv_isequiv g);
+        generalize (equiv_isequiv f) (equiv_isequiv g);
+        generalize (equiv_fun f) (equiv_fun g)
   end.
   let f' := fresh in
   let g' := fresh in


### PR DESCRIPTION
This is required for pattern matching on primitive projections to work
(which I hope we'll be moving to soon) (see
https://coq.inria.fr/bugs/show_bug.cgi?id=3503), and also seems nicer;
we generally don't need to talk about the type arguments to [equiv_fun]
and [equiv_isequiv].
