### PR TITLE
Fix /etc/install_coq.sh for OSX

### DIFF
--- a/etc/install_coq.sh
+++ b/etc/install_coq.sh
@@ -43,4 +43,4 @@ make coqlight coqide
 popd
 
 popd 1>/dev/null
-#popd 1>/dev/null
+popd 1>/dev/null


### PR DESCRIPTION
It turns out that `cd` on my OSX prints out the directory it goes to, so `$DIR` ended up having two copies of the same directory. This closes #438
