### PR TITLE
Normalize variable declarations

### DIFF
--- a/theories/ObjectClassifier.v
+++ b/theories/ObjectClassifier.v
@@ -16,7 +16,7 @@ Definition pullback {A0 B C} (f:B-> A0) (g:C->A0):= {b:B & {c:C & f b = g c}}.
 
 Section FamPow.
 (** We consider Families and Powers over a fixed type [A] *)
-Variable A:Type.
+Variable A : Type.
 Definition Fam A:=sigT (fun I:Type  => I->A).
 Definition p2f: (A->Type)-> Fam A:=  fun Q:(A->Type) => ( (sigT Q) ; @pr1 _ _).
 Definition f2p: Fam A -> (A->Type):=
@@ -76,9 +76,9 @@ Section Subobjectclassifier.
 (** We prove that hProp is the subobject classifier *)
 (** In fact, the proof works for general mere predicates on [Type], 
 not just [IsHProp], truncations and modalities are important examples.*)
-Variable A:Type.
-Variable isP:Type -> Type.
-Variable ishprop_isP: forall I, IsHProp (isP I).
+Variable A : Type.
+Variable isP : Type -> Type.
+Variable ishprop_isP : forall I, IsHProp (isP I).
 Definition IsPfibered {I} (f:I->A):=forall i, isP (hfiber f i).
 Definition PFam := (sig (fun F:Fam A => IsPfibered (pr2 F))).
 (* Bug: abstract should accept more than one tactic.

--- a/theories/categories/Adjoint/Composition/AssociativityLaw.v
+++ b/theories/categories/Adjoint/Composition/AssociativityLaw.v
@@ -21,10 +21,7 @@ Section composition_lemmas.
 
   Context `{H0 : Funext}.
 
-  Variable B : PreCategory.
-  Variable C : PreCategory.
-  Variable D : PreCategory.
-  Variable E : PreCategory.
+  Variables B C D E : PreCategory.
 
   Variable F : Functor B C.
   Variable F' : Functor C B.

--- a/theories/categories/Adjoint/Composition/Core.v
+++ b/theories/categories/Adjoint/Composition/Core.v
@@ -16,9 +16,7 @@ Local Open Scope natural_transformation_scope.
 
 (** ** via the unit+counit+zig+zag definition *)
 Section compose.
-  Variable C : PreCategory.
-  Variable D : PreCategory.
-  Variable E : PreCategory.
+  Variables C D E : PreCategory.
 
   Variable F : Functor C D.
   Variable F' : Functor D E.

--- a/theories/categories/Adjoint/Composition/IdentityLaws.v
+++ b/theories/categories/Adjoint/Composition/IdentityLaws.v
@@ -21,8 +21,7 @@ Section identity_lemmas.
 
   Context `{Funext}.
 
-  Variable C : PreCategory.
-  Variable D : PreCategory.
+  Variables C D : PreCategory.
 
   Variable F : Functor C D.
   Variable G : Functor D C.

--- a/theories/categories/Adjoint/Hom.v
+++ b/theories/categories/Adjoint/Hom.v
@@ -22,8 +22,7 @@ Local Open Scope natural_transformation_scope.
 
 Section Adjunction.
   Context `{Funext}.
-  Variable C : PreCategory.
-  Variable D : PreCategory.
+  Variables C D : PreCategory.
   Variable F : Functor C D.
   Variable G : Functor D C.
 

--- a/theories/categories/Adjoint/HomCoercions.v
+++ b/theories/categories/Adjoint/HomCoercions.v
@@ -26,8 +26,7 @@ Local Open Scope natural_transformation_scope.
 (** ** unit+UMP from hom-set adjunction *)
 Section AdjunctionEquivalences.
   Context `{Funext}.
-  Variable C : PreCategory.
-  Variable D : PreCategory.
+  Variables C D : PreCategory.
   Variable F : Functor C D.
   Variable G : Functor D C.
 
@@ -151,8 +150,7 @@ End AdjunctionEquivalences.
 
 Section isequiv.
   (** We want to be able to use this without needing [Funext].  So, first, we prove that the types of hom-sets are equivalent. *)
-  Variable C : PreCategory.
-  Variable D : PreCategory.
+  Variables C D : PreCategory.
   Variable F : Functor C D.
   Variable G : Functor D C.
 
@@ -187,8 +185,7 @@ End isequiv.
 (** ** hom-set adjunction from unit+ump adjunction *)
 Section AdjunctionEquivalences'.
   Context `{Funext}.
-  Variable C : PreCategory.
-  Variable D : PreCategory.
+  Variables C D : PreCategory.
   Variable F : Functor C D.
   Variable G : Functor D C.
 

--- a/theories/categories/Adjoint/Paths.v
+++ b/theories/categories/Adjoint/Paths.v
@@ -16,8 +16,7 @@ Local Open Scope natural_transformation_scope.
 Section path_adjunction.
   Context `{Funext}.
 
-  Variable C : PreCategory.
-  Variable D : PreCategory.
+  Variables C D : PreCategory.
   Variable F : Functor C D.
   Variable G : Functor D C.
 

--- a/theories/categories/Adjoint/Pointwise.v
+++ b/theories/categories/Adjoint/Pointwise.v
@@ -27,8 +27,7 @@ Local Open Scope natural_transformation_scope.
 Section AdjointPointwise.
   Context `{Funext}.
 
-  Variable C : PreCategory.
-  Variable D : PreCategory.
+  Variables C D : PreCategory.
 
   (** ** [F ⊣ G] → [E^F ⊣ E^G] *)
   Section l.

--- a/theories/categories/Adjoint/UnitCounit.v
+++ b/theories/categories/Adjoint/UnitCounit.v
@@ -70,8 +70,7 @@ Section Adjunction.
      with. *)
 
   Section unit.
-    Variable C : PreCategory.
-    Variable D : PreCategory.
+    Variables C D : PreCategory.
     Variable F : Functor C D.
     Variable G : Functor D C.
 
@@ -124,8 +123,7 @@ Section Adjunction.
     - The statement (o) is the UMP of the counit [U].
     *)
   Section counit.
-    Variable C : PreCategory.
-    Variable D : PreCategory.
+    Variables C D : PreCategory.
     Variable F : Functor C D.
     Variable G : Functor D C.
 
@@ -140,8 +138,7 @@ Section Adjunction.
       so that we can use it to make coercions easier. *)
 
   Section unit_counit_op.
-    Variable C : PreCategory.
-    Variable D : PreCategory.
+    Variables C D : PreCategory.
     Variable F : Functor C D.
     Variable G : Functor D C.
 
@@ -247,8 +244,7 @@ Section Adjunction.
       looks like the insertion of the identity 1 into a monoid.  *)
 
   Section unit_counit.
-    Variable C : PreCategory.
-    Variable D : PreCategory.
+    Variables C D : PreCategory.
     Variable F : Functor C D.
     Variable G : Functor D C.
 

--- a/theories/categories/Adjoint/UnitCounitCoercions.v
+++ b/theories/categories/Adjoint/UnitCounitCoercions.v
@@ -95,8 +95,7 @@ Section equivalences.
 
     (** ** unit+UMP → unit+counit+zig+zag *)
     Section from_unit.
-      Variable C : PreCategory.
-      Variable D : PreCategory.
+      Variables C D : PreCategory.
       Variable F : Functor C D.
       Variable G : Functor D C.
 

--- a/theories/categories/Adjoint/UniversalMorphisms/Core.v
+++ b/theories/categories/Adjoint/UniversalMorphisms/Core.v
@@ -16,8 +16,7 @@ Local Open Scope morphism_scope.
 Section adjunction_universal.
   (** ** [F ⊣ G] gives an initial object of [(Y / G)] for all [Y : C] *)
   Section initial.
-    Variable C : PreCategory.
-    Variable D : PreCategory.
+    Variables C D : PreCategory.
     Variable F : Functor C D.
     Variable G : Functor D C.
     Variable A : F -| G.
@@ -47,8 +46,7 @@ Section adjunction_universal.
 
   (** ** [F ⊣ G] gives a terminal object of [(F / X)] for all [X : D] *)
   Section terminal.
-    Variable C : PreCategory.
-    Variable D : PreCategory.
+    Variables C D : PreCategory.
     Variable F : Functor C D.
     Variable G : Functor D C.
     Variable A : F -| G.
@@ -73,8 +71,7 @@ End adjunction_universal.
 Section adjunction_from_universal.
   (** ** an initial object of [(Y / G)] for all [Y : C] gives a left adjoint to [G] *)
   Section initial.
-    Variable C : PreCategory.
-    Variable D : PreCategory.
+    Variables C D : PreCategory.
 
     Variable G : Functor D C.
     Context `(HM : forall Y, @IsInitialMorphism _ _ Y G (M Y)).
@@ -135,8 +132,7 @@ Section adjunction_from_universal.
 
   (** ** a terminal object of [(F / X)] for all [X : D] gives a right adjoint to [F] *)
   Section terminal.
-    Variable C : PreCategory.
-    Variable D : PreCategory.
+    Variables C D : PreCategory.
 
     Variable F : Functor C D.
     Context `(HM : forall X, @IsTerminalMorphism _ _ F X (M X)).

--- a/theories/categories/Adjoint/UniversalMorphisms/FunctorialLaws.v
+++ b/theories/categories/Adjoint/UniversalMorphisms/FunctorialLaws.v
@@ -33,8 +33,7 @@ Section adjunction_from_universal.
 
     Section identity_of.
       Context `{Funext}.
-      Variable C : PreCategory.
-      Variable D : PreCategory.
+      Variables C D : PreCategory.
 
       Variable G : Functor D C.
       Context `(HM : forall Y, @IsInitialMorphism _ _ Y G (M Y)).
@@ -63,12 +62,9 @@ Section adjunction_from_universal.
     Section composition_of.
       Context `{Funext}.
       (** TODO: How do I write the dependent version? *)
-      Variable C : PreCategory.
-      Variable D : PreCategory.
+      Variables C D : PreCategory.
 
-      Variable G : Functor D C.
-      Variable G' : Functor D C.
-      Variable G'' : Functor D C.
+      Variables G G' G'' : Functor D C.
       Variable T : NaturalTransformation G G'.
       Variable T' : NaturalTransformation G' G''.
       Context `(HM : forall Y, @IsInitialMorphism _ _ Y G (M Y)).
@@ -106,8 +102,7 @@ Section adjunction_from_universal.
   Section terminal.
     Section identity_of.
       Context `{Funext}.
-      Variable C : PreCategory.
-      Variable D : PreCategory.
+      Variables C D : PreCategory.
 
       Variable F : Functor C D.
       Context `(HM : forall X, @IsTerminalMorphism _ _ F X (M X)).
@@ -123,12 +118,9 @@ Section adjunction_from_universal.
     Section composition_of.
       Context `{Funext}.
       (** TODO: How do I write the dependent version? *)
-      Variable C : PreCategory.
-      Variable D : PreCategory.
+      Variables C D : PreCategory.
 
-      Variable F : Functor C D.
-      Variable F' : Functor C D.
-      Variable F'' : Functor C D.
+      Variables F F' F'' : Functor C D.
       Variable T : NaturalTransformation F F'.
       Variable T' : NaturalTransformation F' F''.
       Context `(HM : forall X, @IsTerminalMorphism _ _ F X (M X)).

--- a/theories/categories/Adjoint/UniversalMorphisms/FunctorialParts.v
+++ b/theories/categories/Adjoint/UniversalMorphisms/FunctorialParts.v
@@ -20,11 +20,9 @@ Section initial.
   (** ** action on morphisms of the construction of a left adjoint to [G] from an initial object of [(Y / G)] for all [Y : C] *)
   (** *** functoriality on [C], [D], and [G] *)
   Section also_categories.
-    Variable C : PreCategory.
-    Variable C' : PreCategory.
+    Variables C C' : PreCategory.
     Variable CF : Functor C C'.
-    Variable D : PreCategory.
-    Variable D' : PreCategory.
+    Variables D D' : PreCategory.
     Variable DF : Functor D D'.
 
     Variable G : Functor D C.
@@ -51,11 +49,9 @@ Section initial.
 
   (** *** functoriality in [G] *)
   Section only_functor.
-    Variable C : PreCategory.
-    Variable D : PreCategory.
+    Variables C D : PreCategory.
 
-    Variable G : Functor D C.
-    Variable G' : Functor D C.
+    Variables G G' : Functor D C.
     Variable T : NaturalTransformation G G'.
     Context `(HM : forall Y, @IsInitialMorphism _ _ Y G (M Y)).
     Context `(HM' : forall Y, @IsInitialMorphism _ _ Y G' (M' Y)).

--- a/theories/categories/Cat/Morphisms.v
+++ b/theories/categories/Cat/Morphisms.v
@@ -20,8 +20,7 @@ Section iso_lemmas.
   Variables m1 m2 : morphism C s d.
   Variable p : m1 = m2.
 
-  Variable Fs : PreCategory.
-  Variable Fd : PreCategory.
+  Variables Fs Fd : PreCategory.
   Variable Fm : morphism C s d -> Functor Fs Fd.
 
   Lemma transport_Fc_to_idtoiso

--- a/theories/categories/Category/Prod.v
+++ b/theories/categories/Category/Prod.v
@@ -12,8 +12,7 @@ Local Open Scope morphism_scope.
 
 (** ** Definition of [*] for categories *)
 Section prod.
-  Variable C : PreCategory.
-  Variable D : PreCategory.
+  Variables C D : PreCategory.
 
   Definition prod : PreCategory.
     refine (@Build_PreCategory

--- a/theories/categories/Category/Sum.v
+++ b/theories/categories/Category/Sum.v
@@ -8,8 +8,7 @@ Set Asymmetric Patterns.
 
 (** ** Definition of [+] for categories *)
 Section internals.
-  Variable C : PreCategory.
-  Variable D : PreCategory.
+  Variables C D : PreCategory.
 
   Definition sum_morphism (s d : C + D) : Type
     := match s, d with

--- a/theories/categories/CategoryOfSections/Core.v
+++ b/theories/categories/CategoryOfSections/Core.v
@@ -17,8 +17,7 @@ Local Open Scope functor_scope.
 Section FunctorSectionCategory.
   Context `{Funext}.
 
-  Variable C : PreCategory.
-  Variable D : PreCategory.
+  Variables C D : PreCategory.
   Variable R : Functor C D.
 
   (** There is a category [Sect(R)] of sections of [R]. *)

--- a/theories/categories/Comma/Core.v
+++ b/theories/categories/Comma/Core.v
@@ -51,9 +51,7 @@ Local Open Scope category_scope.
 (** ** Comma category [(S / T)] *)
 Module Import CommaCategory.
   Section comma_category_parts.
-    Variable A : PreCategory.
-    Variable B : PreCategory.
-    Variable C : PreCategory.
+    Variables A B C : PreCategory.
     Variable S : Functor A C.
     Variable T : Functor B C.
 
@@ -311,8 +309,7 @@ Hint Constructors morphism object : category.
 
 (** ** (co)slice category [(a / F)], [(F / a)] *)
 Section slice_category.
-  Variable A : PreCategory.
-  Variable C : PreCategory.
+  Variables A C : PreCategory.
   Variable a : C.
   Variable S : Functor A C.
 

--- a/theories/categories/Comma/Dual.v
+++ b/theories/categories/Comma/Dual.v
@@ -17,9 +17,7 @@ Local Open Scope functor_scope.
 (** ** The dual functors [(S / T) ↔ ((Tᵒᵖ / Sᵒᵖ)ᵒᵖ)] *)
 Section opposite.
   Section op.
-    Variable A : PreCategory.
-    Variable B : PreCategory.
-    Variable C : PreCategory.
+    Variables A B C : PreCategory.
 
     Variable S : Functor A C.
     Variable T : Functor B C.

--- a/theories/categories/Comma/Functorial.v
+++ b/theories/categories/Comma/Functorial.v
@@ -64,16 +64,12 @@ Local Ltac functorial_helper_t unfold_lem :=
 
 Section functorial.
   Section single_source.
-    Variable A : PreCategory.
-    Variable B : PreCategory.
-    Variable C : PreCategory.
+    Variables A B C : PreCategory.
     Variable S : Functor A C.
     Variable T : Functor B C.
 
     Section morphism_of.
-      Variable A' : PreCategory.
-      Variable B' : PreCategory.
-      Variable C' : PreCategory.
+      Variables A' B' C' : PreCategory.
       Variable S' : Functor A' C'.
       Variable T' : Functor B' C'.
 
@@ -148,21 +144,15 @@ Section functorial.
   End single_source.
 
   Section composition_of.
-    Variable A : PreCategory.
-    Variable B : PreCategory.
-    Variable C : PreCategory.
+    Variables A B C : PreCategory.
     Variable S : Functor A C.
     Variable T : Functor B C.
 
-    Variable A' : PreCategory.
-    Variable B' : PreCategory.
-    Variable C' : PreCategory.
+    Variables A' B' C' : PreCategory.
     Variable S' : Functor A' C'.
     Variable T' : Functor B' C'.
 
-    Variable A'' : PreCategory.
-    Variable B'' : PreCategory.
-    Variable C'' : PreCategory.
+    Variables A'' B'' C'' : PreCategory.
     Variable S'' : Functor A'' C''.
     Variable T'' : Functor B'' C''.
 

--- a/theories/categories/Comma/InducedFunctors.v
+++ b/theories/categories/Comma/InducedFunctors.v
@@ -19,9 +19,7 @@ Local Open Scope category_scope.
 (** ** Morphisms in [(A → C)ᵒᵖ × (B → C)] from [(s₀, s₁)] to [(d₀, d₁)] induce functors [(s₀ / s₁) → (d₀ / d₁)] *)
 Section comma_category_induced_functor.
   Context `{Funext}.
-  Variable A : PreCategory.
-  Variable B : PreCategory.
-  Variable C : PreCategory.
+  Variables A B C : PreCategory.
 
   Definition comma_category_induced_functor_object_of s d
              (m : morphism ((A -> C)^op * (B -> C)) s d)

--- a/theories/categories/Comma/Projection.v
+++ b/theories/categories/Comma/Projection.v
@@ -16,9 +16,7 @@ Local Open Scope category_scope.
 
 (** ** First projection [(S / T) → A × B] (for [S : A → C ← B : T]) *)
 Section comma_category.
-  Variable A : PreCategory.
-  Variable B : PreCategory.
-  Variable C : PreCategory.
+  Variables A B C : PreCategory.
   Variable S : Functor A C.
   Variable T : Functor B C.
 

--- a/theories/categories/Comma/ProjectionFunctors.v
+++ b/theories/categories/Comma/ProjectionFunctors.v
@@ -28,9 +28,7 @@ Section comma.
 
   Local Notation Cat := (@sub_pre_cat _ P HF).
 
-  Variable A : PreCategory.
-  Variable B : PreCategory.
-  Variable C : PreCategory.
+  Variables A B C : PreCategory.
 
   Hypothesis PAB : P (A * B).
   Hypothesis P_comma : forall (S : Functor A C) (T : Functor B C),
@@ -133,8 +131,7 @@ Section slice_category_projection_functor.
 
   Local Notation Cat := (@sub_pre_cat _ P HF).
 
-  Variable C : PreCategory.
-  Variable D : PreCategory.
+  Variables C D : PreCategory.
 
   Hypothesis P1C : P (1 * C).
   Hypothesis PC1 : P (C * 1).

--- a/theories/categories/ExponentialLaws/Law2/Functors.v
+++ b/theories/categories/ExponentialLaws/Law2/Functors.v
@@ -15,9 +15,7 @@ Local Notation pair_type := Coq.Init.Datatypes.pair.
 
 Section law2.
   Context `{Funext}.
-  Variable D : PreCategory.
-  Variable C1 : PreCategory.
-  Variable C2 : PreCategory.
+  Variables D C1 C2 : PreCategory.
 
   (** ** [yⁿ⁺ᵐ → yⁿ × yᵐ] *)
   Definition functor

--- a/theories/categories/ExponentialLaws/Law2/Law.v
+++ b/theories/categories/ExponentialLaws/Law2/Law.v
@@ -17,9 +17,7 @@ Local Open Scope functor_scope.
 (** ** [yⁿ⁺ᵐ ≅ yⁿ × yᵐ] *)
 Section Law2.
   Context `{Funext}.
-  Variable D : PreCategory.
-  Variable C1 : PreCategory.
-  Variable C2 : PreCategory.
+  Variables D C1 C2 : PreCategory.
 
 
 

--- a/theories/categories/ExponentialLaws/Law3/Functors.v
+++ b/theories/categories/ExponentialLaws/Law3/Functors.v
@@ -18,9 +18,7 @@ Local Notation pair_type := Coq.Init.Datatypes.pair.
 
 Section law3.
   Context `{Funext}.
-  Variable C1 : PreCategory.
-  Variable C2 : PreCategory.
-  Variable D : PreCategory.
+  Variables C1 C2 D : PreCategory.
 
   (** ** [(y × z)ⁿ → yⁿ × zⁿ] *)
   Definition functor

--- a/theories/categories/ExponentialLaws/Law3/Law.v
+++ b/theories/categories/ExponentialLaws/Law3/Law.v
@@ -16,9 +16,7 @@ Local Open Scope functor_scope.
 (** ** [(y × z)ⁿ ≅ yⁿ × zⁿ] *)
 Section Law3.
   Context `{Funext}.
-  Variable C1 : PreCategory.
-  Variable C2 : PreCategory.
-  Variable D : PreCategory.
+  Variables C1 C2 D : PreCategory.
 
   Lemma helper (c : Functor D C1 * Functor D C2)
   : ((fst o (Datatypes.fst c * Datatypes.snd c))%functor,

--- a/theories/categories/ExponentialLaws/Law4/Functors.v
+++ b/theories/categories/ExponentialLaws/Law4/Functors.v
@@ -10,9 +10,7 @@ Local Open Scope functor_scope.
 
 Section law4.
   Context `{Funext}.
-  Variable C1 : PreCategory.
-  Variable C2 : PreCategory.
-  Variable D : PreCategory.
+  Variables C1 C2 D : PreCategory.
 
   Local Open Scope morphism_scope.
 

--- a/theories/categories/ExponentialLaws/Law4/Law.v
+++ b/theories/categories/ExponentialLaws/Law4/Law.v
@@ -16,9 +16,7 @@ Local Open Scope functor_scope.
 (** ** [(C₁ × C₂ → D) ≅ (C₁ → (C₂ → D))] *)
 Section Law4.
   Context `{Funext}.
-  Variable C1 : PreCategory.
-  Variable C2 : PreCategory.
-  Variable D : PreCategory.
+  Variables C1 C2 D : PreCategory.
 
   Lemma helper1 c
   : functor C1 C2 D (inverse C1 C2 D c) = c.

--- a/theories/categories/Functor/Attributes.v
+++ b/theories/categories/Functor/Attributes.v
@@ -11,8 +11,7 @@ Local Open Scope category_scope.
 
 Section full_faithful.
   Context `{Funext}.
-  Variable C : PreCategory.
-  Variable D : PreCategory.
+  Variables C D : PreCategory.
   Variable F : Functor C D.
 
   (** ** Natural transformation [hom_C(─, ─) → hom_D(Fᵒᵖ(─), F(─))] *)

--- a/theories/categories/Functor/Composition/Core.v
+++ b/theories/categories/Functor/Composition/Core.v
@@ -9,10 +9,7 @@ Set Asymmetric Patterns.
 Local Open Scope morphism_scope.
 
 Section composition.
-  Variable B : PreCategory.
-  Variable C : PreCategory.
-  Variable D : PreCategory.
-  Variable E : PreCategory.
+  Variables B C D E : PreCategory.
   Variable G : Functor D E.
   Variable F : Functor C D.
 

--- a/theories/categories/Functor/Composition/Functorial/Attributes.v
+++ b/theories/categories/Functor/Composition/Functorial/Attributes.v
@@ -32,9 +32,7 @@ Section faithfull_precomposition_essential_surjective.
   is faithful. *)
 
   Context `{fs : Funext}.
-  Variable A : PreCategory.
-  Variable B : PreCategory.
-  Variable C : PreCategory.
+  Variables A B C : PreCategory.
 
   Variable H : Functor A B.
 

--- a/theories/categories/Functor/Composition/Functorial/Core.v
+++ b/theories/categories/Functor/Composition/Functorial/Core.v
@@ -13,9 +13,7 @@ Set Asymmetric Patterns.
 (** * Construction of the functor [_∘_ : (C → D) × (D → E) → (C → E)] and it's curried variant *)
 Section functorial_composition.
   Context `{Funext}.
-  Variable C : PreCategory.
-  Variable D : PreCategory.
-  Variable E : PreCategory.
+  Variables C D E : PreCategory.
 
   Local Open Scope natural_transformation_scope.
 

--- a/theories/categories/Functor/Composition/Laws.v
+++ b/theories/categories/Functor/Composition/Laws.v
@@ -13,8 +13,7 @@ Local Open Scope morphism_scope.
 Section identity_lemmas.
   Context `{Funext}.
 
-  Variable C : PreCategory.
-  Variable D : PreCategory.
+  Variables C D : PreCategory.
 
   Local Open Scope functor_scope.
 
@@ -48,10 +47,7 @@ Hint Immediate @left_identity @right_identity : category functor.
 Section composition_lemmas.
   Context `{fs : Funext}.
 
-  Variable B : PreCategory.
-  Variable C : PreCategory.
-  Variable D : PreCategory.
-  Variable E : PreCategory.
+  Variables B C D E : PreCategory.
 
   Local Open Scope functor_scope.
 

--- a/theories/categories/Functor/Core.v
+++ b/theories/categories/Functor/Core.v
@@ -11,8 +11,7 @@ Delimit Scope functor_scope with functor.
 Local Open Scope morphism_scope.
 
 Section Functor.
-  Variable C : PreCategory.
-  Variable D : PreCategory.
+  Variables C D : PreCategory.
 
   (** Quoting from the lecture notes for MIT's 18.705, Commutative Algebra:
 

--- a/theories/categories/Functor/Paths.v
+++ b/theories/categories/Functor/Paths.v
@@ -14,8 +14,7 @@ Local Open Scope functor_scope.
 Section path_functor.
   Context `{Funext}.
 
-  Variable C : PreCategory.
-  Variable D : PreCategory.
+  Variables C D : PreCategory.
 
   Local Open Scope equiv_scope.
 

--- a/theories/categories/Functor/Pointwise/Core.v
+++ b/theories/categories/Functor/Pointwise/Core.v
@@ -15,12 +15,10 @@ Local Open Scope functor_scope.
 Section pointwise.
   Context `{Funext}.
 
-  Variable C : PreCategory.
-  Variable C' : PreCategory.
+  Variables C C' : PreCategory.
   Variable F : Functor C' C.
 
-  Variable D : PreCategory.
-  Variable D' : PreCategory.
+  Variables D D' : PreCategory.
   Variable G : Functor D D'.
 
   Local Notation pointwise_object_of H := (G o H o F : object (C' -> D')).

--- a/theories/categories/Functor/Pointwise/Properties.v
+++ b/theories/categories/Functor/Pointwise/Properties.v
@@ -41,8 +41,7 @@ Section parts.
 
   (** ** respects identity *)
   Section identity_of.
-    Variable C : PreCategory.
-    Variable D : PreCategory.
+    Variables C D : PreCategory.
 
     Lemma identity_of_helper_helper (x : Functor C D)
     : 1 o x o 1 = x.
@@ -75,12 +74,7 @@ Section parts.
 
   (** ** respects composition *)
   Section composition_of.
-    Variable C : PreCategory.
-    Variable D : PreCategory.
-    Variable C' : PreCategory.
-    Variable D' : PreCategory.
-    Variable C'' : PreCategory.
-    Variable D'' : PreCategory.
+    Variables C D C' D' C'' D'' : PreCategory.
 
     Variable F' : Functor C' C''.
     Variable G : Functor D D'.

--- a/theories/categories/Functor/Prod/Core.v
+++ b/theories/categories/Functor/Prod/Core.v
@@ -37,9 +37,7 @@ End proj.
 
 (** ** Product of two functors from the same domain *)
 Section prod.
-  Variable C : PreCategory.
-  Variable D : PreCategory.
-  Variable D' : PreCategory.
+  Variables C D D' : PreCategory.
 
   Definition prod (F : Functor C D) (F' : Functor C D')
   : Functor C (D * D')
@@ -56,10 +54,7 @@ Local Infix "*" := prod : functor_scope.
 
 (** ** Pairing of two functors *)
 Section pair.
-  Variable C : PreCategory.
-  Variable D : PreCategory.
-  Variable C' : PreCategory.
-  Variable D' : PreCategory.
+  Variables C D C' D' : PreCategory.
   Variable F : Functor C D.
   Variable F' : Functor C' D'.
 
@@ -73,9 +68,7 @@ Local Notation "( x , y , .. , z )" := (pair .. (pair x y) .. z) : functor_scope
 
 (** ** Partially applied functors out of a product precategory *)
 Section induced.
-  Variable C : PreCategory.
-  Variable D : PreCategory.
-  Variable E : PreCategory.
+  Variables C D E : PreCategory.
 
   Variable F : Functor (C * D) E.
 

--- a/theories/categories/Functor/Prod/Functorial.v
+++ b/theories/categories/Functor/Prod/Functorial.v
@@ -17,9 +17,7 @@ Local Notation pair_type := Coq.Init.Datatypes.pair.
 Section functorial.
   Context `{Funext}.
 
-  Variable C : PreCategory.
-  Variable D : PreCategory.
-  Variable D' : PreCategory.
+  Variables C D D' : PreCategory.
 
   Definition functor_morphism_of
              s d

--- a/theories/categories/Functor/Prod/Universal.v
+++ b/theories/categories/Functor/Prod/Universal.v
@@ -19,9 +19,7 @@ Local Open Scope functor_scope.
 Section universal.
   Context `{Funext}.
 
-  Variable A : PreCategory.
-  Variable B : PreCategory.
-  Variable C : PreCategory.
+  Variables A B C : PreCategory.
 
   Local Open Scope functor_scope.
 

--- a/theories/categories/Functor/Sum.v
+++ b/theories/categories/Functor/Sum.v
@@ -13,8 +13,7 @@ Local Notation type_inr := inr.
 
 (** ** Injections [inl : C → C + D] and [inr : D → C + D] *)
 Section sum_functors.
-  Variable C : PreCategory.
-  Variable D : PreCategory.
+  Variables C D : PreCategory.
 
   Definition inl : Functor C (C + D)
     := Build_Functor C (C + D)
@@ -33,9 +32,7 @@ End sum_functors.
 
 (** ** Coproduct of functors [F + F' : C + C' → D] *)
 Section sum.
-  Variable C : PreCategory.
-  Variable C' : PreCategory.
-  Variable D : PreCategory.
+  Variables C C' D : PreCategory.
 
   Definition sum (F : Functor C D) (F' : Functor C' D)
   : Functor (C + C') D.

--- a/theories/categories/FunctorCategory/Core.v
+++ b/theories/categories/FunctorCategory/Core.v
@@ -12,8 +12,7 @@ Set Asymmetric Patterns.
 Section functor_category.
   Context `{Funext}.
 
-  Variable C : PreCategory.
-  Variable D : PreCategory.
+  Variables C D : PreCategory.
 
   (** There is a category Fun(C, D) of functors from [C] to [D]. *)
   Definition functor_category : PreCategory

--- a/theories/categories/FunctorCategory/Morphisms.v
+++ b/theories/categories/FunctorCategory/Morphisms.v
@@ -76,8 +76,7 @@ Hint Immediate isisomorphism_natural_transformation : typeclass_instances.
 (** ** Variant of [idtoiso] for natural transformations *)
 Section idtoiso.
   Context `{Funext}.
-  Variable C : PreCategory.
-  Variable D : PreCategory.
+  Variables C D : PreCategory.
 
   Definition idtoiso_natural_transformation
              (F G : object (C -> D))

--- a/theories/categories/KanExtensions/Core.v
+++ b/theories/categories/KanExtensions/Core.v
@@ -130,9 +130,7 @@ Section kan_extensions.
 
   (** *** Pullback-along functor *)
   Context `{Funext}.
-  Variable C  : PreCategory.
-  Variable C' : PreCategory.
-  Variable D  : PreCategory.
+  Variables C C' D : PreCategory.
 
   Section pullback_along.
     Definition pullback_along_functor

--- a/theories/categories/KanExtensions/Functors.v
+++ b/theories/categories/KanExtensions/Functors.v
@@ -12,9 +12,7 @@ Set Asymmetric Patterns.
 
 Section kan_extension_functors.
   Context `{Funext}.
-  Variable C  : PreCategory.
-  Variable C' : PreCategory.
-  Variable D  : PreCategory.
+  Variables C C' D : PreCategory.
   Variable p : object (C -> C').
 
   (** ** Left Kan extension functor *)

--- a/theories/categories/LaxComma/Core.v
+++ b/theories/categories/LaxComma/Core.v
@@ -115,8 +115,7 @@ Global Instance isstrict_oplax_comma_category `{fs : Funext} A B S T HA HB H
 (** ** Definition of Lax (Co)Slice Category *)
 Section lax_slice_category.
   Context `{Funext}.
-  Variable A : PreCategory.
-  Variable a : PreCategory.
+  Variables A a : PreCategory.
   Variable S : Pseudofunctor A.
   Context `{forall a0, IsHSet (Functor (S a0) a)}.
   Context `{forall a0, IsHSet (Functor a (S a0))}.

--- a/theories/categories/LaxComma/CoreLaws.v
+++ b/theories/categories/LaxComma/CoreLaws.v
@@ -51,8 +51,7 @@ Module Import LaxCommaCategory.
   Include LaxComma.CoreParts.LaxCommaCategoryParts.
   Section lax_comma_category_parts.
     Context `{Funext}.
-    Variable A : PreCategory.
-    Variable B : PreCategory.
+    Variables A B : PreCategory.
 
     Variable S : Pseudofunctor A.
     Variable T : Pseudofunctor B.

--- a/theories/categories/LaxComma/CoreParts.v
+++ b/theories/categories/LaxComma/CoreParts.v
@@ -48,8 +48,7 @@ Local Open Scope category_scope.
 Module Import LaxCommaCategoryParts.
   Section lax_comma_category_parts.
     Context `{Funext}.
-    Variable A : PreCategory.
-    Variable B : PreCategory.
+    Variables A B : PreCategory.
 
     Variable S : Pseudofunctor A.
     Variable T : Pseudofunctor B.

--- a/theories/categories/Limits/Core.v
+++ b/theories/categories/Limits/Core.v
@@ -19,8 +19,7 @@ Local Open Scope category_scope.
 (** ** The diagonal or "constant diagram" functor Δ *)
 Section diagonal_functor.
   Context `{Funext}.
-  Variable C : PreCategory.
-  Variable D : PreCategory.
+  Variables C D : PreCategory.
 
   (**
      Quoting Dwyer and Spalinski:
@@ -63,9 +62,7 @@ Arguments diagonal_functor : simpl never.
 
 Section diagonal_functor_lemmas.
   Context `{Funext}.
-  Variable C : PreCategory.
-  Variable D : PreCategory.
-  Variable D' : PreCategory.
+  Variables C D D' : PreCategory.
 
   Lemma compose_diagonal_functor x (F : Functor D' D)
   : diagonal_functor C D x o F = diagonal_functor _ _ x.
@@ -91,8 +88,7 @@ Hint Rewrite @compose_diagonal_functor : category.
 
 Section Limit.
   Context `{Funext}.
-  Variable C : PreCategory.
-  Variable D : PreCategory.
+  Variables C D : PreCategory.
   Variable F : Functor D C.
 
   (** ** Definition of Limit *)

--- a/theories/categories/Limits/Functors.v
+++ b/theories/categories/Limits/Functors.v
@@ -18,8 +18,7 @@ Local Open Scope category_scope.
 
 Section functors.
   Context `{Funext}.
-  Variable C : PreCategory.
-  Variable D : PreCategory.
+  Variables C D : PreCategory.
 
   (** ** Colimit functor, which is left adjoint to Δ *)
   Section colimit.

--- a/theories/categories/NaturalTransformation/Composition/Core.v
+++ b/theories/categories/NaturalTransformation/Composition/Core.v
@@ -52,8 +52,7 @@ Section composition.
   *)
 
   Section compose.
-    Variable C : PreCategory.
-    Variable D : PreCategory.
+    Variables C D : PreCategory.
     Variables F F' F'' : Functor C D.
 
     Variable T' : NaturalTransformation F' F''.
@@ -98,9 +97,7 @@ Section composition.
                  | progress (etransitivity; try (symmetry; apply composition_of)); [] ].
 
   Section whisker.
-    Variable C : PreCategory.
-    Variable D : PreCategory.
-    Variable E : PreCategory.
+    Variables C D E : PreCategory.
 
     Section L.
       Variable F : Functor D E.

--- a/theories/categories/NaturalTransformation/Composition/Functorial.v
+++ b/theories/categories/NaturalTransformation/Composition/Functorial.v
@@ -11,9 +11,7 @@ Local Open Scope functor_scope.
 
 Section functorial_composition.
   Context `{Funext}.
-  Variable C : PreCategory.
-  Variable D : PreCategory.
-  Variable E : PreCategory.
+  Variables C D E : PreCategory.
 
   Local Open Scope natural_transformation_scope.
 

--- a/theories/categories/NaturalTransformation/Composition/Laws.v
+++ b/theories/categories/NaturalTransformation/Composition/Laws.v
@@ -12,8 +12,7 @@ Local Open Scope natural_transformation_scope.
 Section natural_transformation_identity.
   Context `{Funext}.
 
-  Variable C : PreCategory.
-  Variable D : PreCategory.
+  Variables C D : PreCategory.
 
   (** ** left identity : [1 ∘ T = T] *)
   Lemma left_identity (F F' : Functor C D)
@@ -56,9 +55,7 @@ Section whisker.
 
   (** ** whisker exchange law : [(G' ∘ᴸ T) ∘ (T' ∘ᴿ F) = (T' ∘ᴿ F') ∘ (G ∘ᴸ T)] *)
   Section exch.
-    Variable C : PreCategory.
-    Variable D : PreCategory.
-    Variable E : PreCategory.
+    Variables C D E : PreCategory.
     Variables G G' : Functor D E.
     Variables F F' : Functor C D.
     Variable T' : NaturalTransformation G G'.
@@ -74,8 +71,7 @@ Section whisker.
   End exch.
 
   Section whisker.
-    Variable C : PreCategory.
-    Variable D : PreCategory.
+    Variables C D : PreCategory.
     Variables F G H : Functor C D.
     Variable T : NaturalTransformation G H.
     Variable T' : NaturalTransformation F G.
@@ -99,10 +95,7 @@ End whisker.
 Section associativity.
   (** ** associators - natural transformations between [F ∘ (G ∘ H)] and [(F ∘ G) ∘ H] *)
   Section functors.
-    Variable B : PreCategory.
-    Variable C : PreCategory.
-    Variable D : PreCategory.
-    Variable E : PreCategory.
+    Variables B C D E : PreCategory.
     Variable F : Functor D E.
     Variable G : Functor C D.
     Variable H : Functor B C.
@@ -141,8 +134,7 @@ End associativity.
 Section functor_identity.
   Context `{Funext}.
 
-  Variable C : PreCategory.
-  Variable D : PreCategory.
+  Variables C D : PreCategory.
 
   Local Ltac nt_id_t := split; path_natural_transformation;
                         autorewrite with morphism; reflexivity.

--- a/theories/categories/NaturalTransformation/Core.v
+++ b/theories/categories/NaturalTransformation/Core.v
@@ -12,8 +12,7 @@ Local Open Scope morphism_scope.
 Local Open Scope natural_transformation_scope.
 
 Section NaturalTransformation.
-  Variable C : PreCategory.
-  Variable D : PreCategory.
+  Variables C D : PreCategory.
   Variables F G : Functor C D.
 
   (**

--- a/theories/categories/NaturalTransformation/Identity.v
+++ b/theories/categories/NaturalTransformation/Identity.v
@@ -12,8 +12,7 @@ Local Open Scope path_scope.
 Local Open Scope natural_transformation_scope.
 
 Section identity.
-  Variable C : PreCategory.
-  Variable D : PreCategory.
+  Variables C D : PreCategory.
 
   (** There is an identity natrual transformation.  We create a number
       of variants, for various uses. *)

--- a/theories/categories/NaturalTransformation/Paths.v
+++ b/theories/categories/NaturalTransformation/Paths.v
@@ -13,8 +13,7 @@ Local Open Scope natural_transformation_scope.
 Section path_natural_transformation.
   Context `{Funext}.
 
-  Variable C : PreCategory.
-  Variable D : PreCategory.
+  Variables C D : PreCategory.
   Variables F G : Functor C D.
 
   Local Open Scope equiv_scope.

--- a/theories/categories/NaturalTransformation/Pointwise.v
+++ b/theories/categories/NaturalTransformation/Pointwise.v
@@ -25,10 +25,7 @@ Local Open Scope natural_transformation_scope.
 Section pointwise.
   Context `{Funext}.
 
-  Variable C : PreCategory.
-  Variable D : PreCategory.
-  Variable C' : PreCategory.
-  Variable D' : PreCategory.
+  Variables C D C' D' : PreCategory.
 
   Local Ltac t :=
     path_natural_transformation; simpl;

--- a/theories/categories/NaturalTransformation/Prod.v
+++ b/theories/categories/NaturalTransformation/Prod.v
@@ -31,9 +31,7 @@ Local Infix "*" := prod : natural_transformation_scope.
 
 (** ** Natural transformations between partially applied functors *)
 Section induced.
-  Variable C : PreCategory.
-  Variable D : PreCategory.
-  Variable E : PreCategory.
+  Variables C D E : PreCategory.
 
   Variable F : Functor (C * D) E.
 

--- a/theories/categories/ProductLaws.v
+++ b/theories/categories/ProductLaws.v
@@ -34,9 +34,7 @@ End Swap.
 (** ** [A * (B * C) ≅ (A * B) * C] *)
 Module Associativity.
   Section associativity.
-    Variable A : PreCategory.
-    Variable B : PreCategory.
-    Variable C : PreCategory.
+    Variables A B C : PreCategory.
 
     Definition functor : Functor (A * (B * C)) ((A * B) * C)
       := (fst * (fst o snd)) * (snd o snd).

--- a/theories/categories/Profunctor/Core.v
+++ b/theories/categories/Profunctor/Core.v
@@ -24,8 +24,7 @@ Section profunctor.
       Note that the convention that a profunctor is a functor [Dᵒᵖ * C -> Set] is not universal; some authors reverse C and D and/or put the “op” on the other one. See the discussion below. *)
 
   Context `{Funext}.
-  Variable C : PreCategory.
-  Variable D : PreCategory.
+  Variables C D : PreCategory.
 
   (** We capitalize [Profunctor] just like we capitalize [Functor]. *)
   Definition Profunctor := Functor (D^op * C) set_cat.

--- a/theories/categories/UniversalProperties.v
+++ b/theories/categories/UniversalProperties.v
@@ -37,8 +37,7 @@ Section UniversalMorphism.
   (** ** Initial morphisms *)
   Section InitialMorphism.
     (** *** Definition *)
-    Variable C : PreCategory.
-    Variable D : PreCategory.
+    Variables C D : PreCategory.
 
     Variable X : C.
     Variable U : Functor D C.
@@ -256,8 +255,7 @@ Section UniversalMorphism.
   (** ** Terminal morphisms *)
   Section TerminalMorphism.
     (** *** Definition *)
-    Variable C : PreCategory.
-    Variable D : PreCategory.
+    Variables C D : PreCategory.
 
     Variable U : Functor D C.
     Variable X : C.


### PR DESCRIPTION
We no longer need to separate [Variable foo : PreCategory] onto multiple
lines to separate universes.

This change made by invoking

```
git ls-files '*.v' | xargs python combine_variables.py
```

on

``` python
#!/usr/bin/env python
from __future__ import with_statement
import re, sys

REG = re.compile(r'^(\s*)Variables?\s+([^:]+):([^\.]+)\.\s*$')
def groups_to_string(indent, variables, types):
    variable_list = [i for i in variables.split(' ') if i]
    var = ('Variables' if len(variable_list) > 1 else 'Variable')
    return '%s%s %s : %s.' % (indent,
                              var,
                              ' '.join(variable_list),
                              types.strip())
def fix_file(contents):
    ret = []
    prev_groups = tuple()
    for line in contents.split('\n'):
        next_groups = REG.findall(line)
        if prev_groups:
            indent, variables, types = prev_groups
            if next_groups:
                new_indent, new_variables, new_types = next_groups[0]
                if new_indent == indent and types.strip() == new_types.strip():
                    prev_groups = (indent, variables + ' ' + new_variables, types)
                else:
                    ret.append(groups_to_string(indent, variables, types))
                    prev_groups = (new_indent, new_variables, new_types)
            else:
                ret.append(groups_to_string(indent, variables, types))
                ret.append(line)
                prev_groups = tuple()
        elif next_groups:
            prev_groups = next_groups[0]
        else:
            ret.append(line)
    if prev_groups:
        ret.append(groups_to_string(*prev_groups))
    return '\n'.join(ret)

if __name__ == '__main__':
    if len(sys.argv) == 1 or '--help' in sys.argv or '-h' in sys.argv:
        print('Usage: %s FILE_NAME [FILE_NAME ..]' % sys.argv[0])
        print('Replaces [Variable X : T. Variable Y : T.] with [Variables X Y : T.]')
        sys.exit(0)
    for i in sys.argv[1:]:
        with open(i, 'r') as f:
            contents = f.read()
        new_contents = fix_file(contents)
        if new_contents != contents:
            with open(i, 'w') as f:
                f.write(new_contents)
```
