### PR TITLE
unify ap_ap10 and apD10_ap_*

### DIFF
--- a/theories/PathGroupoids.v
+++ b/theories/PathGroupoids.v
@@ -541,18 +541,26 @@ Definition ap10_V {A B} {f g : A->B} (h : f = g) (x:A)
   : ap10 (h^) x = (ap10 h x)^
 := apD10_V h x.
 
-(** [ap10] also behaves nicely on paths produced by [ap] *)
-Lemma ap_ap10 {A B C} (f g : A -> B) (h : B -> C)
-  (p : f = g) (a : A) :
-  ap h (ap10 p a) = ap10 (ap (fun f' => h o f') p) a.
+(** [apD10] and [ap10] also behave nicely on paths produced by [ap] *)
+Definition apD10_ap_precompose {A B C} (f : A -> B) {g g' : forall x:B, C x} (p : g = g') a
+: apD10 (ap (fun h : forall x:B, C x => h oD f) p) a = apD10 p (f a).
 Proof.
-  destruct p. exact 1.
+  destruct p; reflexivity.
 Defined.
 
-Lemma ap_ap10_L {A B C} (g h : A -> B) (f : C -> A) (p : g = h) (a : C) : ap10 (ap (fun f0 => f0 o f) p) a = ap10 p (f a).
+Definition ap10_ap_precompose {A B C} (f : A -> B) {g g' : B -> C} (p : g = g') a
+: ap10 (ap (fun h : B -> C => h o f) p) a = ap10 p (f a)
+:= apD10_ap_precompose f p a.
+
+Definition apD10_ap_postcompose {A B C} (f : forall x, B x -> C) {g g' : forall x:A, B x} (p : g = g') a
+: apD10 (ap (fun h : forall x:A, B x => fun x => f x (h x)) p) a = ap (f a) (apD10 p a).
 Proof.
-  destruct p. exact idpath.
+  destruct p; reflexivity.
 Defined.
+
+Definition ap10_ap_postcompose {A B C} (f : B -> C) {g g' : A -> B} (p : g = g') a
+: ap10 (ap (fun h : A -> B => f o h) p) a = ap f (ap10 p a)
+:= apD10_ap_postcompose (fun a => f) p a.
 
 (** *** Transport and the groupoid structure of paths *)
 
@@ -671,18 +679,6 @@ Defined.
 Lemma transport_precompose {A B C} (f : A -> B) (g g' : B -> C) (p : g = g')
 : transport (fun h : B -> C => g o f = h o f) p 1 =
   ap (fun h => h o f) p.
-Proof.
-  destruct p; reflexivity.
-Defined.
-
-Lemma apD10_ap_precompose {A B C} (f : A -> B) (g g' : B -> C) (p : g = g') a
-: apD10 (ap (fun h : B -> C => h o f) p) a = apD10 p (f a).
-Proof.
-  destruct p; reflexivity.
-Defined.
-
-Lemma apD10_ap_postcompose {A B C} (f : B -> C) (g g' : A -> B) (p : g = g') a
-: apD10 (ap (fun h : A -> B => f o h) p) a = ap f (apD10 p a).
 Proof.
   destruct p; reflexivity.
 Defined.

--- a/theories/ReflectiveSubuniverse.v
+++ b/theories/ReflectiveSubuniverse.v
@@ -177,7 +177,7 @@ Section Reflective_Subuniverse.
     : forall a, ap10 (path_arrow_modal A B _ _ pi) (eta a) = ap10 pi a.
     Proof.
       intros a.
-      refine ((ap_ap10_L _ _ eta (path_arrow_modal A B f g pi) a) ^ @ _).
+      refine ((ap10_ap_precompose eta (path_arrow_modal A B f g pi) a) ^ @ _).
       apply (ap (fun h => ap10 h a)).
       unfold path_arrow_modal, equiv_inj.
       apply eisretr.
@@ -313,7 +313,7 @@ Section Reflective_Subuniverse.
         unfold eqid. rewrite ap10_path_arrow_modal.
         refine (_ @ pr2_path (ap10 (O_rec_retr A Z g') a)).
         apply (ap (fun p => transport B p _)).
-        exact ((ap_ap10 (f' o O_unit subU A) g' pr1 eqf a)^).
+        exact (ap10_ap_postcompose pr1 eqf a).
       - intros H A B.
         pose (h := fun x => O_rec ({x:A & B x}) A pr1 x).
         pose (p := (fun z => ap10 (O_rec_retr ({x : A & B x}) A pr1) z)
@@ -341,7 +341,7 @@ Section Reflective_Subuniverse.
           apply path_arrow; intro v. exact v. }
         exact (ap10 p u).
       - hnf.
-        rewrite <- ap_ap10_L.
+        rewrite <- ap10_ap_precompose.
         rewrite eisretr. 
         rewrite ap10_path_arrow; reflexivity.
     Qed.

--- a/theories/hit/epi.v
+++ b/theories/hit/epi.v
@@ -1,5 +1,5 @@
 Require Import Overture hit.minus1Trunc HProp Misc TruncType types.Universe Equivalences Trunc HSet types.Unit UnivalenceImpliesFunext.
-Require Import TruncType hit.Pushout hit.Truncations types.Forall types.Sigma Contractible PathGroupoids types.Paths.
+Require Import TruncType hit.Pushout hit.Truncations types.Forall types.Arrow types.Sigma Contractible PathGroupoids types.Paths.
 
 Open Local Scope path_scope.
 Open Local Scope equiv_scope.
@@ -81,7 +81,7 @@ Section cones.
     assert (X : l = r) by (pose (hepi {| setT := cone f |} (truncation_incl o push o inl)); apply path_contr).
     subst l r.
 
-    pose (I0 b := apD10 (X ..1) b).
+    pose (I0 b := ap10 (X ..1) b).
     refine (Truncation_rect _ _).
     pose (fun a : B + Unit => (match a as a return cone_point _ = truncation_incl (push a) with
                                  | inl a' => (I0 a')^
@@ -93,11 +93,11 @@ Section cones.
     unfold cone_point.
     subst I0. simpl.
     pose (X..2) as p. simpl in p. rewrite transport_precompose in p.
-    assert (H':=concat (ap (fun x => apD10 x a) p) (apD10_ap_postcompose truncation_incl _ _ (path_forall pushl pushr pp) _)).
-    rewrite (apD10_path_forall _ _ _ a) in H'.
+    assert (H':=concat (ap (fun x => ap10 x a) p) (ap10_ap_postcompose truncation_incl (path_arrow pushl pushr pp) _)).
+    rewrite ap10_path_arrow in H'.
     clear p.
     (** Apparently [pose; clearbody] is only ~.8 seconds, while [pose proof] is ~4 seconds? *)
-    pose (concat (apD10_ap_precompose f _ _ (X ..1) a)^ H') as p.
+    pose (concat (ap10_ap_precompose f (X ..1) a)^ H') as p.
     clearbody p.
     simpl in p.
     rewrite p.


### PR DESCRIPTION
We had some duplicate lemmas in `PathGroupoids.v`: `ap_ap10` and `ap_ap10_L` were essentially the same as `apD10_ap_postcompose` and `apD10_ap_precompose`.  Moreover, the latter were not stated in the appropriate dependent generality for their names.  This commit generalizes them and defines corresponding non-dependent versions `ap10_ap_*`.  It is on top of #448 (which uses them) and part of #440 (since it uses `composeD`).
