### PR TITLE
Bump trunk

### DIFF
--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -117,7 +117,7 @@ Notation "x .2" := (pr2 x) (at level 3, format "x '.2'") : fibration_scope.
 
 (** Composition of functions. *)
 
-Notation compose := (fun g' f' x => g' (f' x)). (* use primed names because https://coq.inria.fr/bugs/show_bug.cgi?id=3892 *)
+Notation compose := (fun g f x => g (f x)).
 
 (** We put the following notation in a scope because leaving it unscoped causes it to override identical notations in other scopes.  It's convenient to use the same notation for, e.g., function composition, morphism composition in a category, and functor composition, and let Coq automatically infer which one we mean by scopes.  We can't do this if this notation isn't scoped.  Unfortunately, Coq doesn't have a built-in [function_scope] like [type_scope]; [type_scope] is automatically opened wherever Coq is expecting a [Sort], and it would be nice if [function_scope] were automatically opened whenever Coq expects a thing of type [forall _, _] or [_ -> _].  To work around this, we open [function_scope] globally. *)
 Notation "g 'o' f" := (compose g f) (at level 40, left associativity) : function_scope.


### PR DESCRIPTION
This closes #641.

This makes progress towards #657.

This makes #628 possible to solve.

We do not bump trunk all the way to current trunk, because something
broke type inference and typeclass resolution, which now fail in places
they did not used to.