### PR TITLE
Use records, not typeclasses, for subuniverses and modalities

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -242,10 +242,7 @@ Here are some of the typeclasses we are using:
 - equivalences: `IsEquiv`
 - truncation levels: `Contr`, `IsTrunc`
 - axioms (see below): `Funext`, `Univalence`
-- membership in subuniverses; `inO`
-- records that we may want to "open": `ReflectiveSubuniverse`,
-  `Modality`.  These are treated somewhat specially; see the comments
-  in `ReflectiveSubuniverse.v`.
+- subuniverses: `In`, `Replete`
 
 `IsHSet`, `IsHProp`, and `Contr` are notations for `IsTrunc 0`,
 `IsTrunc -1`, and `IsTrunc -2` respectively.  Since `IsTrunc` is
@@ -281,6 +278,18 @@ prevents this), please add a comment to that effect where it is
 defined.  This way no one else will come along and helpfully change it
 back to an `Instance`.
 
+If a particular fact should not be made an ordinary instance, it can
+still be made an "immediate instance", meaning that Coq will use it
+automatically to solve a goal *if* its hypotheses are already present
+in the context, but will not initiate an instance search for those
+hypotheses otherwise.  This avoids infinite instance-search loops.  To
+declare a fact as an immediate instance, make it a `Definition` rather
+than an `Instance` and then say
+
+```coq
+Hint Immediate foo : typeclass_instances.
+```
+
 ### Local and Global Instances ###
 
 When declaring an `Instance` you should *always* use either the
@@ -292,10 +301,6 @@ file), while the latter puts it in the instance database globally.
 If you write `Instance` without `Local` or `Global`, Coq will
 sometimes make it local and sometimes global, so to avoid confusion it
 is better to always specify explicitly which you intend.
-
-The typeclasses for subuniverses and modalities are treated somewhat
-specially: their `Instance`s should *only* be declared `Local`.  See
-the comments in `ReflectiveSubuniverse.v` for details.
 
 ### Using Typeclasses ###
 

--- a/theories/Modality.v
+++ b/theories/Modality.v
@@ -7,26 +7,23 @@ Local Open Scope equiv_scope.
 
 (** * Modalities *)
 
-Class Modality :=
+Record Modality :=
   {
-    mod_usubu : UnitSubuniverse ;
-    mod_replete : Replete mod_usubu ;
-    O_ind : forall A (B : O A -> Type) (B_inO : forall oa, inO (B oa)),
-               (forall a, B (O_unit A a)) -> forall a, B a ;
-    O_ind_beta : forall A B B_inO (f : forall a : A, B (O_unit A a)) a,
-                    O_ind A B B_inO f (O_unit A a) = f a ;
-    inO_paths : forall A (A_inO : inO A) (z z' : A), inO (z = z')
+    msubu : UnitSubuniverse ;
+    mreplete : Replete msubu ;
+    O_ind : forall A (B : msubu A -> Type) (B_inO : forall oa, In msubu (B oa)),
+               (forall a, B (to msubu A a)) -> forall a, B a ;
+    O_ind_beta : forall A B B_inO (f : forall a : A, B (to msubu A a)) a,
+                    O_ind A B B_inO f (to msubu A a) = f a ;
+    inO_paths : forall A (A_inO : In msubu A) (z z' : A), In msubu (z = z')
   }.
 
-Arguments O_ind {Modality} {A} B {B_inO} f a.
-Arguments O_ind_beta {Modality} {A} B {B_inO} f a.
+Arguments O_ind {O} {A} B {B_inO} f a : rename.
+Arguments O_ind_beta {O} {A} B {B_inO} f a : rename.
 
-(** See ReflectiveSubuniverse.v for explanation of how to use (and how not to use) [Modality] as a typeclass. *)
-
-Global Existing Instance mod_usubu.
 (* We don't declare this as a coercion, since soon we're going to declare a coercion from [Modality] to [ReflectiveSubuniverse]; then we'll get this coercion automatically as a composite. *)
 (* Coercion mod_usubu : Modality >-> UnitSubuniverse. *)
-Global Existing Instance mod_replete.
+Global Existing Instance mreplete.
 Global Existing Instance inO_paths.
 
 (** Our definition of modality is slightly different from the one in the book, which requires an induction principle only into families of the form [fun oa => O (B oa)], and similarly only that path-spaces of types [O A] are modal, where "modal" means that the unit is an equivalence.  This is equivalent, roughly since every modal type [A] (in this sense) is equivalent to [O A].
@@ -37,74 +34,73 @@ On the other hand, in other examples (such as [~~] and open modalities) it is ea
 
 Section EasyModality.
 
-  Context (O : Type -> Type).
+  Context (O' : Type -> Type).
 
-  Context (O_unit : forall T, T -> O T).
+  Context (to_O : forall T, T -> O' T).
 
-  Let inO' A := IsEquiv (O_unit A).
+  Let inO' A := IsEquiv (to_O A).
 
-  Context (O_indO : forall A (B : O A -> Type),
-                       (forall a, O (B (O_unit A a)))
-                       -> forall z, O (B z)).
+  Context (O_indO : forall A (B : O' A -> Type),
+                       (forall a, O' (B (to_O A a)))
+                       -> forall z, O' (B z)).
 
-  Context (O_indO_beta : forall A B (f : forall a, O (B (O_unit A a))) a,
-      O_indO A B f (O_unit A a) = f a).
+  Context (O_indO_beta : forall A B (f : forall a, O' (B (to_O A a))) a,
+      O_indO A B f (to_O A a) = f a).
 
-  Context (inO_pathsO : forall A (z z' : O A), inO' (z = z')).
+  Context (inO_pathsO : forall A (z z' : O' A), inO' (z = z')).
 
   (** Here is the defined more general induction principle. *)
 
-  Local Definition O_ind' A (B : O A -> Type)
+  Local Definition O_ind' A (B : O' A -> Type)
         (B_inO : forall oa, inO' (B oa))
-        (f : forall a, B (O_unit A a))
-        (oa : O A) : B oa.
+        (f : forall a, B (to_O A a))
+        (oa : O' A) : B oa.
   Proof.
     pose (H := B_inO oa); unfold inO' in H.
-    apply ((O_unit (B oa))^-1).
+    apply ((to_O (B oa))^-1).
     apply O_indO.
-    intros a; apply O_unit, f.
+    intros a; apply to_O, f.
   Defined.
 
   Local Definition O_ind_beta' A B {B_inO : forall oa, inO' (B oa)}
-        (f : forall a : A, B (O_unit A a)) a
-  : O_ind' A B B_inO f (O_unit A a) = f a.
+        (f : forall a : A, B (to_O A a)) a
+  : O_ind' A B B_inO f (to_O A a) = f a.
   Proof.
     unfold O_ind'.
     apply moveR_equiv_V.
-    apply @O_indO_beta with (f := fun x => O_unit _ (f x)).
+    apply @O_indO_beta with (f := fun x => to_O _ (f x)).
   Qed.
 
   (** We start by building a [UnitSubuniverse]. *)
 
-  Local Definition O_inO' A : inO' (O A).
+  Local Definition O_inO' A : inO' (O' A).
   Proof.
-    refine (isequiv_adjointify (O_unit (O A))
-             (O_indO (O A) (const A) idmap) _ _).
+    refine (isequiv_adjointify (to_O (O' A))
+             (O_indO (O' A) (const A) idmap) _ _).
     - intros x; pattern x; apply O_ind'.
       + intros oa; apply inO_pathsO.
       + intros a; apply ap.
-        exact (O_indO_beta (O A) (const A) idmap a).
+        exact (O_indO_beta (O' A) (const A) idmap a).
     - intros a.
-      exact (O_indO_beta (O A) (const A) idmap a).
+      exact (O_indO_beta (O' A) (const A) idmap a).
   Defined.
 
-  Local Instance usubU : UnitSubuniverse
-    := Build_UnitSubuniverse
-         (fun T => IsEquiv (O_unit T))
-         O O_inO' O_unit _.
+  (** However, it seems to be surprisingly hard to show (without univalence) that this [UnitSubuniverse] is replete.  We basically have to develop enough functoriality of [O] and naturality of [to_O].  We could do that directly, but instead we piggyback by showing that it is a reflective subuniverse.  This is why we excluded repleteness from the basic definition of [ReflectiveSubuniverse] and the proofs of functoriality. *)
 
-  (** However, it seems to be surprisingly hard to show (without univalence) that this [UnitSubuniverse] is replete.  We basically have to develop enough functoriality of [O] and naturality of [O_unit].  We could do that directly, but instead we piggyback by showing that it is a reflective subuniverse.  This is why we excluded repleteness from the basic definition of [ReflectiveSubuniverse] and the proofs of functoriality. *)
-
-  Local Instance rsubU : ReflectiveSubuniverse.
+  Local Definition O : ReflectiveSubuniverse.
   Proof.
-    refine (Build_ReflectiveSubuniverse _ _ _ _ _);
+    refine (Build_ReflectiveSubuniverse
+              (Build_UnitSubuniverse
+                 (fun T => IsEquiv (to_O T))
+                 O' O_inO' to_O _)
+              _ _ _ _);
       intros P Q ?.
     - intros f. exact (O_ind' P (fun _ => Q) (fun _ => Q_inO) f).
     - intros f x. exact (O_ind_beta' P (fun _ => Q) f x).
     - intros g h p x.
       cbn in Q_inO.
-      refine ((ap (O_unit Q))^-1 _).
-      refine (O_ind' P (fun y => O_unit Q (g y) = O_unit Q (h y)) _ _ x).
+      refine ((ap (to_O Q))^-1 _).
+      refine (O_ind' P (fun y => to_O Q (g y) = to_O Q (h y)) _ _ x).
       + intros y. apply inO_pathsO.
       + intros a; apply ap, p.
     - intros g h p x; cbn.
@@ -112,70 +108,33 @@ Section EasyModality.
       rewrite concat_pp_p.
       apply moveR_Vp.
       rewrite <- ap_compose.
-      exact (concat_A1p (eissect (O_unit Q)) (p x)).
+      exact (concat_A1p (eissect (to_O Q)) (p x)).
   Defined.
 
-  (** It is now automatically replete, since in our case [inO] means by definition that [O_unit] is an equivalence. *)
+  (** It is now automatically replete, since in our case [inO] means by definition that [to_O] is an equivalence. *)
 
-  Local Instance replete_rsubU : Replete rsubU
-    := replete_inO_isequiv_O_unit (fun _ H => H).
+  Local Instance replete_rsubU : Replete O.
+  Proof.
+    apply replete_inO_isequiv_to_O; trivial.
+  Defined.
 
   (** Finally, we can build a modality. *)
 
   Definition Build_Modality_easy : Modality.
   Proof.
-    refine (Build_Modality usubU _ O_ind' O_ind_beta' _); cbn.
-    intros A A_inO x y.
-    refine (inO_equiv_inO (O_unit A x = O_unit A y)
-                          (ap (O_unit A))^-1).
+    refine (Build_Modality O _ O_ind' O_ind_beta' _); cbn.
   Defined.
 
 End EasyModality.
-
-(** The induction principle [O_ind], like most induction principles, is an equivalence. *)
-Section OIndEquiv.
-  Context {fs : Funext}.
-  Context {mod : Modality}.
-
-  Section OIndEquivData.
-
-    Context {A : Type} (B : O A -> Type) {B_inO : forall a, inO (B a)}.
-
-    Global Instance isequiv_O_ind : IsEquiv (O_ind B).
-    Proof.
-      apply isequiv_adjointify with (g := fun h => h oD O_unit A).
-      - intros h. apply path_forall.
-        refine (O_ind (fun oa => O_ind B (h oD O_unit A) oa = h oa) _).
-        exact (O_ind_beta B (h oD O_unit A)).
-      - intros f. apply path_forall.
-        exact (O_ind_beta B f).
-    Defined.
-
-    Definition equiv_O_ind
-    : (forall a, B (O_unit A a)) <~> (forall oa, B oa)
-    := BuildEquiv _ _ (O_ind B) _.
-
-    (** Theorem 7.7.7 *)
-    Definition isequiv_oD_O_unit
-    : IsEquiv (fun (h : forall oa, B oa) => h oD O_unit A)
-    := equiv_isequiv (equiv_inverse equiv_O_ind).
-
-  End OIndEquivData.
-
-  Local Definition isequiv_o_O_unit (A B : Type) (B_inO : inO B)
-  : IsEquiv (fun (h : O A -> B) => h o O_unit A)
-    := isequiv_oD_O_unit (fun _ => B).
-
-End OIndEquiv.
 
 (** We show that modalities have underlying reflective subuniverses.  It is important in some applications, such as [Trunc], that this construction uses the general [O_ind] given as part of the modality data, and not one constructed out of [O_indO] as we did when proving [Build_Modality_easy].  For instance, this ensures that [O_functor] reduces to simply an application of [O_ind].
 
  Note also that our choice of how to define reflective subuniverses differently from the book enables us to prove this without using funext. *)
 
 (** Corollary 7.7.8, part 1 *)
-Global Instance modality_to_reflective_subuniverse (mod : Modality)
+Definition modality_to_reflective_subuniverse (O : Modality)
 : ReflectiveSubuniverse
-:= Build_ReflectiveSubuniverse _
+:= Build_ReflectiveSubuniverse (msubu O)
      (fun P Q H => O_ind (fun _ => Q))
      (fun P Q H => O_ind_beta (fun _ => Q))
      (fun P Q H g h => O_ind (fun y => g y = h y))
@@ -184,12 +143,12 @@ Global Instance modality_to_reflective_subuniverse (mod : Modality)
 Coercion modality_to_reflective_subuniverse : Modality >-> ReflectiveSubuniverse.
 
 (** Corollary 7.7.8, part 2 *)
-Global Instance inO_sigma {mod : Modality} (A:Type) (B:A -> Type)
-       {A_inO : inO A} {B_inO : forall a, inO (B a)}
-: inO {x:A & B x}.
+Global Instance inO_sigma {O : Modality} (A:Type) (B:A -> Type)
+       `{In O A} `{forall a, In O (B a)}
+: In O {x:A & B x}.
 Proof.
   generalize dependent A.
-  refine (snd inO_sigma_iff _).
+  refine (snd (inO_sigma_iff _) _).
   intros A B ? g.
   exists (O_ind B g).
   apply O_ind_beta.
@@ -198,18 +157,53 @@ Defined.
 (** Conversely, if a reflective subuniverse is closed under sigmas, it is a modality. *)
 
 Theorem reflective_subuniverse_to_modality
-  (subU : ReflectiveSubuniverse) {rep : Replete subU}
+  (O : ReflectiveSubuniverse) {rep : Replete O}
   (H : forall (A:Type) (B:A -> Type)
-          {A_inO : inO A} {B_inO : forall a, inO (B a)},
-     (inO ({x:A & B x})))
+          `{In O A} `{forall a, In O (B a)},
+     (In O ({x:A & B x})))
   : Modality.
 Proof.
-  pose (K := fst inO_sigma_iff H).
+  pose (K := fst (inO_sigma_iff _) H).
   exact (Build_Modality _ _
            (fun A B B_inO g => pr1 (K A B B_inO g))
            (fun A B B_inO g => pr2 (K A B B_inO g))
            _).
 Defined.
+
+(** The induction principle [O_ind], like most induction principles, is an equivalence. *)
+Section OIndEquiv.
+  Context {fs : Funext} (O : Modality).
+
+  Section OIndEquivData.
+
+    Context {A : Type} (B : O A -> Type) `{forall a, In O (B a)}.
+
+    Global Instance isequiv_O_ind : IsEquiv (O_ind B).
+    Proof.
+      apply isequiv_adjointify with (g := fun h => h oD to O A).
+      - intros h. apply path_forall.
+        refine (O_ind (fun oa => O_ind B (h oD to O A) oa = h oa) _).
+        exact (O_ind_beta B (h oD to O A)).
+      - intros f. apply path_forall.
+        exact (O_ind_beta B f).
+    Defined.
+
+    Definition equiv_O_ind
+    : (forall a, B (to O A a)) <~> (forall oa, B oa)
+    := BuildEquiv _ _ (O_ind B) _.
+
+    (** Theorem 7.7.7 *)
+    Definition isequiv_oD_to_O
+    : IsEquiv (fun (h : forall oa, B oa) => h oD to O A)
+    := equiv_isequiv (equiv_inverse equiv_O_ind).
+
+  End OIndEquivData.
+
+  Local Definition isequiv_o_to_O (A B : Type) (B_inO : In O B)
+  : IsEquiv (fun (h : O A -> B) => h o to O A)
+    := isequiv_oD_to_O (fun _ => B).
+
+End OIndEquiv.
 
 (** Finally, we give one nontrivial example of a modality.  This is Exercise 7.12 in the book. *)
 Definition notnot_modality `{Funext} : Modality.

--- a/theories/ReflectiveSubuniverse.v
+++ b/theories/ReflectiveSubuniverse.v
@@ -13,91 +13,85 @@ Local Arguments compose / .
 (** ** Unit Subuniverses *)
 
 (** A UnitSubuniverse is the common underlying structure of a reflective subuniverse and a modality.  We make it a separate structure in order to use the same names for its fields and functions in the two cases. *)
-Class UnitSubuniverse :=
+Record UnitSubuniverse :=
   {
     inO_internal : Type -> Type ;
-    O : Type -> Type ;
-    O_inO_internal : forall T, inO_internal (O T) ;
-    O_unit : forall T, T -> O T ;
+    O_reflector : Type -> Type ;
+    O_inO_internal : forall T, inO_internal (O_reflector T) ;
+    to : forall T, T -> O_reflector T ;
     (** In most examples, [Funext] is necessary to prove that the predicate of being in the subuniverse is an hprop.  To avoid needing to assume [Funext] as a global hypothesis when constructing such examples, and since [Funext] is often not needed for any of the rest of the theory, we add it as a hypothesis to this specific field of the record. *)
     hprop_inO_internal : Funext -> forall T, IsHProp (inO_internal T)
   }.
 
 (** For reflective subuniverses (and hence also modalities), it will turn out that [inO T] is equivalent to [IsEquiv (O_unit T)].  We could define the former as the latter, and it would simplify some of the general theory.  However, in many examples there is a "more basic" definition of [inO] which is equivalent, but not definitionally identical, to [IsEquiv (O_unit T)].  Thus, including [inO] as data makes more things turn out to be judgmentally what we would expect. *)
 
-(** We made [UnitSubuniverse] into a typeclass, rather than just a record, so that when there is an assumed one around it doesn't need to be given explicitly as an argument to everything.  You should *not* ever declare a global [Instance] of [UnitSubuniverse].  The things to do with it are:
+(** We choose to allow the name of a subuniverse or modality to be used as the name of its reflector. *)
+Coercion O_reflector : UnitSubuniverse >-> Funclass.
 
-  1. Assume an arbitrary one for the purposes of general theory, as we will do here.  In this case it is a variable in the context, so typeclass resolution finds it automatically.
+(* This makes anomalies, see https://coq.inria.fr/bugs/show_bug.cgi?id=3753 *)
+(* Arguments to O T x : rename. *)
 
-  2. Construct a specific one, such as n-types.  You should not define it as a global instance: use [Definition] or [Local Instance].  That way someone else can import your file and still be able to talk about subuniverses other than yours.  (If they do want to use yours, then they can declare it with [Local Existing Instance].)
+(** We now give new names or identities to all the "internal" fields. *)
 
-  3. Apply general theory to a specific example explicitly.  This requires giving the specific example, defined as above, as an explicit argument to the general functions and theorems.
+(** The property of being in the subuniverse, as a typeclass *)
+Class In (O : UnitSubuniverse) (T : Type) :=
+  in_inO_internal : inO_internal O T.
 
-  4. Specify locally that we will be applying the general theory of subuniverses only to a specific example, by declaring that example as a [Local Instance].  (If the subuniverse in question has already been defined somewhere else, you can declare it as an instance locally with [Local Existing Instance].)  This way the instance won't outlast the containing section, module, or file, but inside that section, module, or file, you won't have to give it as an explicit argument.
+Typeclasses Transparent In.
 
-  The same considerations will apply to [ReflectiveSubuniverse] and [Modality].
- *)
+(** Being in the subuniverse is a mere predicate (by hypothesis) *)
+Global Instance hprop_inO {fs : Funext} {O : UnitSubuniverse} (T : Type)
+  : IsHProp (In O T)
+  := hprop_inO_internal O fs T.
 
-Section Unit_Subuniverse.
+(** [O T] is always in the subuniverse (by hypothesis) *)
+Global Instance O_inO {O : UnitSubuniverse} (T : Type) : In O (O T)
+  := O_inO_internal O T.
 
-  Context {subU : UnitSubuniverse}.
+(** The type of types in the subuniverse *)
+Definition Type_ (O : UnitSubuniverse) : Type
+  := {T : Type & In O T}.
 
-  (** The property of being in the subuniverse.  This is a more usual sort of typeclass, to be inferred automatically in many cases.  Note, however, that you shouldn't write [`{inO A}], since the generalizing binders will then introduce a *new* [UnitSubuniverse] hypothesis rather than using the one you intend; write [{A_inO : inO A}] instead.  *)
-  Class inO (T : Type) :=
-    isequiv_inO : inO_internal T.
+Coercion TypeO_pr1 O (T : Type_ O) := @pr1 Type (In O) T.
 
-  Typeclasses Transparent inO.
-
-  (** Being in the subuniverse is a mere predicate (by hypothesis) *)
-  Global Instance hprop_inO {fs : Funext} (T : Type)
-  : IsHProp (inO T)
-  := hprop_inO_internal fs T.
-
-  (** [O T] is always in the subuniverse (by hypothesis) *)
-  Global Instance O_inO T : inO (O T)
-    := O_inO_internal T.
-
-  (** The type of types in the subuniverse *)
-  Definition TypeO : Type
-    := {T : Type & inO T}.
-
-  Coercion TypeO_pr1 (T : TypeO) := @pr1 Type inO T.
-
-  (** The second component of [TypeO] is unique *)
-  Definition path_TypeO {fs : Funext} (T T' : TypeO) (p : T.1 = T'.1)
+(** The second component of [TypeO] is unique *)
+Definition path_TypeO {fs : Funext} O (T T' : Type_ O) (p : T.1 = T'.1)
   : T = T'
   := path_sigma_hprop T T' p.
-
-End Unit_Subuniverse.
 
 (** ** Reflective Subuniverses *)
 
 (** A reflective subuniverse is a [UnitSubuniverse], as above, whose unit has a universal property.  Our definition is somewhat different from that in the book, being instead more similar to the definition of a [Modality]; below we show that it is in fact equivalent. *)
-Class ReflectiveSubuniverse :=
+Record ReflectiveSubuniverse :=
   {
-    rsubu_usubu : UnitSubuniverse ;
-    O_rec : forall {P Q : Type} {Q_inO : inO Q} (f : P -> Q), O P -> Q ;
-    O_rec_beta : forall {P Q : Type} {Q_inO : inO Q} (f : P -> Q) (x : P),
-                      O_rec f (O_unit P x) = f x ;
-    O_indpaths : forall {P Q : Type} {Q_inO : inO Q}
-                         (g h : O P -> Q) (p : g o O_unit P == h o O_unit P),
+    rsubu : UnitSubuniverse ;
+    O_rec : forall {P Q : Type} {Q_inO : In rsubu Q} (f : P -> Q),
+              rsubu P -> Q ;
+    O_rec_beta : forall {P Q : Type} {Q_inO : In rsubu Q} (f : P -> Q) (x : P),
+                   O_rec f (to rsubu P x) = f x ;
+    O_indpaths : forall {P Q : Type} {Q_inO : In rsubu Q}
+                        (g h : rsubu P -> Q) (p : g o to rsubu P == h o to rsubu P),
                     g == h ;
-    O_indpaths_beta : forall {P Q : Type} {Q_inO : inO Q}
-                         (g h : O P -> Q) (p : g o O_unit P == h o O_unit P)
+    O_indpaths_beta : forall {P Q : Type} {Q_inO : In rsubu Q}
+                         (g h : rsubu P -> Q) (p : g o to rsubu P == h o to rsubu P)
                          (x : P),
-                         O_indpaths g h p (O_unit P x) = p x
+                         O_indpaths g h p (to rsubu P x) = p x
   }.
 
-Global Existing Instance rsubu_usubu.
-Coercion rsubu_usubu : ReflectiveSubuniverse >-> UnitSubuniverse.
+Arguments O_rec {O P Q Q_inO} f x : rename.
+Arguments O_rec_beta {O P Q Q_inO} f x : rename.
+Arguments O_indpaths {O P Q Q_inO} g h p x : rename.
+Arguments O_indpaths_beta {O P Q Q_inO} g h p x : rename.
+
+Coercion rsubu : ReflectiveSubuniverse >-> UnitSubuniverse.
 
 (** Here we prove the definition of reflective subuniverse in the book. *)
 Section IsEquiv.
-  Context {fs : Funext} {subU : ReflectiveSubuniverse}.
-  Context (P Q : Type) {Q_inO : inO Q}.
+  Context {fs : Funext} (O : ReflectiveSubuniverse).
+  Context (P Q : Type) `{In O Q}.
 
-  Global Instance isequiv_o_O_unit 
-  : IsEquiv (fun g : O P -> Q => g o O_unit P).
+  Global Instance isequiv_o_to_O 
+  : IsEquiv (fun g : O P -> Q => g o to O P).
   Proof.
     refine (BuildIsEquiv _ _ _ O_rec _ _ _).
     - intros f.
@@ -105,22 +99,22 @@ Section IsEquiv.
       apply O_rec_beta.
     - intros g.
       apply path_arrow; intros x.
-      apply O_indpaths; intros a.
+      apply O_indpaths; try exact _. intros a.
       apply O_rec_beta.
     - intros f; simpl.
       apply moveR_equiv_M; simpl.
       apply path_forall; intros x; symmetry.
-      refine (apD10_ap_precompose (O_unit P) _ x @ _).
-      refine (apD10_path_arrow _ _ _ (O_unit P x) @ _).
+      refine (apD10_ap_precompose (to O P) _ x @ _).
+      refine (apD10_path_arrow _ _ _ (to O P x) @ _).
       exact (O_indpaths_beta _ f _ x).
   Defined.
 
-  Definition equiv_o_O_unit : (O P -> Q) <~> (P -> Q)
-    := BuildEquiv _ _ (fun g : O P -> Q => g o O_unit P) _.
+  Definition equiv_o_to_O : (O P -> Q) <~> (P -> Q)
+    := BuildEquiv _ _ (fun g : O P -> Q => g o to O P) _.
 
   Global Instance isequiv_O_rec
-  : IsEquiv (@O_rec subU P Q _)
-  := (@isequiv_inverse _ _ _ isequiv_o_O_unit).
+  : IsEquiv (@O_rec O P Q _)
+  := (@isequiv_inverse _ _ _ isequiv_o_to_O).
 
   Definition equiv_O_rec : (P -> Q) <~> (O P -> Q)
     := BuildEquiv _ _ O_rec _.
@@ -129,22 +123,20 @@ End IsEquiv.
 
 (** Conversely, from the book's definition we can reconstruct ours. *)
 Section ReflectiveSubuniverseFromIsEquiv.
-
-  Context {fs : Funext}.
-  Context (subU : UnitSubuniverse).
-  Let precomp := fun P Q => (fun g : O P -> Q => g o O_unit P).
-  Context (H : forall {P Q : Type} {Q_inO : inO Q}, IsEquiv (precomp P Q)).
+  Context {fs : Funext} (O : UnitSubuniverse).
+  Let precomp := fun P Q => (fun g : O P -> Q => g o to O P).
+  Context (H : forall {P Q : Type} `{In O Q}, IsEquiv (precomp P Q)).
   
-  Local Definition O_rec' {P Q : Type} {Q_inO : inO Q} (f : P -> Q)
+  Local Definition O_rec' {P Q : Type} `{In O Q} (f : P -> Q)
   : O P -> Q
   := (precomp P Q)^-1 f.
 
-  Local Definition O_rec_beta' {P Q : Type} {Q_inO : inO Q} (f : P -> Q) (x : P)
-  : O_rec' f (O_unit P x) = f x
+  Local Definition O_rec_beta' {P Q : Type} `{In O Q} (f : P -> Q) (x : P)
+  : O_rec' f (to O P x) = f x
   := ap10 (eisretr (precomp P Q) f) x.
 
-  Local Definition O_indpaths' {P Q : Type} {Q_inO : inO Q}
-        (g h : O P -> Q) (p : g o O_unit P == h o O_unit P)
+  Local Definition O_indpaths' {P Q : Type} `{In O Q}
+        (g h : O P -> Q) (p : g o to O P == h o to O P)
   : g == h.
   Proof.
     apply ap10.
@@ -153,12 +145,12 @@ Section ReflectiveSubuniverseFromIsEquiv.
     apply path_arrow, p.
   Defined.
 
-  Local Definition O_indpaths_beta' {P Q : Type} {Q_inO : inO Q}
-        (g h : O P -> Q) (p : g o O_unit P == h o O_unit P) (x : P)
-  : O_indpaths' g h p (O_unit P x) = p x.
+  Local Definition O_indpaths_beta' {P Q : Type} `{In O Q}
+        (g h : O P -> Q) (p : g o to O P == h o to O P) (x : P)
+  : O_indpaths' g h p (to O P x) = p x.
   Proof.
     unfold O_indpaths'.
-    refine ((ap10_ap_precompose (O_unit P) _ x)^ @ _).
+    refine ((ap10_ap_precompose (to O P) _ x)^ @ _).
     refine (apD10 _ x).
     apply moveR_equiv_M.
     rewrite ap_pp, ap_pp, ap_V, <- ap_compose, concat_pp_p.
@@ -169,7 +161,7 @@ Section ReflectiveSubuniverseFromIsEquiv.
 
   Definition reflective_subuniverse_from_isequiv
   : ReflectiveSubuniverse
-  := Build_ReflectiveSubuniverse subU
+  := Build_ReflectiveSubuniverse O
        (@O_rec') (@O_rec_beta') (@O_indpaths') (@O_indpaths_beta').
 
 End ReflectiveSubuniverseFromIsEquiv.
@@ -186,17 +178,19 @@ End ReflectiveSubuniverseFromIsEquiv.
 
 (** A subuniverse is replete if it is closed under equivalence.  This is also a more usual sort of typeclass.  We are not very interested in non-replete subuniverses; the reason for not including repleteness in the main definition is so that functoriality, below, can not depend on it, so that in turn [Build_Modality_easy] can use functoriality to prove repleteness. *)
 
-Class Replete (subU : UnitSubuniverse) :=
-  inO_equiv_inO : forall T U (T_inO : @inO subU T) (f : T -> U) (feq : IsEquiv f), @inO subU U.
+Class Replete (O : UnitSubuniverse) :=
+  inO_equiv_inO :
+    forall T U (T_inO : In O T) (f : T -> U) (feq : IsEquiv f),
+      In O U.
 
 Arguments inO_equiv_inO {_ _} T {U _} f {_}.
 
 (** Of course, with univalence this is automatic.  This is the only appearance of univalence in the theory of reflective subuniverses and (non-lex) modalities. *)
-Global Instance replete_univalence `{Univalence} (subU : UnitSubuniverse)
-: Replete subU.
+Global Instance replete_univalence `{Univalence} (O : UnitSubuniverse)
+: Replete O.
 Proof.
   intros T U ? f ?.
-  refine (transport (@inO subU) _ _).
+  refine (transport (In O) _ _).
   apply path_universe with f; exact _.
 Defined.
 
@@ -204,10 +198,10 @@ Defined.
 
 (** We now prove a bunch of things about an arbitrary reflective subuniverse (sometimes replete). *)
 Section Reflective_Subuniverse.
-  Context {subU : ReflectiveSubuniverse}.
+  Context (O : ReflectiveSubuniverse).
 
   (** Functoriality of [O_rec] homotopies *)
-  Definition O_rec_homotopy {P Q} {Q_inO : inO Q} (f g : P -> Q) (pi : f == g)
+  Definition O_rec_homotopy {P Q} `{In O Q} (f g : P -> Q) (pi : f == g)
   : O_rec f == O_rec g.
   Proof.
     apply O_indpaths; intro x.
@@ -218,12 +212,12 @@ Section Reflective_Subuniverse.
       { symmetry; apply O_rec_beta. } }
   Defined.
 
-  (** If [T] is in the subuniverse, then [O_unit T] is an equivalence. *)
-  Global Instance isequiv_O_unit_inO (T : Type) {T_inO : inO T} : IsEquiv (O_unit T).
+  (** If [T] is in the subuniverse, then [to O T] is an equivalence. *)
+  Global Instance isequiv_to_O_inO (T : Type) `{In O T} : IsEquiv (to O T).
   Proof.
     pose (g := O_rec idmap).
-    refine (isequiv_adjointify (O_unit T) g _ _).
-    - refine (O_indpaths (O_unit T o g) idmap _).
+    refine (isequiv_adjointify (to O T) g _ _).
+    - refine (O_indpaths (to O T o g) idmap _).
       intros x; unfold compose.
       apply ap.
       apply O_rec_beta.
@@ -231,26 +225,26 @@ Section Reflective_Subuniverse.
       apply O_rec_beta.
   Defined.
 
-  Definition equiv_O_unit (T : Type) {T_inO : inO T} : T <~> O T
-    := BuildEquiv T (O T) (O_unit T) _.
+  Definition equiv_O_unit (T : Type) `{In O T} : T <~> O T
+    := BuildEquiv T (O T) (to O T) _.
 
   Section Functor.
 
     (** In this section, we see that [O] is a functor. *)
     
     Definition O_functor {A B : Type} (f : A -> B) : O A -> O B
-      := O_rec (O_unit B o f).
+      := O_rec (to O B o f).
 
     (** Functoriality on composition *)
     Definition O_functor_compose {A B C : Type} (f : A -> B) (g : B -> C)
     : (O_functor (g o f)) == (O_functor g) o (O_functor f).
     Proof.
       apply O_indpaths; intros x; unfold compose.
-      refine (O_rec_beta (O_unit C o g o f) x @ _).
-      transitivity (O_functor g (O_unit B (f x))).
-      - symmetry. exact (O_rec_beta (O_unit C o g) (f x)).
+      refine (O_rec_beta (to O C o g o f) x @ _).
+      transitivity (O_functor g (to O B (f x))).
+      - symmetry. exact (O_rec_beta (to O C o g) (f x)).
       - apply ap; symmetry.
-        exact (O_rec_beta (O_unit B o f) x).
+        exact (O_rec_beta (to O B o f) x).
     Defined.
 
     (** Functoriality on homotopies *)
@@ -258,8 +252,8 @@ Section Reflective_Subuniverse.
     : O_functor f == O_functor g.
     Proof.
       refine (O_indpaths _ _ _); intros x.
-      refine (O_rec_beta (O_unit B o f) x @ _).
-      refine (_ @ (O_rec_beta (O_unit B o g) x)^).
+      refine (O_rec_beta (to O B o f) x @ _).
+      refine (_ @ (O_rec_beta (to O B o g) x)^).
       unfold compose; apply ap.
       apply pi.
     Defined.
@@ -286,17 +280,17 @@ Section Reflective_Subuniverse.
       apply O_rec_beta.
     Qed.
 
-    (** Naturality of [O_unit] *)
-    Definition O_unit_natural {A B} (f : A -> B)
-    : (O_functor f) o (O_unit A) == (O_unit B) o f
+    (** Naturality of [to O] *)
+    Definition to_O_natural {A B} (f : A -> B)
+    : (O_functor f) o (to O A) == (to O B) o f
     := (O_rec_beta _).
 
-    (** The pointed endofunctor ([O],[O_unit]) is well-pointed *)
+    (** The pointed endofunctor ([O],[to O]) is well-pointed *)
     Definition O_functor_wellpointed (A : Type)
-    : O_functor (O_unit A) == O_unit (O A).
+    : O_functor (to O A) == to O (O A).
     Proof.
       refine (O_indpaths _ _ _); intros x.
-      apply O_unit_natural.
+      apply to_O_natural.
     Defined.
 
     (** Preservation of equivalences *)
@@ -321,7 +315,7 @@ Section Reflective_Subuniverse.
     := BuildEquiv _ _ (O_functor f) _.
 
     (** Postcomposition respects [O_rec] *)
-    Definition O_rec_postcompose {A B C} {B_inO : inO B} {C_inO : inO C}
+    Definition O_rec_postcompose {A B C} `{In O B} {C_inO : In O C}
                (f : A -> B) (g : B -> C)
     : g o O_rec f == O_rec (g o f).
     Proof.
@@ -336,49 +330,50 @@ Section Reflective_Subuniverse.
   Section Replete.
 
     (** An equivalent formulation of repleteness is that a type lies in the subuniverse as soon as its unit map is an equivalence. *)
-    Definition inO_isequiv_O_unit {rep : Replete subU} (T:Type)
-    : IsEquiv (O_unit T) -> inO T
-    := fun _ => inO_equiv_inO (O T) (O_unit T)^-1.
+    Definition inO_isequiv_to_O {rep : Replete O} (T:Type)
+    : IsEquiv (to O T) -> In O T
+    := fun _ => inO_equiv_inO (O T) (to O T)^-1.
 
-    Definition inO_iff_isequiv_O_unit {rep : Replete subU} (T:Type)
-    : inO T <-> IsEquiv (O_unit T).
+    (* We don't make this an ordinary instance, but we allow it to solve [In O] constraints if we already have [IsEquiv] as a hypothesis.  *)
+    Hint Immediate inO_isequiv_to_O : typeclass_instances.
+
+    Definition inO_iff_isequiv_to_O {rep : Replete O} (T:Type)
+    : In O T <-> IsEquiv (to O T).
     Proof.
-      split.
-      - apply isequiv_O_unit_inO.
-      - apply inO_isequiv_O_unit.
+      split; exact _.
     Defined.
 
-    Global Instance replete_inO_isequiv_O_unit
-           (H : forall T, IsEquiv (O_unit T) -> inO T)
-    : Replete subU.
+    Definition replete_inO_isequiv_to_O
+           (H : forall T, IsEquiv (to O T) -> In O T)
+    : Replete O.
     Proof.
       intros A B A_inO f feq.
-      pose (uA := BuildEquiv _ _ (O_unit A) _).
-      refine (H B (isequiv_adjointify (O_unit B) _ _ _)); cbn.
+      pose (uA := BuildEquiv _ _ (to O A) _).
+      refine (H B (isequiv_adjointify (to O B) _ _ _)); cbn.
       - exact (f o uA^-1 o (O_functor f)^-1).
       - intros x; unfold compose.
-        refine ((O_unit_natural f _)^ @ _).
+        refine ((to_O_natural f _)^ @ _).
         transitivity (O_functor f ((O_functor f)^-1 x)).
         + apply (ap (O_functor f)).
           apply eisretr.
         + apply eisretr.
       - intros x; unfold compose.
-        transitivity (f (uA^-1 (O_unit A (f^-1 x)))).
-        + apply ap, ap, (O_unit_natural f^-1 x).
+        transitivity (f (uA^-1 (to O A (f^-1 x)))).
+        + apply ap, ap, (to_O_natural f^-1 x).
         + transitivity (f (f^-1 x)).
           * apply ap, eissect.
           * apply eisretr.
     Defined.
 
-    (** Thus, [T] is in a replete subuniverse as soon as [O_unit T] admits a retraction. *)
-    Definition inO_unit_retract {rep : Replete subU} (T:Type) (mu : O T -> T)
-    : Sect (O_unit T) mu -> inO T.
+    (** Thus, [T] is in a replete subuniverse as soon as [to O T] admits a retraction. *)
+    Definition inO_to_O_retract {rep : Replete O} (T:Type) (mu : O T -> T)
+    : Sect (to O T) mu -> In O T.
     Proof.
       unfold Sect; intros H.
-      apply inO_isequiv_O_unit.
+      apply inO_isequiv_to_O.
       apply isequiv_adjointify with (g:=mu).
-      - refine (O_indpaths (O_unit T o mu) idmap _).
-        intros x; exact (ap (O_unit T) (H x)).
+      - refine (O_indpaths (to O T o mu) idmap _).
+        intros x; exact (ap (to O T) (H x)).
       - exact H.
     Defined.
 
@@ -390,73 +385,73 @@ Section Reflective_Subuniverse.
     Notation O_inverts f := (IsEquiv (O_functor f)).
 
     Global Instance O_inverts_O_unit (A : Type)
-    : O_inverts (O_unit A).
+    : O_inverts (to O A).
     Proof.
-      refine (isequiv_homotopic (O_unit (O A)) _).
+      refine (isequiv_homotopic (to O (O A)) _).
       intros x; symmetry; apply O_functor_wellpointed.
     Defined.
 
     (** A map between modal types that is inverted by [O] is already an equivalence. *)
-    Definition isequiv_O_inverts {A B} {A_inO : inO A} {B_inO : inO B}
+    Definition isequiv_O_inverts {A B} `{In O A} `{In O B}
       (f : A -> B) `{O_inverts f}
     : IsEquiv f.
     Proof.
-      refine (isequiv_commsq' f (O_functor f) (O_unit A) (O_unit B) _).
-      apply O_unit_natural.
+      refine (isequiv_commsq' f (O_functor f) (to O A) (to O B) _).
+      apply to_O_natural.
     Defined.
 
-    Definition equiv_O_inverts {A B} {A_inO : inO A} {B_inO : inO B}
+    Definition equiv_O_inverts {A B} `{In O A} `{In O B}
       (f : A -> B) `{O_inverts f}
     : A <~> B
     := BuildEquiv _ _ f (isequiv_O_inverts f).
 
-    Definition O_unit_inv_natural {A B} {A_inO : inO A} {B_inO : inO B}
+    Definition to_O_inv_natural {A B} `{In O A} `{In O B}
                (f : A -> B)
-    : (O_unit B)^-1 o (O_functor f) == f o (O_unit A)^-1.
+    : (to O B)^-1 o (O_functor f) == f o (to O A)^-1.
     Proof.
       refine (O_indpaths _ _ _); intros x.
       unfold compose; apply moveR_equiv_V.
-      refine (O_unit_natural f x @ _).
+      refine (to_O_natural f x @ _).
       unfold compose; do 2 apply ap.
       symmetry; apply eissect.
     Defined.
 
     (** Two maps between modal types that become equal after applying [O_functor] are already equal. *)
-    Definition O_functor_faithful_inO {A B} {A_inO : inO A} {B_inO : inO B}
+    Definition O_functor_faithful_inO {A B} `{In O A} `{In O B}
       (f g : A -> B) (e : O_functor f == O_functor g)
       : f == g.
     Proof.
       intros x.
-      refine (ap f (eissect (O_unit A) x)^ @ _).
-      refine (_ @ ap g (eissect (O_unit A) x)).
-      transitivity ((O_unit B)^-1 (O_functor f (O_unit A x))).
-      + symmetry; apply O_unit_inv_natural.
-      + transitivity ((O_unit B)^-1 (O_functor g (O_unit A x))).
+      refine (ap f (eissect (to O A) x)^ @ _).
+      refine (_ @ ap g (eissect (to O A) x)).
+      transitivity ((to O B)^-1 (O_functor f (to O A x))).
+      + symmetry; apply to_O_inv_natural.
+      + transitivity ((to O B)^-1 (O_functor g (to O A x))).
         * apply ap, e.
-        * apply O_unit_inv_natural.
+        * apply to_O_inv_natural.
     Defined.
 
-    (** Any map to a type in the subuniverse that is inverted by [O] must be equivalent to [O_unit].  More precisely, the type of such maps is contractible. *)
-    Definition typeof_O_unit (A : Type)
-      := { OA : Type & { Ou : A -> OA & ((inO OA) * (O_inverts Ou)) }}.
+    (** Any map to a type in the subuniverse that is inverted by [O] must be equivalent to [to O].  More precisely, the type of such maps is contractible. *)
+    Definition typeof_to_O (A : Type)
+      := { OA : Type & { Ou : A -> OA & ((In O OA) * (O_inverts Ou)) }}.
 
     Global Instance contr_typeof_O_unit `{Univalence} (A : Type)
-    : Contr (typeof_O_unit A).
+    : Contr (typeof_to_O A).
     Proof.
-      exists (O A ; (O_unit A ; (_ , _))).
+      exists (O A ; (to O A ; (_ , _))).
       intros [OA [Ou [? ?]]].
       pose (f := O_rec Ou : O A -> OA).
-      pose (g := (O_functor Ou)^-1 o O_unit OA : (OA -> O A)).
+      pose (g := (O_functor Ou)^-1 o to O OA : (OA -> O A)).
       assert (IsEquiv f).
       { refine (isequiv_adjointify f g _ _).
         - apply O_functor_faithful_inO; intros x.
           rewrite O_functor_idmap.
           fold (f o g); rewrite O_functor_compose.
           unfold g.
-          simpl rewrite (O_functor_compose (O_unit OA) (O_functor Ou)^-1).
+          simpl rewrite (O_functor_compose (to O OA) (O_functor Ou)^-1).
           rewrite O_functor_wellpointed.
-          simpl rewrite (O_unit_natural (O_functor Ou)^-1 x).
-          refine (O_unit_natural f _ @ _).
+          simpl rewrite (to_O_natural (O_functor Ou)^-1 x).
+          refine (to_O_natural f _ @ _).
           set (y := (O_functor Ou)^-1 x).
           transitivity (O_functor Ou y); try apply eisretr.
           unfold f, O_functor, compose.
@@ -465,7 +460,7 @@ Section Reflective_Subuniverse.
           unfold f, compose.
           rewrite O_rec_beta. unfold g.
           apply moveR_equiv_V.
-          symmetry; apply O_unit_natural.
+          symmetry; apply to_O_natural.
       }
       refine (path_sigma _ _ _ _ _); cbn.
       - exact (path_universe f).
@@ -480,43 +475,43 @@ Section Reflective_Subuniverse.
   End OInverts.
 
   Section Types.
-    Context {rep : Replete subU}.
+    Context {rep : Replete O}.
 
     (** ** The [Unit] type *)
-    Global Instance inO_unit : inO Unit.
+    Global Instance inO_unit : In O Unit.
     Proof.
-      apply inO_unit_retract with (mu := fun x => tt).
+      apply inO_to_O_retract with (mu := fun x => tt).
       exact (@contr Unit _).
     Defined.
     
     (** ** Dependent product and arrows *)
     (** Theorem 7.7.2 *)
     Global Instance inO_forall {fs : Funext} (A:Type) (B:A -> Type) 
-    : (forall x, (inO (B x)))
-      -> (inO (forall x:A, (B x))).
+    : (forall x, (In O (B x)))
+      -> (In O (forall x:A, (B x))).
     Proof.
       intro H.
       pose (ev := fun x => (fun (f:(forall x, (B x))) => f x)).
       pose (zz := fun x:A => O_rec (ev x)).
-      apply inO_unit_retract with (mu := fun z => fun x => zz x z).
+      apply inO_to_O_retract with (mu := fun z => fun x => zz x z).
       intro phi.
       unfold zz, ev; clear zz; clear ev.
       apply path_forall; intro x.
       exact (O_rec_beta (fun f : forall x0, (B x0) => f x) phi).
     Defined.
 
-    Global Instance inO_arrow {fs : Funext} (A B : Type) {B_inO : inO B}
-    : inO (A -> B).
+    Global Instance inO_arrow {fs : Funext} (A B : Type) `{In O B}
+    : In O (A -> B).
     Proof.
       apply inO_forall.
       intro a. exact _.
     Defined.
 
     (** ** Product *)
-    Global Instance inO_prod (A B : Type) {A_inO : inO A} {B_inO : inO B}
-    : inO (A*B).
+    Global Instance inO_prod (A B : Type) `{In O A} `{In O B}
+    : In O (A*B).
     Proof.
-      apply inO_unit_retract with
+      apply inO_to_O_retract with
         (mu := fun X => (@O_rec _ (A * B) A _ fst X , O_rec snd X)).
       intros [a b]; apply path_prod; simpl.
       - exact (O_rec_beta fst (a,b)). 
@@ -526,19 +521,19 @@ Section Reflective_Subuniverse.
     (** We show that [OA*OB] has the same universal property as [O(A*B)] *)
 
     Definition equiv_O_prod_unit_precompose
-               {fs : Funext} (A B C : Type) {C_inO : inO C}
+               {fs : Funext} (A B C : Type) `{In O C}
     : ((O A) * (O B) -> C) <~> (A * B -> C).
     Proof.
       apply (equiv_compose' (equiv_uncurry A B C)).
       refine (equiv_compose' _ (equiv_inverse (equiv_uncurry (O A) (O B) C))).
-      apply (equiv_compose' (equiv_o_O_unit A (B -> C))); simpl.
+      apply (equiv_compose' (equiv_o_to_O _ A (B -> C))); simpl.
       apply equiv_postcompose'.
-      exact (equiv_o_O_unit B C).
+      exact (equiv_o_to_O _ B C).
     Defined.
 
     (** The preceding equivalence turns out to be actually (judgmentally!) precomposition with the following function. *)
     Definition O_prod_unit (A B : Type) : A * B -> O A * O B
-      := functor_prod (O_unit A) (O_unit B).
+      := functor_prod (to O A) (to O B).
 
     (** From this, we can define the comparison map for products, and show that precomposing with it is also an equivalence. *)
     Definition O_prod_cmp (A B : Type) : O (A * B) -> O A * O B
@@ -551,7 +546,7 @@ Section Reflective_Subuniverse.
       { apply prod_ind; intro a.
         apply O_rec; intro b; revert a.
         apply O_rec; intro a.
-        apply O_unit.
+        apply (to O).
         exact (a, b). }
       { unfold prod_ind, O_prod_cmp, O_prod_unit.
         intros [oa ob].
@@ -564,7 +559,7 @@ Section Reflective_Subuniverse.
     Defined.
 
     Definition isequiv_O_prod_cmp_precompose
-      {fs : Funext} (A B C : Type) {C_inO : inO C}
+      {fs : Funext} (A B C : Type) {C_inO : In O C}
     : IsEquiv (fun h : O A * O B -> C => h o O_prod_cmp A B).
     Proof.
       apply isequiv_precompose; exact _.
@@ -577,20 +572,20 @@ Section Reflective_Subuniverse.
     (** ** Dependent sums *)
     (** Theorem 7.7.4 *)
     Definition inO_sigma_iff
-    : (forall (A:Type) (B:A -> Type) {A_inO : inO A} {B_inO : forall a, inO (B a)},
-         (inO ({x:A & B x})))
+    : (forall (A:Type) (B:A -> Type) `{In O A} `{forall a, In O (B a)},
+         (In O ({x:A & B x})))
       <->
-      (forall (A:Type) (B: (O A) -> Type) {B_inO : forall a, inO (B a)}
-              (g : forall (a:A), (B (O_unit A a))),
-         {f : forall (z:O A), (B z) & forall a:A, f (O_unit A a) = g a}).
+      (forall (A:Type) (B: (O A) -> Type) `{forall a, In O (B a)}
+              (g : forall (a:A), (B (to O A a))),
+         {f : forall (z:O A), (B z) & forall a:A, f (to O A a) = g a}).
     Proof.
       split.
       - intro H. intros A B ? g.
         pose (Z := sigT B).
-        assert (inO Z). apply H; exact _.
-        pose (g' := (fun a:A => (O_unit A a ; g a)) : A -> Z).
+        assert (In O Z). apply H; exact _.
+        pose (g' := (fun a:A => (to O A a ; g a)) : A -> Z).
         pose (f' := O_rec g').
-        pose (eqf := (O_rec_beta g')  : f' o O_unit A == g').
+        pose (eqf := (O_rec_beta g')  : f' o to O A == g').
         pose (eqid := O_indpaths (pr1 o f') idmap
                                   (fun x => ap pr1 (eqf x))).
         exists (fun z => transport B (eqid z) ((f' z).2)); intros a.
@@ -599,12 +594,12 @@ Section Reflective_Subuniverse.
       - intros H A B ? ?.
         pose (h := fun x => @O_rec _ ({x:A & B x}) A _ pr1 x).
         pose (p := (fun z => O_rec_beta pr1 z)
-                   : h o (O_unit _) == pr1).
+                   : h o (to O _) == pr1).
         pose (g := fun z => (transport B ((p z)^) z.2)).
         simpl in *.
         specialize (H ({x:A & B x}) (B o h) _ g).
         destruct H as [f q].
-        apply inO_unit_retract with (mu := fun w => (h w; f w)).
+        apply inO_to_O_retract with (mu := fun w => (h w; f w)).
         intros [x1 x2].
         refine (path_sigma B _ _ _ _); simpl.
         * apply p.
@@ -614,10 +609,10 @@ Section Reflective_Subuniverse.
 
     (** ** Paths *)
 
-    Global Instance inO_paths (S : Type) {S_inO : inO S} (x y : S)
-    : inO (x=y).
+    Global Instance inO_paths (S : Type) {S_inO : In O S} (x y : S)
+    : In O (x=y).
     Proof.
-      refine (inO_unit_retract _ _ _); intro u.
+      refine (inO_to_O_retract _ _ _); intro u.
       - assert (p : (fun _ : O (x=y) => x) == (fun _=> y)). 
         { refine (O_indpaths _ _ _); unfold compose; simpl.
           intro v; exact v. }
@@ -637,21 +632,21 @@ Section Reflective_Subuniverse.
     : O_functor f o O_monad_mult A == O_monad_mult B o O_functor (O_functor f).
     Proof.
       apply O_indpaths; intros x; unfold compose, O_monad_mult.
-      simpl rewrite (O_unit_natural (O_functor f) x).
+      simpl rewrite (to_O_natural (O_functor f) x).
       rewrite (O_rec_beta idmap x).
       rewrite (O_rec_beta idmap (O_functor f x)).
       reflexivity.
     Qed.
 
     Definition O_monad_unitlaw1 A
-    : O_monad_mult A o (O_unit (O A)) == idmap.
+    : O_monad_mult A o (to O (O A)) == idmap.
     Proof.
       apply O_indpaths; intros x; unfold compose, O_monad_mult.
-      exact (O_rec_beta idmap (O_unit A x)).
+      exact (O_rec_beta idmap (to O A x)).
     Defined.
 
     Definition O_monad_unitlaw2 A
-    : O_monad_mult A o (O_functor (O_unit A)) == idmap.
+    : O_monad_mult A o (O_functor (to O A)) == idmap.
     Proof.
       apply O_indpaths; intros x; unfold O_monad_mult, O_functor, compose.
       repeat rewrite O_rec_beta.
@@ -669,10 +664,10 @@ Section Reflective_Subuniverse.
   End Monad.
 
   Section StrongMonad.
-    Context {fs : Funext} {rep : Replete subU}.
+    Context {fs : Funext} {rep : Replete O}.
 
     Definition O_monad_strength A B : A * O B -> O (A * B)
-      := fun aob => O_rec (fun b a => O_unit (A*B) (a,b)) (snd aob) (fst aob).
+      := fun aob => O_rec (fun b a => to O (A*B) (a,b)) (snd aob) (fst aob).
 
     Definition O_monad_strength_natural A A' B B' (f : A -> A') (g : B -> B')
     : O_functor (functor_prod f g) o O_monad_strength A B ==
@@ -698,7 +693,7 @@ Section Reflective_Subuniverse.
     Qed.
 
     Definition O_monad_strength_unitlaw2 A B
-    : O_monad_strength A B o functor_prod idmap (O_unit B) == O_unit (A*B).
+    : O_monad_strength A B o functor_prod idmap (to O B) == to O (A*B).
     Proof.
       intros [a b].
       unfold O_monad_strength, functor_prod, compose. simpl. 

--- a/theories/hit/PropositionalFracture.v
+++ b/theories/hit/PropositionalFracture.v
@@ -13,7 +13,7 @@ Proof.
   refine (Build_Modality_easy
            (fun X => U -> X)
            (fun X x u => x)
-            _ _ _); unfold O, inO, O_unit.
+            _ _ _).
   - intros A B f z u.
     refine (transport B _ (f (z u) u)).
     apply path_arrow; intros u'.
@@ -30,7 +30,7 @@ Proof.
       apply ap_const.
     * apply eta_path_arrow.
   - intros A z z'.
-    refine (isequiv_adjointify _ _ _ _); unfold O.
+    refine (isequiv_adjointify _ _ _ _).
     * intros f; apply path_arrow; intros u.
       exact (ap10 (f u) u).
     * intros f; apply path_arrow; intros u.
@@ -76,7 +76,7 @@ Section ClosedModality.
       exact _.
   Defined.
 
-  Local Instance closed_modality : Modality.
+  Definition closed_modality : Modality.
   Proof.
     refine (Build_Modality
               (Build_UnitSubuniverse

--- a/theories/hit/Truncations.v
+++ b/theories/hit/Truncations.v
@@ -50,7 +50,7 @@ Definition Trunc_rec {n A X} `{IsTrunc n X}
 Section TruncationModality.
   Context (n : trunc_index).
 
-  Local Instance truncation_modality : Modality.
+  Definition Tr : Modality.
   Proof.
     refine (Build_Modality
               (Build_UnitSubuniverse
@@ -67,9 +67,23 @@ Section TruncationModality.
     refine (trunc_equiv _ f); exact _.
   Defined.
 
+  Global Instance inO_tr_istrunc (A : Type) `{IsTrunc n A}
+  : In Tr A.
+  Proof.
+    assumption.
+  Defined.
+
+  Definition istrunc_inO_tr (A : Type) `{In Tr A}
+  : IsTrunc n A.
+  Proof.
+    assumption.
+  Defined.
+
+  Hint Immediate istrunc_inO_tr : typeclass_instances.
+
   Definition trunc_iff_isequiv_truncation (A : Type)
   : IsTrunc n A <-> IsEquiv (@tr n A)
-  := inO_iff_isequiv_O_unit A.
+  := @inO_iff_isequiv_to_O Tr _ A.
 
   Global Instance isequiv_tr A `{IsTrunc n A} : IsEquiv (@tr n A)
   := fst (trunc_iff_isequiv_truncation A) _.
@@ -84,30 +98,31 @@ Section TruncationModality.
 
   (** ** Functoriality *)
 
+  (* This ought to be [O_functor], but currently that would be insufficiently universe polymorphic. *)
   Definition Trunc_functor {X Y} (f : X -> Y)
   : Trunc n X -> Trunc n Y
   := Trunc_rec (tr o f).
 
   Definition Trunc_functor_compose {X Y Z} (f : X -> Y) (g : Y -> Z)
   : Trunc_functor (g o f) == Trunc_functor g o Trunc_functor f
-  := O_functor_compose f g.
+  := O_functor_compose Tr f g.
 
   Definition Trunc_functor_idmap (X : Type)
   : @Trunc_functor X X idmap == idmap
-  := O_functor_idmap X.
+  := O_functor_idmap Tr X.
 
   Definition isequiv_Trunc_functor {X Y} (f : X -> Y) `{IsEquiv _ _ f}
   : IsEquiv (Trunc_functor f)
-  := isequiv_O_functor f.
+  := isequiv_O_functor Tr f.
 
   Definition equiv_Trunc_prod_cmp `{Funext} {X Y}
   : Trunc n (X * Y) <~> Trunc n X * Trunc n Y
-  := equiv_O_prod_cmp X Y.
+  := equiv_O_prod_cmp Tr X Y.
 
 End TruncationModality.
 
 (** This coercion allows us to use truncation indices where a modality is expected and refer to the corresponding truncation modality.  For instance, the general theory of O-connected maps specializes to the theory of n-connected maps. *)
-Coercion truncation_modality : trunc_index >-> Modality.
+Coercion Tr : trunc_index >-> Modality.
 
 (** It's sometimes convenient to use "infinity" to refer to the identity modality in a similar way.  This clashes with some uses in higher topos theory, where "oo-truncated" means instead "hypercomplete", but this has not yet been a big problem. *)
 Notation oo := identity_modality.


### PR DESCRIPTION
I have been working and thinking about these a lot and I've decided that my original idea of using typeclasses was probably not the best way: when there is more than one modality floating around then it's really better to be passing them explicitly.  This PR turns reflective subuniverses and modalities back into records.
