### PR TITLE
eliminate :> in records and classes

### DIFF
--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -20,8 +20,11 @@ Class Transitive {A} (R : relation A) :=
 
 (** A [PreOrder] is both Reflexive and Transitive. *)
 Class PreOrder {A} (R : relation A) :=
-  { PreOrder_Reflexive :> Reflexive R | 2 ;
-    PreOrder_Transitive :> Transitive R | 2 }.
+  { PreOrder_Reflexive : Reflexive R | 2 ;
+    PreOrder_Transitive : Transitive R | 2 }.
+
+Global Existing Instance PreOrder_Reflexive.
+Global Existing Instance PreOrder_Transitive.
 
 Arguments reflexivity {A R _} / _.
 Arguments symmetry {A R _} / _ _ _.
@@ -307,9 +310,11 @@ Arguments eisadj {A B} f {_} _.
 
 (** A record that includes all the data of an adjoint equivalence. *)
 Record Equiv A B := BuildEquiv {
-  equiv_fun :> A -> B ;
-  equiv_isequiv :> IsEquiv equiv_fun
+  equiv_fun : A -> B ;
+  equiv_isequiv : IsEquiv equiv_fun
 }.
+
+Coercion equiv_fun : Equiv >-> Funclass.
 
 Global Existing Instance equiv_isequiv.
 

--- a/theories/Basics/Trunc.v
+++ b/theories/Basics/Trunc.v
@@ -73,6 +73,8 @@ Definition trunc_equiv' `(f : A <~> B) `{IsTrunc n A}
 (** ** Truncated morphisms *)
 
 Class IsTruncMap (n : trunc_index) {X Y : Type} (f : X -> Y) :=
-  istruncmap_fiber :> forall y:Y, IsTrunc n (hfiber f y).
+  istruncmap_fiber : forall y:Y, IsTrunc n (hfiber f y).
+
+Global Existing Instance istruncmap_fiber.
 
 Notation IsEmbedding := (IsTruncMap -1).

--- a/theories/EquivalenceVarieties.v
+++ b/theories/EquivalenceVarieties.v
@@ -228,18 +228,17 @@ Lemma equiv_path_equiv {A B : Type} (e1 e2 : A <~> B)
 Proof.
   equiv_via ((issig_equiv A B) ^-1 e1 = (issig_equiv A B) ^-1 e2).
     2: symmetry; apply equiv_ap; refine _.
-(* TODO: why does this get the wrong type if [hprop_isequiv] is not supplied? *)
-  exact (@equiv_path_sigma_hprop _ _ hprop_isequiv
-    ((issig_equiv A B) ^-1 e1) ((issig_equiv A B) ^-1 e2)).
+  exact (equiv_path_sigma_hprop ((issig_equiv A B)^-1 e1) ((issig_equiv A B)^-1 e2)).
 Defined.
 
 Definition path_equiv {A B : Type} {e1 e2 : A <~> B}
   : (e1 = e2 :> (A -> B)) -> (e1 = e2 :> (A <~> B))
-:= equiv_path_equiv e1 e2.
+  := equiv_path_equiv e1 e2.
 
 Definition isequiv_path_equiv {A B : Type} {e1 e2 : A <~> B}
   : IsEquiv (@path_equiv _ _ e1 e2)
-:= equiv_path_equiv e1 e2.
+  (* Coq can find this instance by itself, but it's slow. *)
+  := equiv_isequiv (equiv_path_equiv e1 e2).
 
 Lemma istrunc_equiv {n : trunc_index} {A B : Type} `{IsTrunc n.+1 B}
   : IsTrunc n.+1 (A <~> B).
@@ -258,7 +257,7 @@ Proof.
   pose (@istrunc_equiv).
   refine (isequiv_adjointify
             equiv_iff_hprop_uncurried
-            (fun e => (@equiv_fun _ _ e, @equiv_inv _ _ _ e))
+            (fun e => (@equiv_fun _ _ e, @equiv_inv _ _ e _))
             _ _);
     intro;
     by apply path_ishprop.

--- a/theories/HProp.v
+++ b/theories/HProp.v
@@ -1,7 +1,7 @@
 (** * HPropositions *)
 
 Require Import HoTT.Basics.
-Require Import types.Forall types.Sigma types.Prod types.Record types.Paths.
+Require Import types.Forall types.Sigma types.Prod types.Record types.Paths types.Unit types.Empty.
 
 Local Open Scope equiv_scope.
 Local Open Scope path_scope.
@@ -198,15 +198,15 @@ Definition equiv_path_sigma_hprop {A : Type} {P : A -> Type}
   := BuildEquiv _ _ (path_sigma_hprop _ _) _.
 
 (** The type of Propositions *)
-Record hProp := hp { hproptype :> Type ; isp : IsHProp hproptype}.
+Record hProp := hp { hproptype : Type ; isp : IsHProp hproptype}.
 (** This one would allow us to turn the record type of contractible types
 into an [hProp].
 <<
 Canonical Structure default_HProp:= fun T P => (@hp T P).
 >>
 *)
+Coercion hproptype : hProp >-> Sortclass.
 Global Existing Instance isp.
-Require Import Unit Empty.
 
 Definition Unit_hp : hProp := (hp Unit _).
 

--- a/theories/HSet.v
+++ b/theories/HSet.v
@@ -133,11 +133,14 @@ Proof.
   apply path_ishprop.
 Defined.
 
-Record hSet := BuildhSet {setT:> Type; iss :> IsHSet setT}.
+Record hSet := BuildhSet {setT : Type; iss : IsHSet setT}.
+
+Coercion setT : hSet >-> Sortclass.
+Global Existing Instance iss.
+
 (** This one is needed in [epi_surj] to coerce [hProp] into [hSet]*)
 Canonical Structure default_HSet:= fun T P => (@BuildhSet T P).
 Hint Resolve iss.
-Global Existing Instance iss.
 
 Definition issig_hSet: (sigT IsHSet) <~> hSet.
 Proof.

--- a/theories/TruncType.v
+++ b/theories/TruncType.v
@@ -17,7 +17,7 @@ Section TruncType.
 Context `{Univalence}.
 
 Record TruncType (n : trunc_index) := BuildTruncType {
-  trunctype_type :> Type ;
+  trunctype_type : Type ;
   istrunc_trunctype_type : IsTrunc n trunctype_type
 }.
 (* Note: the naming of the second constructor is more than a little clunky.  However, the more obvious [istrunc_trunctype] is taken by the theorem below, that [IsTrunc n.+1 (TruncType n)], which seems to have an even better claim to it. *)
@@ -25,6 +25,8 @@ Record TruncType (n : trunc_index) := BuildTruncType {
 Arguments BuildTruncType _ _ {_}.
 Arguments trunctype_type [_] _.
 Arguments istrunc_trunctype_type [_] _.
+
+Coercion trunctype_type : TruncType >-> Sortclass.
 
 Global Existing Instance istrunc_trunctype_type.
 

--- a/theories/categories/SetCategory/Morphisms.v
+++ b/theories/categories/SetCategory/Morphisms.v
@@ -61,7 +61,7 @@ Section equiv_iso_set_cat.
   Definition iso_equiv (s d : set_cat) (m : s <~> d)
   : s <~=~> d
     := Build_Isomorphic
-         (@isiso_isequiv s d m m).
+         (@isiso_isequiv s d m _).
 
   Global Instance isequiv_isiso_isequiv s d
   : IsEquiv (@iso_equiv s d) | 0.
@@ -116,14 +116,14 @@ Section equiv_iso_prop_cat.
   Definition iso_equiv_prop (s d : prop_cat) (m : s <~> d)
   : s <~=~> d
     := Build_Isomorphic
-         (@isiso_isequiv_prop s d m m).
+         (@isiso_isequiv_prop s d m _).
 
   Global Instance isequiv_isiso_isequiv_prop s d
   : IsEquiv (@iso_equiv_prop s d) | 0.
   Proof.
     refine (isequiv_adjointify
               (@iso_equiv_prop s d)
-              (fun m => BuildEquiv _ _ _ (@isequiv_isiso_prop s d m m))
+              (fun m => BuildEquiv _ _ _ (@isequiv_isiso_prop s d m _))
               _
               _);
     simpl in *;

--- a/theories/hit/Connectedness.v
+++ b/theories/hit/Connectedness.v
@@ -28,7 +28,9 @@ The former requires only core Coq, but blows up the size (universe level) of [Is
 Question: is there a definition of connectedness that neither blows up the universe level, nor requires HIT’s? *)
 
 Class IsConnected (n : trunc_index) (A : Type)
- := isconnected_contr_trunc :> Contr (Trunc n A).
+ := isconnected_contr_trunc : Contr (Trunc n A).
+
+Global Existing Instance isconnected_contr_trunc.
 
 Definition isconnected_elim {n} {A} `{IsConnected n A}
            (C : Type) `{IsTrunc n C} (f : A -> C)
@@ -66,8 +68,9 @@ Defined.
 (** Connectedness of a map can again be defined in two equivalent ways: by connectedness of its fibers (as types), or by the lifting property/elimination principle against truncated types.  We use the former; the equivalence with the latter is given below in [conn_map_elim], [conn_map_comp], and [conn_map_from_extension_elim]. *)
 
 Class IsConnMap (n : trunc_index) {A B : Type} (f : A -> B)
-  := isconnected_hfiber_conn_map :>
-       forall b:B, IsConnected n (hfiber f b).
+  := isconnected_hfiber_conn_map : forall b:B, IsConnected n (hfiber f b).
+
+Global Existing Instance isconnected_hfiber_conn_map.
 
 (** Surjections are the (-1)-connected maps, but they can be characterized more simply since an inhabited hprop is automatically contractible. *)
 Notation IsSurjection := (IsConnMap -1).

--- a/theories/types/Paths.v
+++ b/theories/types/Paths.v
@@ -101,7 +101,7 @@ Definition equiv_ap `(f : A -> B) `{IsEquiv A B f} (x y : A)
   := BuildEquiv _ _ (ap f) _.
 
 (* TODO: Is this really necessary? *)
-Definition equiv_inj `{IsEquiv A B f} {x y : A}
+Definition equiv_inj `(f : A -> B) `{IsEquiv A B f} {x y : A}
   : (f x = f y) -> (x = y)
   := (ap f)^-1.
 

--- a/theories/types/Universe.v
+++ b/theories/types/Universe.v
@@ -2,7 +2,7 @@
 (** * Theorems about the universe, including the Univalence Axiom. *)
 
 Require Import HoTT.Basics.
-Require Import HProp EquivalenceVarieties types.Sigma.
+Require Import HProp EquivalenceVarieties types.Sigma types.Arrow types.Paths.
 Local Open Scope path_scope.
 Local Open Scope equiv_scope.
 
@@ -128,21 +128,9 @@ Global Instance trunc_path_IsHProp `{Funext} X Y `{IsHProp Y}
 Proof.
   apply hprop_allpath.
   intros pf1 pf2.
-  rewrite <- (eta_path_universe pf1), <- (eta_path_universe pf2).
-  lazymatch goal with
-    | [ |- @path_universe _ _ (equiv_fun ?f) ?Hf
-           = @path_universe _ _ (equiv_fun ?g) ?Hg ]
-      => change Hf with (equiv_isequiv f);
-        change Hg with (equiv_isequiv g);
-        generalize (equiv_isequiv f) (equiv_isequiv g);
-        generalize (equiv_fun f) (equiv_fun g)
-  end.
-  let f' := fresh in
-  let g' := fresh in
-  intros f' g' ? ?;
-    assert (f' = g'); [ | path_induction; apply ap; apply path_ishprop ].
-  apply path_forall; intro.
-  apply path_ishprop.
+  apply (equiv_inj (equiv_path X Y)).
+  apply path_equiv, path_arrow.
+  intros x; by apply path_ishprop.
 Qed.
 
 Global Instance isset_hProp `{Funext} : IsHSet hProp | 0.


### PR DESCRIPTION
I propose that we should not use the syntax `:>` in record and class definitions.  I think it's confusing because sometimes it declares a coercion and sometimes an instance, and it's also a very small and easy-to-miss indicator for a very important thing to know about (a coercion).  Instead I think it's better to give explicit `Coercion` and `Existing Instance` declarations.

Along the way I eliminated `equiv_isequiv` as a coercion, which doesn't make sense to me.
