### PR TITLE
Improve arguments for [morphism_inverse]

### DIFF
--- a/theories/categories/Category/Morphisms.v
+++ b/theories/categories/Category/Morphisms.v
@@ -20,7 +20,9 @@ Class IsIsomorphism {C : PreCategory} {s d} (m : morphism C s d) :=
   }.
 Local Set Primitive Projections.
 
-Local Notation "m ^-1" := (morphism_inverse (m := m)) (at level 3, format "m '^-1'") : morphism_scope.
+Arguments morphism_inverse {C s d} m {_}.
+
+Local Notation "m ^-1" := (morphism_inverse m) (at level 3, format "m '^-1'") : morphism_scope.
 
 Hint Resolve left_inverse right_inverse : category morphism.
 Hint Rewrite @left_inverse @right_inverse : category.
@@ -182,7 +184,7 @@ Section iso_equiv_relation.
 
   (** *** Being isomorphic is a symmetric relation *)
   Global Instance isomorphic_sym : Symmetric (@Isomorphic C)
-    := fun x y X => {| morphism_isomorphic := morphism_inverse |}.
+    := fun x y X => {| morphism_isomorphic := X^-1 |}.
 
   (** *** Being isomorphic is a transitive relation *)
   Global Instance isomorphic_trans : Transitive (@Isomorphic C)
@@ -636,7 +638,7 @@ Section associativity_composition.
 End associativity_composition.
 
 Module Export CategoryMorphismsNotations.
-  Notation "m ^-1" := (morphism_inverse (m := m)) (at level 3, format "m '^-1'") : morphism_scope.
+  Notation "m ^-1" := (morphism_inverse m) (at level 3, format "m '^-1'") : morphism_scope.
 
   Infix "<~=~>" := Isomorphic (at level 70, no associativity) : category_scope.
 

--- a/theories/categories/Category/Utf8.v
+++ b/theories/categories/Category/Utf8.v
@@ -3,7 +3,7 @@ Require Import Category.Core Category.Morphisms Category.Dual Category.Prod Cate
 Require Export Category.Notations.
 
 Infix "∘" := compose (at level 40, left associativity) : morphism_scope.
-Notation "m ⁻¹" := (morphism_inverse (m := m)) (at level 3, format "m '⁻¹'") : morphism_scope.
+Notation "m ⁻¹" := (morphism_inverse m) (at level 3, format "m '⁻¹'") : morphism_scope.
 Infix "≅" := Isomorphic (at level 70, no associativity) : category_scope.
 Notation "x ↠ y" := (Epimorphism x y)
                       (at level 99, right associativity, y at level 200).


### PR DESCRIPTION
When we turn off [Printing Notations], we want to see the morphism
that we are inverting.
