### PR TITLE
Fixed False_hp, added Negation_hp

### DIFF
--- a/theories/HProp.v
+++ b/theories/HProp.v
@@ -212,8 +212,7 @@ Definition Unit_hp : hProp := (hp Unit _).
 
 Definition False_hp : hProp := (hp Empty _).
 
-Definition Negation_hp `{Funext} (hprop : hProp) : hProp
-  := (hp ((hproptype hprop) -> Empty) trunc_forall).
+Definition Negation_hp `{Funext} (hprop : hProp) : hProp := hp (~hprop) _.
 (** We could continue with products etc *)
 
 Definition issig_hProp: (sigT IsHProp) <~> hProp.
@@ -237,6 +236,3 @@ Proof.
 Defined.
 
 Definition path_hprop `{Funext} X Y := (@ap _ _ hproptype X Y)^-1%equiv.
-
-
-

--- a/theories/types/Bool.v
+++ b/theories/types/Bool.v
@@ -131,4 +131,3 @@ End EquivBoolEquiv.
 (** canonical map from Bool to hProp *)
 Definition is_true (b : Bool) : hProp
   := if b then Unit_hp else False_hp.
-


### PR DESCRIPTION
Question: where to place (in HProp.v, Bool.v, Misc.v, HoTTBookExercises.v, or elsewhere)?
Require Import Bool.
(*\* canonical map from Bool to hProp *)
Definition Bool_to_hProp (b : Bool) : hProp
  := if b then Unit_hp else False_hp.

In HProp.v this gave an unexpected error ("Bool not found in the current environment") with the latest coq-scripts @ a87e3ca, while it had been typechecked correctly before.
