### PR TITLE
Remove a useless match

### DIFF
--- a/theories/categories/Functor/Prod/Universal.v
+++ b/theories/categories/Functor/Prod/Universal.v
@@ -72,8 +72,6 @@ Section universal.
                  | _ => reflexivity
                  | _ => progress simpl
                  | _ => rewrite !transport_forall_constant
-                 | [ |- appcontext[?f (transport ?P ?p ?z)] ]
-                   => rewrite (@ap_transport _ P _ _ _ p (fun _ => f) z)
                end.
         transport_path_forall_hammer.
         unfold unique_helper.


### PR DESCRIPTION
Discovered as useless due to a bug in Coq trunk:
https://coq.inria.fr/bugs/show_bug.cgi?id=3561
