### PR TITLE
Centers of BAut(X), BAut(Bool), and an incoherent idempotent

### DIFF
--- a/Makefile_targets.mk
+++ b/Makefile_targets.mk
@@ -102,6 +102,8 @@ CORE_VFILES = \
 	$(srcdir)/theories/Spaces/BAut.v \
 	$(srcdir)/theories/Spaces/BAut/Cantor.v \
 	$(srcdir)/theories/Spaces/Finite.v \
+	$(srcdir)/theories/Spaces/BAut/Bool.v \
+	$(srcdir)/theories/Spaces/BAut/Bool/IncoherentIdempotent.v \
 	$(srcdir)/theories/Misc.v \
 	$(srcdir)/theories/Utf8.v \
 	$(srcdir)/theories/HoTT.v \

--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -260,7 +260,7 @@ Definition Book_1_10 := ack.
 (* ================================================== ex:eqvboolbool *)
 (** Exercise 2.13 *)
 
-Definition Book_2_13 := @HoTT.Types.Bool.equiv_bool_equiv_bool_bool.
+Definition Book_2_13 := @HoTT.Types.Bool.equiv_bool_aut_bool.
 
 (* ================================================== ex:equality-reflection *)
 (** Exercise 2.14 *)

--- a/theories/Basics/Contractible.v
+++ b/theories/Basics/Contractible.v
@@ -90,6 +90,22 @@ Proof.
   destruct p; reflexivity.
 Defined.
 
+(** Some useful computation laws for based path spaces *)
+
+Definition ap_pr1_path_contr_basedpaths {X : Type}
+           {x y z : X} (p : x = y) (q : x = z)
+: ap pr1 (path_contr ((y;p):{y':X & x = y'}) (z;q)) = p^ @ q.
+Proof.
+  destruct p,q; reflexivity.
+Defined.
+
+Definition ap_pr1_path_contr_basedpaths' {X : Type}
+           {x y z : X} (p : y = x) (q : z = x)
+: ap pr1 (path_contr ((y;p):{y':X & y' = x}) (z;q)) = p @ q^.
+Proof.
+  destruct p,q; reflexivity.
+Defined.
+
 (** If the domain is contractible, the function is propositionally constant. *)
 Definition contr_dom_equiv {A B} (f : A -> B) `{Contr A} : forall x y : A, f x = f y
   := fun x y => ap f ((contr x)^ @ contr y).

--- a/theories/Basics/Contractible.v
+++ b/theories/Basics/Contractible.v
@@ -90,22 +90,6 @@ Proof.
   destruct p; reflexivity.
 Defined.
 
-(** Some useful computation laws for based path spaces *)
-
-Definition ap_pr1_path_contr_basedpaths {X : Type}
-           {x y z : X} (p : x = y) (q : x = z)
-: ap pr1 (path_contr ((y;p):{y':X & x = y'}) (z;q)) = p^ @ q.
-Proof.
-  destruct p,q; reflexivity.
-Defined.
-
-Definition ap_pr1_path_contr_basedpaths' {X : Type}
-           {x y z : X} (p : y = x) (q : z = x)
-: ap pr1 (path_contr ((y;p):{y':X & y' = x}) (z;q)) = p @ q^.
-Proof.
-  destruct p,q; reflexivity.
-Defined.
-
 (** If the domain is contractible, the function is propositionally constant. *)
 Definition contr_dom_equiv {A B} (f : A -> B) `{Contr A} : forall x y : A, f x = f y
   := fun x y => ap f ((contr x)^ @ contr y).

--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -240,6 +240,15 @@ Section Adjointify.
 
 End Adjointify.
 
+(** An involution is an endomap that is its own inverse. *)
+Definition isequiv_involution {X : Type} (f : X -> X) (isinvol : Sect f f)
+: IsEquiv f
+  := isequiv_adjointify f f isinvol isinvol.
+
+Definition equiv_involution {X : Type} (f : X -> X) (isinvol : Sect f f)
+: X <~> X
+  := equiv_adjointify f f isinvol isinvol.
+
 (** Several lemmas useful for rewriting. *)
 Definition moveR_equiv_M `{IsEquiv A B f} (x : A) (y : B) (p : x = f^-1 y)
   : (f x = y)

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -374,6 +374,11 @@ Notation "A <~> B" := (Equiv A B) (at level 85) : equiv_scope.
 
 Notation "f ^-1" := (@equiv_inv _ _ f _) (at level 3, format "f '^-1'") : equiv_scope.
 
+(** ** Applying paths between equivalences like functions *)
+
+Definition ap10_equiv {A B : Type} {f g : A <~> B} (h : f = g) : f == g
+  := ap10 (ap equiv_fun h).
+
 (** ** Contractibility and truncation levels *)
 
 (** Truncation measures how complicated a type is.  In this library, a witness that a type is n-truncated is formalized by the [IsTrunc n] typeclass.  In many cases, the typeclass machinery of Coq can automatically infer a witness for a type being n-truncated.  Because [IsTrunc n A] itself has no computational content (that is, all witnesses of n-truncation of a type are provably equal), it does not matter much which witness Coq infers.  Therefore, the primary concerns in making use of the typeclass machinery are coverage (how many goals can be automatically solved) and speed (how long does it take to solve a goal, and how long does it take to error on a goal we cannot automatically solve).  Careful use of typeclass instances and priorities, which determine the order of typeclass resolution, can be used to effectively increase both the coverage and the speed in cases where the goal is solvable.  Unfortunately, typeclass resolution tends to spin for a while before failing unless you're very, very, very careful.  We currently aim to achieve moderate coverage and fast speed in solvable cases.  How long it takes to fail typeclass resolution is not currently considered, though it would be nice someday to be even more careful about things.

--- a/theories/Basics/PathGroupoids.v
+++ b/theories/Basics/PathGroupoids.v
@@ -929,6 +929,20 @@ Definition whiskerL_1p {A : Type} {x y : A} {p q : x = y} (h : p = q) :
       1
     end end.
 
+Definition whiskerR_p1_1 {A} {x : A} (h : idpath x = idpath x)
+: whiskerR h 1 = h.
+Proof.
+  refine (_ @ whiskerR_p1 h); simpl.
+  symmetry; refine (concat_p1 _ @ concat_1p _).
+Defined.
+
+Definition whiskerL_1p_1 {A} {x : A} (h : idpath x = idpath x)
+: whiskerL 1 h = h.
+Proof.
+  refine (_ @ whiskerL_1p h); simpl.
+  symmetry; refine (concat_p1 _ @ concat_1p _).
+Defined.
+
 Definition concat2_p1 {A : Type} {x y : A} {p q : x = y} (h : p = q) :
   h @@ 1 = whiskerR h 1 :> (p @ 1 = q @ 1)
   :=

--- a/theories/HoTT.v
+++ b/theories/HoTT.v
@@ -59,6 +59,8 @@ Require Export Spaces.Cantor.
 Require Export Spaces.BAut.
 Require Export Spaces.BAut.Cantor.
 Require Export Spaces.Finite.
+Require Export Spaces.BAut.Bool.
+Require Export Spaces.BAut.Bool.IncoherentIdempotent.
 
 Require Export HoTT.Tactics.
 

--- a/theories/Idempotents.v
+++ b/theories/Idempotents.v
@@ -1,7 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 Require Import HoTT.Basics HoTT.Types.
-Require Import HoTT.Tactics.
-Require Import Fibrations UnivalenceImpliesFunext.
+Require Import Fibrations UnivalenceImpliesFunext EquivalenceVarieties.
 Require Import hit.Truncations.
 
 Local Open Scope path_scope.
@@ -288,20 +287,20 @@ Defined.
 
 (** First we show that given a retract, the composite [s o r] is quasi-idempotent. *)
 
-Global Instance preidem_retract {X : Type} (R : RetractOf X)
+Global Instance ispreidem_retract {X : Type} (R : RetractOf X)
 : IsPreIdempotent (retract_idem R).
 Proof.
   exact (fun x => ap (retract_sect R) (retract_issect R (retract_retr R x))).
 Defined.
 
-Definition preidem_retract' {X : Type} (R : RetractOf X)
+Definition preidem_retract {X : Type} (R : RetractOf X)
 : PreIdempotent X
-:= (retract_idem R ; preidem_retract R).
+:= (retract_idem R ; ispreidem_retract R).
 
+Arguments ispreidem_retract / .
 Arguments preidem_retract / .
-Arguments preidem_retract' / .
 
-Global Instance qidem_retract {X : Type} (R : RetractOf X)
+Global Instance isqidem_retract {X : Type} (R : RetractOf X)
 : IsQuasiIdempotent (retract_idem R).
 Proof.
   destruct R as [A r s H]; intros x; unfold isidem; simpl.
@@ -312,29 +311,29 @@ Proof.
   refine (concat_A1p H (H (r x))).
 Defined.
 
-Definition qidem_retract' {X : Type} (R : RetractOf X)
+Definition qidem_retract {X : Type} (R : RetractOf X)
 : QuasiIdempotent X
-:= (preidem_retract' R ; qidem_retract R).
+:= (preidem_retract R ; isqidem_retract R).
 
 (** In particular, it follows that any split function is quasi-idempotent. *)
 
-Global Instance preidem_split {X : Type} (f : X -> X) (S : Splitting f)
+Global Instance ispreidem_split {X : Type} (f : X -> X) (S : Splitting f)
 : IsPreIdempotent f.
 Proof.
   destruct S as [R p].
   refine (ispreidem_homotopic _ p); exact _.
 Defined.
 
-Arguments preidem_split / .
+Arguments ispreidem_split / .
 
-Global Instance qidem_split {X : Type} (f : X -> X) (S : Splitting f)
-: @IsQuasiIdempotent X f (preidem_split f S).
+Global Instance isqidem_split {X : Type} (f : X -> X) (S : Splitting f)
+: @IsQuasiIdempotent X f (ispreidem_split f S).
 Proof.
   destruct S as [R p].
   refine (isqidem_homotopic _ p); exact _.
 Defined.
 
-Arguments qidem_split / .
+Arguments isqidem_split / .
 
 (** ** Quasi-idempotents split *)
 
@@ -488,7 +487,7 @@ Section Splitting.
     apply moveR_Vp, whiskerR; symmetry; apply J.
   Qed.
 
-  (** We conjucture that the particular witness [J] of quasi-idempotence can *not* in general be recovered from the splitting.  This is analogous to how [eissect] and [eisretr] cannot both be recovered after [isequiv_adjointify]; one of them has to be modified. *)
+  (** However, the particular witness [J] of quasi-idempotence can *not* in general be recovered from the splitting; we will mention a counterexample below.  This is analogous to how [eissect] and [eisretr] cannot both be recovered after [isequiv_adjointify]; one of them has to be modified. *)
 
 End Splitting.
 
@@ -663,10 +662,10 @@ Section RetractOfRetracts.
     refine (Build_RetractOf (QuasiIdempotent X)
                             (RetractOf X)
                             split_idem_retract'
-                            qidem_retract' _).
+                            qidem_retract _).
     intros R.
     exact (@path_retractof _ _
-             R (split_idem_retract' (qidem_retract' R))
+             R (split_idem_retract' (qidem_retract R))
              (equiv_split_idem_retract R)
              (equiv_split_idem_retract_retr R)
              (equiv_split_idem_retract_sect R)
@@ -717,7 +716,7 @@ Section RetractOfRetracts.
               _ (@retractof_equiv'
                    (hfiber (@pr1 _ (fun fi => @IsQuasiIdempotent _ fi.1 fi.2)) f) _ _
                    (retractof_hfiber
-                      retract_retractof_qidem pr1 preidem_retract'
+                      retract_retractof_qidem pr1 preidem_retract
                       _ f))
               (Splitting_PreIdempotent f) _).
     - symmetry; refine (hfiber_fibration f _).
@@ -815,9 +814,9 @@ End CoherentIdempotents.
 
 (** ** Quasi-idempotents need not be fully coherent *)
 
-(** We have shown that every quasi-idempotent can be "coherentified" into a fully coherent idempotent, analogously to how every quasi-inverse can be coherentified into an equivalence.  We now show that, just as for quasi-inverses, not every witness to quasi-idempotency *is itself* coherent.  This is in contrast to a witness of pre-idempotency, which (if it extends to a quasi-idempotent) can itself be extended to a coherent idempotent; this is roughly the content of [split_idem_preidem] and [splitting_preidem_retractof_qidem]. *)
+(** We have shown that every quasi-idempotent can be "coherentified" into a fully coherent idempotent, analogously to how every quasi-inverse can be coherentified into an equivalence.  However, just as for quasi-inverses, not every witness to quasi-idempotency *is itself* coherent.  This is in contrast to a witness of pre-idempotency, which (if it extends to a quasi-idempotent) can itself be extended to a coherent idempotent; this is roughly the content of [split_idem_preidem] and [splitting_preidem_retractof_qidem].
 
-(** We begin by observing that when [f] is the identity, the retract type [Splitting_PreIdempotent f] of [splitting_preidem_retractof_qidem] is equivalent to the type of types-equivalent-to-[X], and hence contractible. *)
+  The key step in showing this is to observe that when [f] is the identity, the retract type [Splitting_PreIdempotent f] of [splitting_preidem_retractof_qidem] is equivalent to the type of types-equivalent-to-[X], and hence contractible. *)
 
 Definition contr_splitting_preidem_idmap {ua : Univalence} (X : Type)
 : Contr (Splitting_PreIdempotent (preidem_idmap X)).
@@ -859,9 +858,8 @@ Proof.
     exact (equiv_ap (ap s) _ _).
 Qed.
 
-(** Therefore, there is a unique coherentification of the canonical witness [preidem_idmap] of pre-idempotency for the identity.  Hence, to show that not every quasi-idempotent is coherent, it suffices to give a witness of quasi-idempotency extending [preidem_idmap] which is nontrivial (i.e. not equal to [qidem_idmap]).
+(** Therefore, there is a unique coherentification of the canonical witness [preidem_idmap] of pre-idempotency for the identity.  Hence, to show that not every quasi-idempotent is coherent, it suffices to give a witness of quasi-idempotency extending [preidem_idmap] which is nontrivial (i.e. not equal to [qidem_idmap]).  Such a witness is exactly an element of the 2-center, and we know that some types such as [BAut (BAut Bool)] have nontrivial 2-centers.  In [Spaces.BAut.Bool.IncoherentIdempotent] we use this to construct an explicit counterexample. *)
 
-TODO: Do this, using [BAut (BAut Bool)]. *)
 
 (** ** A pre-idempotent that is not quasi-idempotent *)
 

--- a/theories/Modalities/Modality.v
+++ b/theories/Modalities/Modality.v
@@ -976,6 +976,14 @@ Section ModalFact.
               (functor_sigma idmap (fun b => to O (hfiber f b)))).
   Defined.
 
+  Global Instance conn_map_factor1_image {A B : Type} (f : A -> B)
+  : IsConnMap O (factor1 (image f))
+    := inclass1 (image f).
+
+  Global Instance inO_map_factor1_image {A B : Type} (f : A -> B)
+  : MapIn O (factor2 (image f))
+    := inclass2 (image f).
+
   (** This is the composite of the three displayed equivalences at the beginning of the proof of Lemma 7.6.5.  Note that it involves only a single factorization of [f]. *)
   Lemma O_hfiber_O_fact {A B : Type} {f : A -> B}
         (fact : Factorization (@IsConnMap O) (@MapIn O) f) (b : B)

--- a/theories/Spaces/BAut.v
+++ b/theories/Spaces/BAut.v
@@ -1,5 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 Require Import HoTT.Basics HoTT.Types.
+Require Import Constant Factorization UnivalenceImpliesFunext.
 Require Import Modalities.Modality hit.Truncations hit.Connectedness.
 Import TrM.
 
@@ -8,8 +9,22 @@ Open Scope equiv_scope.
 
 (** * BAut(X) *)
 
+(** ** Basics *)
+
 (** [BAut X] is the type of types that are merely equivalent to [X]. *)
 Definition BAut (X : Type) := { Z : Type & merely (Z = X) }.
+
+(** Equivalently, [BAut X] is the (-1)-image of the classifying map [1 -> Type] of [X]. *)
+
+Definition equiv_baut_image_unit X
+: BAut X <~> image (Tr -1) (unit_name X).
+Proof.
+  unfold BAut, image; simpl.
+  refine (equiv_functor_sigma' (equiv_idmap Type) _); intros Z; simpl.
+  apply equiv_O_functor; unfold hfiber.
+  refine (equiv_compose' (equiv_inverse (equiv_contr_sigma _)) _).
+  apply equiv_path_inverse.
+Defined.
 
 (** It is canonically pointed by [X] itself. *)
 Global Instance ispointed_baut X : IsPointed (BAut X)
@@ -25,3 +40,230 @@ Proof.
   - apply equiv_path_sigma_hprop.
   - apply equiv_path_universe.
 Defined.
+
+Definition ap_pr1_path_baut `{Univalence} {X}
+           {Z Z' : BAut X} (f : Z <~> Z')
+: ap (BAut_pr1 X) (path_baut Z Z' f) = path_universe f.
+Proof.
+  unfold path_baut, BAut_pr1; simpl.
+  apply ap_pr1_path_sigma_hprop.
+Defined.
+
+Definition transport_path_baut `{Univalence} {X}
+           {Z Z' : BAut X} (f : Z <~> Z') (z : Z)
+: transport (fun (W:BAut X) => W) (path_baut Z Z' f) z = f z.
+Proof.
+  refine (transport_compose idmap (BAut_pr1 X) _ _ @ _).
+  refine (_ @ transport_path_universe f z).
+  apply ap10, ap, ap_pr1_path_baut.
+Defined.
+
+(** ** Truncation *)
+
+(** If [X] is an [n.+1]-type, then [BAut X] is an [n.+2]-type. *)
+Global Instance trunc_baut `{Univalence} {n X} `{IsTrunc n.+1 X}
+: IsTrunc n.+2 (BAut X).
+Proof.
+  intros [Z p] [W q].
+  strip_truncations.
+  refine (@trunc_equiv' _ _ (path_baut _ _) n.+1 _); simpl.
+  symmetry in q; destruct q.
+  symmetry in p; destruct p.
+  exact _.
+Defined.
+
+(** And it is 0-connected *)
+Global Instance isconnected_baut X : IsConnected 0 (BAut X).
+Proof.
+  refine (conn_pointed_type (point (BAut X))); try exact _.
+  pose (c := conn_map_compose (Tr -1)
+                              (factor1 (image (Tr -1) (unit_name X)))
+                              (equiv_baut_image_unit X)^-1).
+  refine (conn_map_homotopic _ _ _ _ c); intros []; reflexivity.
+Defined.
+
+(** Therefore, any two points in it are merely equal. *)
+Definition merely_path_baut `{Univalence} {X} (Z Z' : BAut X)
+: merely (Z = Z')
+:= merely_path_is0connected (BAut X) Z Z'.
+
+(** The following tactic, which applies when trying to prove an hprop, replaces all assumed elements of [BAut X] by [X] itself. *)
+Ltac baut_reduce :=
+  progress repeat
+    match goal with
+      | [ Z : BAut ?X |- _ ]
+        => let Zispoint := fresh "Zispoint" in
+           assert (Zispoint := merely_path_baut (point (BAut X)) Z);
+           strip_truncations;
+           destruct Zispoint
+    end.
+
+(** If [X] is truncated, then so is every element of [BAut X]. *)
+Global Instance trunc_el_baut `{Funext} {n X} `{IsTrunc n X} (Z : BAut X)
+: IsTrunc n Z.
+Proof.
+  destruct Z as [Z p].
+  strip_truncations.
+  destruct p; exact _.
+Defined.
+
+(** ** Centers *)
+
+(** The following lemma says that to define a section of a family [P] of hsets over [BAut X], it is equivalent to define an element of [P X] which is fixed by all automorphisms of [X]. *)
+Lemma baut_ind_hset `{Univalence} X
+      (** It ought to be possible to allow more generally [P : BAut X -> Type], but the proof would get more complicated, and this version suffices for present applications. *)
+      (P : Type -> Type) `{forall (Z : BAut X), IsHSet (P Z)}
+: { e : P (point (BAut X)) &
+    forall g : X <~> X, transport P (path_universe g) e = e }
+  <~> (forall (Z:BAut X), P Z).
+Proof.
+  refine (equiv_compose' (equiv_sigT_ind _) _).
+  (** We use the fact that maps out of a propositional truncation into an hset are equivalent to weakly constant functions. *)
+  refine (equiv_compose'
+           (equiv_functor_forall'
+             (P := fun Z => { f : (Z=X) -> P Z & WeaklyConstant f })
+             (equiv_idmap Type)
+             (fun Z => equiv_merely_rec_hset _ _)) _); simpl.
+  { intros p. change (IsHSet (P (BAut_pr1 X (Z ; tr p)))). exact _. }
+  unfold WeaklyConstant.
+  (** Now we peel away a bunch of contractible types. *)
+  refine (equiv_compose' (equiv_sigT_coind _ _) _).
+  refine (equiv_compose' (equiv_functor_sigma'
+           (P := fun k => forall Z p q, k (Z;p) = k (Z;q))
+           (equiv_inverse (equiv_sigT_ind
+              (fun Zp => P Zp.1))) (fun k => equiv_idmap _)) _).
+  refine (equiv_compose' (equiv_functor_sigma'
+           (equiv_idmap (forall Zp : {Z:Type & Z=X}, P Zp.1))
+           (fun k => equiv_inverse (equiv_sigT_ind
+                     (fun Zp => forall q, k Zp = k (Zp.1;q))))) _).
+  refine (equiv_compose' (equiv_functor_sigma'
+           (equiv_idmap (forall Zp : {Z:Type & Z=X}, P Zp.1))
+           (fun k => equiv_inverse (equiv_contr_forall
+                     (fun Zp => forall q, k Zp = k (Zp.1;q))))) _); simpl.
+  refine (equiv_compose' (equiv_functor_sigma'
+           (P := fun (e : P X) => forall q:X=X, transport P q^ e = e)
+           (equiv_inverse (equiv_contr_forall
+             (fun (Zp:{Z:Type & Z=X}) => P Zp.1)))
+             (fun f => equiv_functor_forall' (equiv_idmap (X=X)) _)) _).
+  { intros g; simpl.
+    refine (equiv_compose' (equiv_path_inverse _ _) _).
+    apply equiv_concat_l.
+    refine (transport_compose P pr1 (path_contr (X;1) (X;g)) f @ _).
+    apply transport2.
+    refine (ap_pr1_path_contr_basedpaths' _ _ @ concat_1p g^). }
+  refine (equiv_functor_sigma' (equiv_idmap _) _); intros e.
+  refine (equiv_functor_forall' (equiv_inverse (equiv_path_universe X X)) _).
+  intros g; simpl.
+  refine (equiv_compose' (equiv_moveR_transport_V _ _ _ _) _).
+  refine (equiv_compose' (equiv_path_inverse _ _) _).
+  apply equiv_concat_l, transport2.
+  symmetry; apply (eissect (equiv_path X X)).
+Defined.
+
+(** This implies that if [X] is a set, then the center of [BAut X] is the set of automorphisms of [X] that commute with every other automorphism (i.e. the center, in the usual sense, of the group of automorphisms of [X]). *)
+
+Definition center_baut `{Univalence} X `{IsHSet X} :
+  { f : X <~> X & forall g:X<~>X, g o f == f o g }
+  <~> (forall Z:BAut X, Z = Z).
+Proof.
+  refine (equiv_compose'
+            (equiv_functor_forall'
+               (P := fun Z => Z.1 = Z.1)
+               (equiv_idmap (BAut X))
+               (fun Z => equiv_path_sigma_hprop Z Z)) _).
+  refine (equiv_compose' (baut_ind_hset X (fun Z => Z = Z)) _).
+  simpl.
+  refine (equiv_functor_sigma' (equiv_path_universe X X) _); intros f.
+  refine (equiv_functor_forall' (equiv_idmap _) _); intros g; simpl.
+  refine (equiv_compose' _ (equiv_path_arrow _ _)).
+  refine (equiv_compose' _ (equiv_path_equiv (equiv_compose' g f) (equiv_compose' f g))).
+  revert g. equiv_intro (equiv_path X X) g.
+  revert f. equiv_intro (equiv_path X X) f.
+  refine (equiv_compose' _ (equiv_concat_l (equiv_path_pp _ _) _)).
+  refine (equiv_compose' _ (equiv_concat_r (equiv_path_pp _ _)^ _)).
+  refine (equiv_compose' _ (equiv_inverse (equiv_ap (equiv_path X X) _ _))).
+  refine (equiv_compose' (equiv_concat_l (transport_paths_lr _ _) _) _).
+  refine (equiv_compose' (equiv_concat_l (concat_pp_p _ _ _) _) _).
+  refine (equiv_compose' (equiv_moveR_Vp _ _ _) _).
+  refine (equiv_compose' (equiv_concat_l _ _) (equiv_concat_r _ _)).
+  - apply concat2; apply eissect.
+  - symmetry; apply concat2; apply eissect.
+Defined.
+
+(** We show that this equivalence takes the identity equivalence to the identity in the center.  We have to be careful in this proof never to [simpl] or [unfold] too many things, or Coq will produce gigantic terms that take it forever to compute with. *)
+Definition id_center_baut `{Univalence} X `{IsHSet X}
+: center_baut X (existT
+                   (fun (f:X<~>X) => forall (g:X<~>X), g o f == f o g)
+                   (equiv_idmap X)
+                   (fun (g:X<~>X) (x:X) => idpath (g x)))
+  = fun Z => idpath Z.
+Proof.
+  apply path_forall; intros Z.
+  assert (IsHSet (Z.1 = Z.1)) by exact _.
+  baut_reduce.
+  exact (ap (path_sigma_hprop _ _) path_universe_1
+            @ path_sigma_hprop_1 _).
+Defined.
+
+(** Similarly, if [X] is a 1-type, we can characterize the 2-center of [BAut X]. *)
+
+(** Coq is too eager about unfolding some things appearing in this proof. *)
+Section Center2BAut.
+Opaque equiv_path_equiv.
+Opaque equiv_path2_universe.
+
+Definition center2_baut `{Univalence} X `{IsTrunc 1 X} :
+  { f : forall x:X, x=x & forall (g:X<~>X) (x:X), ap g (f x) = f (g x) }
+  <~> (forall Z:BAut X, (idpath Z) = (idpath Z)).
+Proof.
+  refine (equiv_compose'
+            (equiv_functor_forall'
+               (P := fun Z => idpath Z.1 = idpath Z.1)
+               (equiv_idmap (BAut X))
+               (fun Z => equiv_compose' (equiv_concat_lr _ _)
+                                        (equiv_ap (equiv_path_sigma_hprop Z Z)
+                                                  (idpath Z.1) (idpath Z.1)))) _).
+  1:symmetry; apply path_sigma_hprop_1.
+  1:apply path_sigma_hprop_1.
+  assert (forall Z:BAut X, IsHSet (idpath Z.1 = idpath Z.1)) by exact _.
+  refine (equiv_compose' (baut_ind_hset X (fun Z => idpath Z = idpath Z)) _).
+  refine (equiv_functor_sigma' _ _).
+  { refine (equiv_compose' _
+              (equiv_path2_universe (equiv_idmap X) (equiv_idmap X))).
+    apply equiv_concat_lr.
+    - symmetry; apply path_universe_1.
+    - apply path_universe_1. }
+  intros f.
+  refine (equiv_functor_forall' (equiv_idmap _) _); intros g.
+  refine (equiv_compose' _ (equiv_path3_universe _ _)).
+  refine (equiv_compose' (dpath_paths2 (path_universe g) _ _) _).
+  simpl.
+  change (equiv_idmap X == equiv_idmap X) in f.
+  refine (equiv_concat_lr _ _).
+  - refine (_ @ (path2_universe_postcompose_idmap f g)^).
+    abstract (rewrite !whiskerR_pp, !concat_pp_p; reflexivity).
+  - refine (path2_universe_precompose_idmap f g @ _).
+    abstract (rewrite !whiskerL_pp, !concat_pp_p; reflexivity).
+Defined.
+
+(** Once again we compute it on the identity.  In this case it seems to be unavoidable to do some [simpl]ing, making this proof somewhat slower. *)
+Definition id_center2_baut `{Univalence} X `{IsTrunc 1 X}
+: center2_baut X (existT
+                   (fun (f:forall x:X, x=x) =>
+                      forall (g:X<~>X) (x:X), ap g (f x) = f (g x))
+                   (fun x => idpath x)
+                   (fun (g:X<~>X) (x:X) => idpath (idpath (g x))))
+  = fun Z => idpath (idpath Z).
+Proof.
+  apply path_forall; intros Z.
+  assert (IsHSet (idpath Z.1 = idpath Z.1)) by exact _.
+  baut_reduce.
+  simpl. unfold functor_forall, sig_rect, merely_rec_hset. simpl.
+  rewrite equiv_path2_universe_1.
+  rewrite !concat_p1, !concat_Vp.
+  simpl.
+  rewrite !concat_p1, !concat_Vp.
+  reflexivity.
+Defined.
+
+End Center2BAut.

--- a/theories/Spaces/BAut.v
+++ b/theories/Spaces/BAut.v
@@ -211,9 +211,8 @@ Defined.
 
 (** Coq is too eager about unfolding some things appearing in this proof. *)
 Section Center2BAut.
-  (** TODO: Can we use [Local Arguments ... : simpl never] instead? *)
-  Opaque equiv_path_equiv.
-  Opaque equiv_path2_universe.
+  Local Arguments equiv_path_equiv : simpl never.
+  Local Arguments equiv_path2_universe : simpl never.
 
   Definition center2_baut `{Univalence} X `{IsTrunc 1 X}
   : { f : forall x:X, x=x & forall (g:X<~>X) (x:X), ap g (f x) = f (g x) }
@@ -249,7 +248,7 @@ Section Center2BAut.
       abstract (rewrite !whiskerL_pp, !concat_pp_p; reflexivity).
   Defined.
 
-  (** Once again we compute it on the identity.  In this case it seems to be unavoidable to do some [simpl]ing, making this proof somewhat slower. *)
+  (** Once again we compute it on the identity.  In this case it seems to be unavoidable to do some [simpl]ing (or at least [cbn]ing), making this proof somewhat slower. *)
   Definition id_center2_baut `{Univalence} X `{IsTrunc 1 X}
   : center2_baut X (existT
                       (fun (f:forall x:X, x=x) =>
@@ -261,7 +260,7 @@ Section Center2BAut.
     apply path_forall; intros Z.
     assert (IsHSet (idpath Z.1 = idpath Z.1)) by exact _.
     baut_reduce.
-    cbn. unfold functor_forall, sig_rect, merely_rec_hset. simpl.
+    cbn. unfold functor_forall, sig_rect, merely_rec_hset. cbn.
     rewrite equiv_path2_universe_1.
     rewrite !concat_p1, !concat_Vp.
     simpl.

--- a/theories/Spaces/BAut/Bool.v
+++ b/theories/Spaces/BAut/Bool.v
@@ -11,484 +11,484 @@ Open Scope equiv_scope.
 (** * BAut(Bool) *)
 
 Section AssumeUnivalence.
-Context `{Univalence}.
+  Context `{Univalence}.
 
-(** ** Nontrivial central homotopy *)
-
-(** The equivalence [Bool <~> (Bool <~> Bool)], and particularly its consequence [abelian_aut_bool], implies that [BAut Bool] has a nontrivial center.  *)
-
-Definition negb_center_baut_bool
-: forall (Z:BAut Bool), Z = Z.
-Proof.
-  apply center_baut; try exact _.
-  exists equiv_negb.
-  intros g; apply abelian_aut_bool.
-Defined.
-
-Definition nontrivial_negb_center_baut_bool
-: negb_center_baut_bool <> (fun Z => idpath Z).
-Proof.
-  intros oops.
-  pose (p := ap10_equiv
-                  ((ap (center_baut Bool))^-1
-                   (oops @ (id_center_baut Bool)^))..1 true).
-  exact (false_ne_true p).
-Defined.
-
-(** In particular, every element of [BAut Bool] has a canonical flip automorphism.  *)
-Definition negb_baut_bool (Z : BAut Bool) : Z <~> Z
-  := equiv_path Z Z (negb_center_baut_bool Z)..1.
-
-Definition negb_baut_bool_ne_idmap (Z : BAut Bool)
-: negb_baut_bool Z <> equiv_idmap Z.
-Proof.
-  intros oops.
-  apply nontrivial_negb_center_baut_bool.
-  apply path_forall; intros Z'.
-  pose (p := merely_path_baut Z Z').
-  clearbody p. strip_truncations.
-  destruct p.
-  unfold negb_baut_bool in oops.
-  apply moveL_equiv_V in oops.
-  refine (_ @ ap (equiv_path_sigma_hprop _ _)
-                 (oops @ path_universe_1) @ _).
-  - symmetry.
-    refine (eisretr (equiv_path_sigma_hprop Z Z) _).
-  - apply moveR_equiv_M; reflexivity.
-Defined.
-
-(** If [Z] is [Bool], then the flip is the usual one. *)
-Definition negb_baut_bool_bool_negb
-: negb_baut_bool (point _) = equiv_negb.
-Proof.
-  pose (c := aut_bool_idmap_or_negb (negb_baut_bool (point _))).
-  destruct c.
-  - pose (negb_baut_bool_ne_idmap (point _) p).
-    contradiction.
-  - assumption.
-Defined.
-
-Definition ap_pr1_negb_baut_bool_bool
-: (negb_center_baut_bool (point _))..1 = path_universe negb.
-Proof.
-  apply moveL_equiv_V.
-  apply negb_baut_bool_bool_negb.
-Defined.
-
-(** Moreover, we can show that every automorphism of a [Z : BAut Bool] must be either the flip or the identity. *)
-Definition aut_baut_bool_idmap_or_negb (Z : BAut Bool) (e : Z <~> Z)
+  (** ** Nontrivial central homotopy *)
+  
+  (** The equivalence [Bool <~> (Bool <~> Bool)], and particularly its consequence [abelian_aut_bool], implies that [BAut Bool] has a nontrivial center.  *)
+  
+  Definition negb_center_baut_bool
+  : forall (Z:BAut Bool), Z = Z.
+  Proof.
+    apply center_baut; try exact _.
+    exists equiv_negb.
+    intros g; apply abelian_aut_bool.
+  Defined.
+  
+  Definition nontrivial_negb_center_baut_bool
+  : negb_center_baut_bool <> (fun Z => idpath Z).
+  Proof.
+    intros oops.
+    pose (p := ap10_equiv
+                 ((ap (center_baut Bool))^-1
+                  (oops @ (id_center_baut Bool)^))..1 true).
+    exact (false_ne_true p).
+  Defined.
+  
+  (** In particular, every element of [BAut Bool] has a canonical flip automorphism.  *)
+  Definition negb_baut_bool (Z : BAut Bool) : Z <~> Z
+    := equiv_path Z Z (negb_center_baut_bool Z)..1.
+  
+  Definition negb_baut_bool_ne_idmap (Z : BAut Bool)
+  : negb_baut_bool Z <> equiv_idmap Z.
+  Proof.
+    intros oops.
+    apply nontrivial_negb_center_baut_bool.
+    apply path_forall; intros Z'.
+    pose (p := merely_path_baut Z Z').
+    clearbody p. strip_truncations.
+    destruct p.
+    unfold negb_baut_bool in oops.
+    apply moveL_equiv_V in oops.
+    refine (_ @ ap (equiv_path_sigma_hprop _ _)
+                   (oops @ path_universe_1) @ _).
+    - symmetry.
+      refine (eisretr (equiv_path_sigma_hprop Z Z) _).
+    - apply moveR_equiv_M; reflexivity.
+  Defined.
+  
+  (** If [Z] is [Bool], then the flip is the usual one. *)
+  Definition negb_baut_bool_bool_negb
+  : negb_baut_bool (point _) = equiv_negb.
+  Proof.
+    pose (c := aut_bool_idmap_or_negb (negb_baut_bool (point _))).
+    destruct c.
+    - pose (negb_baut_bool_ne_idmap (point _) p).
+      contradiction.
+    - assumption.
+  Defined.
+  
+  Definition ap_pr1_negb_baut_bool_bool
+  : (negb_center_baut_bool (point _))..1 = path_universe negb.
+  Proof.
+    apply moveL_equiv_V.
+    apply negb_baut_bool_bool_negb.
+  Defined.
+  
+  (** Moreover, we can show that every automorphism of a [Z : BAut Bool] must be either the flip or the identity. *)
+  Definition aut_baut_bool_idmap_or_negb (Z : BAut Bool) (e : Z <~> Z)
   : (e = equiv_idmap Z) + (e = negb_baut_bool Z).
-Proof.
-  assert (IsHProp ((e = equiv_idmap Z) + (e = negb_baut_bool Z))).
-  { apply ishprop_sum; try exact _.
-    intros p q; exact (negb_baut_bool_ne_idmap Z (q^ @ p)). }
-  baut_reduce.
-  case (aut_bool_idmap_or_negb e).
-  - intros p; exact (inl p).
-  - intros q; apply inr.
-    exact (q @ negb_baut_bool_bool_negb^).
-Defined.
-
-(** ** Connectedness *)
-
-Global Instance isminusoneconnected_baut_bool `{Funext} (Z : BAut Bool)
-: IsConnected -1 Z.
-Proof.
-  baut_reduce.
-  apply contr_inhabited_hprop; try exact _.
-  exact (tr true).
-Defined.
-
-Definition merely_inhab_baut_bool `{Funext} (Z : BAut Bool)
-: merely Z
-  := center (merely Z).
-
-(** ** Equivalence types *)
-
-(** As soon as an element of [BAut Bool] is inhabited, it is (purely) equivalent to [Bool].  (Of course, every element of [BAut Bool] is *merely* inhabited, since [Bool] is.)  In fact, it is equivalent in two canonical ways.
+  Proof.
+    assert (IsHProp ((e = equiv_idmap Z) + (e = negb_baut_bool Z))).
+    { apply ishprop_sum; try exact _.
+      intros p q; exact (negb_baut_bool_ne_idmap Z (q^ @ p)). }
+    baut_reduce.
+    case (aut_bool_idmap_or_negb e).
+    - intros p; exact (inl p).
+    - intros q; apply inr.
+      exact (q @ negb_baut_bool_bool_negb^).
+  Defined.
+  
+  (** ** Connectedness *)
+  
+  Global Instance isminusoneconnected_baut_bool `{Funext} (Z : BAut Bool)
+  : IsConnected -1 Z.
+  Proof.
+    baut_reduce.
+    apply contr_inhabited_hprop; try exact _.
+    exact (tr true).
+  Defined.
+  
+  Definition merely_inhab_baut_bool `{Funext} (Z : BAut Bool)
+  : merely Z
+    := center (merely Z).
+  
+  (** ** Equivalence types *)
+  
+  (** As soon as an element of [BAut Bool] is inhabited, it is (purely) equivalent to [Bool].  (Of course, every element of [BAut Bool] is *merely* inhabited, since [Bool] is.)  In fact, it is equivalent in two canonical ways.
 
 First we define the function that will be the equivalence. *)
-Definition inhab_baut_bool_from_bool (t : Bool)
-           (Z : BAut Bool) (z : Z)
-: Bool -> Z
-  := fun b => if t then
-                if b then z else negb_baut_bool Z z
-              else
-                if b then negb_baut_bool Z z else z.
-
-(** We compute this in the case when [Z] is [Bool]. *)
-Definition inhab_baut_bool_from_bool_bool (t : Bool)
-: inhab_baut_bool_from_bool t (point _) =
-  fun (z : point (BAut Bool)) (b : Bool) =>
-    if t then
-      if b then z else negb z
-    else
-      if b then negb z else z.
-Proof.
-  apply path_forall; intros z'; simpl in z'.
-  apply path_forall; intros b.
-  destruct z', b, t; simpl;
+  Definition inhab_baut_bool_from_bool (t : Bool)
+             (Z : BAut Bool) (z : Z)
+  : Bool -> Z
+    := fun b => if t then
+                  if b then z else negb_baut_bool Z z
+                else
+                  if b then negb_baut_bool Z z else z.
+  
+  (** We compute this in the case when [Z] is [Bool]. *)
+  Definition inhab_baut_bool_from_bool_bool (t : Bool)
+  : inhab_baut_bool_from_bool t (point _) =
+    fun (z : point (BAut Bool)) (b : Bool) =>
+      if t then
+        if b then z else negb z
+      else
+        if b then negb z else z.
+  Proof.
+    apply path_forall; intros z'; simpl in z'.
+    apply path_forall; intros b.
+    destruct z', b, t; simpl;
     try reflexivity;
     try apply (ap10_equiv negb_baut_bool_bool_negb).
-Defined.
-
-(** Now we show that it is an equivalence. *)
-Global Instance isequiv_inhab_baut_bool_from_bool (t : Bool)
-       (Z : BAut Bool) (z : Z)
-: IsEquiv (inhab_baut_bool_from_bool t Z z).
-Proof.
-  baut_reduce.
-  refine (transport IsEquiv (ap10 (inhab_baut_bool_from_bool_bool t)^ z) _). 
-  simpl in z; destruct z, t; simpl.
-  - refine (isequiv_homotopic idmap _); intros []; reflexivity.
-  - apply isequiv_negb.
-  - apply isequiv_negb.
-  - refine (isequiv_homotopic idmap _); intros []; reflexivity.
-Defined.
-
-Definition equiv_inhab_baut_bool_bool (t : Bool)
-           (Z : BAut Bool) (z : Z)
-: Bool <~> Z
-  := BuildEquiv _ _ (inhab_baut_bool_from_bool t Z z) _.
-
-Definition path_baut_bool_inhab (Z : BAut Bool) (z : Z)
-: (point (BAut Bool)) = Z.
-Proof.
-  apply path_baut.
-  exact (equiv_inhab_baut_bool_bool true Z z). (** [true] is a choice! *)
-Defined.
-
-(** In fact, the map sending [z:Z] to this equivalence [Bool <~> Z] is also an equivalence.  To assist with computing the result when [Z] is [Bool], we prove it with an extra parameter first. *)
-Definition isequiv_equiv_inhab_baut_bool_bool_lemma
-       (t : Bool) (Z : BAut Bool) (m : merely (point _ = Z))
-: IsEquiv (equiv_inhab_baut_bool_bool t Z).
-Proof.
-  strip_truncations. destruct m.
-  refine (isequiv_adjointify _ (fun (e : Bool <~> Bool) => e t) _ _).
-  + intros e.
-    apply path_equiv.
-    refine (ap10 (inhab_baut_bool_from_bool_bool t) (e t) @ _).
-    apply path_arrow; intros []; destruct t.
-    * reflexivity.
-    * refine (abelian_aut_bool equiv_negb e false).
-    * refine (abelian_aut_bool equiv_negb e true).
-    * reflexivity.
-  + intros z.
-    refine (ap10 (ap10 (inhab_baut_bool_from_bool_bool t) z) t @ _).
-    destruct t; reflexivity.
-Defined.
-
-Global Instance isequiv_equiv_inhab_baut_bool_bool
-       (t : Bool) (Z : BAut Bool)
-: IsEquiv (equiv_inhab_baut_bool_bool t Z).
-Proof.
-  exact (isequiv_equiv_inhab_baut_bool_bool_lemma t Z
-           (merely_path_baut _ _)).
-Defined.
-
-(** The names are getting pretty ridiculous; below we suggest a better name for this. *)
-Definition equiv_equiv_inhab_baut_bool_bool (t : Bool)
-           (Z : BAut Bool)
-: Z <~> (Bool <~> Z)
-  := BuildEquiv _ _ (equiv_inhab_baut_bool_bool t Z) _.
-
-(** We compute its inverse in the case of [Bool]. *)
-Definition equiv_equiv_inhab_baut_bool_bool_bool_inv (t : Bool)
-           (e : Bool <~> Bool)
-: equiv_inverse (equiv_equiv_inhab_baut_bool_bool t (point _)) e = e t.
-Proof.
-  pose (alt := BuildEquiv _ _ (equiv_inhab_baut_bool_bool t (point _))
-                 (isequiv_equiv_inhab_baut_bool_bool_lemma
-                    t (point _) (tr 1))).
-  assert (p : equiv_equiv_inhab_baut_bool_bool t (point _) = alt).
-  { apply (ap (fun i => BuildEquiv _ _ _ i)).
-    apply (ap (isequiv_equiv_inhab_baut_bool_bool_lemma t (point _))).
-    apply path_ishprop. }
-  exact (ap10_equiv (ap equiv_inverse p) e).
-Defined.
-
-(** ** Group structure *)
-
-(** Homotopically, [BAut Bool] is a [K(Z/2,1)].  In particular, it has a (coherent) abelian group structure induced from that of [Z/2].  With our definition of [BAut Bool], we can construct this operation as follows. *)
-
-Definition baut_bool_pairing : BAut Bool -> BAut Bool -> BAut Bool.
-Proof.
-  intros Z W.
-  exists (Z <~> W).
-  baut_reduce; simpl.
-  apply tr, symmetry.
-  exact (path_universe equiv_bool_aut_bool).
-Defined.
-
-Notation "Z ** W" := (baut_bool_pairing Z W)
-                       (at level 40, no associativity)
-                     : baut_bool_scope.
-Local Open Scope baut_bool_scope.
-
-Local Notation pt := (point (BAut Bool)).
-
-(** Now [equiv_equiv_inhab_baut_bool_bool] is revealed as simply the left unit law of this pairing. *)
-Definition baut_bool_pairing_1Z Z : pt ** Z = Z.
-Proof.
-  apply path_baut, equiv_inverse, equiv_equiv_inhab_baut_bool_bool.
-  exact true.                   (** This is a choice! *)
-Defined.
-
-(** The pairing is obviously symmetric. *)
-Definition baut_bool_pairing_symm Z W : Z ** W = W ** Z.
-Proof.
-  apply path_baut, equiv_equiv_inverse.
-Defined.
-
-(** Whence we get the right unit law as well. *)
-Definition baut_bool_pairing_Z1 Z : Z ** pt = Z
-  := baut_bool_pairing_symm Z pt @ baut_bool_pairing_1Z Z.
-
-(** Every element is its own inverse. *)
-Definition baut_bool_pairing_ZZ Z : Z ** Z = pt.
-Proof.
-  apply symmetry, path_baut_bool_inhab.
-  apply equiv_idmap.            (** A choice!  Could be the flip. *)
-Defined.
-
-(** Associativity is easiest to think about in terms of "curried 2-variable equivalences".  We start with some auxiliary lemmas. *)
-Definition baut_bool_pairing_ZZ_Z_symm_part1 {Y Z W}
-           (e : Y ** (Z ** W)) (z : Z)
-: Y ** W.
-Proof.
-  refine (equiv_adjointify _ _ _ _).
-  + exact (fun y => e y z).
-  + intros w.
-    destruct (path_baut_bool_inhab W w).
-    destruct (path_baut_bool_inhab Z z).
-    (** It might be tempting to just say [e^-1 (equiv_idmap _)] here, but for the rest of the proof to work, we actually need to choose between [idmap] and [negb] based on whether [z] and [w] are equal or not. *)
-    destruct (dec (z=w)).
-    exact (e^-1 (equiv_idmap _)).
-    exact (e^-1 equiv_negb).
-  + intros w.
-    destruct (path_baut_bool_inhab W w).
-    destruct (path_baut_bool_inhab Z z).
-    simpl.
-    destruct z,w; simpl; refine (ap10_equiv (eisretr e _) _).
-  + intros y.
-    destruct (path_baut_bool_inhab Y y).
-    destruct (path_baut_bool_inhab Z z).
-    destruct (path_baut_bool_inhab W (e y z)).
-    simpl. 
-    case (dec (z = e y z)); intros p; apply moveR_equiv_V;
-    destruct (aut_bool_idmap_or_negb (e y)) as [q|q].
-    * symmetry; assumption.
-    * case (not_fixed_negb z (p @ ap10_equiv q z)^).
-    * case (p (ap10_equiv q z)^).
-    * symmetry; assumption.
-Defined.
-
-Definition baut_bool_pairing_ZZ_Z_symm_lemma {Y Z W}
-           (e : Y ** (Z ** W)) (f : Y ** W)
-: merely Y -> Z.
-Proof.
-  pose (k := (fun y => (e y)^-1 (f y))).
-  refine (merely_rec_hset k); intros y1 y2.
-  destruct (path_baut_bool_inhab Y y1).
-  destruct (path_baut_bool_inhab W (f y1)).
-  destruct (path_baut_bool_inhab Z (k y1)).
-  destruct (aut_bool_idmap_or_negb f) as [p|p];
-    refine (ap (e y1)^-1 (ap10_equiv p y1) @ _);
-    refine (_ @ (ap (e y2)^-1 (ap10_equiv p y2))^);
-    clear p f k; simpl.
-  + destruct (dec (y1=y2)) as [p|p].
-    { exact (ap (fun y => (e y)^-1 y) p). }
-    destruct (aut_bool_idmap_or_negb (e y1)) as [q1|q1];
-      destruct (aut_bool_idmap_or_negb (e y2)) as [q2|q2].
-    * case (p ((ap e)^-1 (q1 @ q2^))).
-    * rewrite q1, q2. exact (negb_ne p).
-    * rewrite q1, q2. symmetry. exact (negb_ne (fun r => p r^)).
-    * case (p ((ap e)^-1 (q1 @ q2^))).
-  + destruct (dec (y1=y2)) as [p|p].
-    { exact (ap (fun y => (e y)^-1 (negb y)) p). }
-    destruct (aut_bool_idmap_or_negb (e y1)) as [q1|q1];
-      destruct (aut_bool_idmap_or_negb (e y2)) as [q2|q2].
-    * case (p ((ap e)^-1 (q1 @ q2^))).
-    * rewrite q1, q2.
-      exact (negb_ne (fun r => p ((ap negb)^-1 r))).
-    * rewrite q1, q2. symmetry.
-      exact (negb_ne (fun r => p ((ap negb)^-1 r)^)).
-    * case (p ((ap e)^-1 (q1 @ q2^))).
-Defined.
-
-Definition baut_bool_pairing_ZZ_Z_symm_map Y Z W
-: Y ** (Z ** W) -> Z ** (Y ** W).
-Proof.
-  intros e.
-  refine (equiv_adjointify (baut_bool_pairing_ZZ_Z_symm_part1 e)
-                           _ _ _).
-  - intros f.
-    exact (baut_bool_pairing_ZZ_Z_symm_lemma e f
-             (merely_inhab_baut_bool Y)).
-  - intros f.
-    apply path_equiv, path_arrow; intros y.
-    change ((e y)
-         (baut_bool_pairing_ZZ_Z_symm_lemma e f
-            (merely_inhab_baut_bool Y)) = f y).
-    refine (ap (e y o baut_bool_pairing_ZZ_Z_symm_lemma e f)
-               (path_ishprop _ (tr y)) @ _).
-    simpl. apply eisretr.
-  - intros z.
-    assert (IsHSet Z) by exact _.
-    refine (Trunc_rec _ (merely_inhab_baut_bool Y)); intros y.
-    refine (ap (baut_bool_pairing_ZZ_Z_symm_lemma e _)
-               (path_ishprop _ (tr y)) @ _).
-    simpl. refine (eissect _ _).
-Defined.
-
-Definition baut_bool_pairing_ZZ_Z_symm_inv Y Z W
-: baut_bool_pairing_ZZ_Z_symm_map Y Z W
-  o baut_bool_pairing_ZZ_Z_symm_map Z Y W
-  == idmap.
-Proof.
-  intros e.
-  apply path_equiv, path_arrow; intros z.
-  apply path_equiv, path_arrow; intros y.
-  reflexivity.
-Defined.
-
-Definition baut_bool_pairing_ZZ_Z_symm Y Z W
-: Y ** (Z ** W) <~> Z ** (Y ** W).
-Proof.
-  refine (equiv_adjointify
-            (baut_bool_pairing_ZZ_Z_symm_map Y Z W)
-            (baut_bool_pairing_ZZ_Z_symm_map Z Y W)
-            (baut_bool_pairing_ZZ_Z_symm_inv Y Z W)
-            (baut_bool_pairing_ZZ_Z_symm_inv Z Y W)).
-Defined.
-
-(** Finally, we can prove associativity. *)
-Definition baut_bool_pairing_ZZ_Z Z W Y
-: (Z ** W) ** Y = Z ** (W ** Y).
-Proof.
-  refine (baut_bool_pairing_symm (Z ** W) Y @ _).
-  refine (_ @ ap (fun X => Z ** X) (baut_bool_pairing_symm Y W)).
-  apply path_baut, baut_bool_pairing_ZZ_Z_symm.
-Defined.
+  Defined.
   
-(** Since [BAut Bool] is not a set, we ought to have some coherence for these operations too, but we'll leave that for another time. *)
+  (** Now we show that it is an equivalence. *)
+  Global Instance isequiv_inhab_baut_bool_from_bool (t : Bool)
+         (Z : BAut Bool) (z : Z)
+  : IsEquiv (inhab_baut_bool_from_bool t Z z).
+  Proof.
+    baut_reduce.
+    refine (transport IsEquiv (ap10 (inhab_baut_bool_from_bool_bool t)^ z) _). 
+    simpl in z; destruct z, t; simpl.
+    - refine (isequiv_homotopic idmap _); intros []; reflexivity.
+    - apply isequiv_negb.
+    - apply isequiv_negb.
+    - refine (isequiv_homotopic idmap _); intros []; reflexivity.
+  Defined.
+  
+  Definition equiv_inhab_baut_bool_bool (t : Bool)
+             (Z : BAut Bool) (z : Z)
+  : Bool <~> Z
+    := BuildEquiv _ _ (inhab_baut_bool_from_bool t Z z) _.
+  
+  Definition path_baut_bool_inhab (Z : BAut Bool) (z : Z)
+  : (point (BAut Bool)) = Z.
+  Proof.
+    apply path_baut.
+    exact (equiv_inhab_baut_bool_bool true Z z). (** [true] is a choice! *)
+  Defined.
+  
+  (** In fact, the map sending [z:Z] to this equivalence [Bool <~> Z] is also an equivalence.  To assist with computing the result when [Z] is [Bool], we prove it with an extra parameter first. *)
+  Definition isequiv_equiv_inhab_baut_bool_bool_lemma
+             (t : Bool) (Z : BAut Bool) (m : merely (point _ = Z))
+  : IsEquiv (equiv_inhab_baut_bool_bool t Z).
+  Proof.
+    strip_truncations. destruct m.
+    refine (isequiv_adjointify _ (fun (e : Bool <~> Bool) => e t) _ _).
+    + intros e.
+      apply path_equiv.
+      refine (ap10 (inhab_baut_bool_from_bool_bool t) (e t) @ _).
+      apply path_arrow; intros []; destruct t.
+      * reflexivity.
+      * refine (abelian_aut_bool equiv_negb e false).
+      * refine (abelian_aut_bool equiv_negb e true).
+      * reflexivity.
+    + intros z.
+      refine (ap10 (ap10 (inhab_baut_bool_from_bool_bool t) z) t @ _).
+      destruct t; reflexivity.
+  Defined.
+  
+  Global Instance isequiv_equiv_inhab_baut_bool_bool
+         (t : Bool) (Z : BAut Bool)
+  : IsEquiv (equiv_inhab_baut_bool_bool t Z).
+  Proof.
+    exact (isequiv_equiv_inhab_baut_bool_bool_lemma t Z
+            (merely_path_baut _ _)).
+  Defined.
+  
+  (** The names are getting pretty ridiculous; below we suggest a better name for this. *)
+  Definition equiv_equiv_inhab_baut_bool_bool (t : Bool)
+             (Z : BAut Bool)
+  : Z <~> (Bool <~> Z)
+    := BuildEquiv _ _ (equiv_inhab_baut_bool_bool t Z) _.
+  
+  (** We compute its inverse in the case of [Bool]. *)
+  Definition equiv_equiv_inhab_baut_bool_bool_bool_inv (t : Bool)
+             (e : Bool <~> Bool)
+  : equiv_inverse (equiv_equiv_inhab_baut_bool_bool t (point _)) e = e t.
+  Proof.
+    pose (alt := BuildEquiv _ _ (equiv_inhab_baut_bool_bool t (point _))
+                   (isequiv_equiv_inhab_baut_bool_bool_lemma
+                      t (point _) (tr 1))).
+    assert (p : equiv_equiv_inhab_baut_bool_bool t (point _) = alt).
+    { apply (ap (fun i => BuildEquiv _ _ _ i)).
+      apply (ap (isequiv_equiv_inhab_baut_bool_bool_lemma t (point _))).
+      apply path_ishprop. }
+    exact (ap10_equiv (ap equiv_inverse p) e).
+  Defined.
+  
+  (** ** Group structure *)
+  
+  (** Homotopically, [BAut Bool] is a [K(Z/2,1)].  In particular, it has a (coherent) abelian group structure induced from that of [Z/2].  With our definition of [BAut Bool], we can construct this operation as follows. *)
+  
+  Definition baut_bool_pairing : BAut Bool -> BAut Bool -> BAut Bool.
+  Proof.
+    intros Z W.
+    exists (Z <~> W).
+    baut_reduce; simpl.
+    apply tr, symmetry.
+    exact (path_universe equiv_bool_aut_bool).
+  Defined.
+  
+  Notation "Z ** W" := (baut_bool_pairing Z W)
+                         (at level 40, no associativity)
+                       : baut_bool_scope.
+  Local Open Scope baut_bool_scope.
+  
+  Local Notation pt := (point (BAut Bool)).
+  
+  (** Now [equiv_equiv_inhab_baut_bool_bool] is revealed as simply the left unit law of this pairing. *)
+  Definition baut_bool_pairing_1Z Z : pt ** Z = Z.
+  Proof.
+    apply path_baut, equiv_inverse, equiv_equiv_inhab_baut_bool_bool.
+    exact true.                   (** This is a choice! *)
+  Defined.
+  
+  (** The pairing is obviously symmetric. *)
+  Definition baut_bool_pairing_symm Z W : Z ** W = W ** Z.
+  Proof.
+    apply path_baut, equiv_equiv_inverse.
+  Defined.
+  
+  (** Whence we get the right unit law as well. *)
+  Definition baut_bool_pairing_Z1 Z : Z ** pt = Z
+    := baut_bool_pairing_symm Z pt @ baut_bool_pairing_1Z Z.
+  
+  (** Every element is its own inverse. *)
+  Definition baut_bool_pairing_ZZ Z : Z ** Z = pt.
+  Proof.
+    apply symmetry, path_baut_bool_inhab.
+    apply equiv_idmap.            (** A choice!  Could be the flip. *)
+  Defined.
+  
+  (** Associativity is easiest to think about in terms of "curried 2-variable equivalences".  We start with some auxiliary lemmas. *)
+  Definition baut_bool_pairing_ZZ_Z_symm_part1 {Y Z W}
+             (e : Y ** (Z ** W)) (z : Z)
+  : Y ** W.
+  Proof.
+    refine (equiv_adjointify _ _ _ _).
+    + exact (fun y => e y z).
+    + intros w.
+      destruct (path_baut_bool_inhab W w).
+      destruct (path_baut_bool_inhab Z z).
+      (** It might be tempting to just say [e^-1 (equiv_idmap _)] here, but for the rest of the proof to work, we actually need to choose between [idmap] and [negb] based on whether [z] and [w] are equal or not. *)
+      destruct (dec (z=w)).
+      exact (e^-1 (equiv_idmap _)).
+      exact (e^-1 equiv_negb).
+    + intros w.
+      destruct (path_baut_bool_inhab W w).
+      destruct (path_baut_bool_inhab Z z).
+      simpl.
+      destruct z,w; simpl; refine (ap10_equiv (eisretr e _) _).
+    + intros y.
+      destruct (path_baut_bool_inhab Y y).
+      destruct (path_baut_bool_inhab Z z).
+      destruct (path_baut_bool_inhab W (e y z)).
+      simpl. 
+      case (dec (z = e y z)); intros p; apply moveR_equiv_V;
+      destruct (aut_bool_idmap_or_negb (e y)) as [q|q].
+      * symmetry; assumption.
+      * case (not_fixed_negb z (p @ ap10_equiv q z)^).
+      * case (p (ap10_equiv q z)^).
+      * symmetry; assumption.
+  Defined.
 
-(** ** Automorphisms of [BAut Bool] *)
+  Definition baut_bool_pairing_ZZ_Z_symm_lemma {Y Z W}
+             (e : Y ** (Z ** W)) (f : Y ** W)
+  : merely Y -> Z.
+  Proof.
+    pose (k := (fun y => (e y)^-1 (f y))).
+    refine (merely_rec_hset k); intros y1 y2.
+    destruct (path_baut_bool_inhab Y y1).
+    destruct (path_baut_bool_inhab W (f y1)).
+    destruct (path_baut_bool_inhab Z (k y1)).
+    destruct (aut_bool_idmap_or_negb f) as [p|p];
+      refine (ap (e y1)^-1 (ap10_equiv p y1) @ _);
+      refine (_ @ (ap (e y2)^-1 (ap10_equiv p y2))^);
+      clear p f k; simpl.
+    + destruct (dec (y1=y2)) as [p|p].
+      { exact (ap (fun y => (e y)^-1 y) p). }
+      destruct (aut_bool_idmap_or_negb (e y1)) as [q1|q1];
+        destruct (aut_bool_idmap_or_negb (e y2)) as [q2|q2].
+      * case (p ((ap e)^-1 (q1 @ q2^))).
+      * rewrite q1, q2. exact (negb_ne p).
+      * rewrite q1, q2. symmetry. exact (negb_ne (fun r => p r^)).
+      * case (p ((ap e)^-1 (q1 @ q2^))).
+    + destruct (dec (y1=y2)) as [p|p].
+      { exact (ap (fun y => (e y)^-1 (negb y)) p). }
+      destruct (aut_bool_idmap_or_negb (e y1)) as [q1|q1];
+        destruct (aut_bool_idmap_or_negb (e y2)) as [q2|q2].
+      * case (p ((ap e)^-1 (q1 @ q2^))).
+      * rewrite q1, q2.
+        exact (negb_ne (fun r => p ((ap negb)^-1 r))).
+      * rewrite q1, q2. symmetry.
+        exact (negb_ne (fun r => p ((ap negb)^-1 r)^)).
+      * case (p ((ap e)^-1 (q1 @ q2^))).
+  Defined.
 
-(** Interestingly, like [Bool] itself, [BAut Bool] is equivalent to its own automorphism group. *)
+  Definition baut_bool_pairing_ZZ_Z_symm_map Y Z W
+  : Y ** (Z ** W) -> Z ** (Y ** W).
+  Proof.
+    intros e.
+    refine (equiv_adjointify (baut_bool_pairing_ZZ_Z_symm_part1 e)
+                             _ _ _).
+    - intros f.
+      exact (baut_bool_pairing_ZZ_Z_symm_lemma e f
+               (merely_inhab_baut_bool Y)).
+    - intros f.
+      apply path_equiv, path_arrow; intros y.
+      change ((e y)
+                (baut_bool_pairing_ZZ_Z_symm_lemma e f
+                  (merely_inhab_baut_bool Y)) = f y).
+      refine (ap (e y o baut_bool_pairing_ZZ_Z_symm_lemma e f)
+                 (path_ishprop _ (tr y)) @ _).
+      simpl. apply eisretr.
+    - intros z.
+      assert (IsHSet Z) by exact _.
+      refine (Trunc_rec _ (merely_inhab_baut_bool Y)); intros y.
+      refine (ap (baut_bool_pairing_ZZ_Z_symm_lemma e _)
+                 (path_ishprop _ (tr y)) @ _).
+      simpl. refine (eissect _ _).
+  Defined.
+  
+  Definition baut_bool_pairing_ZZ_Z_symm_inv Y Z W
+  : baut_bool_pairing_ZZ_Z_symm_map Y Z W
+    o baut_bool_pairing_ZZ_Z_symm_map Z Y W
+    == idmap.
+  Proof.
+    intros e.
+    apply path_equiv, path_arrow; intros z.
+    apply path_equiv, path_arrow; intros y.
+    reflexivity.
+  Defined.
+  
+  Definition baut_bool_pairing_ZZ_Z_symm Y Z W
+  : Y ** (Z ** W) <~> Z ** (Y ** W).
+  Proof.
+    refine (equiv_adjointify
+              (baut_bool_pairing_ZZ_Z_symm_map Y Z W)
+              (baut_bool_pairing_ZZ_Z_symm_map Z Y W)
+              (baut_bool_pairing_ZZ_Z_symm_inv Y Z W)
+              (baut_bool_pairing_ZZ_Z_symm_inv Z Y W)).
+  Defined.
+  
+  (** Finally, we can prove associativity. *)
+  Definition baut_bool_pairing_ZZ_Z Z W Y
+  : (Z ** W) ** Y = Z ** (W ** Y).
+  Proof.
+    refine (baut_bool_pairing_symm (Z ** W) Y @ _).
+    refine (_ @ ap (fun X => Z ** X) (baut_bool_pairing_symm Y W)).
+    apply path_baut, baut_bool_pairing_ZZ_Z_symm.
+  Defined.
+  
+  (** Since [BAut Bool] is not a set, we ought to have some coherence for these operations too, but we'll leave that for another time. *)
+  
+  (** ** Automorphisms of [BAut Bool] *)
+  
+  (** Interestingly, like [Bool] itself, [BAut Bool] is equivalent to its own automorphism group. *)
+  
+  (** An initial lemma: every automorphism of [BAut Bool] and its inverse are "adjoint" with respect to the pairing. *)
+  Definition aut_baut_bool_moveR_pairing_V
+             (e : BAut Bool <~> BAut Bool) (Z W : BAut Bool)
+  : (e^-1 Z ** W) = (Z ** e W).
+  Proof.
+    apply path_baut; refine (equiv_adjointify _ _ _ _).
+    - intros f.
+      exact (equiv_path _ _ (moveL_equiv_M _ _ (path_baut _ _ f))..1).
+    - intros g.
+      exact (equiv_path _ _ (moveR_equiv_V _ _ (path_baut _ _ g))..1).
+    - intros g.
+      unfold path_baut; simpl.
+      refine (_ @ eisretr (equiv_path Z (e W)) g); apply ap.
+      refine (@moveR_equiv_V _ _ (path_sigma_hprop Z (e W)) _ _ _ _).
+      apply moveR_equiv_M.
+      apply moveR_equiv_M.
+      refine (eta_path_universe _ @ _).
+      apply ap. unfold moveR_equiv_V; simpl.
+      apply whiskerR, moveL_Vp.
+      refine (_ @ (ap_pp _ _ _)^).
+      apply whiskerR.
+      refine (_ @ ap (ap e^-1) (inv_V _)^).
+      exact (eisadj e^-1 Z).
+    - intros f.
+      unfold path_baut; simpl.
+      apply moveR_equiv_M.
+      refine (@moveR_equiv_V _ _ (path_sigma_hprop (e^-1 Z) W) _ _ _ _).
+      apply moveR_equiv_M.
+      apply moveR_equiv_M.
+      refine (eta_path_universe _ @ _).
+      apply ap. unfold moveL_equiv_M; simpl.
+      refine (_ @ concat_p_pp _ _ _).
+      apply whiskerL, moveL_pM.
+      refine (_ @ (ap_pp _ _ _)^).
+      apply whiskerL.
+      refine (_ @ (ap_V _ _)^).
+      apply inverse2, eisadj.
+  Defined.
 
-(** An initial lemma: every automorphism of [BAut Bool] and its inverse are "adjoint" with respect to the pairing. *)
-Definition aut_baut_bool_moveR_pairing_V
-           (e : BAut Bool <~> BAut Bool) (Z W : BAut Bool)
-: (e^-1 Z ** W) = (Z ** e W).
-Proof.
-  apply path_baut; refine (equiv_adjointify _ _ _ _).
-  - intros f.
-    exact (equiv_path _ _ (moveL_equiv_M _ _ (path_baut _ _ f))..1).
-  - intros g.
-    exact (equiv_path _ _ (moveR_equiv_V _ _ (path_baut _ _ g))..1).
-  - intros g.
-    unfold path_baut; simpl.
-    refine (_ @ eisretr (equiv_path Z (e W)) g); apply ap.
-    refine (@moveR_equiv_V _ _ (path_sigma_hprop Z (e W)) _ _ _ _).
-    apply moveR_equiv_M.
-    apply moveR_equiv_M.
-    refine (eta_path_universe _ @ _).
-    apply ap. unfold moveR_equiv_V; simpl.
-    apply whiskerR, moveL_Vp.
-    refine (_ @ (ap_pp _ _ _)^).
-    apply whiskerR.
-    refine (_ @ ap (ap e^-1) (inv_V _)^).
-    exact (eisadj e^-1 Z).
-  - intros f.
-    unfold path_baut; simpl.
-    apply moveR_equiv_M.
-    refine (@moveR_equiv_V _ _ (path_sigma_hprop (e^-1 Z) W) _ _ _ _).
-    apply moveR_equiv_M.
-    apply moveR_equiv_M.
-    refine (eta_path_universe _ @ _).
-    apply ap. unfold moveL_equiv_M; simpl.
-    refine (_ @ concat_p_pp _ _ _).
-    apply whiskerL, moveL_pM.
-    refine (_ @ (ap_pp _ _ _)^).
-    apply whiskerL.
-    refine (_ @ (ap_V _ _)^).
-    apply inverse2, eisadj.
-Defined.
+  Definition equiv_baut_bool_aut_baut_bool
+  : BAut Bool <~> (BAut Bool <~> BAut Bool).
+  Proof.
+    refine (equiv_adjointify _ _ _ _).
+    - intros Z.
+      refine (equiv_involution (fun W => Z ** W) _).
+      intros W.
+      refine ((baut_bool_pairing_ZZ_Z Z Z W)^ @ _).
+      refine (_ @ baut_bool_pairing_1Z W).
+      apply (ap (fun Y => Y ** W)).
+      apply baut_bool_pairing_ZZ.
+    - intros e.
+      exact (e^-1 pt).
+    - intros e.
+      apply path_equiv, path_arrow; intros Z; simpl.
+      refine (aut_baut_bool_moveR_pairing_V e pt Z @ _).
+      apply baut_bool_pairing_1Z.
+    - intros Z.
+      apply baut_bool_pairing_Z1.
+  Defined.
 
-Definition equiv_baut_bool_aut_baut_bool
-: BAut Bool <~> (BAut Bool <~> BAut Bool).
-Proof.
-  refine (equiv_adjointify _ _ _ _).
-  - intros Z.
-    refine (equiv_involution (fun W => Z ** W) _).
-    intros W.
-    refine ((baut_bool_pairing_ZZ_Z Z Z W)^ @ _).
-    refine (_ @ baut_bool_pairing_1Z W).
-    apply (ap (fun Y => Y ** W)).
-    apply baut_bool_pairing_ZZ.
-  - intros e.
-    exact (e^-1 pt).
-  - intros e.
-    apply path_equiv, path_arrow; intros Z; simpl.
-    refine (aut_baut_bool_moveR_pairing_V e pt Z @ _).
-    apply baut_bool_pairing_1Z.
-  - intros Z.
-    apply baut_bool_pairing_Z1.
-Defined.
+  (** ** [BAut (BAut Bool)]  *)
+  
+  (** Putting all of this together, we can construct a nontrivial 2-central element of [BAut (BAut Bool)]. *)
+  
+  Definition center_baut_bool_central
+             (g : BAut Bool <~> BAut Bool) (W : BAut Bool)
+  : ap g (negb_center_baut_bool W) = negb_center_baut_bool (g W).
+  Proof.
+    revert g; equiv_intro equiv_baut_bool_aut_baut_bool Z.
+    simpl.
+    baut_reduce.
+    refine (_ @ apD negb_center_baut_bool (baut_bool_pairing_1Z pt)^).
+    rewrite transport_paths_lr, inv_V.
+    apply ((ap (equiv_inverse (equiv_path_sigma_hprop _ _)))^-1).
+    simpl.
+    unfold pr1_path.
+    rewrite <- ap_compose. simpl.
+    rewrite ap_compose.
+    rewrite !ap_pp.
+    refine (ap (ap (Equiv Bool)) ap_pr1_negb_baut_bool_bool @ _).
+    refine (_ @ ((1 @@ ap_pr1_negb_baut_bool_bool^) @@ 1)).
+    apply (equiv_inj (equiv_path _ _)).
+    rewrite !equiv_path_pp.
+    apply path_equiv, path_arrow; intros e.
+    simpl.
+    rewrite (transport_idmap_path_universe equiv_negb).
+    refine (ap10_equiv (ap_equiv_path_universe Bool equiv_negb) e @ _).
+    simpl.
+    unfold baut_bool_pairing_1Z, path_baut.
+    simpl.
+    rewrite ap_V, !ap_pr1_path_sigma_hprop.
+    refine (moveL_transport_V idmap _ _ _ _).
+    rewrite !transport_idmap_path_universe_uncurried.
+    rewrite !equiv_equiv_inhab_baut_bool_bool_bool_inv.
+    reflexivity.
+  Qed.
 
-(** ** [BAut (BAut Bool)]  *)
+  Definition negb_center2_baut_baut_bool
+  : forall B : BAut (BAut Bool), (idpath B) = (idpath B).
+  Proof.
+    refine (center2_baut (BAut Bool) _).
+    exists negb_center_baut_bool.
+    apply center_baut_bool_central.
+  Defined.
 
-(** Putting all of this together, we can construct a nontrivial 2-central element of [BAut (BAut Bool)]. *)
-
-Definition center_baut_bool_central
-           (g : BAut Bool <~> BAut Bool) (W : BAut Bool)
-: ap g (negb_center_baut_bool W) = negb_center_baut_bool (g W).
-Proof.
-  revert g; equiv_intro equiv_baut_bool_aut_baut_bool Z.
-  simpl.
-  baut_reduce.
-  refine (_ @ apD negb_center_baut_bool (baut_bool_pairing_1Z pt)^).
-  rewrite transport_paths_lr, inv_V.
-  apply ((ap (equiv_inverse (equiv_path_sigma_hprop _ _)))^-1).
-  simpl.
-  unfold pr1_path.
-  rewrite <- ap_compose. simpl.
-  rewrite ap_compose.
-  rewrite !ap_pp.
-  refine (ap (ap (Equiv Bool)) ap_pr1_negb_baut_bool_bool @ _).
-  refine (_ @ ((1 @@ ap_pr1_negb_baut_bool_bool^) @@ 1)).
-  apply (equiv_inj (equiv_path _ _)).
-  rewrite !equiv_path_pp.
-  apply path_equiv, path_arrow; intros e.
-  simpl.
-  rewrite (transport_idmap_path_universe equiv_negb).
-  refine (ap10_equiv (ap_equiv_path_universe Bool equiv_negb) e @ _).
-  simpl.
-  unfold baut_bool_pairing_1Z, path_baut.
-  simpl.
-  rewrite ap_V, !ap_pr1_path_sigma_hprop.
-  refine (moveL_transport_V idmap _ _ _ _).
-  rewrite !transport_idmap_path_universe_uncurried.
-  rewrite !equiv_equiv_inhab_baut_bool_bool_bool_inv.
-  reflexivity.
-Qed.
-
-Definition negb_center2_baut_baut_bool
-: forall B : BAut (BAut Bool), (idpath B) = (idpath B).
-Proof.
-  refine (center2_baut (BAut Bool) _).
-  exists negb_center_baut_bool.
-  apply center_baut_bool_central.
-Defined.
-
-Definition nontrivial_negb_center_baut_baut_bool
-: negb_center2_baut_baut_bool <> (fun Z => idpath (idpath Z)).
-Proof.
-  intros oops.
-  exact (nontrivial_negb_center_baut_bool
-          (((ap (center2_baut (BAut Bool)))^-1
-              (oops @ (id_center2_baut (BAut Bool))^))..1)).
-Defined.
+  Definition nontrivial_negb_center_baut_baut_bool
+  : negb_center2_baut_baut_bool <> (fun Z => idpath (idpath Z)).
+  Proof.
+    intros oops.
+    exact (nontrivial_negb_center_baut_bool
+             (((ap (center2_baut (BAut Bool)))^-1
+                (oops @ (id_center2_baut (BAut Bool))^))..1)).
+  Defined.
 
 End AssumeUnivalence.

--- a/theories/Spaces/BAut/Bool.v
+++ b/theories/Spaces/BAut/Bool.v
@@ -1,0 +1,494 @@
+(* -*- mode: coq; mode: visual-line -*-  *)
+Require Import HoTT.Basics HoTT.Types.
+Require Import Constant Factorization UnivalenceImpliesFunext.
+Require Import Modalities.Modality hit.Truncations hit.Connectedness.
+Import TrM.
+Require Import Spaces.BAut.
+
+Open Scope path_scope.
+Open Scope equiv_scope.
+
+(** * BAut(Bool) *)
+
+Section AssumeUnivalence.
+Context `{Univalence}.
+
+(** ** Nontrivial central homotopy *)
+
+(** The equivalence [Bool <~> (Bool <~> Bool)], and particularly its consequence [abelian_aut_bool], implies that [BAut Bool] has a nontrivial center.  *)
+
+Definition negb_center_baut_bool
+: forall (Z:BAut Bool), Z = Z.
+Proof.
+  apply center_baut; try exact _.
+  exists equiv_negb.
+  intros g; apply abelian_aut_bool.
+Defined.
+
+Definition nontrivial_negb_center_baut_bool
+: negb_center_baut_bool <> (fun Z => idpath Z).
+Proof.
+  intros oops.
+  pose (p := ap10_equiv
+                  ((ap (center_baut Bool))^-1
+                   (oops @ (id_center_baut Bool)^))..1 true).
+  exact (false_ne_true p).
+Defined.
+
+(** In particular, every element of [BAut Bool] has a canonical flip automorphism.  *)
+Definition negb_baut_bool (Z : BAut Bool) : Z <~> Z
+  := equiv_path Z Z (negb_center_baut_bool Z)..1.
+
+Definition negb_baut_bool_ne_idmap (Z : BAut Bool)
+: negb_baut_bool Z <> equiv_idmap Z.
+Proof.
+  intros oops.
+  apply nontrivial_negb_center_baut_bool.
+  apply path_forall; intros Z'.
+  pose (p := merely_path_baut Z Z').
+  clearbody p. strip_truncations.
+  destruct p.
+  unfold negb_baut_bool in oops.
+  apply moveL_equiv_V in oops.
+  refine (_ @ ap (equiv_path_sigma_hprop _ _)
+                 (oops @ path_universe_1) @ _).
+  - symmetry.
+    refine (eisretr (equiv_path_sigma_hprop Z Z) _).
+  - apply moveR_equiv_M; reflexivity.
+Defined.
+
+(** If [Z] is [Bool], then the flip is the usual one. *)
+Definition negb_baut_bool_bool_negb
+: negb_baut_bool (point _) = equiv_negb.
+Proof.
+  pose (c := aut_bool_idmap_or_negb (negb_baut_bool (point _))).
+  destruct c.
+  - pose (negb_baut_bool_ne_idmap (point _) p).
+    contradiction.
+  - assumption.
+Defined.
+
+Definition ap_pr1_negb_baut_bool_bool
+: (negb_center_baut_bool (point _))..1 = path_universe negb.
+Proof.
+  apply moveL_equiv_V.
+  apply negb_baut_bool_bool_negb.
+Defined.
+
+(** Moreover, we can show that every automorphism of a [Z : BAut Bool] must be either the flip or the identity. *)
+Definition aut_baut_bool_idmap_or_negb (Z : BAut Bool) (e : Z <~> Z)
+  : (e = equiv_idmap Z) + (e = negb_baut_bool Z).
+Proof.
+  assert (IsHProp ((e = equiv_idmap Z) + (e = negb_baut_bool Z))).
+  { apply ishprop_sum; try exact _.
+    intros p q; exact (negb_baut_bool_ne_idmap Z (q^ @ p)). }
+  baut_reduce.
+  case (aut_bool_idmap_or_negb e).
+  - intros p; exact (inl p).
+  - intros q; apply inr.
+    exact (q @ negb_baut_bool_bool_negb^).
+Defined.
+
+(** ** Connectedness *)
+
+Global Instance isminusoneconnected_baut_bool `{Funext} (Z : BAut Bool)
+: IsConnected -1 Z.
+Proof.
+  baut_reduce.
+  apply contr_inhabited_hprop; try exact _.
+  exact (tr true).
+Defined.
+
+Definition merely_inhab_baut_bool `{Funext} (Z : BAut Bool)
+: merely Z
+  := center (merely Z).
+
+(** ** Equivalence types *)
+
+(** As soon as an element of [BAut Bool] is inhabited, it is (purely) equivalent to [Bool].  (Of course, every element of [BAut Bool] is *merely* inhabited, since [Bool] is.)  In fact, it is equivalent in two canonical ways.
+
+First we define the function that will be the equivalence. *)
+Definition inhab_baut_bool_from_bool (t : Bool)
+           (Z : BAut Bool) (z : Z)
+: Bool -> Z
+  := fun b => if t then
+                if b then z else negb_baut_bool Z z
+              else
+                if b then negb_baut_bool Z z else z.
+
+(** We compute this in the case when [Z] is [Bool]. *)
+Definition inhab_baut_bool_from_bool_bool (t : Bool)
+: inhab_baut_bool_from_bool t (point _) =
+  fun (z : point (BAut Bool)) (b : Bool) =>
+    if t then
+      if b then z else negb z
+    else
+      if b then negb z else z.
+Proof.
+  apply path_forall; intros z'; simpl in z'.
+  apply path_forall; intros b.
+  destruct z', b, t; simpl;
+    try reflexivity;
+    try apply (ap10_equiv negb_baut_bool_bool_negb).
+Defined.
+
+(** Now we show that it is an equivalence. *)
+Global Instance isequiv_inhab_baut_bool_from_bool (t : Bool)
+       (Z : BAut Bool) (z : Z)
+: IsEquiv (inhab_baut_bool_from_bool t Z z).
+Proof.
+  baut_reduce.
+  refine (transport IsEquiv (ap10 (inhab_baut_bool_from_bool_bool t)^ z) _). 
+  simpl in z; destruct z, t; simpl.
+  - refine (isequiv_homotopic idmap _); intros []; reflexivity.
+  - apply isequiv_negb.
+  - apply isequiv_negb.
+  - refine (isequiv_homotopic idmap _); intros []; reflexivity.
+Defined.
+
+Definition equiv_inhab_baut_bool_bool (t : Bool)
+           (Z : BAut Bool) (z : Z)
+: Bool <~> Z
+  := BuildEquiv _ _ (inhab_baut_bool_from_bool t Z z) _.
+
+Definition path_baut_bool_inhab (Z : BAut Bool) (z : Z)
+: (point (BAut Bool)) = Z.
+Proof.
+  apply path_baut.
+  exact (equiv_inhab_baut_bool_bool true Z z). (** [true] is a choice! *)
+Defined.
+
+(** In fact, the map sending [z:Z] to this equivalence [Bool <~> Z] is also an equivalence.  To assist with computing the result when [Z] is [Bool], we prove it with an extra parameter first. *)
+Definition isequiv_equiv_inhab_baut_bool_bool_lemma
+       (t : Bool) (Z : BAut Bool) (m : merely (point _ = Z))
+: IsEquiv (equiv_inhab_baut_bool_bool t Z).
+Proof.
+  strip_truncations. destruct m.
+  refine (isequiv_adjointify _ (fun (e : Bool <~> Bool) => e t) _ _).
+  + intros e.
+    apply path_equiv.
+    refine (ap10 (inhab_baut_bool_from_bool_bool t) (e t) @ _).
+    apply path_arrow; intros []; destruct t.
+    * reflexivity.
+    * refine (abelian_aut_bool equiv_negb e false).
+    * refine (abelian_aut_bool equiv_negb e true).
+    * reflexivity.
+  + intros z.
+    refine (ap10 (ap10 (inhab_baut_bool_from_bool_bool t) z) t @ _).
+    destruct t; reflexivity.
+Defined.
+
+Global Instance isequiv_equiv_inhab_baut_bool_bool
+       (t : Bool) (Z : BAut Bool)
+: IsEquiv (equiv_inhab_baut_bool_bool t Z).
+Proof.
+  exact (isequiv_equiv_inhab_baut_bool_bool_lemma t Z
+           (merely_path_baut _ _)).
+Defined.
+
+(** The names are getting pretty ridiculous; below we suggest a better name for this. *)
+Definition equiv_equiv_inhab_baut_bool_bool (t : Bool)
+           (Z : BAut Bool)
+: Z <~> (Bool <~> Z)
+  := BuildEquiv _ _ (equiv_inhab_baut_bool_bool t Z) _.
+
+(** We compute its inverse in the case of [Bool]. *)
+Definition equiv_equiv_inhab_baut_bool_bool_bool_inv (t : Bool)
+           (e : Bool <~> Bool)
+: equiv_inverse (equiv_equiv_inhab_baut_bool_bool t (point _)) e = e t.
+Proof.
+  pose (alt := BuildEquiv _ _ (equiv_inhab_baut_bool_bool t (point _))
+                 (isequiv_equiv_inhab_baut_bool_bool_lemma
+                    t (point _) (tr 1))).
+  assert (p : equiv_equiv_inhab_baut_bool_bool t (point _) = alt).
+  { apply (ap (fun i => BuildEquiv _ _ _ i)).
+    apply (ap (isequiv_equiv_inhab_baut_bool_bool_lemma t (point _))).
+    apply path_ishprop. }
+  exact (ap10_equiv (ap equiv_inverse p) e).
+Defined.
+
+(** ** Group structure *)
+
+(** Homotopically, [BAut Bool] is a [K(Z/2,1)].  In particular, it has a (coherent) abelian group structure induced from that of [Z/2].  With our definition of [BAut Bool], we can construct this operation as follows. *)
+
+Definition baut_bool_pairing : BAut Bool -> BAut Bool -> BAut Bool.
+Proof.
+  intros Z W.
+  exists (Z <~> W).
+  baut_reduce; simpl.
+  apply tr, symmetry.
+  exact (path_universe equiv_bool_aut_bool).
+Defined.
+
+Notation "Z ** W" := (baut_bool_pairing Z W)
+                       (at level 40, no associativity)
+                     : baut_bool_scope.
+Local Open Scope baut_bool_scope.
+
+Local Notation pt := (point (BAut Bool)).
+
+(** Now [equiv_equiv_inhab_baut_bool_bool] is revealed as simply the left unit law of this pairing. *)
+Definition baut_bool_pairing_1Z Z : pt ** Z = Z.
+Proof.
+  apply path_baut, equiv_inverse, equiv_equiv_inhab_baut_bool_bool.
+  exact true.                   (** This is a choice! *)
+Defined.
+
+(** The pairing is obviously symmetric. *)
+Definition baut_bool_pairing_symm Z W : Z ** W = W ** Z.
+Proof.
+  apply path_baut, equiv_equiv_inverse.
+Defined.
+
+(** Whence we get the right unit law as well. *)
+Definition baut_bool_pairing_Z1 Z : Z ** pt = Z
+  := baut_bool_pairing_symm Z pt @ baut_bool_pairing_1Z Z.
+
+(** Every element is its own inverse. *)
+Definition baut_bool_pairing_ZZ Z : Z ** Z = pt.
+Proof.
+  apply symmetry, path_baut_bool_inhab.
+  apply equiv_idmap.            (** A choice!  Could be the flip. *)
+Defined.
+
+(** Associativity is easiest to think about in terms of "curried 2-variable equivalences".  We start with some auxiliary lemmas. *)
+Definition baut_bool_pairing_ZZ_Z_symm_part1 {Y Z W}
+           (e : Y ** (Z ** W)) (z : Z)
+: Y ** W.
+Proof.
+  refine (equiv_adjointify _ _ _ _).
+  + exact (fun y => e y z).
+  + intros w.
+    destruct (path_baut_bool_inhab W w).
+    destruct (path_baut_bool_inhab Z z).
+    (** It might be tempting to just say [e^-1 (equiv_idmap _)] here, but for the rest of the proof to work, we actually need to choose between [idmap] and [negb] based on whether [z] and [w] are equal or not. *)
+    destruct (dec (z=w)).
+    exact (e^-1 (equiv_idmap _)).
+    exact (e^-1 equiv_negb).
+  + intros w.
+    destruct (path_baut_bool_inhab W w).
+    destruct (path_baut_bool_inhab Z z).
+    simpl.
+    destruct z,w; simpl; refine (ap10_equiv (eisretr e _) _).
+  + intros y.
+    destruct (path_baut_bool_inhab Y y).
+    destruct (path_baut_bool_inhab Z z).
+    destruct (path_baut_bool_inhab W (e y z)).
+    simpl. 
+    case (dec (z = e y z)); intros p; apply moveR_equiv_V;
+    destruct (aut_bool_idmap_or_negb (e y)) as [q|q].
+    * symmetry; assumption.
+    * case (not_fixed_negb z (p @ ap10_equiv q z)^).
+    * case (p (ap10_equiv q z)^).
+    * symmetry; assumption.
+Defined.
+
+Definition baut_bool_pairing_ZZ_Z_symm_lemma {Y Z W}
+           (e : Y ** (Z ** W)) (f : Y ** W)
+: merely Y -> Z.
+Proof.
+  pose (k := (fun y => (e y)^-1 (f y))).
+  refine (merely_rec_hset k); intros y1 y2.
+  destruct (path_baut_bool_inhab Y y1).
+  destruct (path_baut_bool_inhab W (f y1)).
+  destruct (path_baut_bool_inhab Z (k y1)).
+  destruct (aut_bool_idmap_or_negb f) as [p|p];
+    refine (ap (e y1)^-1 (ap10_equiv p y1) @ _);
+    refine (_ @ (ap (e y2)^-1 (ap10_equiv p y2))^);
+    clear p f k; simpl.
+  + destruct (dec (y1=y2)) as [p|p].
+    { exact (ap (fun y => (e y)^-1 y) p). }
+    destruct (aut_bool_idmap_or_negb (e y1)) as [q1|q1];
+      destruct (aut_bool_idmap_or_negb (e y2)) as [q2|q2].
+    * case (p ((ap e)^-1 (q1 @ q2^))).
+    * rewrite q1, q2. exact (negb_ne p).
+    * rewrite q1, q2. symmetry. exact (negb_ne (fun r => p r^)).
+    * case (p ((ap e)^-1 (q1 @ q2^))).
+  + destruct (dec (y1=y2)) as [p|p].
+    { exact (ap (fun y => (e y)^-1 (negb y)) p). }
+    destruct (aut_bool_idmap_or_negb (e y1)) as [q1|q1];
+      destruct (aut_bool_idmap_or_negb (e y2)) as [q2|q2].
+    * case (p ((ap e)^-1 (q1 @ q2^))).
+    * rewrite q1, q2.
+      exact (negb_ne (fun r => p ((ap negb)^-1 r))).
+    * rewrite q1, q2. symmetry.
+      exact (negb_ne (fun r => p ((ap negb)^-1 r)^)).
+    * case (p ((ap e)^-1 (q1 @ q2^))).
+Defined.
+
+Definition baut_bool_pairing_ZZ_Z_symm_map Y Z W
+: Y ** (Z ** W) -> Z ** (Y ** W).
+Proof.
+  intros e.
+  refine (equiv_adjointify (baut_bool_pairing_ZZ_Z_symm_part1 e)
+                           _ _ _).
+  - intros f.
+    exact (baut_bool_pairing_ZZ_Z_symm_lemma e f
+             (merely_inhab_baut_bool Y)).
+  - intros f.
+    apply path_equiv, path_arrow; intros y.
+    change ((e y)
+         (baut_bool_pairing_ZZ_Z_symm_lemma e f
+            (merely_inhab_baut_bool Y)) = f y).
+    refine (ap (e y o baut_bool_pairing_ZZ_Z_symm_lemma e f)
+               (path_ishprop _ (tr y)) @ _).
+    simpl. apply eisretr.
+  - intros z.
+    assert (IsHSet Z) by exact _.
+    refine (Trunc_rec _ (merely_inhab_baut_bool Y)); intros y.
+    refine (ap (baut_bool_pairing_ZZ_Z_symm_lemma e _)
+               (path_ishprop _ (tr y)) @ _).
+    simpl. refine (eissect _ _).
+Defined.
+
+Definition baut_bool_pairing_ZZ_Z_symm_inv Y Z W
+: baut_bool_pairing_ZZ_Z_symm_map Y Z W
+  o baut_bool_pairing_ZZ_Z_symm_map Z Y W
+  == idmap.
+Proof.
+  intros e.
+  apply path_equiv, path_arrow; intros z.
+  apply path_equiv, path_arrow; intros y.
+  reflexivity.
+Defined.
+
+Definition baut_bool_pairing_ZZ_Z_symm Y Z W
+: Y ** (Z ** W) <~> Z ** (Y ** W).
+Proof.
+  refine (equiv_adjointify
+            (baut_bool_pairing_ZZ_Z_symm_map Y Z W)
+            (baut_bool_pairing_ZZ_Z_symm_map Z Y W)
+            (baut_bool_pairing_ZZ_Z_symm_inv Y Z W)
+            (baut_bool_pairing_ZZ_Z_symm_inv Z Y W)).
+Defined.
+
+(** Finally, we can prove associativity. *)
+Definition baut_bool_pairing_ZZ_Z Z W Y
+: (Z ** W) ** Y = Z ** (W ** Y).
+Proof.
+  refine (baut_bool_pairing_symm (Z ** W) Y @ _).
+  refine (_ @ ap (fun X => Z ** X) (baut_bool_pairing_symm Y W)).
+  apply path_baut, baut_bool_pairing_ZZ_Z_symm.
+Defined.
+  
+(** Since [BAut Bool] is not a set, we ought to have some coherence for these operations too, but we'll leave that for another time. *)
+
+(** ** Automorphisms of [BAut Bool] *)
+
+(** Interestingly, like [Bool] itself, [BAut Bool] is equivalent to its own automorphism group. *)
+
+(** An initial lemma: every automorphism of [BAut Bool] and its inverse are "adjoint" with respect to the pairing. *)
+Definition aut_baut_bool_moveR_pairing_V
+           (e : BAut Bool <~> BAut Bool) (Z W : BAut Bool)
+: (e^-1 Z ** W) = (Z ** e W).
+Proof.
+  apply path_baut; refine (equiv_adjointify _ _ _ _).
+  - intros f.
+    exact (equiv_path _ _ (moveL_equiv_M _ _ (path_baut _ _ f))..1).
+  - intros g.
+    exact (equiv_path _ _ (moveR_equiv_V _ _ (path_baut _ _ g))..1).
+  - intros g.
+    unfold path_baut; simpl.
+    refine (_ @ eisretr (equiv_path Z (e W)) g); apply ap.
+    refine (@moveR_equiv_V _ _ (path_sigma_hprop Z (e W)) _ _ _ _).
+    apply moveR_equiv_M.
+    apply moveR_equiv_M.
+    refine (eta_path_universe _ @ _).
+    apply ap. unfold moveR_equiv_V; simpl.
+    apply whiskerR, moveL_Vp.
+    refine (_ @ (ap_pp _ _ _)^).
+    apply whiskerR.
+    refine (_ @ ap (ap e^-1) (inv_V _)^).
+    exact (eisadj e^-1 Z).
+  - intros f.
+    unfold path_baut; simpl.
+    apply moveR_equiv_M.
+    refine (@moveR_equiv_V _ _ (path_sigma_hprop (e^-1 Z) W) _ _ _ _).
+    apply moveR_equiv_M.
+    apply moveR_equiv_M.
+    refine (eta_path_universe _ @ _).
+    apply ap. unfold moveL_equiv_M; simpl.
+    refine (_ @ concat_p_pp _ _ _).
+    apply whiskerL, moveL_pM.
+    refine (_ @ (ap_pp _ _ _)^).
+    apply whiskerL.
+    refine (_ @ (ap_V _ _)^).
+    apply inverse2, eisadj.
+Defined.
+
+Definition equiv_baut_bool_aut_baut_bool
+: BAut Bool <~> (BAut Bool <~> BAut Bool).
+Proof.
+  refine (equiv_adjointify _ _ _ _).
+  - intros Z.
+    refine (equiv_involution (fun W => Z ** W) _).
+    intros W.
+    refine ((baut_bool_pairing_ZZ_Z Z Z W)^ @ _).
+    refine (_ @ baut_bool_pairing_1Z W).
+    apply (ap (fun Y => Y ** W)).
+    apply baut_bool_pairing_ZZ.
+  - intros e.
+    exact (e^-1 pt).
+  - intros e.
+    apply path_equiv, path_arrow; intros Z; simpl.
+    refine (aut_baut_bool_moveR_pairing_V e pt Z @ _).
+    apply baut_bool_pairing_1Z.
+  - intros Z.
+    apply baut_bool_pairing_Z1.
+Defined.
+
+(** ** [BAut (BAut Bool)]  *)
+
+(** Putting all of this together, we can construct a nontrivial 2-central element of [BAut (BAut Bool)]. *)
+
+Definition center_baut_bool_central
+           (g : BAut Bool <~> BAut Bool) (W : BAut Bool)
+: ap g (negb_center_baut_bool W) = negb_center_baut_bool (g W).
+Proof.
+  revert g; equiv_intro equiv_baut_bool_aut_baut_bool Z.
+  simpl.
+  baut_reduce.
+  refine (_ @ apD negb_center_baut_bool (baut_bool_pairing_1Z pt)^).
+  rewrite transport_paths_lr, inv_V.
+  apply ((ap (equiv_inverse (equiv_path_sigma_hprop _ _)))^-1).
+  simpl.
+  unfold pr1_path.
+  rewrite <- ap_compose. simpl.
+  rewrite ap_compose.
+  rewrite !ap_pp.
+  refine (ap (ap (Equiv Bool)) ap_pr1_negb_baut_bool_bool @ _).
+  refine (_ @ ((1 @@ ap_pr1_negb_baut_bool_bool^) @@ 1)).
+  apply (equiv_inj (equiv_path _ _)).
+  rewrite !equiv_path_pp.
+  apply path_equiv, path_arrow; intros e.
+  simpl.
+  rewrite (transport_idmap_path_universe equiv_negb).
+  refine (ap10_equiv (ap_equiv_path_universe Bool equiv_negb) e @ _).
+  simpl.
+  unfold baut_bool_pairing_1Z, path_baut.
+  simpl.
+  rewrite ap_V, !ap_pr1_path_sigma_hprop.
+  refine (moveL_transport_V idmap _ _ _ _).
+  rewrite !transport_idmap_path_universe_uncurried.
+  rewrite !equiv_equiv_inhab_baut_bool_bool_bool_inv.
+  reflexivity.
+Qed.
+
+Definition negb_center2_baut_baut_bool
+: forall B : BAut (BAut Bool), (idpath B) = (idpath B).
+Proof.
+  refine (center2_baut (BAut Bool) _).
+  exists negb_center_baut_bool.
+  apply center_baut_bool_central.
+Defined.
+
+Definition nontrivial_negb_center_baut_baut_bool
+: negb_center2_baut_baut_bool <> (fun Z => idpath (idpath Z)).
+Proof.
+  intros oops.
+  exact (nontrivial_negb_center_baut_bool
+          (((ap (center2_baut (BAut Bool)))^-1
+              (oops @ (id_center2_baut (BAut Bool))^))..1)).
+Defined.
+
+End AssumeUnivalence.

--- a/theories/Spaces/BAut/Bool/IncoherentIdempotent.v
+++ b/theories/Spaces/BAut/Bool/IncoherentIdempotent.v
@@ -25,8 +25,8 @@ Section IncoherentQuasiIdempotent.
   : ~ (s o r == idmap).
   Proof.
     intros oops.
-    pose (p := oops nontrivial_qidem_baut_baut_bool); clearbody p.
-    pose (q := oops (isqidem_idmap (BAut (BAut Bool)))); clearbody q; clear oops.
+    assert (p := oops nontrivial_qidem_baut_baut_bool).
+    assert (q := oops (isqidem_idmap (BAut (BAut Bool)))); clear oops.
     apply nontrivial_negb_center_baut_baut_bool.
     refine (p^ @ ap s _ @ q).
     pose (contr_splitting_preidem_idmap (BAut (BAut Bool))).

--- a/theories/Spaces/BAut/Bool/IncoherentIdempotent.v
+++ b/theories/Spaces/BAut/Bool/IncoherentIdempotent.v
@@ -1,0 +1,56 @@
+(* -*- mode: coq; mode: visual-line -*-  *)
+Require Import HoTT.Basics HoTT.Types.
+Require Import EquivalenceVarieties Idempotents.
+Require Import Spaces.BAut Spaces.BAut.Bool.
+
+Open Scope path_scope.
+Open Scope equiv_scope.
+
+(** * An incoherent quasi-idempotent on [BAut (BAut Bool)]. *)
+
+Section IncoherentQuasiIdempotent.
+  Context `{Univalence}.
+
+  (** We use the identity map, and the nontrivial 2-central element of [BAut (BAut Bool)]. *)
+  Definition nontrivial_qidem_baut_baut_bool
+  : IsQuasiIdempotent (preidem_idmap (BAut (BAut Bool)))
+    := negb_center2_baut_baut_bool.
+
+  Let s := retract_sect (splitting_preidem_retractof_qidem (preidem_idmap (BAut (BAut Bool)))).
+  Let r := retract_retr (splitting_preidem_retractof_qidem (preidem_idmap (BAut (BAut Bool)))).
+  Let issect := retract_issect (splitting_preidem_retractof_qidem (preidem_idmap (BAut (BAut Bool)))) : r o s == idmap.
+
+  (** Since the space of splittings of the identity pre-idempotent is contractible, nontriviality of this 2-central element implies that not every quasi-idempotence witness of the identity is recoverable from its own splitting. *)
+  Definition splitting_preidem_notequiv_qidem_baut_baut_bool
+  : ~ (s o r == idmap).
+  Proof.
+    intros oops.
+    pose (p := oops nontrivial_qidem_baut_baut_bool); clearbody p.
+    pose (q := oops (isqidem_idmap (BAut (BAut Bool)))); clearbody q; clear oops.
+    apply nontrivial_negb_center_baut_baut_bool.
+    refine (p^ @ ap s _ @ q).
+    pose (contr_splitting_preidem_idmap (BAut (BAut Bool))).
+    apply path_contr.
+  Defined.
+
+  (** Therefore, not every quasi-idempotence witness is obtainable from *any* splitting, i.e. it may not have any coherentification. *)
+  Definition not_all_coherent_qidem_baut_baut_bool
+  : ~ (forall q : IsQuasiIdempotent (preidem_idmap (BAut (BAut Bool))),
+         { S : Splitting_PreIdempotent (preidem_idmap _) & s S = q }).
+  Proof.
+    intros oops.
+    assert (IsEquiv s).
+    { apply isequiv_biinv; split.
+      - exists r; exact issect.
+      - exists (fun q => (oops q).1).
+        exact (fun q => (oops q).2). }
+    apply splitting_preidem_notequiv_qidem_baut_baut_bool; intros q.
+    refine (ap s (ap r (eisretr s q)^) @ _).
+    refine (ap s (issect (s^-1 q)) @ _).
+    apply eisretr.
+  Defined.
+
+  (** These results show only that not *every* quasi-idempotence witness is coherent.  "Clearly" the nontrivial quasi-idempotence witness [nontrivial_qidem_baut_baut_bool] should be the one that is not coherent.  To show this, we would probably need to show that [isqidem_idmap] *is* in the image of [s], and this seems rather annoying to do based on our construction of [splitting_preidem_retractof_qidem]. *)
+
+End IncoherentQuasiIdempotent.
+

--- a/theories/Spaces/BAut/Cantor.v
+++ b/theories/Spaces/BAut/Cantor.v
@@ -102,9 +102,9 @@ Section Assumptions.
   Definition I0nat_flip
         (x : ((cantor + cantor) + cantor) + cantor)
   : I0 (ff_flip x) = f_flip (I0 x)
-    := ap10 (ap equiv_fun
+    := ap10_equiv
          (Inat (f (point (BAut cantor))) (f (point (BAut cantor)))
-               (equiv_sum_symm cantor cantor)))
+               (equiv_sum_symm cantor cantor))
          x.
 
   (** The value of this is that we can detect which summand an element is in depending on whether or not it is fixed by [f_flip] or [ff_flip]. *)
@@ -178,7 +178,7 @@ Section Assumptions.
                : ((f (point (BAut cantor))) + cantor) + cantor).
     apply (not_is_inl_and_inr' (I (f (point (BAut cantor))) x)).
     - exact (transport is_inl
-                       (ap10 (ap equiv_fun (J (point (BAut cantor)))) x) tt).
+                       (ap10_equiv (J (point (BAut cantor))) x) tt).
     - exact (fst (I0_preserves_inr x) (inr tt)).
   Defined.
 

--- a/theories/Types/Bool.v
+++ b/theories/Types/Bool.v
@@ -4,6 +4,7 @@
 Require Import HoTT.Basics.
 Require Import Types.Prod Types.Equiv.
 Local Open Scope equiv_scope.
+Local Open Scope path_scope.
 
 (* coq calls it "bool", we call it "Bool" *)
 Local Unset Elimination Schemes.
@@ -149,19 +150,21 @@ Section EquivBoolEquiv.
                                               then (equiv_idmap Bool)
                                               else equiv_negb.
 
+  Definition aut_bool_canonical (e : Bool <~> Bool)
+  : e == g (f e).
+  Proof.
+    unfold f, g; clear f g; intros []; simpl.
+    - destruct (e true); reflexivity.
+    - refine (eval_bool_isequiv e @ _).
+      destruct (e true); reflexivity.
+  Defined.
+
   Lemma equiv_bool_aut_bool `{Funext} : Bool <~> (Bool <~> Bool).
   Proof.
-    refine (equiv_adjointify g f _ _);
-    unfold f, g; clear f g;
-    hnf; simpl.
+    refine (equiv_adjointify g f _ _).
     - intro e.
-      destruct e as [e ?].
-      apply path_equiv; try assumption.
-      apply path_forall.
-      intros []; simpl.
-      * destruct (e true); reflexivity.
-      * etransitivity; [ | symmetry; apply eval_bool_isequiv; trivial ].
-        destruct (e true); reflexivity.
+      apply path_equiv, path_forall.
+      intros b; symmetry; apply aut_bool_canonical.
     - intros []; reflexivity.
   Defined.
 
@@ -183,12 +186,16 @@ Section EquivBoolEquiv.
   Defined.
 
   (** In particular, every pair of automorphisms of [Bool] commute with each other. *)
-  Definition abelian_aut_bool `{Funext} (e1 e2 : Bool <~> Bool)
+  Definition abelian_aut_bool (e1 e2 : Bool <~> Bool)
   : e1 o e2 == e2 o e1.
   Proof.
-    revert e1. equiv_intro equiv_bool_aut_bool e1.
-    revert e2. equiv_intro equiv_bool_aut_bool e2.
-    destruct e1, e2; simpl; exact (fun x => 1%path).
+    intro b.
+    refine (ap e1 (aut_bool_canonical e2 b) @ _).
+    refine (aut_bool_canonical e1 _ @ _).
+    refine (_ @ ap e2 (aut_bool_canonical e1 b)^).
+    refine (_ @ (aut_bool_canonical e2 _)^).
+    unfold f, g.
+    destruct (e1 true), (e2 true), b; reflexivity.
   Defined.
 
 End EquivBoolEquiv.

--- a/theories/Types/Bool.v
+++ b/theories/Types/Bool.v
@@ -82,8 +82,8 @@ Definition negb_ne {b1 b2 : Bool}
 Proof.
   destruct b1, b2.
   - intros oops; case (oops idpath).
-  - intros _; reflexivity.
-  - intros _; reflexivity.
+  - reflexivity.
+  - reflexivity.
   - intros oops; case (oops idpath).
 Defined.
 

--- a/theories/Types/Equiv.v
+++ b/theories/Types/Equiv.v
@@ -123,4 +123,16 @@ Section AssumeFunext.
   : (A <~> B) <~> (C <~> D)
   := BuildEquiv _ _ (functor_equiv h k) _.  
 
+  (** Reversing equivalences is an equivalence *)
+  Global Instance isequiv_equiv_inverse {A B}
+  : IsEquiv (@equiv_inverse A B).
+  Proof.
+    refine (isequiv_adjointify _ equiv_inverse _ _);
+      intros e; apply path_equiv; reflexivity.
+  Defined.
+
+  Definition equiv_equiv_inverse A B
+  : (A <~> B) <~> (B <~> A)
+    := BuildEquiv _ _ (@equiv_inverse A B) _.
+
 End AssumeFunext.

--- a/theories/Types/Paths.v
+++ b/theories/Types/Paths.v
@@ -87,6 +87,27 @@ Proof.
   exact ((concat_1p q)^ @ (concat_p1 (1 @ q))^).
 Defined.
 
+(** ** Transporting in 2-path types *)
+
+Definition transport_paths2 {A : Type} {x y : A}
+           (p : x = y) (q : idpath x = idpath x)
+: transport (fun a => idpath a = idpath a) p q
+  =  (concat_Vp p)^
+    @ whiskerL p^ ((concat_1p p)^ @ whiskerR q p @ concat_1p p)
+    @ concat_Vp p.
+Proof.
+  destruct p. simpl.
+  refine (_ @ (concat_p1 _)^).
+  refine (_ @ (concat_1p _)^).
+  (** The tricky thing here is getting a sufficiently general statement that we can prove it by path induction. *)
+  assert (H : forall (p : x = x) (q : 1 = p),
+                (q @ (concat_p1 p)^) @ (concat_1p (p @ 1))^
+                = whiskerL (idpath x) (idpath 1 @ whiskerR q 1 @ idpath (p @ 1))).
+  { intros p' q'. destruct q'. reflexivity. }
+  transitivity (q @ (concat_p1 1)^ @ (concat_1p 1)^).
+  { simpl; exact ((concat_p1 _)^ @ (concat_p1 _)^). }
+  refine (H 1 q).
+Defined.
 
 (** ** Functorial action *)
 
@@ -559,6 +580,21 @@ Proof.
   exact (equiv_concat_r (concat_1p r) (q @ 1)).
 Defined.
 
+Definition dpath_paths2 {A : Type} {x y : A}
+           (p : x = y) (q : idpath x = idpath x)
+           (r : idpath y = idpath y)
+: (concat_1p p)^ @ whiskerR q p @ concat_1p p
+  = (concat_p1 p)^ @ whiskerL p r @ concat_p1 p
+  <~>
+  transport (fun a => idpath a = idpath a) p q = r.
+Proof.
+  destruct p. simpl.
+  refine (equiv_compose' _ (equiv_inverse (equiv_whiskerR _ _ 1))).
+  refine (equiv_compose' _ (equiv_inverse (equiv_whiskerL 1 _ _))).
+  refine (equiv_concat_lr _ _).
+  - symmetry; apply whiskerR_p1_1.
+  - apply whiskerL_1p_1.
+Defined.
 
 (** ** Universal mapping property *)
 

--- a/theories/Types/Sigma.v
+++ b/theories/Types/Sigma.v
@@ -595,3 +595,32 @@ Definition isequiv_ap_pr1_hprop {A} {P : A -> Type}
            x y
 : IsEquiv (@ap _ _ (@pr1 A P) x y)
   := _.
+
+Definition path_sigma_hprop_1 {A : Type} {P : A -> Type}
+           `{forall x, IsHProp (P x)} (u : sigT P)
+: path_sigma_hprop u u 1 = 1.
+Proof.
+  unfold path_sigma_hprop.
+  unfold isequiv_pr1_contr; simpl.
+  (** Ugh *)
+  refine (ap (fun p => match p in (_ = v2) return (u = (u.1; v2)) with 1 => 1 end)
+             (contr (idpath u.2))).
+Defined.
+
+(** The inverse of [path_sigma_hprop] has its own name, so we give special names to the section and retraction homotopies to help [rewrite] out. *)
+Definition path_sigma_hprop_ap_pr1 {A : Type} {P : A -> Type}
+           `{forall x, IsHProp (P x)} (u v : sigT P) (p : u = v)
+: path_sigma_hprop u v (ap pr1 p) = p
+  := eisretr (path_sigma_hprop u v) p.
+Definition path_sigma_hprop_pr1_path {A : Type} {P : A -> Type}
+           `{forall x, IsHProp (P x)} (u v : sigT P) (p : u = v)
+: path_sigma_hprop u v p..1 = p
+  := eisretr (path_sigma_hprop u v) p.
+Definition ap_pr1_path_sigma_hprop {A : Type} {P : A -> Type}
+           `{forall x, IsHProp (P x)} (u v : sigT P) (p : u.1 = v.1)
+: ap pr1 (path_sigma_hprop u v p) = p
+  := eissect (path_sigma_hprop u v) p.
+Definition pr1_path_path_sigma_hprop {A : Type} {P : A -> Type}
+           `{forall x, IsHProp (P x)} (u v : sigT P) (p : u.1 = v.1)
+: (path_sigma_hprop u v p)..1 = p
+  := eissect (path_sigma_hprop u v) p.

--- a/theories/Types/Sum.v
+++ b/theories/Types/Sum.v
@@ -588,7 +588,7 @@ Global Instance hset_sum `{HA : IsHSet A, HB : IsHSet B} : IsHSet (A + B) | 100
 
 (** Sums don't preserve hprops in general, but they do for disjoint sums. *)
 
-Definition ishprop_sum A B `{IsHProp A} `{IsHProp B}
+Global Instance ishprop_sum A B `{IsHProp A} `{IsHProp B}
 : (A -> B -> Empty) -> IsHProp (A + B).
 Proof.
   intros H.

--- a/theories/Types/Universe.v
+++ b/theories/Types/Universe.v
@@ -285,55 +285,55 @@ but I haven't managed to prove them yet.  Fortunately, for existing applications
 
 (** Coq is too eager about unfolding [equiv_path_equiv] in the following proofs, so we tell it not to.  We go into a section in order to limit the scope of the [Opaque] command. *)
 Section OpaquePathEquiv.
-Opaque equiv_path_equiv.
+  Opaque equiv_path_equiv.
 
-Definition path2_universe_postcompose_idmap `{Funext}
-           {A C : Type} (p : forall a:A, a = a)
-           (g : A <~> C)
-: equiv_path2_universe g g (fun a => ap g (p a))
-  = (concat_1p _)^
-    @ whiskerR (path_universe_1)^ (path_universe g)
-    @ whiskerR (equiv_path2_universe (equiv_idmap A) (equiv_idmap A) p)
-               (path_universe g)
-    @ whiskerR path_universe_1 (path_universe g)
-    @ concat_1p _.
-Proof.
-  transitivity ((eta_path_universe (path_universe g))^
-                @ equiv_path2_universe
-                  (equiv_path A C (path_universe g))
-                  (equiv_path A C (path_universe g))
-                  (fun a => ap (equiv_path A C (path_universe g)) (p a))
-                @ eta_path_universe (path_universe g)).
-  - refine ((apD (fun g' => equiv_path2_universe g' g'
-                              (fun a => ap g' (p a)))
-              (eisretr (equiv_path A C) g))^ @ _).
-    refine (transport_paths_FlFr (eisretr (equiv_path A C) g) _ @ _).
-    apply concat2.
-    + apply whiskerR.
-      apply inverse2, symmetry.
-      refine (eisadj (equiv_path A C)^-1 g).
-    + symmetry; refine (eisadj (equiv_path A C)^-1 g).
-  - generalize (path_universe g).
-    intros h. destruct h. simpl.
-    rewrite !concat_1p, !concat_p1.
-    refine (_ @ whiskerR (whiskerR_pp 1 path_universe_1^ _) _).
-    refine (_ @ whiskerR_pp 1 _ path_universe_1).
-    refine (_ @ (whiskerR_p1_1 _)^).
-    apply whiskerR, whiskerL, ap, ap, ap.
-    apply path_forall; intros x; apply ap_idmap.
-Defined.
+  Definition path2_universe_postcompose_idmap `{Funext}
+             {A C : Type} (p : forall a:A, a = a)
+             (g : A <~> C)
+  : equiv_path2_universe g g (fun a => ap g (p a))
+    = (concat_1p _)^
+      @ whiskerR (path_universe_1)^ (path_universe g)
+      @ whiskerR (equiv_path2_universe (equiv_idmap A) (equiv_idmap A) p)
+        (path_universe g)
+      @ whiskerR path_universe_1 (path_universe g)
+      @ concat_1p _.
+  Proof.
+    transitivity ((eta_path_universe (path_universe g))^
+                  @ equiv_path2_universe
+                    (equiv_path A C (path_universe g))
+                    (equiv_path A C (path_universe g))
+                    (fun a => ap (equiv_path A C (path_universe g)) (p a))
+                    @ eta_path_universe (path_universe g)).
+    - refine ((apD (fun g' => equiv_path2_universe g' g'
+                                (fun a => ap g' (p a)))
+                   (eisretr (equiv_path A C) g))^ @ _).
+      refine (transport_paths_FlFr (eisretr (equiv_path A C) g) _ @ _).
+      apply concat2.
+      + apply whiskerR.
+        apply inverse2, symmetry.
+        refine (eisadj (equiv_path A C)^-1 g).
+      + symmetry; refine (eisadj (equiv_path A C)^-1 g).
+    - generalize (path_universe g).
+      intros h. destruct h. simpl.
+      rewrite !concat_1p, !concat_p1.
+      refine (_ @ whiskerR (whiskerR_pp 1 path_universe_1^ _) _).
+      refine (_ @ whiskerR_pp 1 _ path_universe_1).
+      refine (_ @ (whiskerR_p1_1 _)^).
+      apply whiskerR, whiskerL, ap, ap, ap.
+      apply path_forall; intros x; apply ap_idmap.
+  Defined.
 
-Definition path2_universe_precompose_idmap `{Funext}
-           {A B : Type} (p : forall b:B, b = b)
-           (g : A <~> B)
-: equiv_path2_universe g g (fun a => (p (g a)))
-  = (concat_p1 _)^
-    @ whiskerL (path_universe g) (path_universe_1)^
-    @ whiskerL (path_universe g)
-       (equiv_path2_universe (equiv_idmap B) (equiv_idmap B) p)
-    @ whiskerL (path_universe g) (path_universe_1)
-    @ concat_p1 _.
-Proof.
+  Definition path2_universe_precompose_idmap `{Funext}
+             {A B : Type} (p : forall b:B, b = b)
+             (g : A <~> B)
+  : equiv_path2_universe g g (fun a => (p (g a)))
+    = (concat_p1 _)^
+      @ whiskerL (path_universe g) (path_universe_1)^
+      @ whiskerL (path_universe g)
+          (equiv_path2_universe (equiv_idmap B) (equiv_idmap B) p)
+      @ whiskerL (path_universe g) (path_universe_1)
+      @ concat_p1 _.
+  Proof.
   transitivity ((eta_path_universe (path_universe g))^
                 @ equiv_path2_universe
                   (equiv_path A B (path_universe g))
@@ -356,7 +356,7 @@ Proof.
     refine (_ @ whiskerR (whiskerL_pp 1 path_universe_1^ _) _).
     refine (_ @ whiskerL_pp 1 _ path_universe_1).
     exact ((whiskerL_1p_1 _)^).
-Defined.
+  Defined.
 
 End OpaquePathEquiv.
 

--- a/theories/Types/Universe.v
+++ b/theories/Types/Universe.v
@@ -2,7 +2,7 @@
 (** * Theorems about the universe, including the Univalence Axiom. *)
 
 Require Import HoTT.Basics.
-Require Import Types.Sigma Types.Arrow Types.Paths Types.Equiv.
+Require Import Types.Sigma Types.Forall Types.Arrow Types.Paths Types.Equiv.
 Local Open Scope path_scope.
 Local Open Scope equiv_scope.
 
@@ -31,14 +31,6 @@ Proof.
   refine (@path_ishprop _ (hprop_isequiv _) _ _).
 Defined.
 
-Definition equiv_path_pp `{Funext} {A B C : Type} (p : A = B) (q : B = C)
-: equiv_path A C (p @ q) = equiv_compose' (equiv_path B C q) (equiv_path A B p).
-Proof.
-  destruct p, q. simpl.
-  apply path_equiv, path_arrow.
-  intros x; reflexivity.
-Defined.
-
 (** See the note by [Funext] in Overture.v *)
 Class Univalence.
 Axiom isequiv_equiv_path : forall `{Univalence} (A B : Type), IsEquiv (equiv_path A B).
@@ -56,6 +48,10 @@ Definition eta_path_universe {A B : Type} (p : A = B)
   : path_universe (equiv_path A B p) = p
   := eissect (equiv_path A B) p.
 
+Definition eta_path_universe_uncurried {A B : Type} (p : A = B)
+  : path_universe_uncurried (equiv_path A B p) = p
+  := eissect (equiv_path A B) p.
+
 Definition isequiv_path_universe {A B : Type}
   : IsEquiv (@path_universe_uncurried A B)
  := _.
@@ -63,8 +59,60 @@ Definition isequiv_path_universe {A B : Type}
 Definition equiv_path_universe (A B : Type) : (A <~> B) <~> (A = B)
   := BuildEquiv _ _ (@path_universe_uncurried A B) isequiv_path_universe.
 
+
 Definition equiv_equiv_path  (A B : Type) : (A = B) <~> (A <~> B)
   := equiv_inverse (equiv_path_universe A B).
+
+(** These operations have too many names, making [rewrite] a pain.  So we give lots of names to the computation laws. *)
+Definition path_universe_equiv_path {A B : Type} (p : A = B)
+  : path_universe (equiv_path A B p) = p
+  := eissect (equiv_path A B) p.
+Definition path_universe_uncurried_equiv_path {A B : Type} (p : A = B)
+  : path_universe_uncurried (equiv_path A B p) = p
+  := eissect (equiv_path A B) p.
+Definition path_universe_transport_idmap {A B : Type} (p : A = B)
+  : path_universe (transport idmap p) = p
+  := eissect (equiv_path A B) p.
+Definition path_universe_uncurried_transport_idmap {A B : Type} (p : A = B)
+  : path_universe_uncurried (equiv_transport idmap A B p) = p
+  := eissect (equiv_path A B) p.
+Definition equiv_path_path_universe {A B : Type} (f : A <~> B)
+  : equiv_path A B (path_universe f) = f
+  := eisretr (equiv_path A B) f.
+Definition equiv_path_path_universe_uncurried {A B : Type} (f : A <~> B)
+  : equiv_path A B (path_universe_uncurried f) = f
+  := eisretr (equiv_path A B) f.
+Definition transport_idmap_path_universe {A B : Type} (f : A <~> B)
+  : transport idmap (path_universe f) = f
+  := ap equiv_fun (eisretr (equiv_path A B) f).
+Definition transport_idmap_path_universe_uncurried {A B : Type} (f : A <~> B)
+  : transport idmap (path_universe_uncurried f) = f
+  := ap equiv_fun (eisretr (equiv_path A B) f).
+
+(** ** Behavior on path operations *)
+
+Definition equiv_path_pp `{Funext} {A B C : Type} (p : A = B) (q : B = C)
+: equiv_path A C (p @ q) = equiv_compose' (equiv_path B C q) (equiv_path A B p).
+Proof.
+  destruct p, q. simpl.
+  apply path_equiv, path_arrow.
+  intros x; reflexivity.
+Defined.
+
+Definition path_universe_compose `{Funext} {A B C : Type}
+           (f : A <~> B) (g : B <~> C)
+: path_universe (equiv_compose' g f) = path_universe f @ path_universe g.
+Proof.
+  revert f. equiv_intro (equiv_path A B) f.
+  revert g. equiv_intro (equiv_path B C) g.
+  refine ((ap path_universe_uncurried (equiv_path_pp f g))^ @ _).
+  refine (eta_path_universe (f @ g) @ _).
+  apply concat2; symmetry; apply eta_path_universe.
+Defined.
+
+Definition path_universe_1 {A : Type}
+: path_universe (equiv_idmap A) = 1
+  := eta_path_universe 1.
 
 Definition path_universe_V_uncurried `{Funext} {A B : Type} (f : A <~> B)
   : path_universe_uncurried (equiv_inverse f) = (path_universe_uncurried f)^.
@@ -81,6 +129,19 @@ Definition path_universe_V `{Funext} `(f : A -> B) `{IsEquiv A B f}
   : path_universe (f^-1) = (path_universe f)^
   := path_universe_V_uncurried (BuildEquiv A B f _).
 
+(** [ap (Equiv A)] behaves like postcomposition. *)
+Definition ap_equiv_path_universe `{Funext} A {B C} (f : B <~> C)
+: equiv_path (A <~> B) (A <~> C) (ap (Equiv A) (path_universe f))
+  = equiv_functor_equiv (equiv_idmap A) f.
+Proof.
+  revert f. equiv_intro (equiv_path B C) f.
+  rewrite (eissect (equiv_path B C) f : path_universe (equiv_path B C f) = f).
+  destruct f; simpl.
+  apply path_equiv, path_forall; intros g.
+  apply path_equiv, path_forall; intros a.
+  reflexivity.
+Defined.
+
 (** ** Transport *)
 
 (** There are two ways we could define [transport_path_universe]: we could give an explicit definition, or we could reduce it to paths by [equiv_ind] and give an explicit definition there.  The two should be equivalent, but we choose the second for now as it makes the currently needed coherence lemmas easier to prove. *)
@@ -96,7 +157,7 @@ Definition transport_path_universe
            {A B : Type} (f : A -> B) {feq : IsEquiv f} (z : A)
   : transport (fun X:Type => X) (path_universe f) z = f z
   := transport_path_universe_uncurried (BuildEquiv A B f feq) z.
-(* Alternatively, [ap10 (ap equiv_fun (eisretr (equiv_path A B) (BuildEquiv _ _ f feq))) z]. *)
+(* Alternatively, [ap10_equiv (eisretr (equiv_path A B) (BuildEquiv _ _ f feq)) z]. *)
 
 Definition transport_path_universe_equiv_path
            {A B : Type} (p : A = B) (z : A)
@@ -162,6 +223,160 @@ Definition transport_path_universe_Vp `{Funext}
   = transport_Vp idmap (path_universe f) z
 := transport_path_universe_Vp_uncurried (BuildEquiv A B f feq) z.
 
+(** ** 2-paths *)
+
+Definition equiv_path2_universe `{Funext}
+           {A B : Type} (f g : A <~> B)
+: (f == g) <~> (path_universe f = path_universe g).
+Proof.
+  refine (equiv_compose' _ (equiv_path_arrow f g)).
+  refine (equiv_compose' _ (equiv_path_equiv f g)).
+  exact (equiv_ap (equiv_path A B)^-1 _ _).
+Defined.
+
+Definition path2_universe `{Funext}
+           {A B : Type} {f g : A <~> B}
+: (f == g) -> (path_universe f = path_universe g)
+  := equiv_path2_universe f g.
+
+Definition equiv_path2_universe_1 `{Funext}
+           {A B : Type} (f : A <~> B)
+: equiv_path2_universe f f (fun x => 1) = 1.
+Proof.
+  simpl.
+  rewrite concat_1p, concat_p1, path_forall_1, path_sigma_hprop_1.
+  reflexivity.
+Qed.
+
+Definition path2_universe_1 `{Funext}
+           {A B : Type} (f : A <~> B)
+: @path2_universe _ _ _ f f (fun x => 1) = 1
+  := equiv_path2_universe_1 f.
+
+(** There ought to be a lemma which says something like this:
+
+<<
+Definition path2_universe_postcompose `{Funext}
+           {A B C : Type} {f1 f2 : A <~> B} (p : f1 == f2)
+           (g : B <~> C)
+: equiv_path2_universe (equiv_compose' g f1)
+                       (equiv_compose' g f2)
+                       (fun a => ap g (p a))
+  = path_universe_compose f1 g
+    @ whiskerR (path2_universe p) (path_universe g)
+    @ (path_universe_compose f2 g)^.
+>>
+
+and similarly
+
+<<
+Definition path2_universe_precompose `{Funext}
+           {A B C : Type} {f1 f2 : B <~> C} (p : f1 == f2)
+           (g : A <~> B)
+: equiv_path2_universe (equiv_compose' f1 g)
+                       (equiv_compose' f2 g)
+                       (fun a => (p (g a)))
+  = path_universe_compose g f1
+    @ whiskerL (path_universe g) (path2_universe p)
+    @ (path_universe_compose g f2)^.
+>>
+
+but I haven't managed to prove them yet.  Fortunately, for existing applications what we actually need is the following rather different-looking version that applies only when [f1] and [f2] are identities. *)
+
+(** Coq is too eager about unfolding [equiv_path_equiv] in the following proofs, so we tell it not to.  We go into a section in order to limit the scope of the [Opaque] command. *)
+Section OpaquePathEquiv.
+Opaque equiv_path_equiv.
+
+Definition path2_universe_postcompose_idmap `{Funext}
+           {A C : Type} (p : forall a:A, a = a)
+           (g : A <~> C)
+: equiv_path2_universe g g (fun a => ap g (p a))
+  = (concat_1p _)^
+    @ whiskerR (path_universe_1)^ (path_universe g)
+    @ whiskerR (equiv_path2_universe (equiv_idmap A) (equiv_idmap A) p)
+               (path_universe g)
+    @ whiskerR path_universe_1 (path_universe g)
+    @ concat_1p _.
+Proof.
+  transitivity ((eta_path_universe (path_universe g))^
+                @ equiv_path2_universe
+                  (equiv_path A C (path_universe g))
+                  (equiv_path A C (path_universe g))
+                  (fun a => ap (equiv_path A C (path_universe g)) (p a))
+                @ eta_path_universe (path_universe g)).
+  - refine ((apD (fun g' => equiv_path2_universe g' g'
+                              (fun a => ap g' (p a)))
+              (eisretr (equiv_path A C) g))^ @ _).
+    refine (transport_paths_FlFr (eisretr (equiv_path A C) g) _ @ _).
+    apply concat2.
+    + apply whiskerR.
+      apply inverse2, symmetry.
+      refine (eisadj (equiv_path A C)^-1 g).
+    + symmetry; refine (eisadj (equiv_path A C)^-1 g).
+  - generalize (path_universe g).
+    intros h. destruct h. simpl.
+    rewrite !concat_1p, !concat_p1.
+    refine (_ @ whiskerR (whiskerR_pp 1 path_universe_1^ _) _).
+    refine (_ @ whiskerR_pp 1 _ path_universe_1).
+    refine (_ @ (whiskerR_p1_1 _)^).
+    apply whiskerR, whiskerL, ap, ap, ap.
+    apply path_forall; intros x; apply ap_idmap.
+Defined.
+
+Definition path2_universe_precompose_idmap `{Funext}
+           {A B : Type} (p : forall b:B, b = b)
+           (g : A <~> B)
+: equiv_path2_universe g g (fun a => (p (g a)))
+  = (concat_p1 _)^
+    @ whiskerL (path_universe g) (path_universe_1)^
+    @ whiskerL (path_universe g)
+       (equiv_path2_universe (equiv_idmap B) (equiv_idmap B) p)
+    @ whiskerL (path_universe g) (path_universe_1)
+    @ concat_p1 _.
+Proof.
+  transitivity ((eta_path_universe (path_universe g))^
+                @ equiv_path2_universe
+                  (equiv_path A B (path_universe g))
+                  (equiv_path A B (path_universe g))
+                  (fun a => p (equiv_path A B (path_universe g) a))
+                @ eta_path_universe (path_universe g)).
+  - refine ((apD (fun g' => equiv_path2_universe g' g'
+                              (fun a => p (g' a)))
+              (eisretr (equiv_path A B) g))^ @ _).
+    refine (transport_paths_FlFr (eisretr (equiv_path A B) g) _ @ _).
+    apply concat2.
+    + apply whiskerR.
+      apply inverse2, symmetry.
+      refine (eisadj (equiv_path A B)^-1 g).
+    + symmetry; refine (eisadj (equiv_path A B)^-1 g).
+  - generalize (path_universe g).
+    intros h. destruct h. simpl.
+    rewrite !concat_p1.
+    refine (_ @ (((concat_1p (whiskerL 1 path_universe_1^))^ @@ 1) @@ 1)).
+    refine (_ @ whiskerR (whiskerL_pp 1 path_universe_1^ _) _).
+    refine (_ @ whiskerL_pp 1 _ path_universe_1).
+    exact ((whiskerL_1p_1 _)^).
+Defined.
+
+End OpaquePathEquiv.
+
+(** ** 3-paths *)
+
+Definition equiv_path3_universe `{Funext}
+           {A B : Type} {f g : A <~> B} (p q : f == g)
+: (p == q) <~> (path2_universe p = path2_universe q).
+Proof.
+  refine (equiv_compose' _ (equiv_path_forall p q)).
+  refine (equiv_compose' _ (equiv_ap (equiv_path_arrow f g) p q)).
+  refine (equiv_compose' _ (equiv_ap (equiv_path_equiv f g) _ _)).
+  unfold path2_universe, equiv_path2_universe.
+  simpl. refine (equiv_ap (ap (equiv_path A B)^-1) _ _).
+Defined.
+
+Definition path3_universe `{Funext}
+           {A B : Type} {f g : A <~> B} {p q : f == g}
+: (p == q) -> (path2_universe p = path2_universe q)
+  := equiv_path3_universe p q.
 
 Definition transport_path_universe_pV_uncurried `{Funext}
            {A B : Type} (f : A <~> B) (z : B)
@@ -234,10 +449,19 @@ Defined.
 Global Instance contr_basedequiv' {X : Type}
 : Contr {Y : Type & Y <~> X}.
 Proof.
-Proof.
   refine (trunc_equiv' {Y : Type & Y = X}
            (equiv_functor_sigma' (equiv_idmap Type)
              (fun Y => equiv_equiv_path Y X))).
+Defined.
+
+(** ** Truncations *)
+
+(** Truncatedness of the universe is a subtle question, but with univalence we can conclude things about truncations of certain of its path-spaces. *)
+Global Instance istrunc_paths_Type `{Funext}
+       {n : trunc_index} {A B : Type} `{IsTrunc n.+1 B}
+: IsTrunc n.+1 (A = B).
+Proof.
+  refine (trunc_equiv _ path_universe_uncurried).
 Defined.
 
 End Univalence.

--- a/theories/Types/Universe.v
+++ b/theories/Types/Universe.v
@@ -283,9 +283,9 @@ Definition path2_universe_precompose `{Funext}
 
 but I haven't managed to prove them yet.  Fortunately, for existing applications what we actually need is the following rather different-looking version that applies only when [f1] and [f2] are identities. *)
 
-(** Coq is too eager about unfolding [equiv_path_equiv] in the following proofs, so we tell it not to.  We go into a section in order to limit the scope of the [Opaque] command. *)
-Section OpaquePathEquiv.
-  Opaque equiv_path_equiv.
+(** Coq is too eager about unfolding [equiv_path_equiv] in the following proofs, so we tell it not to.  We go into a section in order to limit the scope of the [simpl never] command. *)
+Section PathEquivSimplNever.
+  Local Arguments equiv_path_equiv : simpl never.
 
   Definition path2_universe_postcompose_idmap `{Funext}
              {A C : Type} (p : forall a:A, a = a)
@@ -314,7 +314,7 @@ Section OpaquePathEquiv.
         refine (eisadj (equiv_path A C)^-1 g).
       + symmetry; refine (eisadj (equiv_path A C)^-1 g).
     - generalize (path_universe g).
-      intros h. destruct h. simpl.
+      intros h. destruct h. cbn.
       rewrite !concat_1p, !concat_p1.
       refine (_ @ whiskerR (whiskerR_pp 1 path_universe_1^ _) _).
       refine (_ @ whiskerR_pp 1 _ path_universe_1).
@@ -350,7 +350,7 @@ Section OpaquePathEquiv.
       refine (eisadj (equiv_path A B)^-1 g).
     + symmetry; refine (eisadj (equiv_path A B)^-1 g).
   - generalize (path_universe g).
-    intros h. destruct h. simpl.
+    intros h. destruct h. cbn.
     rewrite !concat_p1.
     refine (_ @ (((concat_1p (whiskerL 1 path_universe_1^))^ @@ 1) @@ 1)).
     refine (_ @ whiskerR (whiskerL_pp 1 path_universe_1^ _) _).
@@ -358,7 +358,7 @@ Section OpaquePathEquiv.
     exact ((whiskerL_1p_1 _)^).
   Defined.
 
-End OpaquePathEquiv.
+End PathEquivSimplNever.
 
 (** ** 3-paths *)
 

--- a/theories/hit/Connectedness.v
+++ b/theories/hit/Connectedness.v
@@ -54,6 +54,29 @@ Proof.
                        which by induction is m'-truncated. *)
 Defined.
 
+(** ** 0-connectedness *)
+
+(** To be 0-connected is the same as to be (-1)-connected and that any two points are merely equal. *)
+Definition merely_path_is0connected `{Univalence}
+           (A : Type) `{IsConnected 0 A} (x y : A)
+: merely (x = y).
+Proof.
+  refine ((equiv_path_Tr x y)^-1 (path_contr (tr x) (tr y))).
+Defined.
+
+Definition is0connected_merely_allpath `{Univalence}
+           (A : Type) `{merely A}
+           (p : forall (x y:A), merely (x = y))
+: IsConnected 0 A.
+Proof.
+  strip_truncations.
+  apply (contr_inhabited_hprop).
+  - apply hprop_allpath; intros z w.
+    strip_truncations.
+    refine (equiv_path_Tr z w (p z w)).
+  - apply tr; assumption.
+Defined.
+
 (** ** Connectivity of pointed types *)
 
 (** The connectivity of a pointed type and (the inclusion of) its point are intimately connected. *)


### PR DESCRIPTION
Here we characterize the center and 2-center of BAut(X), and use those to construct an example of a quasi-idempotent that cannot be extended to a coherent one (though, by the general splitting construction, its underlying pre-idempotent can).