### PR TITLE
Restore the old definition of path_via

### DIFF
--- a/theories/Overture.v
+++ b/theories/Overture.v
@@ -414,7 +414,7 @@ Hint Resolve
 Hint Resolve @idpath : core.
 
 Ltac path_via mid :=
-  transitivity mid; auto with path_hints.
+  apply @concat with (y := mid); auto with path_hints.
 
 (** We put [Empty] here, instead of in [Empty.v], because [Ltac done] uses it. *)
 (** HoTT/coq is broken and somehow interprets [Type1] as [Prop] with regard to elimination schemes. *)


### PR DESCRIPTION
As per #454 / #451.
