### PR TITLE
make "happly" a parsing notation for "ap10"

### DIFF
--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -246,6 +246,9 @@ Definition apD10 {A} {B:A->Type} {f g : forall x, B x} (h:f=g)
 Definition ap10 {A B} {f g:A->B} (h:f=g) : f == g
   := apD10 h.
 
+(** For the benefit of readers of the HoTT Book: *)
+Notation happly := ap10 (only parsing).
+
 Definition ap11 {A B} {f g:A->B} (h:f=g) {x y:A} (p:x=y) : f x = g y.
 Proof.
   case h, p; reflexivity.


### PR DESCRIPTION
@marcbezem pointed out that the book uses `happly` for our `ap10` but nowhere is it mentioned that they are the same.  It would be nice to mention this in `HoTTBook.v` as well, but the definition of `happly` in the book is not a theorem or definition, it's _equation_ (2.9.2), and thus doesn't appear therein.  What can be done?
