### PR TITLE
Break a loop that shows up with Keyed Unification

### DIFF
--- a/theories/Basics/PathGroupoids.v
+++ b/theories/Basics/PathGroupoids.v
@@ -717,6 +717,17 @@ Definition transport_idmap_ap A (P : A -> Type) x y (p : x = y) (u : P x)
 : transport P p u = transport idmap (ap P p) u
   := match p with idpath => idpath end.
 
+(** Sometimes, it's useful to have the goal be in terms of [ap], so we can use lemmas about [ap].  However, we can't just [rewrite !transport_idmap_ap], as that's likely to loop.  So, instead, we provide a tactic [transport_to_ap], that replaces all [transport P p u] with [transport idmap (ap P p) u] for non-[idmap] [P]. *)
+Ltac transport_to_ap :=
+  repeat match goal with
+           | [ |- context[transport ?P ?p ?u] ]
+             => match P with
+                  | idmap => fail 1 (* we don't want to turn [transport idmap (ap _ _)] into [transport idmap (ap idmap (ap _ _))] *)
+                  | _ => idtac
+                end;
+               progress rewrite (transport_idmap_ap _ P _ _ p u)
+         end.
+
 (** *** The behavior of [ap] and [apD]. *)
 
 (** In a constant fibration, [apD] reduces to [ap], modulo [transport_const]. *)

--- a/theories/categories/Functor/Pointwise/Properties.v
+++ b/theories/categories/Functor/Pointwise/Properties.v
@@ -13,10 +13,6 @@ Local Open Scope functor_scope.
 Section parts.
   Context `{Funext}.
 
-  Let transport_idmap_ap A (P : A -> Type) x y (p : x = y) (u : P x)
-  : transport idmap (ap P p) u = transport P p u
-  := inverse (transport_compose idmap _ _ _).
-
   (** We could do this all in a big [repeat match], but we split it
       up, to shave off about two seconds per proof. *)
   Local Ltac functor_pointwise_t helper_lem_match helper_lem :=
@@ -28,14 +24,7 @@ Section parts.
                => simpl rewrite (@ap_transport _ P _ _ _ p (fun _ => components_of) z)
            end;
     rewrite !transport_forall_constant;
-    repeat match goal with
-             | [ |- context[transport ?P ?p ?u] ]
-               => match P with
-                    | idmap => fail 1 (* we don't want to turn [transport idmap (ap _ _)] into [transport idmap (ap idmap (ap _ _))] *)
-                    | _ => idtac
-                  end;
-                 progress (rewrite <- (transport_idmap_ap P p u); simpl)
-           end;
+    transport_to_ap;
     repeat match goal with
              | [ x : _ |- context[ap (fun x3 : ?T => ?f (object_of x3 ?z))] ]
                => rewrite (@ap_compose' _ _ _ (fun x3' : T => object_of x3') (fun Ox3 => f (Ox3 x)))


### PR DESCRIPTION
Without keyed unification, `rewrite` inferred that a particular endpoint
of a particular path was `((1 ∘ x ∘ 1) x2)`.  However, in the goal, this
endpoint was passed as (the judgmentally equivalent) `x2`.  So after
`rewrite` finished filling in its holes, it couldn't find the subterm
anymore, breaking the loop.  With keyed unification, it can find the
subterm, so the rewrite loops.

Perhaps we want to factor this bit of logic out into a separate tactic with the spec "replace all `transport P p` with `transport idmap (ap P p)` for non-`idmap` `P`"?  (Would this go in HoTT.Tactics?  Basics.PathGroupoids?)
