### PR TITLE
Factor out tactic scripts for exponential laws

### DIFF
--- a/Makefile_targets.mk
+++ b/Makefile_targets.mk
@@ -154,6 +154,7 @@ CATEGORY_VFILES = \
 	$(srcdir)/theories/categories/ExponentialLaws/Law4.v \
 	$(srcdir)/theories/categories/ExponentialLaws/Law4/Functors.v \
 	$(srcdir)/theories/categories/ExponentialLaws/Law4/Law.v \
+	$(srcdir)/theories/categories/ExponentialLaws/Tactics.v \
 	\
 	$(srcdir)/theories/categories/Functor/Composition/Functorial.v \
 	$(srcdir)/theories/categories/Functor/Composition/Functorial/Core.v \

--- a/theories/categories/ExponentialLaws.v
+++ b/theories/categories/ExponentialLaws.v
@@ -21,3 +21,7 @@ Require ExponentialLaws.Law3.
 (** ** Currying *)
 (** *** [(yⁿ)ᵐ ≅ yⁿᵐ] *)
 Require ExponentialLaws.Law4.
+
+
+Require ExponentialLaws.Tactics.
+Include ExponentialLaws.Tactics.

--- a/theories/categories/ExponentialLaws/Law1/Law.v
+++ b/theories/categories/ExponentialLaws/Law1/Law.v
@@ -1,7 +1,7 @@
 (** * Exponential laws about the terminal category *)
 Require Import Category.Core Functor.Core FunctorCategory.Core Functor.Identity NaturalTransformation.Core Functor.Paths NaturalTransformation.Paths ExponentialLaws.Law1.Functors Functor.Composition.Core.
 Require Import InitialTerminalCategory.Core.
-Require Import HoTT.Tactics types.Forall types.Prod PathGroupoids.
+Require Import HoTT.Tactics ExponentialLaws.Tactics.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.
@@ -26,14 +26,7 @@ Section law1.
     path_functor.
     exists (path_forall _ _ (fun x => ap (object_of c) (contr _))).
     abstract (
-        repeat (apply path_forall; intro);
-        rewrite !transport_forall_constant;
-        simpl;
-        transport_path_forall_hammer;
-        repeat match goal with
-                 | [ H : object 1 |- _ ] => destruct (contr H)
-                 | [ H : morphism 1 _ _ |- _ ] => destruct (contr H)
-               end;
+        exp_laws_t;
         simpl;
         rewrite <- identity_of;
         f_ap;
@@ -49,30 +42,7 @@ Section law1.
     split;
     path_functor.
     exists (path_forall _ _ helper).
-    repeat (apply (@path_forall _) || intro || path_functor || path_natural_transformation).
-    repeat match goal with
-             | _ => reflexivity
-             | _ => progress simpl
-             | [ H : object 1 |- _ ] => destruct (contr H)
-             | [ H : morphism 1 _ _ |- _ ] => destruct (contr H)
-             | _ => rewrite !transport_forall_constant
-             | [ |- context[components_of (transport ?P ?p ?z)] ]
-               => simpl rewrite (@ap_transport _ P _ _ _ p (fun _ => components_of) z)
-             | _ => rewrite path_forall_2_beta, ?transport_const
-             | _ => transport_path_forall_hammer
-           end.
     unfold helper.
-    repeat match goal with
-             | [ |- context[transport (fun y => ?f (@object_of ?C ?D y ?x))] ]
-               => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (y' x)) (@object_of C D))
-             | [ |- context[transport (fun y => ?f (@object_of ?C ?D y ?x) ?z)] ]
-               => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (y' x) z) (@object_of C D))
-           end.
-    rewrite !path_functor'_sig_fst.
-    simpl. (* https://coq.inria.fr/bugs/show_bug.cgi?id=3587 *)
-    transport_path_forall_hammer.
-    assert (idpath = contr (center 1%category)) by exact (center _).
-    path_induction.
-    reflexivity.
+    exp_laws_t.
   Qed.
 End law1.

--- a/theories/categories/ExponentialLaws/Law2/Law.v
+++ b/theories/categories/ExponentialLaws/Law2/Law.v
@@ -5,7 +5,7 @@ Require Import Functor.Pointwise.Core Functor.Prod.Core.
 Require Import Category.Sum Functor.Sum NaturalTransformation.Sum.
 Require Import Functor.Paths NaturalTransformation.Paths.
 Require Import Functor.Identity Functor.Composition.Core.
-Require Import types.Prod HoTT.Tactics types.Forall PathGroupoids.
+Require Import types.Prod HoTT.Tactics ExponentialLaws.Tactics.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.
@@ -20,6 +20,8 @@ Section Law2.
   Variable D : PreCategory.
   Variable C1 : PreCategory.
   Variable C2 : PreCategory.
+
+
 
   Lemma helper1 (c : Functor C1 D * Functor C2 D)
   : ((1 o (Datatypes.fst c + Datatypes.snd c) o inl C1 C2)%functor,
@@ -40,17 +42,7 @@ Section Law2.
   Proof.
     path_functor.
     (exists (path_forall _ _ (@helper2_helper c))).
-    abstract (
-        repeat (apply (@path_forall _); intro);
-        repeat match goal with
-                 | [ H : Empty |- _ ] => by destruct H
-                 | _ => reflexivity
-                 | [ H : (_ + _)%type |- _ ] => destruct H
-                 | [ |- context[transport (fun x : ?A => forall y : ?B, @?C x y) ?p ?f ?k] ]
-                   => simpl rewrite (@transport_forall_constant A B C _ _ p f k)
-                 | _ => progress transport_path_forall_hammer
-               end
-      ).
+    abstract exp_laws_t.
   Defined.
 
   Lemma law
@@ -61,32 +53,8 @@ Section Law2.
     path_functor;
     [ (exists (path_forall _ _ helper1))
     | (exists (path_forall _ _ helper2)) ];
-    repeat (apply (@path_forall _) || apply path_prod || intro || path_functor || path_natural_transformation);
-    destruct_head prod;
-    rewrite !transport_forall_constant;
-    transport_path_forall_hammer;
+    exp_laws_t;
     unfold helper1, helper2;
-    repeat match goal with
-             | _ => progress simpl in *
-             | _ => reflexivity
-             | [ H : (_ * _)%type |- _ ] => destruct H
-             | [ H : (_ + _)%type |- _ ] => destruct H
-             | [ |- context[Datatypes.fst (transport ?P ?p ?z)] ]
-               => simpl rewrite (@ap_transport _ P _ _ _ p (fun _ => @Datatypes.fst _ _) z)
-             | [ |- context[Datatypes.snd (transport ?P ?p ?z)] ]
-               => simpl rewrite (@ap_transport _ P _ _ _ p (fun _ => @Datatypes.snd _ _) z)
-             | [ |- context[components_of (transport ?P ?p ?z)] ]
-               => simpl rewrite (@ap_transport _ P _ _ _ p (fun _ => components_of) z)
-             | _ => rewrite !transport_path_prod
-             | _ => rewrite !transport_const
-             | _ => rewrite !transport_forall_constant
-             | [ |- context[transport (fun y => ?f (@object_of ?C ?D y ?x))] ]
-               => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (y' x)) (@object_of C D))
-             | [ |- context[transport (fun y => ?f (@object_of ?C ?D y ?x) ?z)] ]
-               => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (y' x) z) (@object_of C D))
-             | [ |- context[ap (@object_of ?C ?D) (@path_functor'_sig ?H ?C ?D ?F ?G (?HO; ?HM))] ]
-               => simpl rewrite (@path_functor'_sig_fst H C D F G HO HM)
-             | _ => transport_path_forall_hammer
-           end.
+    exp_laws_t.
   Qed.
 End Law2.

--- a/theories/categories/ExponentialLaws/Law3/Law.v
+++ b/theories/categories/ExponentialLaws/Law3/Law.v
@@ -4,7 +4,7 @@ Require Import Functor.Prod Functor.Prod.Functorial Functor.Prod.Universal.
 Require Import Functor.Paths NaturalTransformation.Paths.
 Require Import Functor.Identity Functor.Composition.Core.
 Require Import ExponentialLaws.Law3.Functors.
-Require Import types.Prod HoTT.Tactics types.Forall PathGroupoids.
+Require Import types.Prod HoTT.Tactics ExponentialLaws.Tactics.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.
@@ -34,37 +34,10 @@ Section Law3.
     /\ inverse C1 C2 D o functor C1 C2 D = 1.
   Proof.
     split; path_functor;
-    [ (exists (path_forall _ _ helper));
-      repeat (apply path_forall || intros [? ?])
-    | (exists (path_forall _ _ (fun _ => Functor.Prod.Universal.unique idpath idpath)));
-      repeat (apply path_forall || intro) ];
-    rewrite !transport_forall_constant;
-    transport_path_forall_hammer;
-    repeat (apply path_prod || path_natural_transformation || simpl);
+    [ (exists (path_forall _ _ helper))
+    | (exists (path_forall _ _ (fun _ => Functor.Prod.Universal.unique idpath idpath))) ];
+    exp_laws_t;
     unfold helper, compose_fst_prod, compose_snd_prod, Functor.Prod.Universal.unique, Functor.Prod.Universal.unique_helper;
-    repeat match goal with
-             | _ => progress simpl in *
-             | _ => reflexivity
-             | [ |- context[Datatypes.fst (transport ?P ?p ?z)] ]
-               => simpl rewrite (@ap_transport _ P _ _ _ p (fun _ => @Datatypes.fst _ _) z)
-             | [ |- context[Datatypes.snd (transport ?P ?p ?z)] ]
-               => simpl rewrite (@ap_transport _ P _ _ _ p (fun _ => @Datatypes.snd _ _) z)
-             | [ |- context[components_of (transport ?P ?p ?z)] ]
-               => simpl rewrite (@ap_transport _ P _ _ _ p (fun _ => components_of) z)
-             | _ => rewrite !transport_path_prod
-             | _ => rewrite !transport_const
-             | _ => rewrite !transport_forall_constant
-             | [ |- context[transport (fun y => ?f (@object_of ?C ?D y ?x))] ]
-               => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (y' x)) (@object_of C D))
-             | [ |- context[transport (fun y => ?f (@object_of ?C ?D y ?x) ?z)] ]
-               => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (y' x) z) (@object_of C D))
-             | [ |- context[transport (fun y => ?f (?g (@object_of ?C ?D y ?x)))] ]
-               => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (g (y' x))) (@object_of C D))
-             | [ |- context[transport (fun y => ?f (?g (@object_of ?C ?D y ?x)) ?z)] ]
-               => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (g (y' x)) z) (@object_of C D))
-             | [ |- context[ap (@object_of ?C ?D) (@path_functor'_sig ?H ?C ?D ?F ?G (?HO; ?HM))] ]
-               => simpl rewrite (@path_functor'_sig_fst H C D F G HO HM)
-             | _ => transport_path_forall_hammer
-           end.
+    exp_laws_t.
   Qed.
 End Law3.

--- a/theories/categories/ExponentialLaws/Law4/Law.v
+++ b/theories/categories/ExponentialLaws/Law4/Law.v
@@ -4,7 +4,7 @@ Require Import Functor.Prod.Core.
 Require Import Functor.Paths NaturalTransformation.Paths.
 Require Import Functor.Identity Functor.Composition.Core.
 Require Import ExponentialLaws.Law4.Functors.
-Require Import types.Prod HoTT.Tactics types.Forall PathGroupoids.
+Require Import types.Prod HoTT.Tactics types.Forall Basics.PathGroupoids ExponentialLaws.Tactics.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.
@@ -25,12 +25,9 @@ Section Law4.
   Proof.
     path_functor.
     abstract (
-        simpl;
-        repeat (apply path_forall || intro);
+        exp_laws_t;
         rewrite <- composition_of;
-        simpl;
-        autorewrite with morphism;
-        reflexivity
+        exp_laws_t
       ).
   Defined.
 
@@ -38,61 +35,15 @@ Section Law4.
   : inverse C1 C2 D (functor C1 C2 D c) x = c x.
   Proof.
     path_functor.
-    abstract (
-        repeat (apply path_forall || intro);
-        rewrite !transport_forall_constant;
-        simpl;
-        rewrite (identity_of c); simpl;
-          by autorewrite with morphism
-      ).
+    abstract exp_laws_t.
   Defined.
-
-  Local Ltac exp_t :=
-    repeat match goal with
-             | _ => progress simpl in *
-             | _ => reflexivity
-             | _ => rewrite !identity_of
-             | _ => progress autorewrite with morphism
-             | [ |- context[Datatypes.fst (transport ?P ?p ?z)] ]
-               => simpl rewrite (@ap_transport _ P _ _ _ p (fun _ => @Datatypes.fst _ _) z)
-             | [ |- context[Datatypes.snd (transport ?P ?p ?z)] ]
-               => simpl rewrite (@ap_transport _ P _ _ _ p (fun _ => @Datatypes.snd _ _) z)
-             | [ |- context[components_of (transport ?P ?p ?z)] ]
-               => simpl rewrite (@ap_transport _ P _ _ _ p (fun _ => components_of) z)
-             | _ => rewrite !transport_path_prod
-             | _ => rewrite !transport_const
-             | _ => rewrite !transport_forall_constant
-             | [ |- context[transport (fun y => ?f (@object_of ?C ?D y ?x))] ]
-               => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (y' x)) (@object_of C D))
-             | [ |- context[transport (fun y => ?f (@object_of ?C ?D y ?x) ?z)] ]
-               => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (y' x) z) (@object_of C D))
-             | [ |- context[transport (fun y => ?f (?g (@object_of ?C ?D y ?x)))] ]
-               => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (g (y' x))) (@object_of C D))
-             | [ |- context[transport (fun y => ?f (?g (@object_of ?C ?D y ?x)) ?z)] ]
-               => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (g (y' x)) z) (@object_of C D))
-             | [ |- context[transport (fun y => ?f (?g (@object_of ?C ?D y ?x) ?k))] ]
-               => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (g (y' x) k)) (@object_of C D))
-             | [ |- context[transport (fun y => ?f (?g (@object_of ?C ?D y ?x) ?k) ?z)] ]
-               => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (g (y' x) k) z) (@object_of C D))
-             | [ |- context[ap (@object_of ?C ?D) (@path_functor'_sig ?H ?C ?D ?F ?G (?HO; ?HM))] ]
-               => simpl rewrite (@path_functor'_sig_fst H C D F G HO HM)
-             | _ => transport_path_forall_hammer
-           end.
 
   Lemma helper2 c
   : inverse C1 C2 D (functor C1 C2 D c) = c.
   Proof.
     path_functor.
     exists (path_forall _ _ (helper2_helper c)).
-    abstract (
-        repeat (apply path_forall || intro || path_natural_transformation);
-        rewrite !transport_forall_constant;
-        simpl;
-        transport_path_forall_hammer;
-        unfold helper2_helper;
-        simpl;
-        exp_t
-      ).
+    abstract (unfold helper2_helper; exp_laws_t).
   Defined.
 
   Lemma law
@@ -103,11 +54,7 @@ Section Law4.
     path_functor;
     [ (exists (path_forall _ _ helper1))
     | (exists (path_forall _ _ helper2)) ];
-    repeat (apply path_forall || intro || path_natural_transformation);
-    rewrite !transport_forall_constant;
     unfold helper1, helper2, helper2_helper;
-    destruct_head Datatypes.prod.
-    - exp_t.
-    - exp_t.
+    exp_laws_t.
   Qed.
 End Law4.

--- a/theories/categories/ExponentialLaws/Tactics.v
+++ b/theories/categories/ExponentialLaws/Tactics.v
@@ -1,0 +1,82 @@
+(** * Miscellaneous helper tactics for proving exponential laws *)
+Require Import Category.Core Functor.Core NaturalTransformation.Core.
+Require Import Functor.Paths NaturalTransformation.Paths.
+Require Import HoTT.Tactics Basics.PathGroupoids types.Forall types.Prod.
+
+(** These are probably more general than just exponential laws, but I haven't tried them more widely, yet. *)
+
+(** Miscellaneous tactics to try *)
+Ltac exp_laws_misc_t' :=
+  idtac;
+  match goal with
+    | _ => reflexivity
+    | _ => progress intros
+    | _ => progress simpl in *
+    | _ => apply (@path_forall _); intro
+    | _ => rewrite !identity_of
+    | _ => progress autorewrite with morphism
+  end.
+
+(** Safe transformations to simplify complex types in the hypotheses or goal *)
+Ltac exp_laws_simplify_types' :=
+  idtac;
+  match goal with
+    | [ H : (_ + _)%type |- _ ] => destruct H
+    | [ H : Unit |- _ ] => destruct H
+    | [ H : Empty |- _ ] => destruct H
+    | [ H : (_ * _)%type |- _ ] => destruct H
+    | [ |- _ = _ :> Functor _ _ ] => progress path_functor
+    | [ |- _ = _ :> NaturalTransformation _ _ ] => progress path_natural_transformation
+    | [ |- _ = _ :> prod _ _ ] => apply path_prod
+  end.
+
+(** Do some simplifications of contractible types *)
+Ltac exp_laws_handle_contr' :=
+  idtac;
+  match goal with
+    | [ H : Contr ?T, x : ?T |- _ ] => progress destruct (contr x)
+    | [ H : forall a, Contr (?T a), x : ?T _ |- _ ] => progress destruct (contr x)
+    | [ H : forall a b, Contr (?T a b), x : ?T _ _ |- _ ] => progress destruct (contr x)
+    | [ |- context[contr (center ?x)] ]
+      => progress let H := fresh in
+                  assert (H : idpath = contr (center x)) by exact (center _);
+                    destruct H
+  end.
+
+(** Try to simplify [transport] with some heuristics *)
+Ltac exp_laws_handle_transport' :=
+  idtac;
+  match goal with
+    | _ => progress rewrite ?transport_forall_constant, ?path_forall_2_beta, ?transport_const, ?path_functor'_sig_fst, ?transport_path_prod
+    | [ |- context[transport (fun y => ?f (@object_of ?C ?D y ?x))] ]
+      => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (y' x)) (@object_of C D))
+    | [ |- context[transport (fun y => ?f (@object_of ?C ?D y ?x) ?z)] ]
+      => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (y' x) z) (@object_of C D))
+    | [ |- context[transport (fun y => ?f (@object_of ?C ?D y ?x) ?z)] ]
+      => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (y' x) z) (@object_of C D))
+    | [ |- context[transport (fun y => ?f (?g (@object_of ?C ?D y ?x)))] ]
+      => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (g (y' x))) (@object_of C D))
+    | [ |- context[transport (fun y => ?f (?g (@object_of ?C ?D y ?x)) ?z)] ]
+      => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (g (y' x)) z) (@object_of C D))
+    | _ => progress transport_path_forall_hammer
+    | [ |- context[components_of (transport ?P ?p ?z)] ]
+      => simpl rewrite (@ap_transport _ P _ _ _ p (fun _ => components_of) z)
+    | [ |- context[object_of (transport ?P ?p ?z)] ]
+      => simpl rewrite (@ap_transport _ P _ _ _ p (fun _ => object_of) z)
+    | [ |- context[morphism_of (transport ?P ?p ?z)] ]
+      => simpl rewrite (@ap_transport _ P _ _ _ p (fun _ => morphism_of) z)
+    | [ |- context[fst (transport ?P ?p ?z)] ]
+      => simpl rewrite (@ap_transport _ P _ _ _ p (fun _ => fst) z)
+    | [ |- context[snd (transport ?P ?p ?z)] ]
+      => simpl rewrite (@ap_transport _ P _ _ _ p (fun _ => snd) z)
+    | [ |- context[pr1 (transport ?P ?p ?z)] ]
+      => simpl rewrite (@ap_transport _ P _ _ _ p (fun _ => pr1) z)
+  end.
+
+Ltac exp_laws_t' :=
+  first [ exp_laws_misc_t'
+        | exp_laws_simplify_types'
+        | exp_laws_handle_contr'
+        | exp_laws_handle_transport' ].
+
+Ltac exp_laws_t := repeat exp_laws_t'.


### PR DESCRIPTION
These can probably be put in a more general place, and be used more
widely in categories.  In general, the parts of a proof done by tactics
in categories are, in no particular order:
- apply type-driven principles, such as destructing [sum]-types in
  hypotheses and applying [path_prod] or [path_functor] to the goal
- eliminate composition with identities and inverses and normalize
  morphisms (w.r.t., e.g., associativity)
- eliminate [transport]s
- miscellany, such as eliminating points in contractible types,
  inducting on paths, using [simpl] and [reflexivity], or using
  hypotheses

The first is very systematic and general, and the second is amenable to
systematic tactics or reflective proof scripts.  The third is,
currently, rather ad-hoc, and the fourth is generally straightforward
but occasionally complicated.
