### PR TITLE
complete the proof of contr_from_Empty

### DIFF
--- a/theories/Types/Empty.v
+++ b/theories/Types/Empty.v
@@ -13,10 +13,11 @@ Local Open Scope path_scope.
 (** ** Universal mapping properties *)
 
 Global Instance contr_from_Empty {_ : Funext} (A : Type) :
-  Contr (Empty -> A) :=
-  BuildContr _
-             (Empty_ind (fun _ => A))
-             (fun f => path_forall _ f (fun x => Empty_ind _ x)).
+  Contr (Empty -> A).
+Proof.
+  refine (BuildContr (Empty -> A) (Empty_rec A) _).
+  intros f; apply path_forall; intros x; elim x.
+Defined.  
 
 (** ** Behavior with respect to truncation *)
 


### PR DESCRIPTION
The proof of `contr_from_Empty` was not actually complete, but due to [bug 3890](https://coq.inria.fr/bugs/show_bug.cgi?id=3890) (and also [3632](https://coq.inria.fr/bugs/show_bug.cgi?id=3632)) nobody noticed.
