### PR TITLE
Actually install all of the symlinks to stdlib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_script:
 # `make-pretty-timed` is not an indication that the build succeeded.
 # We also use `make strict-test` at the beginning so that we error
 # quickly if someone commited .v files but neglected to mention them.
-script: "./autogen.sh && ./configure && if [ -z \"$UPDATE_QUICK_DOC\" ]; then make strict-test && ./etc/coq-scripts/timing/make-pretty-timed.sh V=1 -j2 && make && ./etc/coq-scripts/timing/cat-timing-files.sh && cat ./time-of-build-pretty.log && echo; fi && ./etc/ci/after_success.sh"
+script: "./autogen.sh && ./configure && if [ -z \"$UPDATE_QUICK_DOC\" ]; then make strict-test && ./etc/coq-scripts/timing/make-pretty-timed.sh V=1 -j2 && make && ./etc/ci/test-install-target.sh && ./etc/coq-scripts/timing/cat-timing-files.sh && cat ./time-of-build-pretty.log && echo; fi && ./etc/ci/after_success.sh"
 
 
 after_success:

--- a/Makefile.am
+++ b/Makefile.am
@@ -14,6 +14,9 @@ EXTRA_DIST = coq theories etc LICENSE.txt CREDITS.txt INSTALL.txt README.markdow
 # The path to the Coq library in $(srcdir)
 SRCCOQLIB=$(srcdir)/coq
 
+# Extra standard library replacements to install
+STDLIB_EXTRA_DIST = $(shell find -P $(addprefix "$(SRCCOQLIB)/",$(STDLIB_REPLACEMENT_DIRS)) -type f)
+
 # support the TIMED variable like coq_makefile
 TIMED=
 TIMECMD=
@@ -30,6 +33,11 @@ Q = $(Q_$(V))
 VECHO_0 := @echo
 VECHO_1 := @true
 VECHO = $(VECHO_$(V))
+
+# inner vecho, without the @
+VIECHO_0 := echo
+VIECHO_1 := true
+VIECHO = $(VIECHO_$(V))
 
 SILENCE_HOQC_0 := @echo \"HOQC $$<\"; #
 SILENCE_HOQC_1 :=
@@ -119,6 +127,7 @@ nobase_hott_DATA = \
 	$(CORE_VOFILES) \
 	$(CATEGORY_VOFILES) \
 	$(CONTRIB_VOFILES) \
+	$(STDLIB_EXTRA_DIST) \
 	$(shell find "$(SRCCOQLIB)/theories" -name "README.txt")
 
 # The Coq compiler, adapted to HoTT
@@ -137,12 +146,15 @@ all-am: Makefile $(SCRIPTS) $(DATA) $(MAKEFILE_TARGETS_FILE)
 
 .PHONY: stdlib hottlib hott-core hott-categories contrib clean html proviola timing-html clean-local install-data-local proviola-all proviola-xml svg-file-dep-graphs svg-aggregate-dep-graphs svg-dep-graphs clean-dpdgraph strict strict-test strict-no-axiom quick vi2vo checkproofs
 
-# TODO(JasonGross): Get this to work on Windows, where symlinks are unreliable
+if install_stdlib_symlinks
 install-data-local:
 	$(MKDIR_P) "$(hottdir)/coq"
-	rm -f "$(hottdir)/coq/dev" "$(hottdir)/coq/plugins"
-	$(LN_S) "$(COQLIB)/dev" "$(hottdir)/coq"
-	$(LN_S) "$(COQLIB)/plugins" "$(hottdir)/coq"
+	$(Q)for i in $(STDLIB_REPLACEMENT_DIRS); do \
+		$(VIECHO) "INSTALL coq/$$i"; \
+		rm -f "$(hottdir)/coq/$$i"; \
+		$(LN_S) "$(COQLIB)/$$i" "$(hottdir)/coq"; \
+	done
+endif
 
 # The standard library files must be compiled in a special way
 stdlib: $(STD_VOFILES)

--- a/configure.ac
+++ b/configure.ac
@@ -163,29 +163,25 @@ AC_MSG_NOTICE([Creating symbolic links into Coq standard library])
 # First remove existing links.  If they are symlinks, use -f.  If they are
 # physical directories, use -rf.  This ensures that we don't delete the
 # contents of symlinked directories.
-AS_IF([test -h "$srcdir/coq/dev"], [rm -f "$srcdir/coq/dev"],
-      [test -d "$srcdir/coq/dev"], [rm -rf "$srcdir/coq/dev"])
-AS_IF([test -h "$srcdir/coq/kernel"], [rm -f "$srcdir/coq/kernel"],
-      [test -d "$srcdir/coq/kernel"], [rm -rf "$srcdir/coq/kernel"])
-AS_IF([test -h "$srcdir/coq/library"], [rm -f "$srcdir/coq/library"],
-      [test -d "$srcdir/coq/library"], [rm -rf "$srcdir/coq/library"])
-AS_IF([test -h "$srcdir/coq/plugins"], [rm -f "$srcdir/coq/plugins"],
-      [test -d "$srcdir/coq/plugins"], [rm -rf "$srcdir/coq/plugins"])
-AS_IF([test -h "$srcdir/coq/stm"], [rm -f "$srcdir/coq/stm"],
-      [test -d "$srcdir/coq/stm"], [rm -rf "$srcdir/coq/stm"])
-AS_IF([test -h "$srcdir/coq/toploop"], [rm -f "$srcdir/coq/toploop"],
-      [test -d "$srcdir/coq/toploop"], [rm -rf "$srcdir/coq/toploop"])
-AS_IF([test -d "$COQLIB/ide"],
-      [AS_IF([test -h "$srcdir/coq/ide"], [rm -f "$srcdir/coq/ide"],
-             [test -d "$srcdir/coq/ide"], [rm -rf "$srcdir/coq/ide"])
-       ln -s "$COQLIB/ide" "$srcdir/coq"
-      ])
-ln -s "$COQLIB/dev" "$COQLIB/kernel" "$COQLIB/library" "$COQLIB/plugins" "$COQLIB/stm" "$COQLIB/toploop" "$srcdir/coq"
-# TODO(jgross): Should we use AC_CONFIG_LINKS?  But $COQLIB/dev
-# doesn't exist in my installation, and that would make configure
-# error...
-#AC_CONFIG_LINKS([$srcdir/coq/plugins:$COQLIB/plugins
-#                 $srcdir/coq/dev:$COQLIB/dev])
+#
+# We do not use AC_CONFIG_LINKS because it creates links in the build
+# directory, not the source directory.  (Question: Even if that were
+# not a problem, would it work for directory links, or only file
+# links?)
+#
+# We also add successful directories to STDLIB_REPLACEMENT_DIRS, so
+# that the Makefile can manipulate them
+STDLIB_REPLACEMENT_DIRS=""
+for stdlibdir in dev kernel library plugins stm toploop ide ; do
+    AS_IF([test -h "$srcdir/coq/$stdlibdir"], [rm -f "$srcdir/coq/$stdlibdir"],
+          [test -d "$srcdir/coq/$stdlibdir"], [rm -rf "$srcdir/coq/$stdlibdir"])
+    AS_IF([test -d "$COQLIB/$stdlibdir"],
+          [ln -s "$COQLIB/$stdlibdir" "$srcdir/coq"
+           STDLIB_REPLACEMENT_DIRS="$STDLIB_REPLACEMENT_DIRS $stdlibdir"
+          ])
+done
+AC_SUBST([STDLIB_REPLACEMENT_DIRS])
+
 AC_MSG_CHECKING([whether your coqtop supports directory symlinks to the stdlib])
 coqtop_out="$("$COQTOP" -coqlib "$srcdir/coq" < /dev/null 2>&1 | grep -c 'Warning: Cannot open')"
 AS_IF([test "$coqtop_out" = 0],
@@ -197,6 +193,7 @@ AS_IF([test "$coqtop_out" = 0],
        AS_IF([test -d "$COQLIB/ide"],
              [cp -R "$COQLIB/ide" "$srcdir/coq"])])
 
+AM_CONDITIONAL(install_stdlib_symlinks, [test "$coqtop_out" = 0])
 
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([hoq-config])

--- a/etc/ci/test-install-target.sh
+++ b/etc/ci/test-install-target.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+PS4='$ '
+set -x
+
+# in case we're run from out of git repo
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+pushd "$DIR" 1>/dev/null
+
+# now change to the git root
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR"
+
+sudo make install "$@" || exit $?
+(echo | hoqtop) || exit $?
+hoqc -v || exit $?
+
+popd 1>/dev/null


### PR DESCRIPTION
Previously, we had separate logic in Makefile.am and configure.ac for
dealing with symlinks to the standard library.  Since no one was testing
the install target regularly, they had gotten out of sync.  This was
causing hoqide to fail when the library was installed.

Now, the configure script makes a list of symlinks for the makefile to
copy over in the install target.  This should fix hoqide.  Additionally,
the install target should now work fine on (Windows) configurations
where symlinks don't work.

Finally, we now test each stdlib directory for existence before
symlinking to it.  This prevents us from installing dangling symlinks to
the system, which wouldn't serve any purpose.

Also, test the install target on travis.

I don't actually have an install with hoqide though, so someone with hoqide (@spitters?) should test this before it's merged.  The motivation for this PR is to fix the opam install (also untested), which @spitters is working on.
I propose that if this passes travis, and @spitters or someone else verifies that it fixes a `make install`ed hoqide, and there are no objections to the (idea of the) change, then it should be merged (independently of if anyone wants to actually read the autogoo changes I've made.