### PR TITLE
Use [refine] rather than [apply] in more places

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -645,12 +645,6 @@ universe.  Thus, applying `symmetry` to an `Equiv` introduces a
 strictly larger universe.  A solution is to `apply equiv_inverse`
 instead.  Similarly, use `equiv_compose'` instead of `transitivity`.
 
-Given `P : B -> Type` and `f : A -> B`, writing `P o f` introduces a
-universe parameter strictly larger than the codomain of `P` (since it
-has to be passed to the function `compose`).  A solution is to write
-`fun a => P (f a)` instead.  (This may no longer be true with
-`compose` a notation rather than a function.)
-
 Typeclass inference doesn't always find the simplest solution, and may
 insert unnecessary calls to instances that introduce additional
 universes.  One solution is to alter the proofs of those instances as
@@ -898,10 +892,14 @@ instead.
 ### Notations ###
 
 The operation `compose`, notation `g o f`, is simply a notation for
-`fun x => g (f x)` rather than a defined constant.  This means that,
-for instance, you can't partially apply it and write `compose g` for
-`fun f => g o f`.  We could define `compose := (fun g f x => g (f x))`
-instead of `compose g f := (fun x => g (f x))` to allow this, but we
+`fun x => g (f x)` rather than a defined constant.  We define `compose
+:= (fun g f x => g (f x))` so that typeclass inference can pick up
+`isequiv_compose` instances.  This has the unfortunate side-effect
+that `simpl`/`cbn` is enough to "unfold" `compose`, and there's no way
+to prevent this.  We could additionally define `g o f := (fun x => g
+(f x))` to change this, but this would result in identically looking
+goals which are really different.  We consider it poor style to use
+`compose` as a partially applied constant, such as `compose g`; we
 take the point of view that `fun f => g o f` is more readable anyway.
 
 ### Unfolding definitions ###
@@ -986,6 +984,20 @@ where they are defined.
   automatically.  If you need a version with more fields than yet
   exists, feel free to add it.)
 
+- `rapply`, `erapply`: Defined in `coq/theories/Program/Tactics` and
+  `Basics/Overture` respectively, these tactics are more well-behaved
+  variants of `apply` for theorems with fewer than 16 arguments.  (It
+  is trivial to extend it to *n* arguments for any finite fixed *n*.)
+  The unification algorithm used by `apply` is different and often
+  less powerful than the one used by `refine`, though it is
+  occasionally better at pattern matching.  If `apply` fails with a
+  unification error you think it shouldn't have, try `rapply` or
+  `erapply`.
+
+  The difference between `rapply` and `erapply` is that `rapply` only
+  accepts lemmas with no holes (and will do typeclass inference
+  early), while `erapply` accepts lemmas with holes (such as `ap f`,
+  i.e., `@ap _ _ f _ _`), and does typeclass inference late.
 
 ## Contributing to the library ##
 

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -117,7 +117,7 @@ Notation "x .2" := (pr2 x) (at level 3, format "x '.2'") : fibration_scope.
 
 (** Composition of functions. *)
 
-Notation compose g f := (fun x => g (f x)).
+Notation compose := (fun g' f' x => g' (f' x)). (* use primed names because https://coq.inria.fr/bugs/show_bug.cgi?id=3892 *)
 
 (** We put the following notation in a scope because leaving it unscoped causes it to override identical notations in other scopes.  It's convenient to use the same notation for, e.g., function composition, morphism composition in a category, and functor composition, and let Coq automatically infer which one we mean by scopes.  We can't do this if this notation isn't scoped.  Unfortunately, Coq doesn't have a built-in [function_scope] like [type_scope]; [type_scope] is automatically opened wherever Coq is expecting a [Sort], and it would be nice if [function_scope] were automatically opened whenever Coq expects a thing of type [forall _, _] or [_ -> _].  To work around this, we open [function_scope] globally. *)
 Notation "g 'o' f" := (compose g f) (at level 40, left associativity) : function_scope.
@@ -601,6 +601,14 @@ Global Existing Instance ispointed_type.
 (** Homotopy fibers are homotopical inverse images of points.  *)
 
 Definition hfiber {A B : Type} (f : A -> B) (y : B) := { x : A & f x = y }.
+
+(** *** More tactics *)
+
+(** We want access to useful standard library tactics, such as [rapply]. *)
+Require Export Coq.Program.Tactics.
+
+(** [erapply lem] is like [apply lem] (rather, [rapply lem]), but it allows holes in [lem] *)
+Tactic Notation "erapply" open_constr(term) := rapply term.
 
 (** Ssreflect tactics, adapted by Robbert Krebbers *)
 Ltac done :=

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -290,7 +290,7 @@ Section Reflective_Subuniverse.
   Section Functor.
 
     (** In this section, we see that [O] is a functor. *)
-    
+
     Definition O_functor {A B : Type} (f : A -> B) : O A -> O B
       := O_rec (to O B o f).
 
@@ -325,10 +325,10 @@ Section Reflective_Subuniverse.
     Proof.
       intros x.
       transitivity (O_functor (f o pi1) x).
-      - symmetry; apply O_functor_compose.
+      - symmetry; erapply O_functor_compose.
       - transitivity (O_functor (g o pi2) x).
         * apply O_functor_homotopy, comm.
-        * apply O_functor_compose.
+        * erapply O_functor_compose.
     Defined.
 
     (** Functoriality on identities *)
@@ -380,7 +380,7 @@ Section Reflective_Subuniverse.
         + intros y; apply eissect.
         + apply O_functor_idmap.
     Defined.
-      
+
     Definition equiv_O_functor {A B : Type} (f : A <~> B)
     : O A <~> O B
     := BuildEquiv _ _ (O_functor f) _.
@@ -546,7 +546,7 @@ Section Reflective_Subuniverse.
 
     (** ** Dependent product and arrows *)
     (** Theorem 7.7.2 *)
-    Global Instance inO_forall {fs : Funext} (A:Type) (B:A -> Type) 
+    Global Instance inO_forall {fs : Funext} (A:Type) (B:A -> Type)
     : (forall x, (In O (B x)))
       -> (In O (forall x:A, (B x))).
     Proof.
@@ -574,7 +574,7 @@ Section Reflective_Subuniverse.
       apply inO_to_O_retract with
         (mu := fun X => (@O_rec _ (A * B) A _ fst X , O_rec snd X)).
       intros [a b]; apply path_prod; simpl.
-      - exact (O_rec_beta fst (a,b)). 
+      - exact (O_rec_beta fst (a,b)).
       - exact (O_rec_beta snd (a,b)).
     Defined.
 
@@ -712,14 +712,14 @@ Section Reflective_Subuniverse.
     : In O (x=y).
     Proof.
       refine (inO_to_O_retract _ _ _); intro u.
-      - assert (p : (fun _ : O (x=y) => x) == (fun _=> y)). 
+      - assert (p : (fun _ : O (x=y) => x) == (fun _=> y)).
         { refine (O_indpaths _ _ _); simpl.
           intro v; exact v. }
         exact (p u).
       - hnf.
         rewrite O_indpaths_beta; reflexivity.
     Qed.
-    
+
   End Types.
 
   Section Monad.
@@ -780,13 +780,13 @@ Section Reflective_Subuniverse.
       repeat rewrite O_rec_beta.
       reflexivity.
     Qed.
-      
+
     (** The diagrams for strength, see http://en.wikipedia.org/wiki/Strong_monad *)
     Definition O_monad_strength_unitlaw1 (A : Type)
     : O_functor (@snd Unit A) o O_monad_strength Unit A == @snd Unit (O A).
     Proof.
       intros [[] oa]; revert oa.
-      apply O_indpaths; intros x; unfold O_monad_strength, O_functor. simpl. 
+      apply O_indpaths; intros x; unfold O_monad_strength, O_functor. simpl.
       repeat rewrite O_rec_beta.
       reflexivity.
     Qed.
@@ -795,7 +795,7 @@ Section Reflective_Subuniverse.
     : O_monad_strength A B o functor_prod idmap (to O B) == to O (A*B).
     Proof.
       intros [a b].
-      unfold O_monad_strength, functor_prod. simpl. 
+      unfold O_monad_strength, functor_prod. simpl.
       repeat rewrite O_rec_beta.
       reflexivity.
     Qed.
@@ -809,7 +809,7 @@ Section Reflective_Subuniverse.
       revert oc; apply O_indpaths.
       intros c; simpl.
       apply path_arrow; intros b. apply path_arrow; intros a.
-      unfold O_monad_strength, O_functor, functor_prod. simpl. 
+      unfold O_monad_strength, O_functor, functor_prod. simpl.
       repeat rewrite O_rec_beta.
       reflexivity.
     Qed.
@@ -821,13 +821,13 @@ Section Reflective_Subuniverse.
       intros [a oob]. revert a; apply ap10.
       revert oob; apply O_indpaths. apply O_indpaths.
       intros b; simpl. apply path_arrow; intros a.
-      unfold O_monad_strength, O_functor, O_monad_mult, functor_prod. simpl. 
+      unfold O_monad_strength, O_functor, O_monad_mult, functor_prod. simpl.
       repeat (rewrite O_rec_beta; simpl).
       reflexivity.
     Qed.
-      
+
   End StrongMonad.
-      
+
 End Reflective_Subuniverse.
 
 (** Make the [O_inverts] notation global. *)

--- a/theories/UnivalenceImpliesFunext.v
+++ b/theories/UnivalenceImpliesFunext.v
@@ -44,7 +44,7 @@ Section UnivalenceImpliesFunext.
              (A -> B)
              (fun g => (fst o pr1) o g).
   Proof.
-    apply @univalence_isequiv_postcompose.
+    rapply @univalence_isequiv_postcompose.
     refine (isequiv_adjointify
               (fst o pr1) (fun x => ((x, x); idpath))
               (fun _ => idpath)
@@ -61,7 +61,7 @@ Section UnivalenceImpliesFunext.
              (A -> B)
              (fun g => (snd o pr1) o g).
   Proof.
-    apply @univalence_isequiv_postcompose.
+    rapply @univalence_isequiv_postcompose.
     refine (isequiv_adjointify
               (snd o pr1) (fun x => ((x, x); idpath))
               (fun _ => idpath)
@@ -82,7 +82,7 @@ Section UnivalenceImpliesFunext.
     (** If we compose [d] and [e] with [free_path_target], we get [f] and [g], respectively. So, if we had a path from [d] to [e], we would get one from [f] to [g]. *)
     change f with ((snd o pr1) o d).
     change g with ((snd o pr1) o e).
-    apply (ap (fun g => snd o pr1 o g)).
+    erapply (ap (fun g => snd o pr1 o g)).
     (** Since composition with [src] is an equivalence, we can freely compose with [src]. *)
     pose (fun A B x y=> @equiv_inv _ _ _ (@isequiv_ap _ _ _ (@isequiv_src_compose A B) x y)) as H'.
     apply H'.

--- a/theories/categories/Category/Sigma/Univalent.v
+++ b/theories/categories/Category/Sigma/Univalent.v
@@ -295,6 +295,7 @@ Section on_both.
                  | [ |- transport (fun x => ?f (@morphism_inverse _ _ _ (@morphism_isomorphic _ _ _ x) _)) _ _ = _ ]
                    => rewrite (@transport_compose _ _ _ _ f (fun x => (@morphism_inverse _ _ _ (@morphism_isomorphic _ _ _ x) (@isisomorphism_isomorphic _ _ _ x))))
                  | [ |- transport (?f o ?g) _ _ = _ ] => rewrite (@transport_compose _ _ _ _ f g)
+                 | [ |- transport (fun x => ?f (?g x)) _ _ = _ ] => rewrite (@transport_compose _ _ _ _ f g)
                  | [ |- context[ap (@morphism_isomorphic ?a ?b ?c) (path_isomorphic ?i ?j ?x)] ]
                    => change (ap (@morphism_isomorphic a b c)) with ((path_isomorphic i j)^-1%equiv);
                      rewrite (@eissect _ _ (path_isomorphic i j) _ x)


### PR DESCRIPTION
See #657 for discussion.  Mainly, this is a way to aggregate the changes
and allow discussion of the name `reapply` (for a combination of
`rapply` and `eapply`), so that the commit that bumps trunk will be
small.