### PR TITLE
export hit.Connectedness from HoTT

### DIFF
--- a/theories/HoTT.v
+++ b/theories/HoTT.v
@@ -28,6 +28,7 @@ Require Export types.Universe.
 
 Require Export hit.Interval.
 Require Export hit.Truncations.
+Require Export hit.Connectedness.
 Require Export hit.Flattening.
 Require Export hit.Circle.
 Require Export hit.Suspension.


### PR DESCRIPTION
How did this get left out, I wonder?
