### PR TITLE
Include useful redundant data in modalities

### DIFF
--- a/contrib/Freudenthal.v
+++ b/contrib/Freudenthal.v
@@ -112,13 +112,8 @@ Proof.
   { hnf. apply Truncation_rect. intros ?; apply trunc_succ.
     intros [x r]; simpl.
     unfold functor_sigma; simpl.
-    unfold wedge_incl_elim_uncurried.
-    simpl.
-    apply symmetry.
-    etransitivity.
-    refine (ap10 (wedge_incl_comp1 x0 x0 _ _ _ _ x) r).
-    unfold FST_Codes_cross_x0.
-    reflexivity. }
+    symmetry.
+    exact (ap10 (wedge_incl_comp1 x0 x0 _ _ _ _ x) r). }
 Defined.
 
 Definition FST_Codes

--- a/theories/HProp.v
+++ b/theories/HProp.v
@@ -104,6 +104,14 @@ Defined.
 (** Two propositions are equivalent as soon as there are maps in both
    directions. *)
 
+Definition isequiv_iff_hprop `{IsHProp A} `{IsHProp B}
+  (f : A -> B) (g : B -> A)
+: IsEquiv f.
+Proof.
+  apply (isequiv_adjointify f g);
+    intros ?; apply allpath_hprop.
+Defined.
+
 Definition equiv_iff_hprop_uncurried `{IsHProp A} `{IsHProp B}
   : (A <-> B) -> (A <~> B).
 Proof.

--- a/theories/Modality.v
+++ b/theories/Modality.v
@@ -1,7 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 
-Require Import Overture PathGroupoids HProp Equivalences EquivalenceVarieties
-        UnivalenceImpliesFunext.
+Require Import Overture PathGroupoids HProp Equivalences EquivalenceVarieties.
 Require Import types.Empty types.Unit types.Arrow types.Sigma types.Paths
         types.Forall types.Prod types.Universe ObjectClassifier.
 Require Import ReflectiveSubuniverse.
@@ -11,71 +10,141 @@ Local Open Scope equiv_scope.
 
 (** * Modalities *)
 
-Section Modalities.
-  Context `{Funext}.
+(** A modality consists of *)
+Class Modality :=
+  {
+    (** a replete [UnitSubuniverse], whose types are called "modal", *)
+    mod_usubu : UnitSubuniverse ;
+    mod_replete : Replete mod_usubu ;
+    (** an induction principle into families of modal types *)
+    O_rect : forall A (B : O A -> Type) (B_inO : forall oa, inO (B oa)),
+               (forall a, B (O_unit A a)) -> forall a, B a ;
+    (** with a computation rule *)
+    O_rect_beta : forall A B B_inO (f : forall a : A, B (O_unit A a)) a,
+                    O_rect A B B_inO f (O_unit A a) = f a ;
+    (** and which is closed under path spaces. *)
+    inO_paths : forall A (A_inO : inO A) (z z' : A), inO (z = z')
+  }.
 
-  (** A modality consists of *)
-  Class Modality :=
-    {
-      (** a UnitSubuniverse, whose types are called "modal", *)
-      mod_usubu : UnitSubuniverse ;
-      (** an induction principle into families of modal types *)
-      O_rect : forall A (B : O A -> Type) (B_inO : forall oa, inO (B oa)),
-        (forall a, B (O_unit A a)) -> forall a, B a ;
-      (** with a computation rule *)
-      O_rect_beta : forall A B B_inO (f : forall a : A, B (O_unit A a)) a,
-        O_rect A B B_inO f (O_unit A a) = f a ;
-      (** such that [O] maps into the subuniverse *)
-      O_inO_modality : forall A, inO (O A) ;
-      (** and which is closed under path spaces. *)
-      inO_paths : forall A (A_inO : inO A) (z z' : A), inO (z = z')
-    }.
+Arguments O_rect {Modality} {A} B {B_inO} f a.
+Arguments O_rect_beta {Modality} {A} B {B_inO} f a.
 
-  Arguments O_rect {Modality} {A} B {B_inO} f a.
-  Arguments O_rect_beta {Modality} {A} B {B_inO} f a.
-  
-  (** See ReflectiveSubuniverse.v for explanation of how to use (and how not to use) [Modality] as a typeclass. *)
+(** See ReflectiveSubuniverse.v for explanation of how to use (and how not to use) [Modality] as a typeclass. *)
 
-  Global Existing Instance mod_usubu.
-  Coercion mod_usubu : Modality >-> UnitSubuniverse.
-  Global Existing Instance O_inO_modality.
-  Global Existing Instance inO_paths.
+Global Existing Instance mod_usubu.
+Coercion mod_usubu : Modality >-> UnitSubuniverse.
+Global Existing Instance mod_replete.
+Global Existing Instance inO_paths.
 
-  (** Our definition of modality is slightly different from the one in the book, which requires an induction principle only into families of the form [fun oa => O (B oa)] and similarly only that path-spaces of types [O A] are modal.  This is "obviously" equivalent since every modal type is equivalent to one of the form [O A].  However, our definition is more convenient in formalized applications because in some examples, there is a naturally occurring [O_rect] into all modal types that is not judgmentally equal to the one that can be constructed by passing through [O] and back again.
+(** Our definition of modality is slightly different from the one in the book, which requires an induction principle only into families of the form [fun oa => O (B oa)], and similarly only that path-spaces of types [O A] are modal, where "modal" means that the unit is an equivalence.  This is equivalent, roughly since every modal type [A] (in this sense) is equivalent to [O A].  However, our definition is more convenient in formalized applications because in some examples (such as [Truncation] and closed modalities), there is a naturally occurring [O_rect] into all modal types that is not judgmentally equal to the one that can be constructed by passing through [O] and back again.
 
-     However, in other examples it is easier to construct the latter weaker induction principle, so we now show how to do this. *)
+   However, in other examples (such as [~~] and open modalities) it is easier to construct the latter weaker induction principle.  Thus, we now show how to get from that to our definition of modality. *)
 
-  Definition Build_Modality_easy `{Univalence}
-    (mod_usubu : UnitSubuniverse)
-    (O_rectO : forall A (B : O A -> Type),
-      (forall a, O (B (O_unit A a))) -> forall z, O (B z))
-    (O_rectO_beta : forall A B (f : forall a : A, O (B (O_unit A a))) a,
-      O_rectO A B f (O_unit A a) = f a)
-    (inO_pathsO : forall A (z z' : O A), inO (z = z'))
-    : Modality.
+Section EasyModality.
+  Context {fs : Funext}.
+
+  Context (O : Type -> Type).
+
+  Context (O_unit : forall T, T -> O T).
+
+  Let inO' A := IsEquiv (O_unit A).
+
+  Context (O_rectO : forall A (B : O A -> Type),
+                       (forall a, O (B (O_unit A a)))
+                       -> forall z, O (B z)).
+
+  Context (O_rectO_beta : forall A B (f : forall a, O (B (O_unit A a))) a,
+      O_rectO A B f (O_unit A a) = f a).
+
+  Context (inO_pathsO : forall A (z z' : O A), inO' (z = z')).
+
+  (** Here is the defined more general induction principle. *)
+
+  Local Definition O_rect' A (B : O A -> Type)
+        (B_inO : forall oa, inO' (B oa))
+        (f : forall a, B (O_unit A a))
+        (oa : O A) : B oa.
   Proof.
-    refine (Build_Modality mod_usubu _ _ _ _).
-    - intros A B B_inO f oa.
-      apply ((O_unit (B oa))^-1).
-      apply O_rectO.
-      intros a; apply O_unit. apply f.
-    - intros A B B_inO f a; unfold O_rect.
-      apply moveR_equiv_V.
-      apply @O_rectO_beta with (f := fun x => O_unit _ (f x)).
-    - intros A; apply inO_isequiv_O_unit.
-      refine (isequiv_adjointify (O_unit (O A)) (O_rectO (O A) (fun _ => A) idmap) _ _).
-      + intro x.
-        apply ((O_unit _)^-1).
-        generalize dependent x; apply O_rectO; intro a.
-        apply O_unit. apply ap.
-        apply (O_rectO_beta _ (fun _ : O (O A) => A) (fun u:O A => u) a).
-      + exact (O_rectO_beta _ (fun _ : O (O A) => A) idmap).
-    - intros A A_inO x y.
-      refine (@transport Type inO (O_unit A x = O_unit A y) (x = y) _ _).
-      symmetry; exact (path_universe (equiv_ap (O_unit A) _ _)).
+    pose (H := B_inO oa); unfold inO' in H.
+    apply ((O_unit (B oa))^-1).
+    apply O_rectO.
+    intros a; apply O_unit, f.
   Defined.
 
-  (** For the rest of this section, we work with an arbitrary modality. *)
+  Local Definition O_rect_beta' A B {B_inO : forall oa, inO' (B oa)}
+        (f : forall a : A, B (O_unit A a)) a
+  : O_rect' A B B_inO f (O_unit A a) = f a.
+  Proof.
+    unfold O_rect'.
+    apply moveR_equiv_V.
+    apply @O_rectO_beta with (f := fun x => O_unit _ (f x)).
+  Qed.
+
+  (** We start by building a [UnitSubuniverse]. *)
+
+  Local Definition O_inO' A : inO' (O A).
+  Proof.
+    refine (isequiv_adjointify (O_unit (O A))
+             (O_rectO (O A) (const A) idmap) _ _).
+    - intros x; pattern x; apply O_rect'.
+      + intros oa; apply inO_pathsO.
+      + intros a; apply ap.
+        exact (O_rectO_beta (O A) (const A) idmap a).
+    - intros a.
+      exact (O_rectO_beta (O A) (const A) idmap a).
+  Defined.
+
+  Local Instance usubU : UnitSubuniverse
+    := Build_UnitSubuniverse
+         (fun T => hp (IsEquiv (O_unit T)) _)
+         O O_inO' O_unit.
+
+  (** However, it seems to be surprisingly hard to show (without univalence) that this [UnitSubuniverse] is replete.  We basically have to develop enough functoriality of [O] and naturality of [O_unit].  We could do that directly, but instead we piggyback by showing that it is a reflective subuniverse. *)
+
+  Local Instance rsubU : ReflectiveSubuniverse.
+  Proof.
+    assert (H : forall P Q, inO' Q ->
+             IsEquiv (fun f : O P -> Q => f o O_unit P)).
+    { intros P Q Q_inO.
+      refine (isequiv_adjointify _
+               (O_rect' P (const Q) (const Q_inO)) _ _).
+      - intros f.
+        apply path_forall; intros x.
+        apply O_rect_beta'.
+      - intros f.
+        refine (@equiv_inj _ _
+                 (compose (O_unit Q))
+                 (@isequiv_postcompose _ _ _ _ (O_unit Q) Q_inO) _ _ _).
+        apply path_forall; intros x; pattern x.
+        apply O_rect'.
+        + intros oa; apply inO_pathsO. 
+        + intros a; unfold compose.
+          apply ap.
+          apply (O_rect_beta' P (const Q)). }
+    exact (Build_ReflectiveSubuniverse usubU H).
+  Defined.
+
+  (** It is now automatically replete, since in our case [inO] means by definition that [O_unit] is an equivalence. *)
+
+  Local Instance replete_rsubU : Replete rsubU
+    := replete_inO_isequiv_O_unit (fun _ H => H).
+
+  (** Finally, we can build a modality. *)
+
+  Definition Build_Modality_easy : Modality.
+  Proof.
+    refine (Build_Modality usubU _ O_rect' O_rect_beta' _); cbn.
+    intros A A_inO x y.
+    refine (inO_equiv_inO (O_unit A x = O_unit A y) (x = y)
+                          (inO_pathsO A _ _)
+                          (ap (O_unit A))^-1 _).
+  Defined.
+
+End EasyModality.
+
+(** We now prove various useful things about a general modality. *)
+Section Modalities.
+  Context {fs : Funext}.
   Context {mod : Modality}.
 
   (** The induction principle [O_rect], like most induction principles, is an equivalence. *)
@@ -109,12 +178,12 @@ Section Modalities.
   : IsEquiv (fun (h : O A -> B) => h o O_unit A)
     := isequiv_oD_O_unit (fun _ => B).
 
+  (** We show that modalities have underlying reflective subuniverses.  It is important in some applications, such as [Truncation], that this construction uses the general [O_rect] given as part of the modality data, and not one constructed out of [O_rectO] as we did when proving [Build_Modality_easy].  For instance, this ensures that [O_functor] reduces to simply an application of [O_rect]. *)
+
   (** Corollary 7.7.8, part 1 *)
   Global Instance modality_to_reflective_subuniverse
   : ReflectiveSubuniverse
-    := Build_ReflectiveSubuniverse _
-         O_inO_modality
-         isequiv_o_O_unit.
+    := Build_ReflectiveSubuniverse _ isequiv_o_O_unit.
 
   (** Corollary 7.7.8, part 2 *)
   Global Instance inO_sigma (A:Type) (B:A -> Type)
@@ -130,41 +199,36 @@ Section Modalities.
 
 End Modalities.
 
+(** Conversely, if a reflective subuniverse is closed under sigmas, it is a modality. *)
+
 Theorem reflective_subuniverse_to_modality `{fs : Funext}
-  (subU : ReflectiveSubuniverse)
+  (subU : ReflectiveSubuniverse) {rep : Replete subU}
   (H : forall (A:Type) (B:A -> Type)
           {A_inO : inO A} {B_inO : forall a, inO (B a)},
      (inO ({x:A & B x})))
   : Modality.
 Proof.
   pose (K := fst inO_sigma_iff H).
-  exact (Build_Modality _
+  exact (Build_Modality _ _
            (fun A B B_inO g => pr1 (K A B B_inO g))
            (fun A B B_inO g => pr2 (K A B B_inO g))
-           _ _).
+           _).
 Defined.
 
-(** Exercise 7.12 *)
-Definition notnot_modality `{Univalence} : Modality.
+(** Finally, we give one example of a modality.  This is Exercise 7.12 in the book. *)
+Definition notnot_modality `{Funext} : Modality.
 Proof.
   refine (Build_Modality_easy
-            (Build_UnitSubuniverse_easy
-               (fun X => ~~X)
-               (fun X x nx => nx x))
+            (fun X => ~~X)
+            (fun X x nx => nx x)
             (fun A B f z nBz =>
               z (fun a => f a (transport (fun x => ~B x)
                                           (allpath_hprop _ _)
                                           nBz)))
             _ _).
-  - intros A B f a. apply allpath_hprop.
-  - intros A z z'.
-    refine (@transport Type inO Unit (z = z') _ _).
-    * assert (f : Unit <~> (z = z')).
-      { apply equiv_iff_hprop.
-        + intros; apply allpath_hprop.
-        + intros; exact tt. }
-      apply (path_universe f).
-    * exact (equiv_isequiv
-               (@equiv_iff_hprop Unit _ (~~Unit) _
-                                 (fun u nu => nu u) (fun _ => tt))).
+  - intros; apply allpath_hprop.
+  - intros; refine (isequiv_iff_hprop _ _).
+    intros; apply allpath_hprop.
 Defined.
+
+(** For more examples of modalities, see hit/Truncations.v and hit/PropositionalFracture.v. *)

--- a/theories/ReflectiveSubuniverse.v
+++ b/theories/ReflectiveSubuniverse.v
@@ -1,7 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 
-Require Import Overture PathGroupoids Trunc HProp Equivalences EquivalenceVarieties
-        UnivalenceImpliesFunext Functorish.
+Require Import Overture PathGroupoids Trunc HProp Equivalences EquivalenceVarieties.
 Require Import types.Empty types.Unit types.Arrow types.Sigma types.Paths
         types.Forall types.Prod types.Universe ObjectClassifier.
 
@@ -10,30 +9,22 @@ Local Open Scope equiv_scope.
 
 (** * Reflective Subuniverses *)
 
-Section Unit_Subuniverse.
+(** A UnitSubuniverse is the common underlying structure of a reflective subuniverse and a modality.  We make it a separate structure in order to use the same names for its fields and functions in the two cases.  It consists of: *)
+Class UnitSubuniverse :=
+  {
+    (** a predicate [inO] on types, *)
+    inO_internal : Type -> hProp ;
+    (** an endomorphism [O] of [Type] *)
+    O : Type -> Type ;
+    (** which maps into the predicate *)
+    O_inO_internal : forall T, inO_internal (O T) ;
+    (** and maps [T -> O T] for all [T]. *)
+    O_unit : forall T, T -> O T
+  }.
 
-  (** A UnitSubuniverse is the common underlying structure of a reflective subuniverse and a modality.  It consists of: *)
-  Class UnitSubuniverse :=
-    {
-      (** a predicate [inO] on types, *)
-      inO_internal : Type -> Type ;
-      (** an endomorphism [O] of [Type], and *)
-      O : Type -> Type ;
-      (** maps [T -> O T] for all [T], such that *)
-      O_unit : forall T, T -> O T ;
-      (** the predicate [inO] is equivalent to [O_unit] being an equivalence. *)
-      equiv_inO_internal_isequiv_O_unit : forall T, inO_internal T <~> IsEquiv (O_unit T)
-    }.
+(** For reflective subuniverses (and hence also modalities), it will turn out that [inO T] is equivalent to [IsEquiv (O_unit T)].  We could define the former as the latter, and it would simplify some of the general theory.  However, in many examples there is a "more basic" definition of [inO] which is equivalent, but not definitionally identical, to [IsEquiv (O_unit T)].  Thus, including [inO] as data makes more things turn out to be judgmentally what we would expect. *)
 
-  (** Obviously, the definition is redundant: we don't need to include [inO] if it is equivalent to [IsEquiv (O_unit T)].  We include it, and the equivalence, explicitly, because in many examples there is a "more basic" definition of [inO] which only later happens to be equivalent to the unit maps being equivalences.  Thus, including it as data makes more things turn out to be judgmentally what we would expect.
-
-     However, in cases where there is no other definition, we can construct a [UnitSubuniverse] more simply. *)
-
-  Definition Build_UnitSubuniverse_easy (O : Type -> Type) (O_unit : forall T, T -> O T)
-    : UnitSubuniverse
-    := Build_UnitSubuniverse (fun T => IsEquiv (O_unit T)) O O_unit (fun T => equiv_idmap _).
-
-  (** We made [UnitSubuniverse] into a typeclass, rather than just a record, so that when there is an assumed one around it doesn't need to be given explicitly as an argument to everything.  You should *not* ever declare a global [Instance] of [UnitSubuniverse].  The things to do with it are:
+(** We made [UnitSubuniverse] into a typeclass, rather than just a record, so that when there is an assumed one around it doesn't need to be given explicitly as an argument to everything.  You should *not* ever declare a global [Instance] of [UnitSubuniverse].  The things to do with it are:
 
   1. Assume an arbitrary one for the purposes of general theory, as we will do here.  In this case it is a variable in the context, so typeclass resolution finds it automatically.
 
@@ -44,7 +35,9 @@ Section Unit_Subuniverse.
   4. Specify locally that we will be applying the general theory of subuniverses only to a specific example, by declaring that example as a [Local Instance].  (If the subuniverse in question has already been defined somewhere else, you can declare it as an instance locally with [Local Existing Instance].)  This way the instance won't outlast the containing section, module, or file, but inside that section, module, or file, you won't have to give it as an explicit argument.
 
   The same considerations will apply to [ReflectiveSubuniverse] and [Modality].
-  *)
+ *)
+
+Section Unit_Subuniverse.
 
   Context {subU : UnitSubuniverse}.
 
@@ -53,17 +46,13 @@ Section Unit_Subuniverse.
     isequiv_inO : inO_internal T.
 
   Typeclasses Transparent inO.
-  Global Instance isequiv_O_unit_inO (T : Type) {T_inO : inO T} : IsEquiv (O_unit T)
-    := equiv_inO_internal_isequiv_O_unit T isequiv_inO.
 
-  Definition equiv_O_unit (T : Type) {T_inO : inO T} : T <~> O T
-    := BuildEquiv T (O T) (O_unit T) _.
+  (** Being in the subuniverse is a mere predicate (by hypothesis) *)
+  Global Instance hprop_inO (T : Type) : IsHProp (inO T) := _.
 
-  Definition inO_isequiv_O_unit (T : Type) `{IsEquiv _ _ (O_unit T)} : inO T
-    := (equiv_inO_internal_isequiv_O_unit T)^-1 _.
-
-  Global Instance hprop_inO `{Funext} (T : Type) : IsHProp (inO T)
-    := (trunc_equiv ((equiv_inO_internal_isequiv_O_unit T)^-1)).
+  (** [O T] is always in the subuniverse (by hypothesis) *)
+  Global Instance O_inO T : inO (O T)
+    := O_inO_internal T.
 
   (** The type of types in the subuniverse *)
   Definition TypeO : Type
@@ -72,8 +61,7 @@ Section Unit_Subuniverse.
   Coercion TypeO_pr1 (T : TypeO) := @pr1 Type inO T.
 
   (** The second component of [TypeO] is unique *)
-  Definition path_TypeO `{Funext}
-    : forall (T T' : TypeO), T.1 = T'.1 -> T = T'.
+  Definition path_TypeO : forall (T T' : TypeO), T.1 = T'.1 -> T = T'.
   Proof.
     intros [T h] [T' h'] X.
     apply (path_sigma _ _ _ X). cbn.
@@ -82,91 +70,88 @@ Section Unit_Subuniverse.
 
 End Unit_Subuniverse.
 
+(** A reflective subuniverse is a [UnitSubuniverse], as above, whose unit has a universal property. *)
+Class ReflectiveSubuniverse :=
+  {
+    (** The underlying [UnitSubuniverse] *)
+    rsubu_usubu : UnitSubuniverse ;
+    (** an equivalence [((O P)->Q) <~> (P -> Q)] *)
+    isequiv_o_O_unit : forall (P Q : Type) (Q_inO : inO Q), 
+                         IsEquiv (fun f : O P -> Q => f o O_unit P)
+  }.
 
-Section Reflective_Subuniverse.
-  Context {fs : Funext}.
+Global Existing Instance rsubu_usubu.
+Coercion rsubu_usubu : ReflectiveSubuniverse >-> UnitSubuniverse.
+Global Existing Instance isequiv_o_O_unit.
 
-  (** A reflective subuniverse is a subuniverse with unit, as above,
-     for which the unit has a universal property. *)
-  Class ReflectiveSubuniverse :=
-    {
-      (** The underlying [UnitSubuniverse] *)
-      rsubu_usubu : UnitSubuniverse ;
-      (** [O T] is in the subuniverse for all [T] *)
-      O_inO : forall T, inO (O T) ;
-      (** an equivalence [((O P)->Q) <~> (P -> Q)] *)
-      isequiv_o_O_unit : forall (P Q : Type) (Q_inO : inO Q), 
-                  IsEquiv (fun f : O P -> Q => f o O_unit P)
-    }.
-
-  Global Existing Instance rsubu_usubu.
-  Coercion rsubu_usubu : ReflectiveSubuniverse >-> UnitSubuniverse.
-  Global Existing Instance O_inO.
-  Global Existing Instance isequiv_o_O_unit.
+Section ORectnd.
 
   Context {subU : ReflectiveSubuniverse}.
 
-  Section ORec.
+  Context (P Q : Type) {Q_inO : inO Q}.
 
-    Context (P Q : Type) {Q_inO : inO Q}.
+  (** The equivalence arising from [isequiv_o_O_unit] *)
+  Definition equiv_O_rectnd : (O P -> Q) <~> (P -> Q)
+    := BuildEquiv _ _ (fun f => f o (O_unit P)) _.
+  
+  (** Some shortcuts to manipulate the above equivalence.  Here is a "recursor" for [O]. *)
+  Definition O_rectnd : (P -> Q) -> (O P) -> Q
+    := equiv_O_rectnd^-1.
 
-    (** The equivalence arising from [isequiv_o_O_unit] *)
-    Definition equiv_O_rectnd : (O P -> Q) <~> (P -> Q)
-      := BuildEquiv _ _ (fun f => f o (O_unit P)) _.
-    
-    (** Some shortcuts to manipulate the above equivalence.  Here is a "recursor" for [O]. *)
-    Definition O_rectnd : (P -> Q) -> (O P) -> Q
-      := equiv_O_rectnd^-1.
+  Context (f : P -> Q).
 
-    Context (f : P -> Q).
+  (** Here is its "computation rule". *)
+  Definition O_rectnd_retr : O_rectnd f o O_unit _ = f
+    := eisretr equiv_O_rectnd f.
 
-    (** Here is its "computation rule". *)
-    Definition O_rectnd_retr : O_rectnd f o O_unit _ = f
-      := eisretr equiv_O_rectnd f.
+  (** Versions of [O_rectnd_retr] with [compose] unfolded and that are further pre- or post-composed with another function.  This enables [rewrite] to recognize them. *)
+  Definition O_rectnd_retr' : (fun x => O_rectnd f (O_unit _ x)) = f
+    := O_rectnd_retr.
+  Definition O_rectnd_retr'_pre (A : Type) (g : A -> P)
+  : (fun x => O_rectnd f (O_unit _ (g x))) = f o g
+    := ap (fun k => k o g) O_rectnd_retr.
+  Definition O_rectnd_retr'_post (B : Type) (h : Q -> B)
+  : (fun x => h (O_rectnd f (O_unit _ x))) = h o f
+    := ap (fun k => h o k) O_rectnd_retr.
+  Definition O_rectnd_retr'_prepost (A B : Type) (g : A -> P) (h : Q -> B)
+  : (fun x => h (O_rectnd f (O_unit _ (g x)))) = h o f o g
+    := ap (fun k => h o k o g) O_rectnd_retr.
 
-    (** Versions of [O_rectnd_retr] with [compose] unfolded and that are further pre- or post-composed with another function.  This enables [rewrite] to recognize them. *)
-    Definition O_rectnd_retr' : (fun x => O_rectnd f (O_unit _ x)) = f
-      := O_rectnd_retr.
-    Definition O_rectnd_retr'_pre (A : Type) (g : A -> P)
-      : (fun x => O_rectnd f (O_unit _ (g x))) = f o g
-      := ap (fun k => k o g) O_rectnd_retr.
-    Definition O_rectnd_retr'_post (B : Type) (h : Q -> B)
-      : (fun x => h (O_rectnd f (O_unit _ x))) = h o f
-      := ap (fun k => h o k) O_rectnd_retr.
-    Definition O_rectnd_retr'_prepost (A B : Type) (g : A -> P) (h : Q -> B)
-      : (fun x => h (O_rectnd f (O_unit _ (g x)))) = h o f o g
-      := ap (fun k => h o k o g) O_rectnd_retr.
+  (** And here is the "uniqueness rule" for the "recursor" *)
+  Definition O_rectnd_sect (f : O P -> Q) : O_rectnd (f o O_unit _) = f
+    := eissect equiv_O_rectnd f.
 
-    (** And here is the "uniqueness rule" for the "recursor" *)
-    Definition O_rectnd_sect (f : O P -> Q) : O_rectnd (f o O_unit _) = f
-      := eissect equiv_O_rectnd f.
+End ORectnd.
 
-  End ORec.
+(** Here is a tactic that tries all the forms of [O_rectnd_retr]. *)
+Ltac rewrite_O_rectnd_retr :=
+  repeat first
+         [ unfold compose; rewrite O_rectnd_retr'
+         | unfold compose; rewrite O_rectnd_retr'_post
+         | unfold compose; rewrite O_rectnd_retr'_pre
+         | unfold compose; rewrite O_rectnd_retr'_prepost
+         ].
 
-  (** Here is a tactic that tries all the forms of [O_rectnd_retr]. *)
-  Ltac rewrite_O_rectnd_retr :=
-    repeat first
-      [ unfold compose; rewrite O_rectnd_retr'
-        | unfold compose; rewrite O_rectnd_retr'_post
-        | unfold compose; rewrite O_rectnd_retr'_pre
-        | unfold compose; rewrite O_rectnd_retr'_prepost
-      ].
+(** A subuniverse is replete if it is closed under equivalence.  This is also a more usual sort of typeclass. *)
+
+Class Replete (subU : UnitSubuniverse) :=
+  inO_equiv_inO : forall T U (T_inO : @inO subU T) (f : T -> U) (feq : IsEquiv f), @inO subU U.
+
+(** Of course, with univalence this is automatic.  This is the only appearance of univalence in the theory of reflective subuniverses and (non-lex) modalities. *)
+Global Instance replete_univalence `{Univalence} (subU : UnitSubuniverse)
+: Replete subU.
+Proof.
+  intros T U ? f ?.
+  refine (transport (@inO subU) _ _).
+  apply path_universe with f; exact _.
+Defined.
+
+(** We now prove a bunch of things about an arbitrary reflective subuniverse (sometimes replete). *)
+Section Reflective_Subuniverse.
+  Context {fs : Funext}.
+  Context {subU : ReflectiveSubuniverse}.
 
   Section Basic_facts.
-    
-    (** [T] is in the subuniverse as soon as [O_unit T] admits a retraction. *)
-    Definition inO_unit_retract (T:Type) (mu : O T -> T)
-    : Sect (O_unit T) mu -> inO T.
-    Proof.
-      unfold Sect; intros H.
-      apply inO_isequiv_O_unit.
-      apply isequiv_adjointify with (g:=mu).
-      - apply ap10.
-        apply ((ap (equiv_O_rectnd T (O T)))^-1).
-        apply path_arrow; intros x; unfold compose; simpl.
-        exact (ap (O_unit T) (H x)).
-      - exact H.
-    Defined.
 
     (** Injectivity of composing with the unit. *)
     
@@ -184,6 +169,22 @@ Section Reflective_Subuniverse.
       unfold path_arrow_modal, equiv_inj.
       apply eisretr.
     Qed.
+
+    (** If [T] is in the subuniverse, then [O_unit T] is an equivalence. *)
+    Global Instance isequiv_O_unit_inO (T : Type) {T_inO : inO T} : IsEquiv (O_unit T).
+    Proof.
+      pose (g := O_rectnd T T idmap).
+      refine (isequiv_adjointify (O_unit T) g _ _).
+      - change (O_unit T o g == idmap); apply ap10.
+        apply path_arrow_modal; unfold compose.
+        unfold g; rewrite_O_rectnd_retr.
+        reflexivity.
+      - apply ap10; unfold g.
+        apply O_rectnd_retr.
+    Qed.
+
+    Definition equiv_O_unit (T : Type) {T_inO : inO T} : T <~> O T
+      := BuildEquiv T (O T) (O_unit T) _.
 
   End Basic_facts.
 
@@ -273,19 +274,52 @@ Section Reflective_Subuniverse.
     : O A <~> O B
     := BuildEquiv _ _ (O_functor f) _.
 
-    (** Being in the universe transports along equivalences. *)
-    Definition inO_equiv_inO (T : Type) {U : Type} {T_inO : inO T} (f : T <~> U)
-      : inO U.
+  End Functor.
+
+  Section Replete.
+
+    (** An equivalent formulation of repleteness is that a type lies in the subuniverse as soon as its unit map is an equivalence. *)
+    Definition inO_isequiv_O_unit {rep : Replete subU} (T:Type)
+    : IsEquiv (O_unit T) -> inO T
+    := fun _ => inO_equiv_inO (O T) T _ (O_unit T)^-1 _.
+
+    Global Instance replete_inO_isequiv_O_unit
+           (H : forall T, IsEquiv (O_unit T) -> inO T)
+    : Replete subU.
     Proof.
-      apply inO_isequiv_O_unit.
-      assert (IsEquiv (O_unit U o f)).
-      - apply isequiv_homotopic with (O_functor f o O_unit T).
-        + apply isequiv_compose.
-        + apply ap10, O_unit_natural.
-      - refine (cancelR_isequiv f).
+      intros A B A_inO f feq.
+      pose (uA := BuildEquiv _ _ (O_unit A) _).
+      refine (H B (isequiv_adjointify (O_unit B) _ _ _)); cbn.
+      - exact (f o uA^-1 o (O_functor f)^-1).
+      - intros x; unfold compose.
+        refine ((ap10 (O_unit_natural f) _) ^ @ _).
+        transitivity (O_functor f ((O_functor f)^-1 x)).
+        + apply (ap (O_functor f)).
+          apply eisretr.
+        + apply eisretr.
+      - intros x; unfold compose.
+        transitivity (f (uA^-1 (O_unit A (f^-1 x)))).
+        + apply ap, ap, (ap10 (O_unit_natural (f^-1)) x).
+        + transitivity (f (f^-1 x)).
+          * apply ap, eissect.
+          * apply eisretr.
     Defined.
 
-  End Functor.
+    (** Thus, [T] is in a replete subuniverse as soon as [O_unit T] admits a retraction. *)
+    Definition inO_unit_retract {rep : Replete subU} (T:Type) (mu : O T -> T)
+    : Sect (O_unit T) mu -> inO T.
+    Proof.
+      unfold Sect; intros H.
+      apply inO_isequiv_O_unit.
+      apply isequiv_adjointify with (g:=mu).
+      - apply ap10.
+        apply ((ap (equiv_O_rectnd T (O T)))^-1).
+        apply path_arrow; intros x; unfold compose; simpl.
+        exact (ap (O_unit T) (H x)).
+      - exact H.
+    Defined.
+
+  End Replete.
 
   Section OInverts.
 
@@ -380,6 +414,7 @@ Section Reflective_Subuniverse.
   End OInverts.
 
   Section Types.
+    Context {rep : Replete subU}.
 
     (** ** The [Unit] type *)
     Global Instance inO_unit : inO Unit.

--- a/theories/hit/PropositionalFracture.v
+++ b/theories/hit/PropositionalFracture.v
@@ -1,5 +1,4 @@
-Require Import Overture PathGroupoids Contractible HProp Equivalences EquivalenceVarieties
-        UnivalenceImpliesFunext.
+Require Import Overture PathGroupoids Contractible HProp Equivalences EquivalenceVarieties.
 Require Import types.Empty types.Unit types.Arrow types.Sigma types.Paths
         types.Forall types.Prod types.Universe.
 Require Import ReflectiveSubuniverse Modality.
@@ -11,12 +10,11 @@ Local Open Scope equiv_scope.
 (** * Open and closed modalities and the propositional fracture theorem *)
 
 (** Exercise 7.13(i): Open modalities *)
-Definition open_modality `{Univalence} (U : hProp) : Modality.
+Definition open_modality `{Funext} (U : hProp) : Modality.
 Proof.
   refine (Build_Modality_easy
-            (Build_UnitSubuniverse_easy
-               (fun X => U -> X)
-               (fun X x u => x))
+           (fun X => U -> X)
+           (fun X x u => x)
             _ _ _); unfold O, inO, O_unit.
   - intros A B f z u.
     refine (transport B _ (f (z u) u)).
@@ -80,30 +78,31 @@ Section ClosedModality.
       exact _.
   Defined.
 
-  Local Instance closed_modality : Modality
-    := (Build_Modality
-         (Build_UnitSubuniverse
-           (fun X => U -> Contr X)
-           (fun X => join U X)
-           (fun X x => push (inr x))
-           equiv_inO_closed)
-         _ _ _ _).
+  Local Instance closed_modality : Modality.
   Proof.
+    refine (Build_Modality
+              (Build_UnitSubuniverse
+                 (fun X => hp (U -> Contr X) _)
+                 (fun X => join U X)
+                 _
+                 (fun X x => push (inr x)))
+              _ _ _ _); cbn; try exact _.
+    - intros A u.
+      pose (contr_inhabited_hprop U u).
+      exact _.
+    - intros A B inO_A f ?; cbn in *; intros u; pose (inO_A u).
+      apply contr_equiv with f; exact _.
     - intros A B ? f z.
       refine (pushout_rect _ _ B _ _ z).
       * intros [u | a].
         + apply center, B_inO, u.
         + apply f.
       * intros [u a].
-        pose (B_inO (O_unit A a) u).
+        pose (B_inO (push (inr a)) u).
         apply path_contr.
     - reflexivity.
-    - intros A u.
-      pose (contr_inhabited_hprop U u).
-      exact _.
     - intros A A_inO z z' u.
-      pose (A_inO u).
-      exact _.
+      pose (A_inO u); exact _.
   Defined.
 
 End ClosedModality.

--- a/theories/hit/Truncations.v
+++ b/theories/hit/Truncations.v
@@ -73,14 +73,16 @@ Section TruncationModality.
   Proof.
     refine (Build_Modality
               (Build_UnitSubuniverse
-                (IsTrunc n)
+                (fun A => hp (IsTrunc n A) _)
                 (Truncation n)
-                (@truncation_incl n)
-                trunc_iff_isequiv_truncation)
+                _
+                (@truncation_incl n))
+              _
               (@Truncation_rect n)
               (fun A B B_inO f a => 1)
-              _ _);
-    simpl; exact _.
+              _); cbn; try exact _.
+    intros A B ? f ?; cbn in *.
+    apply trunc_equiv with f; exact _.
   Defined.
 
   (** ** Functoriality *)


### PR DESCRIPTION
This adds to a `ReflectiveSubuniverse` the data of a predicate to be in the subuniverse, and to `Modality` the data of a general induction principle into modal types.  These can be defined, up to equivalence, from the data that used to be there, but in some examples (like `Truncation`) one or both of these data occur naturally in a way that is judgmentally different from (and better than) the one that can be constructed from the other data.  So I think it's better to include them as extra redundant data, with "easy" constructors that fill them in automatically if desired.  In particular, this fixes the problem Jason noticed in Freudenthal.  I think this is analogous to our choice to define `IsEquiv` using half-adjoint equivalences rather than, say, contractible fibers, so that the inverse function would be remembered as explicit data.
