### PR TITLE
Update the install script to retry after cleaning

### DIFF
--- a/etc/install_coq.sh
+++ b/etc/install_coq.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 
-# exit immediately if any command fails
-set -e
+# exit immediately if you interrupt or kill this script
+trap "exit 1" SIGHUP SIGINT SIGTERM
 
 # in case we're run from out of git repo
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-pushd "$DIR" 1>/dev/null
+pushd "$DIR" 1>/dev/null || exit 1
 
 # now change to the git root
 ROOT_DIR="$(git rev-parse --show-toplevel)"
-pushd "$ROOT_DIR" 1>/dev/null
+pushd "$ROOT_DIR" 1>/dev/null || exit 1
 
 if test ! -d .git
 then
@@ -19,27 +19,26 @@ then
 fi
 
 echo '$ git submodule sync'
-git submodule sync
+git submodule sync || exit 1
 echo '$ git submodule update --init --recursive'
-git submodule update --init --recursive
+git submodule update --init --recursive || exit 1
 
-pushd coq-HoTT
-echo '$ Patching configure'
-if [ ! -z "$(grep '\[ "$MAKEVERSIONMAJOR" -eq 3 -a "$MAKEVERSIONMINOR" -ge 81 \]' configure)" ]
-then sed -e 's/\[ "$MAKEVERSIONMAJOR" -eq 3 -a "$MAKEVERSIONMINOR" -ge 81 \]/[ "$MAKEVERSIONMAJOR" -eq 3 -a "$MAKEVERSIONMINOR" -ge 81 -o "$MAKEVERSIONMAJOR" -gt 3 ]/g' \
-	 <configure >configure.tmp
-     mv configure.tmp configure
-     chmod a+x configure
-fi
-if [ ! -z "$(grep fno-defer-pop configure)" ]
-then sed -e 's/-fno-defer-pop//' <configure >configure.tmp
-     mv configure.tmp configure
-     chmod a+x configure
-fi
+pushd coq-HoTT || exit 1
 echo '$ ./configure -local '"$@"
-./configure -local "$@"
+./configure -local "$@" || exit 1
 echo '$ make coqlight coqide'
 make coqlight coqide
+if [ $? -ne 0 ]
+then
+    echo "make failed; cleaning the directory and trying again"
+    sleep 3
+    git clean -xfd || echo 'WARNING: Cleaning failed'
+    git reset --hard || echo 'WARNING: Cleaning failed'
+    echo '$ ./configure -local '"$@"
+    ./configure -local "$@" || exit 1
+    echo '$ make coqlight coqide'
+    make coqlight coqide || exit 1
+fi
 popd
 
 popd 1>/dev/null


### PR DESCRIPTION
Sometimes, Coq's Makefile is terrible at noticing that things have
changed.  So we try to clean up if `make` fails.

Also, we don't need to patch `configure` anymore; Coq trunk uses a
configure.ml file.

Warning: this has only been lightly tested
