### PR TITLE
Don't use "Set Implicit Arguments" in the core.

### DIFF
--- a/STYLE.txt
+++ b/STYLE.txt
@@ -290,3 +290,13 @@ Definition concat_p1 {A : Type} {x y : A} (p : x = y) : p @ 1 = p
 
 Of course, if the term is longer than one line, it should be broken
 across lines, with later lines indented further.
+
+
+7. IMPLICIT ARGUMENTS
+
+Do not use "Set Implicit Arguments" in the core.  It makes it
+difficult for a newcomer to read the code; use braces {...} to
+explicitly mark which arguments are implicit.  If necessary, you can
+use the "Arguments" command to adjust implicitness of arguments after
+a function is defined, but this should be avoided if possible for the
+same reason.

--- a/theories/Tactics.v
+++ b/theories/Tactics.v
@@ -3,8 +3,6 @@
 Require Import Overture types.Prod types.Forall PathGroupoids Contractible types.Paths.
 Require Export Tactics.BinderApply.
 
-Set Implicit Arguments.
-
 (** * Extra tactics for homotopy type theory. *)
 
 (** ** Tactics for dealing with [Funext] *)
@@ -237,20 +235,20 @@ Ltac step_clear_paths_in_match :=
 Ltac clear_paths_in_match := progress repeat step_clear_paths_in_match.
 
 (** Now some lemmas about trivial [match]es *)
-Definition match_eta T (x y : T) (H0 : x = y)
+Definition match_eta {T} {x y : T} (H0 : x = y)
 : (H0 = match H0 in (_ = y) return (x = y) with
           | idpath => idpath
         end)
   := match H0 with idpath => idpath end.
 
-Definition match_eta1 T (x : T) (E : x = x)
+Definition match_eta1 {T} {x : T} (E : x = x)
 : (match E in (_ = y) return (x = y) with
      | idpath => idpath
    end = idpath)
   -> idpath = E
   := fun H => ((H # match_eta E) ^)%path.
 
-Definition match_eta2 T (x : T) (E : x = x)
+Definition match_eta2 {T} {x : T} (E : x = x)
 : (idpath
    = match E in (_ = y) return (x = y) with
        | idpath => idpath

--- a/theories/UnivalenceImpliesFunext.v
+++ b/theories/UnivalenceImpliesFunext.v
@@ -1,7 +1,6 @@
 Require Import Overture types.Universe FunextVarieties Equivalences types.Paths types.Unit.
 
 Generalizable All Variables.
-Set Implicit Arguments.
 
 (** * Univalence Implies Functional Extensionality *)
 

--- a/theories/types/Sum.v
+++ b/theories/types/Sum.v
@@ -7,7 +7,6 @@ Require Import types.Bool types.Forall types.Sigma.
 Local Open Scope path_scope.
 Local Open Scope equiv_scope.
 Generalizable Variables X A B f g n.
-Set Implicit Arguments.
 
 (** ** CoUnpacking *)
 
@@ -33,7 +32,7 @@ Definition path_sum {A B : Type} (z z' : A + B)
   destruct z, z', pq; exact idpath.
 Defined.
 
-Definition path_sum_inv {A B : Type} (z z' : A + B)
+Definition path_sum_inv {A B : Type} {z z' : A + B}
            (pq : z = z')
 : match z, z' with
     | inl z0, inl z'0 => z0 = z'0
@@ -155,7 +154,7 @@ Defined.
 
 (** Ordinary universal mapping properties are expressed as equivalences of sets or spaces of functions.  In type theory, we can go beyond this and express an equivalence of types of *dependent* functions. *)
 
-Definition sum_rect_uncurried A B (P : A + B -> Type)
+Definition sum_rect_uncurried {A B} (P : A + B -> Type)
            (fg : (forall a, P (inl a)) * (forall b, P (inr b)))
 : forall s, P s
   := @sum_rect A B P (fst fg) (snd fg).

--- a/theories/types/UniverseLevel.v
+++ b/theories/types/UniverseLevel.v
@@ -1,7 +1,5 @@
 Require Import Overture.
 
-Set Implicit Arguments.
-
 (** * Universe Levels *)
 
 (** We provide casting definitions for raising universe levels. *)


### PR DESCRIPTION
I am aware that this may be controversial, so feel free to object.  But personally, I dislike "Set Implicit Arguments" a lot; it annoys me to no end when I read a function definition and realize that I can't tell by looking at it which arguments are implicit; I have to compile it and ask Coq.  It's also not clear to me that Coq always makes the "right" choice anyway.
