### PR TITLE
move NullHomotopy into its own file

### DIFF
--- a/Makefile_targets.mk
+++ b/Makefile_targets.mk
@@ -59,6 +59,7 @@ CORE_VFILES = \
 	$(srcdir)/theories/UnivalenceAxiom.v \
 	$(srcdir)/theories/ObjectClassifier.v \
 	$(srcdir)/theories/ReflectiveSubuniverse.v \
+	$(srcdir)/theories/NullHomotopy.v \
 	$(srcdir)/theories/Modality.v \
 	$(srcdir)/theories/Factorization.v \
 	$(srcdir)/theories/hit/Circle.v \

--- a/theories/HoTT.v
+++ b/theories/HoTT.v
@@ -17,6 +17,7 @@ Require Export Modality.
 Require Export Factorization.
 Require Export ObjectClassifier.
 Require Export TruncType.
+Require Export NullHomotopy.
 
 Require Export hit.Interval.
 Require Export hit.Truncations.

--- a/theories/Misc.v
+++ b/theories/Misc.v
@@ -1,5 +1,5 @@
 (* -*- mode: coq; mode: visual-line -*- *)
-(** * Misecllaneous material *)
+(** * Miscellaneous material *)
 
 (** If you have a lemma or group of lemmas that you can’t find a better home for, put them here.  However, big “Miscellaneous” files are sub-optimal to work with, so some caveats:
 
@@ -8,33 +8,8 @@
 - generally, be extra-careful keeping this file well-organised and documented.
 - any time you see a chance to move lemmas from this file to a better home, do so without hesitation! *)
 
-(** Dependencies: we should allow this file to depend at least on files from the [types] directory; ipso facto, we should not put anything here that those files depend on.
-
-Conversely, several files in [hit] now depend on this file; so we should probably avoid using HIT’s in this file. *)
-
-Require Import HoTT.Basics.
-Require Import Types.Sigma Types.Paths Types.Record Types.Arrow Types.Forall Types.Bool.
+Require Import HoTT.Basics HoTT.Types.
 Local Open Scope path_scope.
 Local Open Scope equiv_scope.
 
-(** ** Null homotopies of maps *)
-Section NullHomotopy.
-
-Context `{Funext}.
-
-(** Geometrically, a nullhomotopy of a map [f : X -> Y] is an extension of [f] to a map [Cone X -> Y].  One might more simply call it e.g. [Constant f], but that is a little ambiguous: it could also reasonably mean e.g. a factorisation of [f] through [ Trunc -1 X ].  (Should the unique map [0 -> Y] be constant in one way, or in [Y]-many ways?) *)
-
-(* These use [trunc_sigma], so depend on [types.Sigma]. *)
-Definition NullHomotopy {X Y : Type} (f : X -> Y)
-  := {y : Y & forall x:X, f x = y}.
-
-Lemma istrunc_nullhomotopy {n : trunc_index}
-  {X Y : Type} (f : X -> Y) `{IsTrunc n Y}
-  : IsTrunc n (NullHomotopy f).
-Proof.
-  apply @trunc_sigma; auto.
-  intros y. apply (@trunc_forall _).
-  intros x. apply trunc_succ.
-Defined.
-
-End NullHomotopy.
+(** Currently there is nothing here. *)

--- a/theories/NullHomotopy.v
+++ b/theories/NullHomotopy.v
@@ -1,0 +1,25 @@
+(* -*- mode: coq; mode: visual-line -*- *)
+Require Import HoTT.Basics.
+Require Import Types.Sigma Types.Forall.
+Local Open Scope path_scope.
+Local Open Scope equiv_scope.
+
+(** * Null homotopies of maps *)
+Section NullHomotopy.
+Context `{Funext}.
+
+(** Geometrically, a nullhomotopy of a map [f : X -> Y] is an extension of [f] to a map [Cone X -> Y].  One might more simply call it e.g. [Constant f], but that is a little ambiguous: it could also reasonably mean e.g. a factorisation of [f] through [ Trunc -1 X ].  (Should the unique map [0 -> Y] be constant in one way, or in [Y]-many ways?) *)
+
+Definition NullHomotopy {X Y : Type} (f : X -> Y)
+  := {y : Y & forall x:X, f x = y}.
+
+Lemma istrunc_nullhomotopy {n : trunc_index}
+  {X Y : Type} (f : X -> Y) `{IsTrunc n Y}
+  : IsTrunc n (NullHomotopy f).
+Proof.
+  apply @trunc_sigma; auto.
+  intros y. apply (@trunc_forall _).
+  intros x. apply trunc_succ.
+Defined.
+
+End NullHomotopy.

--- a/theories/hit/Spheres.v
+++ b/theories/hit/Spheres.v
@@ -4,7 +4,7 @@
 
 Require Import HoTT.Basics.
 Require Import Types.Sigma Types.Forall Types.Paths Types.Bool.
-Require Import HProp Misc.
+Require Import HProp NullHomotopy.
 Require Import hit.Suspension hit.Circle.
 Local Open Scope trunc_scope.
 Local Open Scope path_scope.

--- a/theories/hit/Suspension.v
+++ b/theories/hit/Suspension.v
@@ -2,7 +2,7 @@
 
 (** * The suspension of a type *)
 
-Require Import HoTT.Basics Types.Paths Misc.
+Require Import HoTT.Basics Types.Paths NullHomotopy.
 Local Open Scope path_scope.
 Local Open Scope equiv_scope.
 Generalizable Variables X A B f g n.


### PR DESCRIPTION
It's the only thing in `Misc` right now, so why not give the imports a more suggestive name.
