### PR TITLE
Give a key to function_scope

### DIFF
--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -122,6 +122,8 @@ Notation compose g f := (fun x => g (f x)).
 (** We put the following notation in a scope because leaving it unscoped causes it to override identical notations in other scopes.  It's convenient to use the same notation for, e.g., function composition, morphism composition in a category, and functor composition, and let Coq automatically infer which one we mean by scopes.  We can't do this if this notation isn't scoped.  Unfortunately, Coq doesn't have a built-in [function_scope] like [type_scope]; [type_scope] is automatically opened wherever Coq is expecting a [Sort], and it would be nice if [function_scope] were automatically opened whenever Coq expects a thing of type [forall _, _] or [_ -> _].  To work around this, we open [function_scope] globally. *)
 Notation "g 'o' f" := (compose g f) (at level 40, left associativity) : function_scope.
 Open Scope function_scope.
+(** We allow writing [(f o g)%function] to force [function_scope] over, e.g., [equiv_scope]. *)
+Delimit Scope function_scope with function.
 
 (** Composition of logical equivalences *)
 Definition iff_compose {A B C : Type} (g : B <-> C) (f : A <-> B)


### PR DESCRIPTION
This allows us to force [function_scope] without opening it.