### PR TITLE
Pointed types and the loop-suspension adjunction

### DIFF
--- a/Makefile_targets.mk
+++ b/Makefile_targets.mk
@@ -58,6 +58,7 @@ CORE_VFILES = \
 	$(srcdir)/theories/Tactics/RewriteModuloAssociativity.v \
 	$(srcdir)/theories/Tactics/BinderApply.v \
 	$(srcdir)/theories/TruncType.v \
+	$(srcdir)/theories/PType.v \
 	$(srcdir)/theories/Functorish.v \
 	$(srcdir)/theories/FunextAxiom.v \
 	$(srcdir)/theories/UnivalenceAxiom.v \

--- a/contrib/HoTTBook.v
+++ b/contrib/HoTTBook.v
@@ -89,7 +89,7 @@ Definition Book_2_1_6 := @HoTT.Basics.PathGroupoids.eckmann_hilton.
 (* ================================================== def:pointedtype *)
 (** Definition 2.1.7 *)
 
-Definition Book_2_1_7 := @HoTT.Basics.Overture.pointedType.
+Definition Book_2_1_7 := @HoTT.Basics.Overture.pType.
 
 (* ================================================== def:loopspace *)
 (** Definition 2.1.8 *)
@@ -801,7 +801,7 @@ Definition Book_6_5_1 := @HoTT.hit.Spheres.isequiv_Sph1_to_S1.
 (* ================================================== lem:susp-loop-adj *)
 (** Lemma 6.5.4 *)
 
-
+Definition Book_6_5_4 := @HoTT.hit.Suspension.loop_susp_adjoint.
 
 (* ================================================== defn:cocone *)
 (** Definition 6.8.1 *)

--- a/theories/Basics/Contractible.v
+++ b/theories/Basics/Contractible.v
@@ -33,7 +33,7 @@ Global Instance contr_paths_contr `{Contr A} (x y : A) : Contr (x = y) | 10000 :
 (** Also, the total space of any based path space is contractible.  We define the [contr] fields as separate definitions, so that we can give them [simpl nomatch] annotations. *)
 
 Definition path_basedpaths {X : Type} {x y : X} (p : x = y)
-: (exist (fun y => x = y) x 1) = (y;p).
+: (x;1) = (y;p) :> {z:X & x=z}.
 Proof.
   destruct p; reflexivity.
 Defined.
@@ -41,18 +41,20 @@ Defined.
 Arguments path_basedpaths {X x y} p : simpl nomatch.
 
 Global Instance contr_basedpaths {X : Type} (x : X) : Contr {y : X & x = y} | 100.
+Proof.
   exists (x ; 1).
   intros [y p]; apply path_basedpaths.
 Defined.
 
 Definition path_basedpaths' {X : Type} {x y : X} (p : y = x)
-: (exist (fun y => y = x) x 1) = (y;p).
+: (x;1) = (y;p) :> {z:X & z=x}.
 Proof.
   destruct p; reflexivity.
 Defined.
 
 Global Instance contr_basedpaths' {X : Type} (x : X) : Contr {y : X & y = x} | 100.
-  exists (existT (fun y => y = x) x 1).
+Proof.
+  refine (BuildContr _ (x;1) _).
   intros [y p]; apply path_basedpaths'.
 Defined.
 

--- a/theories/Basics/Contractible.v
+++ b/theories/Basics/Contractible.v
@@ -24,20 +24,68 @@ Defined.
 
 (** It follows that any space of paths in a contractible space is contractible. *)
 (** Because [Contr] is a notation, and [Contr_internal] is the record, we need to iota expand to fool Coq's typeclass machinery into accepting supposedly "mismatched" contexts. *)
+
 Global Instance contr_paths_contr `{Contr A} (x y : A) : Contr (x = y) | 10000 := let c := {|
   center := (contr x)^ @ contr y;
   contr := path2_contr ((contr x)^ @ contr y)
 |} in c.
 
-(** Also, the total space of any based path space is contractible. *)
+(** Also, the total space of any based path space is contractible.  We define the [contr] fields as separate definitions, so that we can give them [simpl nomatch] annotations. *)
+
+Definition path_basedpaths {X : Type} {x y : X} (p : x = y)
+: (exist (fun y => x = y) x 1) = (y;p).
+Proof.
+  destruct p; reflexivity.
+Defined.
+
+Arguments path_basedpaths {X x y} p : simpl nomatch.
+
 Global Instance contr_basedpaths {X : Type} (x : X) : Contr {y : X & x = y} | 100.
   exists (x ; 1).
-  intros [y []]; reflexivity.
+  intros [y p]; apply path_basedpaths.
+Defined.
+
+Definition path_basedpaths' {X : Type} {x y : X} (p : y = x)
+: (exist (fun y => y = x) x 1) = (y;p).
+Proof.
+  destruct p; reflexivity.
 Defined.
 
 Global Instance contr_basedpaths' {X : Type} (x : X) : Contr {y : X & y = x} | 100.
   exists (existT (fun y => y = x) x 1).
-  intros [y []]; reflexivity.
+  intros [y p]; apply path_basedpaths'.
+Defined.
+
+Arguments path_basedpaths' {X x y} p : simpl nomatch.
+
+(** Some useful computation laws for based path spaces *)
+
+Definition ap_pr1_path_contr_basedpaths {X : Type}
+           {x y z : X} (p : x = y) (q : x = z)
+: ap pr1 (path_contr ((y;p):{y':X & x = y'}) (z;q)) = p^ @ q.
+Proof.
+  destruct p,q; reflexivity.
+Defined.
+
+Definition ap_pr1_path_contr_basedpaths' {X : Type}
+           {x y z : X} (p : y = x) (q : z = x)
+: ap pr1 (path_contr ((y;p):{y':X & y' = x}) (z;q)) = p @ q^.
+Proof.
+  destruct p,q; reflexivity.
+Defined.
+
+Definition ap_pr1_path_basedpaths {X : Type}
+           {x y : X} (p : x = y)
+: ap pr1 (path_basedpaths p) = p.
+Proof.
+  destruct p; reflexivity.
+Defined.
+
+Definition ap_pr1_path_basedpaths' {X : Type}
+           {x y : X} (p : y = x)
+: ap pr1 (path_basedpaths' p) = p^.
+Proof.
+  destruct p; reflexivity.
 Defined.
 
 (** If the domain is contractible, the function is propositionally constant. *)

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -713,7 +713,7 @@ Ltac remember_as term name eqname :=
   pose (eqname := idpath : term = name);
   clearbody eqname name.
 
-Tactic Notation "remember" constr(term) "as" ident(name) "eqn" ident(eqname) :=
+Tactic Notation "remember" constr(term) "as" ident(name) "eqn:" ident(eqname) :=
   remember_as term name eqname.
 
 (** A variant that doesn't substitute in the goal and hypotheses. *)
@@ -722,5 +722,5 @@ Ltac recall_as term name eqname :=
   pose (eqname := idpath : term = name);
   clearbody eqname name.
 
-Tactic Notation "recall" constr(term) "as" ident(name) "eqn" ident(eqname) :=
+Tactic Notation "recall" constr(term) "as" ident(name) "eqn:" ident(eqname) :=
   recall_as term name eqname.

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -585,8 +585,16 @@ Definition Unit_rect := Unit_ind.
 
 (** A space is pointed if that space has a point. *)
 Class IsPointed (A : Type) := point : A.
-Definition pointedType := { u : Type & IsPointed u }.
+
 Arguments point A {_}.
+
+Record pType :=
+  { pointed_type : Type ;
+    ispointed_type : IsPointed pointed_type }.
+
+Coercion pointed_type : pType >-> Sortclass.
+
+Global Existing Instance ispointed_type.
 
 (** *** Homotopy fibers *)
 
@@ -698,3 +706,21 @@ Tactic Notation "transparent" "assert" "(" ident(name) ":" constr(type) ")" :=
 Tactic Notation "transparent" "assert" "(" ident(name) ":" constr(type) ")" "by" tactic3(tac) := let name := fresh "H" in transparent assert (name : type); [ solve [ tac ] | ].
 Tactic Notation "transparent" "eassert" "(" ident(name) ":" open_constr(type) ")" := transparent assert (name : type).
 Tactic Notation "transparent" "eassert" "(" ident(name) ":" open_constr(type) ")" "by" tactic3(tac) := transparent assert (name : type) by tac.
+
+(** A version of Coq's [remember] that uses our equality. *)
+Ltac remember_as term name eqname :=
+  set (name := term) in *;
+  pose (eqname := idpath : term = name);
+  clearbody eqname name.
+
+Tactic Notation "remember" constr(term) "as" ident(name) "eqn" ident(eqname) :=
+  remember_as term name eqname.
+
+(** A variant that doesn't substitute in the goal and hypotheses. *)
+Ltac recall_as term name eqname :=
+  pose (name := term);
+  pose (eqname := idpath : term = name);
+  clearbody eqname name.
+
+Tactic Notation "recall" constr(term) "as" ident(name) "eqn" ident(eqname) :=
+  recall_as term name eqname.

--- a/theories/Basics/PathGroupoids.v
+++ b/theories/Basics/PathGroupoids.v
@@ -525,6 +525,24 @@ Proof.
   reflexivity.
 Defined.
 
+(** Some coherence lemmas for functoriality *)
+
+Lemma concat_1p_1 {A} {x : A} (p : x = x) (q : p = 1)
+: concat_1p p @ q = ap (fun p' => 1 @ p') q.
+Proof.
+  rewrite <- (inv_V q).
+  set (r := q^). clearbody r; clear q; destruct r.
+  reflexivity.
+Defined.
+
+Lemma concat_p1_1 {A} {x : A} (p : x = x) (q : p = 1)
+: concat_p1 p @ q = ap (fun p' => p' @ 1) q.
+Proof.
+  rewrite <- (inv_V q).
+  set (r := q^). clearbody r; clear q; destruct r.
+  reflexivity.
+Defined.
+
 (** *** Action of [apD10] and [ap10] on paths. *)
 
 (** Application of paths between functions preserves the groupoid structure *)
@@ -828,10 +846,40 @@ Definition concat2 {A} {x y z : A} {p p' : x = y} {q q' : y = z} (h : p = p') (h
 
 Notation "p @@ q" := (concat2 p q)%path (at level 20) : path_scope.
 
+Arguments concat2 : simpl nomatch.
+
 (** 2-dimensional path inversion *)
 Definition inverse2 {A : Type} {x y : A} {p q : x = y} (h : p = q)
   : p^ = q^
 := ap inverse h.
+
+(** Some higher coherences *)
+
+Lemma ap_pp_concat_pV {A B} (f : A -> B) {x y : A} (p : x = y)
+: ap_pp f p p^ @ ((1 @@ ap_V f p) @ concat_pV (ap f p))
+  = ap (ap f) (concat_pV p).
+Proof.
+  destruct p; reflexivity.
+Defined.
+
+Lemma ap_pp_concat_Vp {A B} (f : A -> B) {x y : A} (p : x = y)
+: ap_pp f p^ p @ ((ap_V f p @@ 1) @ concat_Vp (ap f p))
+  = ap (ap f) (concat_Vp p).
+Proof.
+  destruct p; reflexivity.
+Defined.
+
+Lemma concat_pV_inverse2 {A} {x y : A} (p q : x = y) (r : p = q)
+: (r @@ inverse2 r) @ concat_pV q = concat_pV p.
+Proof.
+  destruct r, p; reflexivity.
+Defined.
+
+Lemma concat_Vp_inverse2 {A} {x y : A} (p q : x = y) (r : p = q)
+: (inverse2 r @@ r) @ concat_Vp q = concat_Vp p.
+Proof.
+  destruct r, p; reflexivity.
+Defined.
 
 (** *** Whiskering *)
 

--- a/theories/Basics/Pointed.v
+++ b/theories/Basics/Pointed.v
@@ -77,6 +77,14 @@ Definition pmap_compose {A B C : pType}
 
 Infix "o*" := pmap_compose (at level 40).
 
+(** Another option would be
+<<
+Delimit Scope pmap_scope with pmap.
+Bind Scope pmap_scope with pMap.
+Infix "o" := pmap_compose : pmap_scope.
+>>
+which would allow us to use [o] for pointed maps as well most of the time.  However, it would sometimes require adding [%pmap] scoping markers. *)
+
 (** ** Pointed homotopies *)
 
 Record pHomotopy {A B : pType} (f g : pMap A B) :=

--- a/theories/Basics/Pointed.v
+++ b/theories/Basics/Pointed.v
@@ -101,8 +101,8 @@ Ltac pointed_reduce :=
          end;
   cbn in *; unfold point in *;
   path_induction; cbn;
-  try rewrite !concat_p1;
-  try rewrite !concat_1p.
+  (** TODO: [pointed_reduce] uses [rewrite], and thus according to our current general rules, it should only be used in opaque proofs.  We don't yet need any of the proofs that use it to be transparent, but there's a good chance we will eventually.  At that point we can consider whether to allow it in transparent proofs, modify it to not use [rewrite], or exclude it from proofs that need to be transparent. *)
+  rewrite ?concat_p1, ?concat_1p.
 
 Definition loops_2functor {A B : pType} {f g : A ->* B} (p : f ==* g)
 : (loops_functor f) ==* (loops_functor g).
@@ -116,7 +116,7 @@ Proof.
     refine (concat_Ap p q).
   - simpl.
     abstract (rewrite !concat_p1; reflexivity).
-Defined.
+Qed.
 
 (** ** Associativity of pointed map composition *)
 
@@ -128,25 +128,25 @@ Proof.
   refine (Build_pHomotopy _ _); cbn.
   - intros ?; reflexivity.
   - reflexivity.
-Defined.
+Qed.
 
-Definition pmap_compose_preid {A B : pType} (f : A ->* B)
+Definition pmap_precompose_idmap {A B : pType} (f : A ->* B)
 : f o* pmap_idmap A ==* f.
 Proof.
   pointed_reduce.
   refine (Build_pHomotopy _ _); cbn.
   - intros ?; reflexivity.
   - reflexivity.
-Defined.
+Qed.
 
-Definition pmap_compose_postid {A B : pType} (f : A ->* B)
+Definition pmap_postcompose_idmap {A B : pType} (f : A ->* B)
 : pmap_idmap B o* f ==* f.
 Proof.
   pointed_reduce.
   refine (Build_pHomotopy _ _); cbn.
   - intros ?; reflexivity.
   - reflexivity.
-Defined.
+Qed.
 
 (** ** Whiskering of pointed homotopies by pointed functions *)
 
@@ -158,7 +158,7 @@ Proof.
   refine (Build_pHomotopy _ _); cbn.
   - intros a; apply ap, p.
   - reflexivity.
-Defined.
+Qed.
 
 Definition pmap_prewhisker {A B C : pType} (f : A ->* B)
            {g h : B ->* C} (p : g ==* h)
@@ -168,7 +168,7 @@ Proof.
   refine (Build_pHomotopy _ _); cbn.
   - intros a; apply p.
   - refine (concat_p1 _ @ (concat_1p _)^).
-Defined.
+Qed.
 
 (** ** Composition of pointed homotopies *)
 
@@ -180,7 +180,7 @@ Proof.
   refine (Build_pHomotopy _ _); cbn.
   - intros x; exact (p x @ q x).
   - apply concat_p1.
-Defined.
+Qed.
 
 Infix "@*" := phomotopy_compose (at level 30).
 
@@ -191,7 +191,7 @@ Proof.
   refine (Build_pHomotopy _ _); cbn.
   - intros x; exact ((p x)^).
   - apply concat_Vp.
-Defined.
+Qed.
 
 Notation "p ^*" := (phomotopy_inverse p) (at level 20).
 
@@ -210,7 +210,7 @@ Proof.
     refine (_ @ ap (ap g) (concat_p1 _)^).
     apply ap_compose.
   - reflexivity.
-Defined.
+Qed.
 
 Definition loops_functor_idmap (A : pType)
 : loops_functor (pmap_idmap A) ==* pmap_idmap (loops A).
@@ -220,7 +220,7 @@ Proof.
   - intros p.
     refine (concat_1p _ @ concat_p1 _ @ ap_idmap _).
   - reflexivity.
-Defined.
+Qed.
 
 (** ** Pointed equivalences *)
 

--- a/theories/Basics/Pointed.v
+++ b/theories/Basics/Pointed.v
@@ -1,7 +1,7 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 (** * Pointed Types *)
 
-Require Import Overture.
+Require Import Overture PathGroupoids Equivalences.
 
 Local Open Scope path_scope.
 Local Open Scope equiv_scope.
@@ -9,7 +9,9 @@ Local Open Scope equiv_scope.
 (** Allow ourselves to implicitly generalize over types [A] and [B], and a function [f]. *)
 Generalizable Variables A B f.
 
-(** Any contratible type is pointed. *)
+(** ** Constructions of pointed types *)
+
+(** Any contractible type is pointed. *)
 Global Instance ispointed_contr `{Contr A} : IsPointed A := center A.
 
 (** A pi type with a pointed target is pointed. *)
@@ -26,15 +28,223 @@ Global Instance ispointed_sigma `{IsPointed A} `{IsPointed (B (point A))}
 Global Instance ispointed_prod `{IsPointed A, IsPointed B} : IsPointed (A * B)
   := (point A, point B).
 
+(** ** Loop spaces *)
+
 (** The type [x = x] is pointed. *)
-Global Instance ispointed_loop_space A (a : A) : IsPointed (a = a) := idpath.
+Global Instance ispointed_loops A (a : A)
+: IsPointed (a = a)
+  := idpath.
 
 (** We can build an iterated loop space *)
-Definition loopSpace (A : pointedType) : pointedType :=
-  (A.1 = A.1; idpath).
+Definition loops (A : pType) : pType :=
+  Build_pType (point A = point A) idpath.
 
-Fixpoint iteratedLoopSpace (n : nat) (A : Type) `{H : IsPointed A} {struct n} : pointedType
+Fixpoint iterated_loops (n : nat) (A : Type) `{H : IsPointed A}
+         {struct n} : pType
   := match n with
-       | O => existT IsPointed A (@point A H)
-       | S p => iteratedLoopSpace p (point = point)
+       | O => Build_pType A (@point A H)
+       | S p => iterated_loops p (point A = point A)
      end.
+
+(** ** Pointed functions *)
+
+Record pMap (A B : pType) :=
+  { pointed_fun : A -> B ;
+    point_eq : pointed_fun (point A) = point B }.
+
+Arguments point_eq {A B} f : rename.
+Coercion pointed_fun : pMap >-> Funclass.
+
+Infix "->*" := pMap (at level 99).
+
+Definition loops_functor {A B : pType} (f : A ->* B)
+: (loops A) ->* (loops B).
+Proof.
+  refine (Build_pMap (loops A) (loops B)
+            (fun p => (point_eq f)^ @ (ap f p @ point_eq f)) _).
+  apply moveR_Vp; simpl.
+  refine (concat_1p _ @ (concat_p1 _)^).
+Defined.
+
+Definition pmap_idmap (A : pType): A ->* A
+  := Build_pMap A A idmap 1.
+
+Definition pmap_compose {A B C : pType}
+           (g : B ->* C) (f : A ->* B)
+: A ->* C
+  := Build_pMap A C (g o f)
+                (ap g (point_eq f) @ point_eq g).
+
+Infix "o*" := pmap_compose (at level 40).
+
+(** ** Pointed homotopies *)
+
+Record pHomotopy {A B : pType} (f g : pMap A B) :=
+  { pointed_htpy : f == g ;
+    point_htpy : pointed_htpy (point A) @ point_eq g = point_eq f }.
+
+Arguments Build_pHomotopy {A B f g} p q : rename.
+Arguments point_htpy {A B f g} p : rename.
+Arguments pointed_htpy {A B f g} p x.
+
+Coercion pointed_htpy : pHomotopy >-> pointwise_paths.
+
+Infix "==*" := pHomotopy (at level 70, no associativity).
+
+(** The following tactic often allows us to "pretend" that pointed maps and homotopies preserve basepoints strictly.  We have carefully defined [pMap] and [pHomotopy] so that when destructed, their second components are paths with right endpoints free, to which we can apply Paulin-Morhing path-induction. *)
+Ltac pointed_reduce :=
+  unfold pointed_fun, pointed_htpy; cbn;
+  repeat match goal with
+           | [ X : pType |- _ ] => destruct X as [X ?]
+           | [ phi : pMap ?X ?Y |- _ ] => destruct phi as [phi ?]
+           | [ alpha : pHomotopy ?f ?g |- _ ] => destruct alpha as [alpha ?]
+         end;
+  cbn in *; unfold point in *;
+  path_induction; cbn;
+  try rewrite !concat_p1;
+  try rewrite !concat_1p.
+
+Definition loops_2functor {A B : pType} {f g : A ->* B} (p : f ==* g)
+: (loops_functor f) ==* (loops_functor g).
+Proof.
+  pointed_reduce.
+  refine (Build_pHomotopy _ _); simpl.
+  - intros q.
+    refine (_ @ (concat_1p _)^).
+    refine (_ @ (concat_p1 _)^).
+    apply moveR_Vp.
+    refine (concat_Ap p q).
+  - simpl.
+    abstract (rewrite !concat_p1; reflexivity).
+Defined.
+
+(** ** Associativity of pointed map composition *)
+
+Definition pmap_compose_assoc {A B C D : pType}
+           (h : C ->* D) (g : B ->* C) (f : A ->* B)
+: (h o* g) o* f ==* h o* (g o* f).
+Proof.
+  pointed_reduce.
+  refine (Build_pHomotopy _ _); cbn.
+  - intros ?; reflexivity.
+  - reflexivity.
+Defined.
+
+Definition pmap_compose_preid {A B : pType} (f : A ->* B)
+: f o* pmap_idmap A ==* f.
+Proof.
+  pointed_reduce.
+  refine (Build_pHomotopy _ _); cbn.
+  - intros ?; reflexivity.
+  - reflexivity.
+Defined.
+
+Definition pmap_compose_postid {A B : pType} (f : A ->* B)
+: pmap_idmap B o* f ==* f.
+Proof.
+  pointed_reduce.
+  refine (Build_pHomotopy _ _); cbn.
+  - intros ?; reflexivity.
+  - reflexivity.
+Defined.
+
+(** ** Whiskering of pointed homotopies by pointed functions *)
+
+Definition pmap_postwhisker {A B C : pType} {f g : A ->* B}
+           (h : B ->* C) (p : f ==* g)
+: h o* f ==* h o* g.
+Proof.
+  pointed_reduce.
+  refine (Build_pHomotopy _ _); cbn.
+  - intros a; apply ap, p.
+  - reflexivity.
+Defined.
+
+Definition pmap_prewhisker {A B C : pType} (f : A ->* B)
+           {g h : B ->* C} (p : g ==* h)
+: g o* f ==* h o* f.
+Proof.
+  pointed_reduce.
+  refine (Build_pHomotopy _ _); cbn.
+  - intros a; apply p.
+  - refine (concat_p1 _ @ (concat_1p _)^).
+Defined.
+
+(** ** Composition of pointed homotopies *)
+
+Definition phomotopy_compose {A B : pType} {f g h : A ->* B}
+           (p : f ==* g) (q : g ==* h)
+: f ==* h.
+Proof.
+  pointed_reduce.
+  refine (Build_pHomotopy _ _); cbn.
+  - intros x; exact (p x @ q x).
+  - apply concat_p1.
+Defined.
+
+Infix "@*" := phomotopy_compose (at level 30).
+
+Definition phomotopy_inverse {A B : pType} {f g : A ->* B}
+: (f ==* g) -> (g ==* f).
+Proof.
+  intros p; pointed_reduce.
+  refine (Build_pHomotopy _ _); cbn.
+  - intros x; exact ((p x)^).
+  - apply concat_Vp.
+Defined.
+
+Notation "p ^*" := (phomotopy_inverse p) (at level 20).
+
+(** ** Functoriality of loop spaces *)
+
+Definition loops_functor_compose {A B C : pType}
+           (g : B ->* C) (f : A ->* B)
+: (loops_functor (pmap_compose g f))
+   ==* (pmap_compose (loops_functor g) (loops_functor f)).
+Proof.
+  pointed_reduce.
+  refine (Build_pHomotopy _ _); simpl.
+  - intros p.
+    apply whiskerL, whiskerR.
+    refine (_ @ ap (ap g) (concat_1p _)^).
+    refine (_ @ ap (ap g) (concat_p1 _)^).
+    apply ap_compose.
+  - reflexivity.
+Defined.
+
+Definition loops_functor_idmap (A : pType)
+: loops_functor (pmap_idmap A) ==* pmap_idmap (loops A).
+Proof.
+  pointed_reduce.
+  refine (Build_pHomotopy _ _); simpl.
+  - intros p.
+    refine (concat_1p _ @ concat_p1 _ @ ap_idmap _).
+  - reflexivity.
+Defined.
+
+(** ** Pointed equivalences *)
+
+Record pEquiv (A B : pType) :=
+  { pointed_equiv_fun : A ->* B ;
+    pointed_isequiv : IsEquiv pointed_equiv_fun
+  }.
+
+Infix "<~>*" := pEquiv (at level 85).
+
+Coercion pointed_equiv_fun : pEquiv >-> pMap.
+Global Existing Instance pointed_isequiv.
+
+Definition pointed_equiv_equiv {A B} (f : A <~>* B)
+: A <~> B
+  := BuildEquiv A B f _.
+
+Coercion pointed_equiv_equiv : pEquiv >-> Equiv.
+
+Definition pequiv_inverse {A B} (f : A <~>* B)
+: B <~>* A.
+Proof.
+  refine (Build_pEquiv B A
+            (Build_pMap _ _ f^-1 _)
+            _).
+  apply moveR_equiv_V; symmetry; apply point_eq.
+Defined.

--- a/theories/HoTT.v
+++ b/theories/HoTT.v
@@ -19,6 +19,7 @@ Require Export Factorization.
 Require Export Constant.
 Require Export ObjectClassifier.
 Require Export TruncType.
+Require Export PType.
 Require Export NullHomotopy.
 Require Export Idempotents.
 

--- a/theories/ObjectClassifier.v
+++ b/theories/ObjectClassifier.v
@@ -49,8 +49,8 @@ apply (equiv_adjointify p2f f2p).
 Defined.
 
 (** We construct the universal diagram for the object classifier *)
-Definition topmap {B} (f:B->A) (b:B): pointedType :=
-  (hfiber f (f b) ; (b ; idpath (f b))).
+Definition topmap {B} (f:B->A) (b:B): pType :=
+  Build_pType (hfiber f (f b)) (b ; idpath (f b)).
 
 Local Definition help_objclasspb_is_fibrantreplacement (P:A-> Type): (sigT P)->
   (pullback P (@pr1 _ (fun u :Type => u))):=

--- a/theories/PType.v
+++ b/theories/PType.v
@@ -1,0 +1,168 @@
+(* -*- mode: coq; mode: visual-line -*- *)
+
+Require Import HoTT.Basics HoTT.Types.
+Require Import hit.Truncations.
+Local Open Scope path_scope.
+Local Open Scope equiv_scope.
+
+(** * More about pointed types *)
+
+(** ** Equivalences *)
+
+Definition issig_ptype : { X : Type & X } <~> pType.
+Proof.
+  issig Build_pType pointed_type ispointed_type.
+Defined.
+
+Definition issig_pmap (A B : pType)
+: { f : A -> B & f (point A) = point B } <~> (A ->* B).
+Proof.
+  issig (@Build_pMap A B) (@pointed_fun A B) (@point_eq A B).
+Defined.
+
+Definition issig_phomotopy {A B : pType} (f g : A ->* B)
+: { p : f == g & p (point A) @ point_eq g = point_eq f } <~> (f ==* g).
+Proof.
+  issig (@Build_pHomotopy A B f g) (@pointed_htpy A B f g) (@point_htpy A B f g).
+Defined.
+
+Definition equiv_path_pmap `{Funext} {A B : pType} (f g : A ->* B)
+: (f ==* g) <~> (f = g).
+Proof.
+  refine (equiv_compose' (equiv_inverse (equiv_ap' (equiv_inverse (issig_pmap A B)) f g)) _); cbn.
+  refine (equiv_compose' _ (equiv_inverse (issig_phomotopy f g))).
+  refine (equiv_compose' (equiv_path_sigma _ _ _) _); cbn.
+  refine (equiv_functor_sigma' (equiv_path_arrow f g) _); intros p. cbn.
+  refine (equiv_compose' _ (equiv_moveL_Vp _ _ _)).
+  refine (equiv_compose' _ (equiv_path_inverse _ _)).
+  apply equiv_concat_l.
+  refine (transport_paths_Fl (path_forall f g p) (point_eq f) @ _).
+  apply whiskerR, inverse2.
+  refine (ap_apply_l (path_forall f g p) (point A) @ _).
+  apply ap10_path_forall.
+Defined.
+
+Definition path_pmap `{Funext} {A B : pType} {f g : A ->* B}
+: (f ==* g) -> (f = g)
+  := equiv_path_pmap f g.
+
+Definition issig_pequiv (A B : pType)
+: { f : A <~> B & f (point A) = point B } <~> (A <~>* B).
+Proof.
+  refine (equiv_compose' (B := { f : A ->* B & IsEquiv f }) _ _).
+  1:issig (@Build_pEquiv A B) (@pointed_equiv_fun A B) (@pointed_isequiv A B).
+  refine (equiv_compose' (equiv_functor_sigma'
+                            (P := fun f => IsEquiv f.1)
+                            (issig_pmap A B) (fun f => equiv_idmap _)) _).
+  refine (equiv_compose' _ (equiv_functor_sigma'
+                              (Q := fun f => f.1 (point A) = point B)
+                              (equiv_inverse (issig_equiv A B))
+                              (fun f => equiv_idmap _))).
+  refine (equiv_compose' _ (equiv_inverse (equiv_sigma_assoc _ _))).
+  refine (equiv_compose' (equiv_sigma_assoc _ _) _).
+  refine (equiv_functor_sigma' (equiv_idmap _) _); intros f; simpl. 
+  apply equiv_sigma_symm0.
+Defined.
+
+Definition equiv_path_ptype `{Univalence} (A B : pType)
+: (A <~>* B) <~> (A = B :> pType).
+Proof.
+  destruct A as [A a]. destruct B as [B b].
+  refine (equiv_compose' (equiv_ap issig_ptype (A;a) (B;b)) _).
+  refine (equiv_compose' (equiv_path_sigma _ _ _) _).
+  refine (equiv_compose' _ (equiv_inverse (issig_pequiv _ _))); simpl.
+  refine (equiv_functor_sigma' (equiv_path_universe A B) _); intros f.
+  apply equiv_concat_l.
+  apply transport_path_universe.
+Defined.
+
+Definition path_ptype `{Univalence} {A B : pType}
+: (A <~>* B) -> (A = B :> pType)
+  := equiv_path_ptype A B.
+
+(** ** Loop spaces *)
+
+(** Loop inversion is a pointed equivalence *)
+Definition loops_inv (A : pType) : loops A <~>* loops A.
+Proof.
+  refine (Build_pEquiv _ _ (Build_pMap (loops A) (loops A) inverse 1)
+                       (isequiv_path_inverse _ _)).
+Defined.
+
+(** ** Pointed fibers *)
+
+Definition pfiber {A B : pType} (f : A ->* B) : pType.
+Proof.
+  refine (Build_pType (hfiber f (point B)) _); try exact _.
+  exists (point A).
+  apply point_eq.
+Defined.
+
+Definition pfib {A B : pType} (f : A ->* B) : pfiber f ->* A
+  := (Build_pMap (pfiber f) A pr1 1).
+
+(** The double fiber object is equivalent to loops on the base. *)
+Definition pfiber2_loops {A B : pType} (f : A ->* B)
+: pfiber (pfib f) <~>* loops B.
+Proof.
+  apply issig_pequiv; refine (_;_).
+  - simpl; unfold hfiber.
+    refine (equiv_compose' _ (equiv_inverse (equiv_sigma_assoc _ _))); simpl.
+    refine (equiv_compose' _
+              (equiv_functor_sigma'
+                 (P := fun a => {_ : f a = point B & a = point A})
+                 (Q := fun a => {_ : a = point A & f a = point B })
+                 (equiv_idmap A) (fun a => equiv_sigma_symm0 _ _))).
+    refine (equiv_compose' _ (equiv_sigma_assoc _ (fun a => f a.1 = point B))).
+    refine (equiv_compose' _ (equiv_contr_sigma _)); simpl.
+    apply equiv_concat_l.
+    symmetry; apply point_eq.
+  - simpl.
+    apply concat_Vp.
+Defined.
+
+(** The triple-fiber functor is equal to the negative of the loopspace functor. *)
+Definition pfiber2_loops_functor {A B : pType} (f : A ->* B)
+: loops_inv _ o* pfiber2_loops f o* pfib (pfib (pfib f))
+  ==* loops_functor f o* pfiber2_loops (pfib f).
+Proof.
+  pointed_reduce.
+  refine (Build_pHomotopy _ _).
+  - intros [[xp q] r]. simpl in *.
+    rewrite !transport_paths_Fl.
+    rewrite inv_pp, !ap_V, !inv_V, ap_compose, !ap_pp, inv_pp.
+    simpl; rewrite !concat_1p, !concat_p1.
+    rewrite ap_pr1_path_basedpaths'.
+    rewrite ap_V, inv_V; apply whiskerR.
+    match goal with
+        |- ?a = ap f (ap ?g ?z) =>
+        change (a = ap f (ap (pr1 o pr1) z))
+    end.
+    rewrite (ap_compose pr1 pr1).
+    rewrite ap_pr1_path_basedpaths'.
+    (** In order to destruct [r], we have to invert it to match Paulin-Mohring path induction.  I don't know why the [set] fails to catch the [r^] in the conclusion. *)
+    set (s := r^); change ((xp.2)^ = ap f (ap pr1 s)).
+    clearbody s; clear r; destruct s; reflexivity.
+  - reflexivity.
+Qed.
+
+(** ** Truncations *)
+
+Global Instance ispointed_tr (n : trunc_index) (A : Type) `{IsPointed A}
+: IsPointed (Tr n A)
+  := tr (point A).
+
+Definition pTr (n : trunc_index) (A : pType) : pType
+  := Build_pType (Tr n A) _.
+
+Definition ptr_loops `{Univalence} (n : trunc_index) (A : pType)
+: pTr n (loops A) <~>* loops (pTr n.+1 A).
+Proof.
+  refine (issig_pequiv _ _ (_;_)).
+  - apply equiv_path_Tr.
+  - reflexivity.
+Defined.
+
+Definition ptr_loops_eq `{Univalence} (n : trunc_index) (A : pType)
+: pTr n (loops A) = loops (pTr n.+1 A) :> pType
+  := path_ptype (ptr_loops n A).

--- a/theories/Types/Paths.v
+++ b/theories/Types/Paths.v
@@ -100,6 +100,10 @@ Definition equiv_ap `(f : A -> B) `{IsEquiv A B f} (x y : A)
   : (x = y) <~> (f x = f y)
   := BuildEquiv _ _ (ap f) _.
 
+Definition equiv_ap' `(f : A <~> B) (x y : A)
+  : (x = y) <~> (f x = f y)
+  := equiv_ap f x y.
+
 (* TODO: Is this really necessary? *)
 Definition equiv_inj `(f : A -> B) `{IsEquiv A B f} {x y : A}
   : (f x = f y) -> (x = y)

--- a/theories/Types/Sigma.v
+++ b/theories/Types/Sigma.v
@@ -475,6 +475,14 @@ Proof.
                        _ _ _); intros [x y]; reflexivity.
 Defined.
 
+Definition equiv_sigma_prod0 (A B : Type)
+: {a : A & B} <~> A * B.
+Proof.
+  refine (BuildEquiv _ _ (fun (w:{a:A & B}) => (w.1 , w.2)) _).
+  refine (BuildIsEquiv _ _ _ (fun (z:A*B) => (fst z ; snd z))
+                       _ _ _); intros [x y]; reflexivity.
+Defined.
+
 (** ** Universal mapping properties *)
 
 (** *** The positive universal property. *)

--- a/theories/hit/Suspension.v
+++ b/theories/hit/Suspension.v
@@ -363,14 +363,14 @@ Proof.
     refine (pmap_postwhisker _ (loop_susp_unit_natural g)^* @* _).
     refine ((pmap_compose_assoc _ _ _)^* @* _).
     refine (pmap_prewhisker g (loop_susp_triangle1 B) @* _).
-    apply pmap_compose_postid.
+    apply pmap_postcompose_idmap.
   - intros f. apply path_pmap.
     refine (pmap_postwhisker _ (psusp_functor_compose _ _) @* _).
     refine ((pmap_compose_assoc _ _ _)^* @* _).
     refine (pmap_prewhisker _ (loop_susp_counit_natural f)^* @* _).
     refine (pmap_compose_assoc _ _ _ @* _).
     refine (pmap_postwhisker f (loop_susp_triangle2 A) @* _).
-    apply pmap_compose_preid.
+    apply pmap_precompose_idmap.
 Defined.
 
 (** And its naturality is easy. *)

--- a/theories/hit/Suspension.v
+++ b/theories/hit/Suspension.v
@@ -2,7 +2,8 @@
 
 (** * The suspension of a type *)
 
-Require Import HoTT.Basics Types.Paths NullHomotopy.
+Require Import HoTT.Basics HoTT.Types.
+Require Import PType NullHomotopy.
 Local Open Scope path_scope.
 Local Open Scope equiv_scope.
 Generalizable Variables X A B f g n.
@@ -80,6 +81,29 @@ Definition Susp_eta `{Funext}
   : f = Susp_ind P (f North) (f South) (fun x => apD f (merid x))
 := path_forall _ _ (Susp_eta_homot f).
 
+(** ** Universal property *)
+
+Definition equiv_Susp_rec `{Funext} (X Y : Type)
+: (Susp X -> Y) <~> { NS : Y * Y & X -> fst NS = snd NS }.
+Proof.
+  refine (BuildEquiv (Susp X -> Y)
+                     { NS : Y * Y & X -> fst NS = snd NS } _ _).
+  { intros f.
+    exists (f North , f South).
+    intros x. exact (ap f (merid x)). }
+  refine (isequiv_adjointify _ _ _ _).
+  - intros [[N S] m].
+    exact (Susp_rec N S m).
+  - intros [[N S] m].
+    apply ap, path_arrow. intros x; apply Susp_comp_nd_merid.
+  - intros f.
+    symmetry.
+    refine (Susp_eta f @ _).
+    unfold Susp_rec; apply ap.
+    apply path_forall; intros x.
+    apply apD_const.
+Defined.
+
 (** ** Nullhomotopies of maps out of suspensions *)
 
 Definition nullhomot_susp_from_paths {X Z: Type} (f : Susp X -> Z)
@@ -114,3 +138,261 @@ Global Instance ispointed_path_susp `{IsPointed X} : IsPointed (North = South :>
 
 Global Instance ispointed_path_susp' `{IsPointed X} : IsPointed (South = North :> Susp X) | 0
   := (merid (point X))^.
+
+Definition psusp (X : pType) : pType
+  := Build_pType (Susp X) _.
+
+(** ** Suspension Functor *)
+
+Definition psusp_functor {X Y : pType} (f : X ->* Y)
+: psusp X ->* psusp Y.
+Proof.
+  refine (Build_pMap (psusp X) (psusp Y)
+                     (Susp_rec North South (fun x => merid (f x))) 1).
+Defined.
+
+Definition psusp_functor_compose {X Y Z : pType}
+           (g : Y ->* Z) (f : X ->* Y)
+: psusp_functor (g o* f) ==* psusp_functor g o* psusp_functor f.
+Proof.
+  pointed_reduce; refine (Build_pHomotopy _ _); cbn.
+  - refine (Susp_ind _ _ _ _); cbn; try reflexivity.
+    intros x.
+    rewrite transport_paths_FlFr.
+    rewrite concat_p1; apply moveR_Vp; rewrite concat_p1.
+    rewrite ap_compose.
+    rewrite !Susp_comp_nd_merid.
+    refine (Susp_comp_nd_merid _).
+  - reflexivity.
+Qed.
+
+(** ** Loop-Suspension Adjunction *)
+
+Module Book_Loop_Susp_Adjunction.
+
+  (** Here is the proof of the adjunction isomorphism given in the book (6.5.4); we put it in a non-exported module for reasons discussed below. *)
+  Definition loop_susp_adjoint `{Funext} (A B : pType)
+  : (psusp A ->* B) <~> (A ->* loops B).
+  Proof.
+    refine (equiv_compose' _ (equiv_inverse (issig_pmap (psusp A) B))).
+    refine (equiv_compose' _
+              (equiv_functor_sigma'
+                 (Q := fun NSm => fst NSm.1 = point B)
+                 (equiv_Susp_rec A B)
+                 (fun f => equiv_idmap _))).
+    refine (equiv_compose' _
+              (equiv_inverse (equiv_sigma_assoc _ _))); simpl.
+    refine (equiv_compose' _
+              (equiv_functor_sigma'
+                 (Q := fun a => {_ : fst a = point B & A -> fst a = snd a })
+                 (equiv_idmap (B * B))
+                 (fun NS => equiv_sigma_symm0
+                              (A -> fst NS = snd NS)
+                              (fst NS = point B)))).
+    refine (equiv_compose' _ (equiv_inverse (equiv_sigma_prod _))); simpl.
+    refine (equiv_compose' _
+              (equiv_functor_sigma'
+                 (Q := fun b => {_ : b = point B & { p : B & A -> b = p}})
+                 (equiv_idmap B)
+                 (fun b => equiv_sigma_symm (A := B) (B := b = point B)
+                             (fun p _ => A -> b = p)))).
+    refine (equiv_compose' _
+              (equiv_sigma_assoc (fun b => b = point B)
+                                 (fun bq => {p:B & A -> bq.1 = p}))).
+    refine (equiv_compose' _ (equiv_contr_sigma _)); simpl.
+    refine (equiv_compose' _
+              (equiv_inverse
+                 (equiv_sigma_contr
+                    (A := {p : B & A -> point B = p})
+                    (fun pm => { q : point B = pm.1 & pm.2 (point A) = q })))).
+    refine (equiv_compose' _ (equiv_inverse (equiv_sigma_assoc _ _))); simpl.
+    refine (equiv_compose' _
+              (equiv_functor_sigma'
+                 (Q := fun b => {q : point B = b & {p : A -> point B = b & p (point A) = q}})
+                 (equiv_idmap B)
+                 (fun b => equiv_sigma_symm (fun p q => p (point A) = q)))).
+    refine (equiv_compose' _
+              (equiv_sigma_assoc
+                 (fun b => point B = b)
+                 (fun bq => {p : A -> point B = bq.1 & p (point A) = bq.2}))).
+    refine (equiv_compose' _ (equiv_contr_sigma _)); simpl.
+    refine (issig_pmap A (loops B)).
+  Defined.
+
+  (** Unfortunately, with this definition it seems to be quite hard to prove that the isomorphism is natural on pointed maps.  The following proof gets partway there, but ends with a pretty intractable goal.  It's also quite slow, so we don't want to compile it all the time. *)
+  (**
+<<
+  Definition loop_susp_adjoint_nat_r `{Funext} (A B B' : pType)
+             (f : psusp A ->* B) (g : B ->* B')
+  : loop_susp_adjoint A B' (g o* f)
+    ==* loops_functor g o* loop_susp_adjoint A B f.
+  Proof.
+    pointed_reduce.
+    refine (Build_pHomotopy _ _).
+    - intros a. simpl.
+      refine (_ @ (concat_1p _)^).
+      refine (_ @ (concat_p1 _)^).
+      rewrite !transport_sigma. simpl.
+      rewrite !(transport_arrow_fromconst (B := A)).
+      rewrite !transport_paths_Fr.
+      rewrite !ap_V, !ap_pr1_path_basedpaths.
+      rewrite ap_pp, !(ap_compose f g), ap_V.
+      reflexivity.
+    - cbn.
+      Fail reflexivity.
+      (** ...but this goal is pretty intractable. *)
+  Abort.
+>>
+   *)
+
+End Book_Loop_Susp_Adjunction.
+
+(** Thus, instead we will construct the adjunction in terms of a unit and counit natural transformation. *)
+
+Definition loop_susp_unit (X : pType) : X ->* loops (psusp X).
+Proof.
+  refine (Build_pMap X (loops (psusp X))
+                     (fun x => merid x @ (merid (point X))^) _).
+  apply concat_pV.
+Defined.
+
+Definition loop_susp_unit_natural {X Y : pType} (f : X ->* Y)
+: loop_susp_unit Y o* f
+  ==* loops_functor (psusp_functor f) o* loop_susp_unit X.
+Proof.
+  pointed_reduce.
+  refine (Build_pHomotopy _ _); cbn.
+  - intros x; symmetry.
+    refine (concat_1p _@ (concat_p1 _ @ _)).
+    refine (ap_pp (Susp_rec North South (merid o f))
+                  (merid x) (merid (point X))^ @ _).
+    refine ((1 @@ ap_V _ _) @ _).
+    refine (Susp_comp_nd_merid _ @@ inverse2 (Susp_comp_nd_merid _)).
+  - cbn. rewrite !inv_pp, !concat_pp_p, concat_1p; symmetry.
+    apply moveL_Vp.
+    refine (concat_pV_inverse2 _ _ (Susp_comp_nd_merid (point X)) @ _).
+    do 2 apply moveL_Vp.
+    refine (ap_pp_concat_pV _ _ @ _).
+    do 2 apply moveL_Vp.
+    rewrite concat_p1_1, concat_1p_1.
+    cbn; symmetry.
+    refine (concat_p1 _ @ _).
+    refine (ap_compose (fun p' => (ap (Susp_rec North South (merid o f))) p' @ 1)
+                       (fun p' => 1 @ p')
+                       (concat_pV (merid (point X))) @ _).
+    apply ap.
+    refine (ap_compose (ap (Susp_rec North South (merid o f)))
+                       (fun p' => p' @ 1) _).
+Qed.
+
+Definition loop_susp_counit (X : pType) : psusp (loops X) ->* X.
+Proof.
+  refine (Build_pMap (psusp (loops X)) X
+                     (Susp_rec (point X) (point X) idmap) 1).
+Defined.
+
+Definition loop_susp_counit_natural {X Y : pType} (f : X ->* Y)
+: f o* loop_susp_counit X
+  ==* loop_susp_counit Y o* psusp_functor (loops_functor f).
+Proof.
+  pointed_reduce.
+  refine (Build_pHomotopy _ _); simpl.
+  - refine (Susp_ind _ _ _ _); cbn; try reflexivity; intros p.
+    rewrite transport_paths_FlFr, ap_compose, concat_p1.
+    apply moveR_Vp.
+    refine (ap_compose
+              (Susp_rec North South (fun x0 => merid (1 @ (ap f x0 @ 1))))
+              (Susp_rec (point Y) (point Y) idmap) (merid p) @ _).
+    do 2 rewrite Susp_comp_nd_merid.
+    refine (Susp_comp_nd_merid _ @ _). (** Not sure why [rewrite] fails here *)
+    apply concat_1p.
+  - reflexivity.
+Qed.
+
+(** Now the triangle identities *)
+
+Definition loop_susp_triangle1 (X : pType)
+: loops_functor (loop_susp_counit X) o* loop_susp_unit (loops X)
+  ==* pmap_idmap (loops X).
+Proof.
+  refine (Build_pHomotopy _ _).
+  - intros p; cbn.
+    refine (concat_1p _ @ (concat_p1 _ @ _)).
+    refine (ap_pp (Susp_rec (point X) (point X) idmap)
+                  (merid p) (merid (point (point X = point X)))^ @ _).
+    refine ((1 @@ ap_V _ _) @ _).
+    refine ((Susp_comp_nd_merid p @@ inverse2 (Susp_comp_nd_merid (point (loops X)))) @ _).
+    exact (concat_p1 _).
+  - destruct X as [X x]; cbn; unfold point.
+    apply whiskerR.
+    rewrite (concat_pV_inverse2
+               (ap (Susp_rec x x idmap) (merid 1))
+               1 (Susp_comp_nd_merid 1)).
+    rewrite (ap_pp_concat_pV (Susp_rec x x idmap) (merid 1)).
+    rewrite ap_compose, (ap_compose _ (fun p => p @ 1)).
+    rewrite concat_1p_1; apply ap.
+    apply concat_p1_1.
+Qed.
+
+Definition loop_susp_triangle2 (X : pType)
+: loop_susp_counit (psusp X) o* psusp_functor (loop_susp_unit X)
+  ==* pmap_idmap (psusp X).
+Proof.
+  refine (Build_pHomotopy _ _);
+  [ refine (Susp_ind _ _ _ _) | ]; try reflexivity; cbn.
+  - exact (merid (point X)).
+  - intros x.
+    rewrite transport_paths_FlFr, ap_idmap, ap_compose.
+    rewrite Susp_comp_nd_merid.
+    apply moveR_pM; rewrite concat_p1.
+    refine (inverse2 (Susp_comp_nd_merid _) @ _).
+    rewrite inv_pp, inv_V; reflexivity.
+Qed.
+
+(** Now we can finally construct the adjunction equivalence. *)
+
+Definition loop_susp_adjoint `{Funext} (A B : pType)
+: (psusp A ->* B) <~> (A ->* loops B).
+Proof.
+  refine (equiv_adjointify
+            (fun f => loops_functor f o* loop_susp_unit A)
+            (fun g => loop_susp_counit B o* psusp_functor g) _ _).
+  - intros g. apply path_pmap.
+    refine (pmap_prewhisker _ (loops_functor_compose _ _) @* _).
+    refine (pmap_compose_assoc _ _ _ @* _).
+    refine (pmap_postwhisker _ (loop_susp_unit_natural g)^* @* _).
+    refine ((pmap_compose_assoc _ _ _)^* @* _).
+    refine (pmap_prewhisker g (loop_susp_triangle1 B) @* _).
+    apply pmap_compose_postid.
+  - intros f. apply path_pmap.
+    refine (pmap_postwhisker _ (psusp_functor_compose _ _) @* _).
+    refine ((pmap_compose_assoc _ _ _)^* @* _).
+    refine (pmap_prewhisker _ (loop_susp_counit_natural f)^* @* _).
+    refine (pmap_compose_assoc _ _ _ @* _).
+    refine (pmap_postwhisker f (loop_susp_triangle2 A) @* _).
+    apply pmap_compose_preid.
+Defined.
+
+(** And its naturality is easy. *)
+
+Definition loop_susp_adjoint_nat_r `{Funext} (A B B' : pType)
+           (f : psusp A ->* B) (g : B ->* B')
+: loop_susp_adjoint A B' (g o* f)
+  ==* loops_functor g o* loop_susp_adjoint A B f.
+Proof.
+  cbn.
+  refine (_ @* pmap_compose_assoc _ _ _).
+  apply pmap_prewhisker.
+  refine (loops_functor_compose g f).
+Defined.
+
+Definition loop_susp_adjoint_nat_l `{Funext} (A A' B : pType)
+           (f : A ->* loops B) (g : A' ->* A)
+: (loop_susp_adjoint A' B)^-1 (f o* g)
+  ==* (loop_susp_adjoint A B)^-1 f o* psusp_functor g.
+Proof.
+  cbn.
+  refine (_ @* (pmap_compose_assoc _ _ _)^*).
+  apply pmap_postwhisker.
+  refine (psusp_functor_compose f g).
+Defined.


### PR DESCRIPTION
If anyone can manage to prove that the loop-suspension adjunction isomorphism given in the book is natural with respect to pointed maps, I'd love to see it!  I had to resort to a different definition using a unit and counit.

I am kind of pleased with the tactic `pointed_reduce`.  I had always expected that one of the more annoying things about HoTT for a classical homotopy theorist would be that basepoints can't be preserved strictly, so we have to carry around paths relating them everywhere.  But if we set things up correctly, then usually most of those paths can be path-inducted-away when actually proving things.
