### PR TITLE
Don't match on pairs where we don't need to

### DIFF
--- a/theories/categories/Category/Sum.v
+++ b/theories/categories/Category/Sum.v
@@ -12,10 +12,10 @@ Section internals.
   Variable D : PreCategory.
 
   Definition sum_morphism (s d : C + D) : Type
-    := match (s, d) with
-         | (inl s, inl d) => morphism C s d
-         | (inr s, inr d) => morphism D s d
-         | _ => Empty
+    := match s, d with
+         | inl s, inl d => morphism C s d
+         | inr s, inr d => morphism D s d
+         | _, _ => Empty
        end.
 
   Global Arguments sum_morphism _ _ / .


### PR DESCRIPTION
It's slightly better style, I think, to do it this way.  Also, when we
move to primitive projections, this code will break (see
https://coq.inria.fr/bugs/show_bug.cgi?id=3558).
