### PR TITLE
Revert "Remove [path_via]"

### DIFF
--- a/contrib/Freudenthal.v
+++ b/contrib/Freudenthal.v
@@ -119,7 +119,7 @@ Proof.
   intros x. apply (@path_forall (fst funext_large)); intros p.
   refine (transport_arrow _ _ _ @ _).
   refine (transport_const _ _ @ _).
-  transitivity (FST_Codes_No (p @ (mer x)^)); auto with path_hints.
+  path_via (FST_Codes_No (p @ (mer x)^)).
     apply ap, transport_paths_r.
   apply path_universe_uncurried.
   exists (FST_Codes_cross x p).
@@ -207,10 +207,10 @@ Definition FST_Codes_contr_No (p : No = No) (rr : FST_Codes No p)
 Proof.
   revert rr. apply Truncation_rect. intros ?; apply trunc_succ.
   intros [x1 r]. destruct r. unfold FST_Codes_center. simpl.
-  transitivity (truncation_incl
+  path_via (truncation_incl
     (transport (fun p => hfiber mer' p) (transport_paths_r p 1 @ concat_1p p)
     (transportD (paths No)
-; auto with path_hints; simpl in *.
+simpl in *.
 
 Global Instance Freudenthal
   : IsConnMap (n -2+ n) (@merid X).

--- a/theories/Contractible.v
+++ b/theories/Contractible.v
@@ -19,7 +19,7 @@ Definition path2_contr `{Contr A} {x y : A} (p q : x = y) : p = q.
 Proof.
   assert (K : forall (r : x = y), r = path_contr x y).
     intro r; destruct r; symmetry; now apply concat_Vp.
-  transitivity (path_contr x y); auto with path_hints.
+  path_via (path_contr x y).
 Defined.
 
 (** It follows that any space of paths in a contractible space is contractible. *)

--- a/theories/HSet.v
+++ b/theories/HSet.v
@@ -83,7 +83,7 @@ Proof.
   destruct q as [q | q'].
     intro qp0; apply (cancelL q). transitivity (transport _ p q).
       symmetry; apply transport_paths_r.
-      transitivity q; auto with path_hints. apply @inl_injective with (B := (~ x = x)).
+      path_via q. apply @inl_injective with (B := (~ x = x)).
       exact ((ap_transport p (fun y => @inl (x = y) (~x = y)) q) @ qp0).
   induction (q' p).
 Defined.

--- a/theories/Overture.v
+++ b/theories/Overture.v
@@ -413,6 +413,9 @@ Hint Resolve
 
 Hint Resolve @idpath : core.
 
+Ltac path_via mid :=
+  transitivity mid; auto with path_hints.
+
 (** We put [Empty] here, instead of in [Empty.v], because [Ltac done] uses it. *)
 (** HoTT/coq is broken and somehow interprets [Type1] as [Prop] with regard to elimination schemes. *)
 Unset Elimination Schemes.

--- a/theories/hit/V.v
+++ b/theories/hit/V.v
@@ -250,10 +250,10 @@ Proof.
   intros A B f g eqimg _ _ _. apply path_iff_hProp_uncurried; split; simpl.
   - intro H. refine (minus1Trunc_ind _ H).
     intros [a p]. generalize (fst eqimg a). apply minus1Trunc_map.
-    intros [b p']. exists b. transitivity (f a); auto with path_hints.
+    intros [b p']. exists b. path_via (f a).
   - intro H. refine (minus1Trunc_ind _ H).
     intros [b p]. generalize (snd eqimg b). apply minus1Trunc_map.
-    intros [a p']. exists a. transitivity (g b); auto with path_hints.
+    intros [a p']. exists a. path_via (g b).
 Defined.
 
 Notation "x ∈ v" := (mem x v)
@@ -385,7 +385,7 @@ Proof.
       refine (quotient_rect (ker_bisim f) _ _ _). intros a' p p'.
       + apply related_classes_eq.
         refine (transport (fun X => X) (bisimulation_equals_id _ _) _).
-        transitivity (m (e a)); auto with path_hints. transitivity (m (e a')); auto with path_hints.
+        path_via (m (e a)). path_via (m (e a')).
         exact (p @ p'^).
       + intros; apply allpath_hprop.
       + intros; apply allpath_hprop. }
@@ -736,7 +736,7 @@ Proof.
       generalize (transport (fun z => [x, y] ∈ z) p_phi^ Hy). apply minus1Trunc_ind. intros [a p].
       generalize (transport (fun z => [x, y'] ∈ z) p_phi^ Hy'). apply minus1Trunc_ind. intros [a' p'].
       destruct (fst path_pair_ord p) as (px, py). destruct (fst path_pair_ord p') as (px', py').
-      transitivity (func_of_members (h a)); auto with path_hints. transitivity (func_of_members (h a')); auto with path_hints.
+      path_via (func_of_members (h a)). path_via (func_of_members (h a')).
       refine (ap func_of_members _). refine (ap h _).
       apply (is_mono_isinj func_of_members is_mono_funcofmembers a a' (px @ px'^)).
   - intros ((H1, H2), H3). simpl.
@@ -755,7 +755,7 @@ Proof.
       exact (transport (fun w => w ∈ phi) Ha (pr2 (h a))).
     + intros z Hz. simpl.
       generalize (H1 z Hz). apply minus1Trunc_map. intros [(a,b) p]. simpl in p.
-      exists a. transitivity ([func_of_members a, func_of_members b]); auto with path_hints.
+      exists a. path_via ([func_of_members a, func_of_members b]).
       apply path_pair_ord. split. reflexivity.
       apply H3 with (func_of_members a). split.
       exact (pr2 (h a)).
@@ -771,7 +771,7 @@ Proof.
     intros [a p]. exists (f a). split. apply min1; exists a; auto. assumption.
   - apply minus1Trunc_ind.
     intros [z [h p]]. generalize h. apply minus1Trunc_map.
-    intros [a p']. exists a. transitivity (r z); auto with path_hints. exact (ap r p').
+    intros [a p']. exists a. path_via (r z). exact (ap r p').
 Qed.
 
 Lemma separation (C : V -> hProp) : forall a : V,

--- a/theories/hit/epi.v
+++ b/theories/hit/epi.v
@@ -113,7 +113,7 @@ apply (minus1Trunc_rect_nondep (A:=(sigT (fun x : X => f x = y))));
   try assumption.
  intros [x p]. set (p0:=apD10 ep x).
  transitivity (g (f x)). by apply ap.
- transitivity (h (f x)); auto with path_hints. by apply ap.
+ path_via (h (f x)). by apply ap.
 intros. by apply @set_path2.
 Qed.
 

--- a/theories/types/ObjectClassifier.v
+++ b/theories/types/ObjectClassifier.v
@@ -100,10 +100,10 @@ Theorem transport_exp (U V:Type)(w:U<~>V): forall (f:U->A),
 set (p:=equiv_induction (fun (U:Type) (V:Type) w => forall f : U -> A,
  (@transport _ (fun I : Type => I -> A) U V (path_universe w) f) = (exp w f))).
 apply p.
-intros T f. transitivity f; auto with path_hints.
-transitivity (@transport _ (fun I : Type => I -> A) _ _
-  (path_universe (equiv_path _ _ (idpath T) )) f); auto with path_hints.
-transitivity (@transport Type (fun I : Type => I -> A) T T (idpath T) f ); auto with path_hints.
+intros T f. path_via f.
+path_via (@transport _ (fun I : Type => I -> A) _ _
+  (path_universe (equiv_path _ _ (idpath T) )) f).
+path_via (@transport Type (fun I : Type => I -> A) T T (idpath T) f ).
 apply (@transport2 Type (fun I:Type => I-> A) T T).
 apply eta_path_universe.
 Qed.


### PR DESCRIPTION
This reverts commit dd9121da211cdcb3cdb434a0da2cf10b178eee58.

As per @mikeshulman's
https://github.com/HoTT/HoTT/pull/451#issuecomment-54104523:

> I don't understand why we are so cavalier about replacing a tactic
> that's used throughout the library by a tactic that does something
> different.  I think we should revert this change and then continue the
> discussion about the advantages and disadvantages of all possible
> options before making a decision.
> 
> My experience suggests that even if we manage to make transitivity
> "pretend" that it is just concat, eventually it will bite someone
> somewhere.
> 
> Also, there's undoubtedly a reason why we added `auto with path_hints`
> to `path_via`.  Is the questionable advantage of calling the tactic
> "transitivity" worth having to type that manually every time we need
> it?
