### PR TITLE
Add format specifiers to notations to remove space

### DIFF
--- a/theories/Overture.v
+++ b/theories/Overture.v
@@ -59,9 +59,9 @@ Open Scope fibration_scope.
 Notation pr1 := projT1.
 Notation pr2 := projT2.
 
-(** The following notation is very convenient, although it unfortunately clashes with Proof General's "electric period". *)
-Notation "x .1" := (projT1 x) (at level 3) : fibration_scope.
-Notation "x .2" := (projT2 x) (at level 3) : fibration_scope.
+(** The following notation is very convenient, although it unfortunately clashes with Proof General's "electric period".  We add [format] specifiers so that it will display without an extra space, as [x.1] rather than as [x .1]. *)
+Notation "x .1" := (projT1 x) (at level 3, format "x '.1'") : fibration_scope.
+Notation "x .2" := (projT2 x) (at level 3, format "x '.2'") : fibration_scope.
 
 (** Composition of functions. *)
 Definition compose {A B C : Type} (g : B -> C) (f : A -> B) :=
@@ -133,7 +133,7 @@ Notation "1" := idpath : path_scope.
 Notation "p @ q" := (concat p q) (at level 20) : path_scope.
 
 (** The inverse of a path. *)
-Notation "p ^" := (inverse p) (at level 3) : path_scope.
+Notation "p ^" := (inverse p) (at level 3, format "p '^'") : path_scope.
 
 (** An alternative notation which puts each path on its own line.  Useful as a temporary device during proofs of equalities between very long composites; to turn it on inside a section, say [Open Scope long_path_scope]. *)
 Notation "p @' q" := (concat p q) (at level 21, left associativity,
@@ -256,7 +256,7 @@ Notation "A <~> B" := (Equiv A B) (at level 85) : equiv_scope.
 
 (** A notation for the inverse of an equivalence.  We can apply this to a function as long as there is a typeclass instance asserting it to be an equivalence.  We can also apply it to an element of [A <~> B], since there is an implicit coercion to [A -> B] and also an existing instance of [IsEquiv]. *)
 
-Notation "f ^-1" := (@equiv_inv _ _ f _) (at level 3) : equiv_scope.
+Notation "f ^-1" := (@equiv_inv _ _ f _) (at level 3, format "f '^-1'") : equiv_scope.
 
 (** ** Contractibility and truncation levels *)
 

--- a/theories/categories/Adjoint/Dual.v
+++ b/theories/categories/Adjoint/Dual.v
@@ -64,10 +64,10 @@ Section opposite.
          (unit_counit_equation_1 A).
 End opposite.
 
-Local Notation "A ^op" := (opposite A) : adjunction_scope.
-Local Notation "A ^op'" := (opposite_inv A) : adjunction_scope.
-Local Notation "A ^op'L" := (opposite'L A) (at level 3) : adjunction_scope.
-Local Notation "A ^op'R" := (opposite'R A) (at level 3) : adjunction_scope.
+Local Notation "A ^op" := (opposite A) (at level 3, format "A '^op'") : adjunction_scope.
+Local Notation "A ^op'" := (opposite_inv A) (at level 3, format "A '^op''") : adjunction_scope.
+Local Notation "A ^op'L" := (opposite'L A) (at level 3, format "A '^op'L'") : adjunction_scope.
+Local Notation "A ^op'R" := (opposite'R A) (at level 3, format "A '^op'R'") : adjunction_scope.
 
 Section opposite_involutive.
   Variable C : PreCategory.
@@ -110,8 +110,8 @@ Section opposite_involutive.
 End opposite_involutive.
 
 Module Export AdjointDualNotations.
-  Notation "A ^op" := (opposite A) : adjunction_scope.
-  Notation "A ^op'" := (opposite_inv A) : adjunction_scope.
-  Notation "A ^op'L" := (opposite'L A) (at level 3) : adjunction_scope.
-  Notation "A ^op'R" := (opposite'R A) (at level 3) : adjunction_scope.
+  Notation "A ^op" := (opposite A) (at level 3, format "A '^op'") : adjunction_scope.
+  Notation "A ^op'" := (opposite_inv A) (at level 3, format "A '^op''") : adjunction_scope.
+  Notation "A ^op'L" := (opposite'L A) (at level 3, format "A '^op'L'") : adjunction_scope.
+  Notation "A ^op'R" := (opposite'R A) (at level 3, format "A '^op'R'") : adjunction_scope.
 End AdjointDualNotations.

--- a/theories/categories/Adjoint/Utf8.v
+++ b/theories/categories/Adjoint/Utf8.v
@@ -5,12 +5,9 @@ Infix "⊣" := Adjunction (at level 60, right associativity) : type_scope.
 
 Infix "∘" := compose (at level 40, left associativity) : adjunction_scope.
 
-(* This notation should be [only parsing] for now, because otherwise
-   copy/paste doesn't work, because the parser doesn't recognize the
-   unicode characters [ᵒᵖ].  So, really, this notation is just a
-   reminder to do something when Coq's parser is better. *)
-
-Notation "A 'ᵒᵖ'" := (opposite A) (at level 3, only parsing) : adjunction_scope.
-Notation "A 'ᵒᵖ''" := (opposite_inv A) (at level 3, only parsing) : adjunction_scope.
-Notation "A 'ᵒᵖ'ᴸ'" := (opposite'L A) (at level 3, only parsing) : adjunction_scope.
-Notation "A 'ᵒᵖ'ᴿ'" := (opposite'R A) (at level 3, only parsing) : adjunction_scope.
+(** It would be nice to put [, format "A 'ᵒᵖ'"] here, but that would
+    make this notation unparseable. *)
+Notation "A 'ᵒᵖ'" := (opposite A) (at level 3) : adjunction_scope.
+Notation "A 'ᵒᵖ''" := (opposite_inv A) (at level 3) : adjunction_scope.
+Notation "A 'ᵒᵖ'ᴸ'" := (opposite'L A) (at level 3) : adjunction_scope.
+Notation "A 'ᵒᵖ'ᴿ'" := (opposite'R A) (at level 3) : adjunction_scope.

--- a/theories/categories/Category/Dual.v
+++ b/theories/categories/Category/Dual.v
@@ -26,7 +26,7 @@ Section opposite.
          _.
 End opposite.
 
-Local Notation "C ^op" := (opposite C) (at level 3) : category_scope.
+Local Notation "C ^op" := (opposite C) (at level 3, format "C '^op'") : category_scope.
 
 (** ** [ᵒᵖ] is propositionally involutive *)
 Section DualCategories.
@@ -55,5 +55,5 @@ Section DualObjects.
 End DualObjects.
 
 Module Export CategoryDualNotations.
-  Notation "C ^op" := (opposite C) (at level 3) : category_scope.
+  Notation "C ^op" := (opposite C) (at level 3, format "C '^op'") : category_scope.
 End CategoryDualNotations.

--- a/theories/categories/Category/Morphisms.v
+++ b/theories/categories/Category/Morphisms.v
@@ -18,7 +18,7 @@ Class IsIsomorphism {C : PreCategory} {s d} (m : morphism C s d) :=
     right_inverse : m o morphism_inverse = identity _
   }.
 
-Local Notation "m ^-1" := (morphism_inverse (m := m)) : morphism_scope.
+Local Notation "m ^-1" := (morphism_inverse (m := m)) (at level 3, format "m '^-1'") : morphism_scope.
 
 Hint Resolve left_inverse right_inverse : category morphism.
 Hint Rewrite @left_inverse @right_inverse : category.
@@ -634,7 +634,7 @@ Section associativity_composition.
 End associativity_composition.
 
 Module Export CategoryMorphismsNotations.
-  Notation "m ^-1" := (morphism_inverse (m := m)) : morphism_scope.
+  Notation "m ^-1" := (morphism_inverse (m := m)) (at level 3, format "m '^-1'") : morphism_scope.
 
   Infix "<~=~>" := Isomorphic (at level 70, no associativity) : category_scope.
 

--- a/theories/categories/Category/Utf8.v
+++ b/theories/categories/Category/Utf8.v
@@ -3,18 +3,16 @@ Require Import Category.Core Category.Morphisms Category.Dual Category.Prod Cate
 Require Export Category.Notations.
 
 Infix "∘" := compose (at level 40, left associativity) : morphism_scope.
-Notation "m ⁻¹" := (morphism_inverse (m := m)) (at level 3) : morphism_scope.
+Notation "m ⁻¹" := (morphism_inverse (m := m)) (at level 3, format "m '⁻¹'") : morphism_scope.
 Infix "≅" := Isomorphic (at level 70, no associativity) : category_scope.
 Notation "x ↠ y" := (Epimorphism x y)
                       (at level 99, right associativity, y at level 200).
 Notation "x ↪ y" := (Monomorphism x y)
                       (at level 99, right associativity, y at level 200).
 
-(** This notation should be [only parsing] for now, because otherwise
-    copy/paste doesn't work, because the parser doesn't recognize the
-    unicode characters [ᵒᵖ].  So, really, this notation is just a
-    reminder to do something when Coq's parser is better. *)
-Notation "C 'ᵒᵖ'" := (opposite C) (at level 3, only parsing) : category_scope.
+(** It would be nice to put [, format "C 'ᵒᵖ'"] here, but that makes
+    this notation unparseable. *)
+Notation "C 'ᵒᵖ'" := (opposite C) (at level 3) : category_scope.
 
 Notation "∀  x .. y , P" := (forall x, .. (forall y, P) ..)
                               (at level 200, x binder, y binder, right associativity).

--- a/theories/categories/Functor/Dual.v
+++ b/theories/categories/Functor/Dual.v
@@ -46,10 +46,10 @@ Section opposite.
                      (identity_of F).
 End opposite.
 
-Local Notation "F ^op" := (opposite F) : functor_scope.
-Local Notation "F ^op'" := (opposite_inv F) (at level 3) : functor_scope.
-Local Notation "F ^op'L" := (opposite_invL F) (at level 3) : functor_scope.
-Local Notation "F ^op'R" := (opposite_invR F) (at level 3) : functor_scope.
+Local Notation "F ^op" := (opposite F) (at level 3, format "F ^op") : functor_scope.
+Local Notation "F ^op'" := (opposite_inv F) (at level 3, format "F ^op'") : functor_scope.
+Local Notation "F ^op'L" := (opposite_invL F) (at level 3, format "F ^op'L") : functor_scope.
+Local Notation "F ^op'R" := (opposite_invR F) (at level 3, format "F ^op'R") : functor_scope.
 
 Section opposite_involutive.
   Local Open Scope functor_scope.
@@ -91,8 +91,8 @@ Section opposite_involutive.
 End opposite_involutive.
 
 Module Export FunctorDualNotations.
-  Notation "F ^op" := (opposite F) : functor_scope.
-  Notation "F ^op'" := (opposite_inv F) (at level 3) : functor_scope.
-  Notation "F ^op'L" := (opposite_invL F) (at level 3) : functor_scope.
-  Notation "F ^op'R" := (opposite_invR F) (at level 3) : functor_scope.
+  Notation "F ^op" := (opposite F) (at level 3, format "F ^op") : functor_scope.
+  Notation "F ^op'" := (opposite_inv F) (at level 3, format "F ^op'") : functor_scope.
+  Notation "F ^op'L" := (opposite_invL F) (at level 3, format "F ^op'L") : functor_scope.
+  Notation "F ^op'R" := (opposite_invR F) (at level 3, format "F ^op'R") : functor_scope.
 End FunctorDualNotations.

--- a/theories/categories/InitialTerminalCategory/Functors.v
+++ b/theories/categories/InitialTerminalCategory/Functors.v
@@ -53,7 +53,7 @@ Definition from_1 C c : Functor 1 C
 Definition from_0 C : Functor 0 C
   := Eval simpl in from_initial C.
 
-Local Notation "! x" := (from_terminal _ x) (at level 3) : functor_scope.
+Local Notation "! x" := (from_terminal _ x) (at level 3, format "'!' x") : functor_scope.
 
 (** *** Uniqueness principles about initial and terminal categories and functors *)
 Section unique.
@@ -108,5 +108,5 @@ Section unique.
 End unique.
 
 Module Export InitialTerminalCategoryFunctorsNotations.
-  Notation "! x" := (from_terminal _ x) : functor_scope.
+  Notation "! x" := (from_terminal _ x) (at level 3, format "'!' x") : functor_scope.
 End InitialTerminalCategoryFunctorsNotations.

--- a/theories/categories/InitialTerminalCategory/Pseudofunctors.v
+++ b/theories/categories/InitialTerminalCategory/Pseudofunctors.v
@@ -61,8 +61,8 @@ Definition from_1 `{Funext} c : Pseudofunctor 1
 Definition from_0 `{Funext} : Pseudofunctor 0
   := Eval simpl in from_initial.
 
-Local Notation "! x" := (from_terminal x) (at level 3) : pseudofunctor_scope.
+Local Notation "! x" := (from_terminal x) (at level 3, format "'!' x") : pseudofunctor_scope.
 
 Module Export InitialTerminalCategoryPseudofunctorsNotations.
-  Notation "! x" := (from_terminal x) : pseudofunctor_scope.
+  Notation "! x" := (from_terminal x) (at level 3, format "'!' x") : pseudofunctor_scope.
 End InitialTerminalCategoryPseudofunctorsNotations.

--- a/theories/categories/NaturalTransformation/Dual.v
+++ b/theories/categories/NaturalTransformation/Dual.v
@@ -54,10 +54,10 @@ Section opposite.
                                     (fun s d => commutes T d s).
 End opposite.
 
-Notation "T ^op" := (opposite T) : natural_transformation_scope.
-Notation "T ^op'" := (opposite' T) : natural_transformation_scope.
-Notation "T ^op''" := (opposite_finv T) (at level 3) : natural_transformation_scope.
-Notation "T ^op'''" := (opposite_tinv T) (at level 3) : natural_transformation_scope.
+Local Notation "T ^op" := (opposite T) (at level 3, format "T ^op") : natural_transformation_scope.
+Local Notation "T ^op'" := (opposite' T) (at level 3, format "T ^op'") : natural_transformation_scope.
+Local Notation "T ^op''" := (opposite_finv T) (at level 3, format "T ^op''") : natural_transformation_scope.
+Local Notation "T ^op'''" := (opposite_tinv T) (at level 3, format "T ^op'''") : natural_transformation_scope.
 
 (** ** [ᵒᵖ] is propositionally involutive *)
 Section opposite_involutive.
@@ -94,8 +94,8 @@ Section opposite_involutive.
 End opposite_involutive.
 
 Module Export NaturalTransformationDualNotations.
-  Notation "T ^op" := (opposite T) : natural_transformation_scope.
-  Notation "T ^op'" := (opposite' T) : natural_transformation_scope.
-  Notation "T ^op''" := (opposite_finv T) : natural_transformation_scope.
-  Notation "T ^op'''" := (opposite_tinv T) : natural_transformation_scope.
+  Notation "T ^op" := (opposite T) (at level 3, format "T ^op") : natural_transformation_scope.
+  Notation "T ^op'" := (opposite' T) (at level 3, format "T ^op'") : natural_transformation_scope.
+  Notation "T ^op''" := (opposite_finv T) (at level 3, format "T ^op''") : natural_transformation_scope.
+  Notation "T ^op'''" := (opposite_tinv T) (at level 3, format "T ^op'''") : natural_transformation_scope.
 End NaturalTransformationDualNotations.


### PR DESCRIPTION
Now things like `p^` will display as `p^` rather than `p ^`.  This means that confusing expressions like

```
p ^ @ ! x
```

will be rendered as the less confusing

```
p^ @ !x
```
