### PR TITLE
-emacs-U is deprecated

### DIFF
--- a/contrib/old/HIT/ImpredicativeInterval.v
+++ b/contrib/old/HIT/ImpredicativeInterval.v
@@ -75,6 +75,6 @@ Defined.
 
 (*
 Local Variables:
-coq-prog-args: ("-emacs-U" "-impredicative-set")
+coq-prog-args: ("-emacs" "-impredicative-set")
 End:
 *)

--- a/coq/theories/.dir-locals.el
+++ b/coq/theories/.dir-locals.el
@@ -1,4 +1,4 @@
 ((coq-mode . ((eval . (let ((default-directory (locate-dominating-file
                                                 buffer-file-name ".dir-locals.el")))
                         (make-local-variable 'coq-prog-args)
-                        (setq coq-prog-args `("-no-native-compiler" "-indices-matter" "-boot" "-nois" "-coqlib" ,(expand-file-name "..") "-R" ,(expand-file-name ".") "Coq" "-emacs-U")))))))
+                        (setq coq-prog-args `("-no-native-compiler" "-indices-matter" "-boot" "-nois" "-coqlib" ,(expand-file-name "..") "-R" ,(expand-file-name ".") "Coq" "-emacs")))))))


### PR DESCRIPTION
Use -emacs instead in .dir-locals.el

I'm going to merge this directly, because it doesn't touch anything of real significance.
