### PR TITLE
make clean in the install script

### DIFF
--- a/etc/install_coq.sh
+++ b/etc/install_coq.sh
@@ -41,5 +41,9 @@ then
 fi
 popd
 
+# now clean the HoTT repository, so that we don't have inconsistent compiled files
+echo '$ make clean'
+make clean
+
 popd 1>/dev/null
 popd 1>/dev/null


### PR DESCRIPTION
As per
https://github.com/HoTT/HoTT/commit/bab2b34719108dbc5da66ac40c6fe01e64f4071b#commitcomment-7695206,
this will prevent having subtlely inconsistent .vo files when you
recompile Coq.
