### PR TITLE
use Existing Class to get rid of some '_internal's

### DIFF
--- a/theories/Modalities/Accessible.v
+++ b/theories/Modalities/Accessible.v
@@ -39,13 +39,13 @@ Module Type Accessible_ReflectiveSubuniverses
   Parameter acc_gen : ReflectiveSubuniverse@{u a} -> LocalGenerators@{a}.
   Check acc_gen@{u a}.    (** Verify that we have the right number of universes *)
 
-  Parameter inO_iff_islocal_internal
+  Parameter inO_iff_islocal
   : forall (O : ReflectiveSubuniverse@{u a}) (X : Type@{i}),
       (** We call [iff] explicitly to control the number of universe parameters. *)
       iff@{i i i}
-         (inO_internal@{u a i} O X)
+         (In@{u a i} O X)
          (IsLocal@{i i a} (acc_gen@{u a} O) X).
-  Check inO_iff_islocal_internal@{u a i}.
+  Check inO_iff_islocal@{u a i}.
 
 End Accessible_ReflectiveSubuniverses.
 
@@ -55,10 +55,6 @@ Module Accessible_ReflectiveSubuniverses_Theory
 
   Import Os Acc.
   Module Import Os_Theory := ReflectiveSubuniverses_Theory Os.
-
-  Definition inO_iff_islocal
-  : forall O (X : Type), In O X <-> IsLocal (acc_gen O) X
-  := inO_iff_islocal_internal.
 
   Definition O_inverts_generators {O : ReflectiveSubuniverse}
              (i : lgen_indices (acc_gen O))
@@ -136,17 +132,18 @@ Definition ooextendable_isnull_fibers {A B} (f : A -> B) (C : B -> Type)
 (** We define a modality to be accessible if it consists of the null types for some family of generators as above. *)
 Module Type Accessible_Modalities (Os : Modalities).
   Import Os.
+  Module Import Os_Theory := Modalities_Theory Os.
 
   (** See comment in [Accessible_ReflectiveSubuniverses] about collapsing universes. *)
   Parameter acc_gen : Modality@{u a} -> NullGenerators@{a}.
   Check acc_gen@{u a}.    (** Verify that we have the right number of universes *)
 
-  Parameter inO_iff_isnull_internal
+  Parameter inO_iff_isnull
   : forall (O : Modality@{u a}) (X : Type@{i}),
       iff@{i i i}
-         (inO_internal@{u a i} O X)
+         (In@{u a i} O X)
          (IsNull@{a i} (acc_gen@{u a} O) X).
-  Check inO_iff_isnull_internal@{u a i}.
+  Check inO_iff_isnull@{u a i}.
 
 End Accessible_Modalities.
 
@@ -156,10 +153,6 @@ Module Accessible_Modalities_Theory
 
   Export Os Acc.
   Module Export Os_Theory := Modalities_Theory Os.
-
-  Definition inO_iff_isnull
-  : forall O (X : Type), In O X <-> IsNull (acc_gen O) X
-  := inO_iff_isnull_internal.
 
   Global Instance isconnected_acc_gen O i : IsConnected O (acc_gen O i).
   Proof.
@@ -188,12 +181,12 @@ Module Accessible_Modalities_to_ReflectiveSubuniverses
       := fun (O : ReflectiveSubuniverse@{u a}) =>
            (null_to_local_generators (acc_gen O)).
 
-    Definition inO_iff_islocal_internal
+    Definition inO_iff_islocal
     : forall (O : ReflectiveSubuniverse@{u a}) (X : Type@{i}),
       iff@{i i i}
-         (inO_internal@{u a i} O X)
+         (In@{u a i} O X)
          (IsLocal@{i i a} (acc_gen@{u a} O) X)
-      := inO_iff_isnull_internal@{u a i}.
+      := inO_iff_isnull@{u a i}.
 
   End AccRSU.
 End Accessible_Modalities_to_ReflectiveSubuniverses.
@@ -225,14 +218,14 @@ Module Accessible_Modalities_from_ReflectiveSubuniverses
       intros [ [i x] | [i x] ]; exact (hfiber (to O _) x).
     Defined.
 
-    Definition inO_iff_isnull_internal (O : Modality@{u a}) (X : Type@{i})
+    Definition inO_iff_isnull (O : Modality@{u a}) (X : Type@{i})
     : iff@{i i i} (In@{u a i} O X) (IsNull@{a i} (acc_gen O) X).
     Proof.
       split.
       - intros X_inO [ [i x] | [i x] ];
           exact (ooextendable_const_isconnected_inO@{u a a i i} O _ _ ).
       - intros Xnull.
-        apply (snd (inO_iff_islocal_internal O X)); intros i.
+        apply (snd (inO_iff_islocal O X)); intros i.
         refine (cancelL_ooextendable@{a a a i i i i i i i}
                   (fun _ => X) (Acc.acc_gen O i)
                   (to O (lgen_codomain (Acc.acc_gen O) i)) _ _).
@@ -268,12 +261,12 @@ Module Accessible_Restriction_ReflectiveSubuniverses
     Definition acc_gen : New.ReflectiveSubuniverse@{u a} -> LocalGenerators@{a}
       := fun O => Acc.acc_gen (Res.ReflectiveSubuniverses_restriction O).
 
-    Definition inO_iff_islocal_internal
+    Definition inO_iff_islocal
     : forall (O : New.ReflectiveSubuniverse@{u a}) (X : Type@{i}),
         iff@{i i i}
-           (inO_internal@{u a i} O X)
+           (In@{u a i} O X)
            (IsLocal@{i i a} (acc_gen@{u a} O) X)
-      := fun O => Acc.inO_iff_islocal_internal (Res.ReflectiveSubuniverses_restriction O).
+      := fun O => Acc.inO_iff_islocal (Res.ReflectiveSubuniverses_restriction O).
 
   End Accessible_New.
 
@@ -289,15 +282,17 @@ Module Accessible_Restriction_Modalities
 
   Module Accessible_New <: Accessible_Modalities New.
 
+    Module Import Os_Theory := Modalities_Theory New.
+
     Definition acc_gen : New.Modality@{u a} -> NullGenerators@{a}
       := fun O => Acc.acc_gen (Res.Modalities_restriction O).
 
-    Definition inO_iff_isnull_internal
+    Definition inO_iff_isnull
     : forall (O : New.Modality@{u a}) (X : Type@{i}),
         iff@{i i i}
-           (inO_internal@{u a i} O X)
+           (In@{u a i} O X)
            (IsNull@{a i} (acc_gen@{u a} O) X)
-      := fun O => Acc.inO_iff_isnull_internal (Res.Modalities_restriction O).
+      := fun O => Acc.inO_iff_isnull (Res.Modalities_restriction O).
 
   End Accessible_New.
 

--- a/theories/Modalities/Closed.v
+++ b/theories/Modalities/Closed.v
@@ -53,11 +53,11 @@ Module ClosedModalities <: Modalities.
   Definition O_reflector : Modality@{u a} -> Type@{i} -> Type@{i}
     := fun O X => join@{a i i} (unCl O) X.
 
-  Definition inO_internal : Modality@{u a} -> Type@{i} -> Type@{i}
+  Definition In : Modality@{u a} -> Type@{i} -> Type@{i}
     := fun O X => unCl O -> Contr X.
 
-  Definition O_inO_internal (O : Modality@{u a}) (T : Type@{i})
-  : inO_internal@{u a i} O (O_reflector@{u a i} O T).
+  Definition O_inO (O : Modality@{u a}) (T : Type@{i})
+  : In@{u a i} O (O_reflector@{u a i} O T).
   Proof.
     intros u.
     pose (contr_inhabited_hprop _ u).
@@ -68,24 +68,24 @@ Module ClosedModalities <: Modalities.
   : T -> O_reflector@{u a i} O T
     := fun x => push (inr x).
 
-  Definition inO_equiv_inO_internal (O : Modality@{u a}) (T U : Type@{i})
-     (T_inO : inO_internal@{u a i} O T) (f : T -> U) (feq : IsEquiv@{i i} f)
-  : inO_internal@{u a i} O U.
+  Definition inO_equiv_inO (O : Modality@{u a}) (T U : Type@{i})
+     (T_inO : In@{u a i} O T) (f : T -> U) (feq : IsEquiv@{i i} f)
+  : In@{u a i} O U.
   Proof.
     intros u; pose (T_inO u).
     refine (contr_equiv _ f); exact _.
   Defined.
 
-  Definition hprop_inO_internal `{Funext}
+  Definition hprop_inO `{Funext}
              (O : Modality@{u a}) (T : Type@{i})
-  : IsHProp (inO_internal@{u a i} O T).
+  : IsHProp (In@{u a i} O T).
   Proof.
     exact _.
   Defined.
 
   Definition O_ind_internal (O : Modality@{u a})
              (A : Type@{i}) (B : O_reflector O A -> Type@{j})
-             (B_inO : forall oa, inO_internal@{u a j} O (B oa))
+             (B_inO : forall oa, In@{u a j} O (B oa))
   : let gei := ((fun x => x) : Type@{i} -> Type@{k}) in
     let gej := ((fun x => x) : Type@{j} -> Type@{k}) in
     (forall a, B (to@{u a i} O A a)) -> forall a, B a.
@@ -102,15 +102,15 @@ Module ClosedModalities <: Modalities.
 
   Definition O_ind_beta_internal (O : Modality@{u a}) (A : Type@{i})
              (B : O_reflector@{u a i} O A -> Type@{j})
-             (B_inO : forall oa, inO_internal@{u a j} O (B oa))
+             (B_inO : forall oa, In@{u a j} O (B oa))
              (f : forall a : A, B (to O A a)) (a : A)
   : O_ind_internal O A B B_inO f (to O A a) = f a
   := 1.
 
   Definition minO_paths (O : Modality@{u a}) (A : Type@{i})
-             (A_inO : inO_internal@{u a i} O A)
+             (A_inO : In@{u a i} O A)
              (z z' : A)
-  : inO_internal@{u a i} O (z = z').
+  : In@{u a i} O (z = z').
   Proof.
     intros u; pose (A_inO u); apply contr_paths_contr.
   Defined.
@@ -128,14 +128,16 @@ Coercion Closed_Modality_to_Modality :=
 Module Accessible_ClosedModalities
   <: Accessible_Modalities ClosedModalities.
 
+  Module Os_Theory := Modalities_Theory ClosedModalities.
+
   Definition acc_gen
     := fun (O : ClosedModalities.Modality@{u a}) =>
          Build_NullGenerators@{a} (unCl O) (fun _ => Empty@{a}).
 
-  Definition inO_iff_isnull_internal
+  Definition inO_iff_isnull
              (O : ClosedModalities.Modality@{u a}) (X : Type@{i})
   : iff@{i i i}
-      (ClosedModalities.inO_internal@{u a i} O X)
+      (ClosedModalities.In@{u a i} O X)
       (IsNull (acc_gen O) X).
   Proof.
     split.

--- a/theories/Modalities/Identity.v
+++ b/theories/Modalities/Identity.v
@@ -21,33 +21,33 @@ Module Identity_Modalities <: Modalities.
                             Type@{i} -> Type@{i}
     := fun O X => X.
 
-  Definition inO_internal : forall (O : Modality@{u a}),
+  Definition In : forall (O : Modality@{u a}),
                              Type@{i} -> Type@{i}
     := fun O X => Unit@{i}.
 
-  Definition O_inO_internal : forall (O : Modality@{u a}) (T : Type@{i}),
-                               inO_internal@{u a i} O (O_reflector@{u a i} O T)
+  Definition O_inO : forall (O : Modality@{u a}) (T : Type@{i}),
+                               In@{u a i} O (O_reflector@{u a i} O T)
     := fun O X => tt.
 
   Definition to : forall (O : Modality@{u a}) (T : Type@{i}),
                    T -> O_reflector@{u a i} O T
     := fun O X x => x.
 
-  Definition inO_equiv_inO_internal :
+  Definition inO_equiv_inO :
       forall (O : Modality@{u a}) (T U : Type@{i})
-             (T_inO : inO_internal@{u a i} O T) (f : T -> U) (feq : IsEquiv f),
-        inO_internal@{u a i} O U
+             (T_inO : In@{u a i} O T) (f : T -> U) (feq : IsEquiv f),
+        In@{u a i} O U
     := fun O T U _ _ _ => tt.
 
-  Definition hprop_inO_internal
+  Definition hprop_inO
   : Funext -> forall (O : Modality@{u a}) (T : Type@{i}),
-                IsHProp (inO_internal@{u a i} O T)
+                IsHProp (In@{u a i} O T)
     := fun _ O T => _.
 
   Definition O_ind_internal
   : forall (O : Modality@{u a})
            (A : Type@{i}) (B : O_reflector O A -> Type@{j})
-           (B_inO : forall oa, inO_internal@{u a j} O (B oa)),
+           (B_inO : forall oa, In@{u a j} O (B oa)),
       let gei := ((fun x => x) : Type@{i} -> Type@{k}) in
       let gej := ((fun x => x) : Type@{j} -> Type@{k}) in
       (forall a, B (to O A a)) -> forall a, B a
@@ -56,15 +56,15 @@ Module Identity_Modalities <: Modalities.
   Definition O_ind_beta_internal
   : forall (O : Modality@{u a})
            (A : Type@{i}) (B : O_reflector O A -> Type@{j})
-           (B_inO : forall oa, inO_internal@{u a j} O (B oa))
+           (B_inO : forall oa, In@{u a j} O (B oa))
            (f : forall a : A, B (to O A a)) (a:A),
       O_ind_internal O A B B_inO f (to O A a) = f a
     := fun _ _ _ _ _ _ => 1.
 
   Definition minO_paths
   : forall (O : Modality@{u a})
-           (A : Type@{i}) (A_inO : inO_internal@{u a i} O A) (z z' : A),
-      inO_internal@{u a i} O (z = z')
+           (A : Type@{i}) (A_inO : In@{u a i} O A) (z z' : A),
+      In@{u a i} O (z = z')
     := fun _ _ _ _ _ => tt.
 
 End Identity_Modalities.
@@ -79,15 +79,15 @@ Coercion Identity_Modalities_to_Modalities := idmap
 
 Module Accessible_Identity <: Accessible_Modalities Identity_Modalities.
 
-  Import Identity_Modalities.
+  Module Import Os_Theory := Modalities_Theory Identity_Modalities.
 
   Definition acc_gen : Modality@{u a} -> NullGenerators@{a}
     := fun _ => Build_NullGenerators Empty@{a} (fun _ => Empty@{a}).
 
-  Definition inO_iff_isnull_internal
+  Definition inO_iff_isnull
   : forall (O : Modality@{u a}) (X : Type@{i}),
       iff@{i i i}
-        (inO_internal@{u a i} O X)
+        (In@{u a i} O X)
         (IsNull@{a i} (acc_gen O) X)
     := fun O X => (fun _ => Empty_ind _ , fun _ => tt).
 

--- a/theories/Modalities/Localization.v
+++ b/theories/Modalities/Localization.v
@@ -346,34 +346,34 @@ Module Localization_ReflectiveSubuniverses <: ReflectiveSubuniverses.
   Definition O_reflector : ReflectiveSubuniverse@{u a} -> Type@{i} -> Type@{i}
     := fun O => Localize@{a i} (unLoc O).
 
-  Definition inO_internal : ReflectiveSubuniverse@{u a} -> Type@{i} -> Type@{i}
+  Definition In : ReflectiveSubuniverse@{u a} -> Type@{i} -> Type@{i}
     := fun O X => IsLocal@{i i a} (unLoc O) X.
 
-  Definition O_inO_internal :
+  Definition O_inO :
     forall (O : ReflectiveSubuniverse@{u a}) (T : Type@{i}),
-      inO_internal O (O_reflector O T)
+      In O (O_reflector O T)
     := fun O => islocal_localize@{a i i} (unLoc O).
 
   Definition to :
     forall (O : ReflectiveSubuniverse@{u a}) (T : Type@{i}), T -> O_reflector O T
     := fun O => @loc@{a i} (unLoc O).
 
-  Definition inO_equiv_inO_internal :
+  Definition inO_equiv_inO :
     forall (O : ReflectiveSubuniverse@{u a}) (T U : Type@{i}),
-      inO_internal@{u a i} O T -> forall f : T -> U, IsEquiv f -> inO_internal@{u a i} O U
+      In@{u a i} O T -> forall f : T -> U, IsEquiv f -> In@{u a i} O U
     := fun O => islocal_equiv_islocal@{a i i} (unLoc O).
 
-  Definition hprop_inO_internal `{Funext}
+  Definition hprop_inO `{Funext}
              (O : ReflectiveSubuniverse@{u a}) (T : Type@{i})
-  : IsHProp (inO_internal@{u a i} O T).
+  : IsHProp (In@{u a i} O T).
   Proof.
     apply (@trunc_forall@{a i i} _); intros i.
     apply ishprop_ooextendable@{a a i i i i}.
   Defined.
 
-  Definition extendable_to_O_internal
+  Definition extendable_to_O
              (O : ReflectiveSubuniverse@{u a}) {P : Type@{i}}
-             {Q : Type@{j}} {Q_inO : inO_internal@{u a j} O Q}
+             {Q : Type@{j}} {Q_inO : In@{u a j} O Q}
   : ooExtendableAlong@{i i j k} (to O P) (fun _ => Q).
   Proof.
     apply ext_localize_ind@{a i j i k i k}; intros ?.
@@ -456,9 +456,9 @@ Module Accessible_Localization
   Definition acc_gen : ReflectiveSubuniverse -> LocalGenerators
     := unLoc.
 
-  Definition inO_iff_islocal_internal
+  Definition inO_iff_islocal
              (O : ReflectiveSubuniverse@{u a}) (X : Type@{i})
-  : iff@{i i i} (inO_internal O X) (IsLocal (acc_gen O) X)
+  : iff@{i i i} (In O X) (IsLocal (acc_gen O) X)
     := (idmap , idmap).
 
 End Accessible_Localization.

--- a/theories/Modalities/Modality.v
+++ b/theories/Modalities/Modality.v
@@ -19,36 +19,37 @@ Module Type Modalities.
                             Type2le@{i a} -> Type2le@{i a}.
   Check O_reflector@{u a i}.    (** Verify that we have the right number of universes *)
 
-  Parameter inO_internal : forall (O : Modality@{u a}),
+  Parameter In : forall (O : Modality@{u a}),
                             Type2le@{i a} -> Type2le@{i a}.
-  Check inO_internal@{u a i}.
+  Check In@{u a i}.
 
-  Parameter O_inO_internal : forall (O : Modality@{u a}) (T : Type@{i}),
-                               inO_internal@{u a i} O (O_reflector@{u a i} O T).
-  Check O_inO_internal@{u a i}.
+  Parameter O_inO : forall (O : Modality@{u a}) (T : Type@{i}),
+                               In@{u a i} O (O_reflector@{u a i} O T).
+  Check O_inO@{u a i}.
 
   Parameter to : forall (O : Modality@{u a}) (T : Type@{i}),
                    T -> O_reflector@{u a i} O T.
   Check to@{u a i}.
 
-  Parameter inO_equiv_inO_internal :
+  Parameter inO_equiv_inO :
       forall (O : Modality@{u a}) (T U : Type@{i})
-             (T_inO : inO_internal@{u a i} O T) (f : T -> U) (feq : IsEquiv f),
-        inO_internal@{u a i} O U.
-  Check inO_equiv_inO_internal@{u a i}.
+             (T_inO : In@{u a i} O T) (f : T -> U) (feq : IsEquiv f),
+        In@{u a i} O U.
+  Check inO_equiv_inO@{u a i}.
 
-  Parameter hprop_inO_internal
+  Parameter hprop_inO
   : Funext -> forall (O : Modality@{u a}) (T : Type@{i}),
-                IsHProp (inO_internal@{u a i} O T).
-  Check hprop_inO_internal@{u a i}.
+                IsHProp (In@{u a i} O T).
+  Check hprop_inO@{u a i}.
 
   (** Now instead of [extendable_to_O], we have an ordinary induction principle. *)
 
+  (** Unfortunately, we have to define these parameters as [_internal] versions and redefine them later.  This is because eventually we want the [In] fields of [O_ind] and [O_ind_beta] to refer to the [In] typeclass defined for [ReflectiveSubuniverse]s, but in order to prove that modalities *are* reflective subuniverses we need to already have [O_ind] and [O_ind_beta]. *)
   Parameter O_ind_internal
   : forall (O : Modality@{u a})
            (A : Type2le@{i a})
            (B : O_reflector@{u a i} O A -> Type2le@{j a})
-           (B_inO : forall oa, inO_internal@{u a j} O (B oa)),
+           (B_inO : forall oa, In@{u a j} O (B oa)),
       (** We add an extra unused universe parameter [k] that's [>= max(i,j)].  This seems to be necessary for some examples, such as [Nullification], which are constructed by way of an operation that requires such a universe.  *)
       let gei := ((fun x => x) : Type@{i} -> Type@{k}) in
       let gej := ((fun x => x) : Type@{j} -> Type@{k}) in
@@ -58,15 +59,15 @@ Module Type Modalities.
   Parameter O_ind_beta_internal
   : forall (O : Modality@{u a})
            (A : Type@{i}) (B : O_reflector O A -> Type@{j})
-           (B_inO : forall oa, inO_internal@{u a j} O (B oa))
+           (B_inO : forall oa, In@{u a j} O (B oa))
            (f : forall a : A, B (to O A a)) (a:A),
       O_ind_internal@{u a i j k} O A B B_inO f (to O A a) = f a.
   Check O_ind_beta_internal@{u a i j k}.
 
   Parameter minO_paths
   : forall (O : Modality@{u a})
-           (A : Type2le@{i a}) (A_inO : inO_internal@{u a i} O A) (z z' : A),
-      inO_internal@{u a i} O (z = z').
+           (A : Type2le@{i a}) (A_inO : In@{u a i} O A) (z z' : A),
+      In@{u a i} O (z = z').
   Check minO_paths@{u a i}.
 
 End Modalities.
@@ -84,7 +85,7 @@ Module Modalities_to_ReflectiveSubuniverses
 
   Fixpoint O_extendable (O : Modality@{u a})
            (A : Type@{i}) (B : O_reflector O A -> Type@{j})
-           (B_inO : forall a, inO_internal@{u a j} O (B a)) (n : nat)
+           (B_inO : forall a, In@{u a j} O (B a)) (n : nat)
   : ExtendableAlong@{i i j k} n (to O A) B.
   Proof.
     destruct n as [|n].
@@ -102,15 +103,26 @@ Module Modalities_to_ReflectiveSubuniverses
 
   Definition O_reflector := O_reflector.
   (** Work around https://coq.inria.fr/bugs/show_bug.cgi?id=3807 *)
-  Definition inO_internal := inO_internal@{u a i}.
-  Definition O_inO_internal := O_inO_internal@{u a i}.
+  Definition In : forall (O : ReflectiveSubuniverse@{u a}),
+                   Type2le@{i a} -> Type2le@{i a}
+    := In@{u a i}.
+  Definition O_inO : forall (O : ReflectiveSubuniverse@{u a}) (T : Type@{i}),
+                               In@{u a i} O (O_reflector@{u a i} O T)
+    := O_inO@{u a i}.
   Definition to := to.
-  Definition inO_equiv_inO_internal := inO_equiv_inO_internal@{u a i}.
-  Definition hprop_inO_internal := hprop_inO_internal@{u a i}.
+  Definition inO_equiv_inO :
+      forall (O : ReflectiveSubuniverse@{u a}) (T U : Type@{i})
+             (T_inO : In@{u a i} O T) (f : T -> U) (feq : IsEquiv f),
+        In@{u a i} O U
+    := inO_equiv_inO@{u a i}.
+  Definition hprop_inO
+  : Funext -> forall (O : ReflectiveSubuniverse@{u a}) (T : Type@{i}),
+                IsHProp (In@{u a i} O T)
+    := hprop_inO@{u a i}.
 
   (** Corollary 7.7.8, part 1 *)
-  Definition extendable_to_O_internal (O : ReflectiveSubuniverse@{u a})
-    {P : Type@{i}} {Q : Type@{j}} {Q_inO : inO_internal@{u a j} O Q}
+  Definition extendable_to_O (O : ReflectiveSubuniverse@{u a})
+             {P : Type2le@{i a}} {Q : Type2le@{j a}} {Q_inO : In@{u a j} O Q}
   : ooExtendableAlong@{i i j k} (to O P) (fun _ => Q)
     := fun n => O_extendable O P (fun _ => Q) (fun _ => Q_inO) n.
 
@@ -126,9 +138,9 @@ Module Type SigmaClosed (Os : ReflectiveSubuniverses).
   Parameter inO_sigma
   : forall (O : ReflectiveSubuniverse@{u a})
            (A:Type@{i}) (B:A -> Type@{j})
-           (A_inO : inO_internal@{u a i} O A)
-           (B_inO : forall a, inO_internal@{u a j} O (B a)),
-      inO_internal@{u a k} O {x:A & B x}.
+           (A_inO : In@{u a i} O A)
+           (B_inO : forall a, In@{u a j} O (B a)),
+      In@{u a k} O {x:A & B x}.
   Check inO_sigma@{u a i j k}.    (** Verify that we have the right number of universes *)
 
 End SigmaClosed.
@@ -145,31 +157,31 @@ Module ReflectiveSubuniverses_to_Modalities
 
   Definition O_reflector := O_reflector.
   (** Work around https://coq.inria.fr/bugs/show_bug.cgi?id=3807 *)
-  Definition inO_internal := inO_internal@{u a i}.
-  Definition O_inO_internal := O_inO_internal@{u a i}.
+  Definition In := In@{u a i}.
+  Definition O_inO := @O_inO@{u a i}.
   Definition to := to.
-  Definition inO_equiv_inO_internal := inO_equiv_inO_internal@{u a i}.
-  Definition hprop_inO_internal := hprop_inO_internal@{u a i}.
+  Definition inO_equiv_inO := @inO_equiv_inO@{u a i}.
+  Definition hprop_inO := hprop_inO@{u a i}.
 
-  (** The reason Coq won't actually accept this as a module of type [Modalities] is that the following definitions of [O_ind_internal] and [O_ind_beta_internal] have an extra universe parameter [k] that's at least as large as both [i] and [j].  This is because [extendable_to_O_internal] has such a parameter, which in turn is because [ooExtendableAlong] does.  Unfortunately, we can't directly instantiate [k] to [max(i,j)] because Coq doesn't allow "algebraic universes" in arbitrary position.  We could probably work around it by defining [ExtendableAlong] inductively rather than recursively, but given the non-usefulness of this construction in practice, that doesn't seem to be worth the trouble at the moment. *)
+  (** The reason Coq won't actually accept this as a module of type [Modalities] is that the following definitions of [O_ind_internal] and [O_ind_beta_internal] have an extra universe parameter [k] that's at least as large as both [i] and [j].  This is because [extendable_to_O] has such a parameter, which in turn is because [ooExtendableAlong] does.  Unfortunately, we can't directly instantiate [k] to [max(i,j)] because Coq doesn't allow "algebraic universes" in arbitrary position.  We could probably work around it by defining [ExtendableAlong] inductively rather than recursively, but given the non-usefulness of this construction in practice, that doesn't seem to be worth the trouble at the moment. *)
   Definition O_ind_internal (O : Modality@{u a})
              (A : Type@{i}) (B : O_reflector@{u a i} O A -> Type@{j})
-             (B_inO : forall oa, inO_internal@{u a j} O (B oa))
+             (B_inO : forall oa, In@{u a j} O (B oa))
   : (forall a, B (to O A a)) -> forall a, B a
   := fun g => pr1 ((O_ind_from_inO_sigma@{u a i j k k j} O (inO_sigma O))
                      A B B_inO g).
 
   Definition O_ind_beta_internal (O : Modality@{u a})
              (A : Type@{i}) (B : O_reflector@{u a i} O A -> Type@{j})
-             (B_inO : forall oa, inO_internal@{u a j} O (B oa))
+             (B_inO : forall oa, In@{u a j} O (B oa))
              (f : forall a : A, B (to O A a)) (a:A)
   : O_ind_internal O A B B_inO f (to O A a) = f a
   := pr2 ((O_ind_from_inO_sigma@{u a i j k k j} O (inO_sigma O))
                      A B B_inO f) a.
 
   Definition minO_paths (O : Modality@{u a})
-             (A : Type@{i}) (A_inO : inO_internal@{u a i} O A) (z z' : A)
-  : inO_internal O (z = z')
+             (A : Type@{i}) (A_inO : In@{u a i} O A) (z z' : A)
+  : In O (z = z')
   := @inO_paths@{u a i i} O A A_inO z z'.
 
 End ReflectiveSubuniverses_to_Modalities.
@@ -228,27 +240,27 @@ Module EasyModalities_to_Modalities (Os : EasyModalities)
   Definition O_reflector := O_reflector@{u a i}.
   Definition to := to@{u a i}.
 
-  Definition inO_internal
+  Definition In
   : forall (O : Modality@{u a}), Type@{i} -> Type@{i}
   := fun O A => IsEquiv@{i i} (to O A).
 
-  Definition hprop_inO_internal `{Funext} (O : Modality@{u a})
+  Definition hprop_inO `{Funext} (O : Modality@{u a})
              (T : Type@{i})
-  : IsHProp (inO_internal@{u a i} O T).
+  : IsHProp (In@{u a i} O T).
   Proof.
-    unfold inO_internal.
+    unfold In.
     exact (hprop_isequiv (to O T)).
   Defined.
 
   Definition O_ind_internal (O : Modality@{u a})
              (A : Type@{i}) (B : O_reflector@{u a i} O A -> Type@{j})
-             (B_inO : forall oa, inO_internal@{u a j} O (B oa))
+             (B_inO : forall oa, In@{u a j} O (B oa))
   : let gei := ((fun x => x) : Type@{i} -> Type@{k}) in
     let gej := ((fun x => x) : Type@{j} -> Type@{k}) in
     (forall a, B (to O A a)) -> forall oa, B oa.
   Proof.
     simpl; intros f oa.
-    pose (H := B_inO oa); unfold inO_internal in H.
+    pose (H := B_inO oa); unfold In in H.
     apply ((to O (B oa))^-1).
     apply O_indO.
     intros a; apply to, f.
@@ -256,7 +268,7 @@ Module EasyModalities_to_Modalities (Os : EasyModalities)
 
   Definition O_ind_beta_internal (O : Modality@{u a})
              (A : Type@{i}) (B : O_reflector@{u a i} O A -> Type@{j})
-             (B_inO : forall oa, inO_internal@{u a j} O (B oa))
+             (B_inO : forall oa, In@{u a j} O (B oa))
              (f : forall a : A, B (to O A a)) (a:A)
   : O_ind_internal O A B B_inO f (to O A a) = f a.
   Proof.
@@ -265,8 +277,8 @@ Module EasyModalities_to_Modalities (Os : EasyModalities)
     apply @O_indO_beta with (f := fun x => to O _ (f x)).
   Qed.
 
-  Definition O_inO_internal (O : Modality@{u a}) (A : Type@{i})
-  : inO_internal@{u a i} O (O_reflector@{u a i} O A).
+  Definition O_inO (O : Modality@{u a}) (A : Type@{i})
+  : In@{u a i} O (O_reflector@{u a i} O A).
   Proof.
     refine (isequiv_adjointify (to O (O_reflector O A))
              (O_indO O (O_reflector O A) (fun _ => A) idmap) _ _).
@@ -279,19 +291,19 @@ Module EasyModalities_to_Modalities (Os : EasyModalities)
   Defined.
 
   (** It seems to be surprisingly hard to show repleteness (without univalence).  We basically have to manually develop enough functoriality of [O] and naturality of [to O]. *)
-  Definition inO_equiv_inO_internal (O : Modality@{u a}) (A B : Type@{i})
-    (A_inO : inO_internal@{u a i} O A) (f : A -> B) (feq : IsEquiv f)
-  : inO_internal@{u a i} O B.
+  Definition inO_equiv_inO (O : Modality@{u a}) (A B : Type@{i})
+    (A_inO : In@{u a i} O A) (f : A -> B) (feq : IsEquiv f)
+  : In@{u a i} O B.
   Proof.
     refine (isequiv_commsq (to O A) (to O B) f
              (O_ind_internal O A (fun _ => O_reflector O B) _ (fun a => to O B (f a))) _).
-    - intros; apply O_inO_internal.
+    - intros; apply O_inO.
     - intros a; refine (O_ind_beta_internal O A (fun _ => O_reflector O B) _ _ a).
     - apply A_inO.
     - refine (isequiv_adjointify _
                (O_ind_internal O B (fun _ => O_reflector O A) _ (fun b => to O A (f^-1 b))) _ _);
         intros x.
-      + apply O_inO_internal.
+      + apply O_inO.
       + pattern x; refine (O_ind_internal O B _ _ _ x); intros.
         * apply minO_pathsO.
         * simpl; abstract (repeat rewrite O_ind_beta_internal; apply ap, eisretr).
@@ -301,10 +313,10 @@ Module EasyModalities_to_Modalities (Os : EasyModalities)
   Defined.
 
   Definition minO_paths (O : Modality@{u a})
-             (A : Type@{i}) (A_inO : inO_internal@{u a i} O A) (a a' : A)
-  : inO_internal O (a = a').
+             (A : Type@{i}) (A_inO : In@{u a i} O A) (a a' : A)
+  : In O (a = a').
   Proof.
-    refine (inO_equiv_inO_internal O (to O A a = to O A a') _ _
+    refine (inO_equiv_inO O (to O A a = to O A a') _ _
                           (@ap _ _ (to O A) a a')^-1 _).
     - apply minO_pathsO.
     - refine (@isequiv_ap _ _ _ A_inO _ _).
@@ -329,6 +341,7 @@ Module Export Coercions.
     := idmap : Modality -> ReflectiveSubuniverse.
 End Coercions.
 
+(** As promised, we redefine [O_ind] and [O_ind_beta] so that their [In] hypotheses refer to the typeclass [RSU.In]. *)
 Definition O_ind {O : Modality@{u a}}
            {A : Type@{i}} (B : O A -> Type@{j})
            {B_inO : forall oa, In O (B oa)}
@@ -489,7 +502,7 @@ Section ConnectedTypes.
     -> IsConnected O A.
   Proof.
     intros H.
-    exact (isconnected_from_elim_to_O (H (O A) (O_inO A) (to O A))).
+    exact (isconnected_from_elim_to_O (H (O A) _ (to O A))).
   Defined.
 
   (** Connected types are closed under sigmas. *)
@@ -1118,16 +1131,16 @@ Module Modalities_Restriction
 
   Definition O_reflector (O : Modality@{u a})
     := Os.O_reflector@{u a i} (Res.Modalities_restriction O).
-  Definition inO_internal (O : Modality@{u a})
-    := Os.inO_internal@{u a i} (Res.Modalities_restriction O).
-  Definition O_inO_internal (O : Modality@{u a})
-    := Os.O_inO_internal@{u a i} (Res.Modalities_restriction O).
+  Definition In (O : Modality@{u a})
+    := Os.In@{u a i} (Res.Modalities_restriction O).
+  Definition O_inO (O : Modality@{u a})
+    := Os.O_inO@{u a i} (Res.Modalities_restriction O).
   Definition to (O : Modality@{u a})
     := Os.to@{u a i} (Res.Modalities_restriction O).
-  Definition inO_equiv_inO_internal (O : Modality@{u a})
-    := Os.inO_equiv_inO_internal@{u a i} (Res.Modalities_restriction O).
-  Definition hprop_inO_internal (H : Funext) (O : Modality@{u a})
-    := Os.hprop_inO_internal@{u a i} H (Res.Modalities_restriction O).
+  Definition inO_equiv_inO (O : Modality@{u a})
+    := Os.inO_equiv_inO@{u a i} (Res.Modalities_restriction O).
+  Definition hprop_inO (H : Funext) (O : Modality@{u a})
+    := Os.hprop_inO@{u a i} H (Res.Modalities_restriction O).
   Definition O_ind_internal (O : Modality@{u a})
     := Os.O_ind_internal@{u a i j k} (Res.Modalities_restriction O).
   Definition O_ind_beta_internal (O : Modality@{u a})
@@ -1155,18 +1168,18 @@ Module Modalities_FamUnion (Os1 Os2 : Modalities)
                   | exact (Os2.O_reflector@{u a i} O) ].
   Defined.
 
-  Definition inO_internal : forall (O : Modality@{u a}),
+  Definition In : forall (O : Modality@{u a}),
                             Type2le@{i a} -> Type2le@{i a}.
   Proof.
-    intros [O|O]; [ exact (Os1.inO_internal@{u a i} O)
-                  | exact (Os2.inO_internal@{u a i} O) ].
+    intros [O|O]; [ exact (Os1.In@{u a i} O)
+                  | exact (Os2.In@{u a i} O) ].
   Defined.
 
-  Definition O_inO_internal : forall (O : Modality@{u a}) (T : Type@{i}),
-                               inO_internal@{u a i} O (O_reflector@{u a i} O T).
+  Definition O_inO : forall (O : Modality@{u a}) (T : Type@{i}),
+                               In@{u a i} O (O_reflector@{u a i} O T).
   Proof.
-    intros [O|O]; [ exact (Os1.O_inO_internal@{u a i} O)
-                  | exact (Os2.O_inO_internal@{u a i} O) ].
+    intros [O|O]; [ exact (Os1.O_inO@{u a i} O)
+                  | exact (Os2.O_inO@{u a i} O) ].
   Defined.
 
   Definition to : forall (O : Modality@{u a}) (T : Type@{i}),
@@ -1176,27 +1189,27 @@ Module Modalities_FamUnion (Os1 Os2 : Modalities)
                   | exact (Os2.to@{u a i} O) ].
   Defined.
 
-  Definition inO_equiv_inO_internal :
+  Definition inO_equiv_inO :
       forall (O : Modality@{u a}) (T U : Type@{i})
-             (T_inO : inO_internal@{u a i} O T) (f : T -> U) (feq : IsEquiv f),
-        inO_internal@{u a i} O U.
+             (T_inO : In@{u a i} O T) (f : T -> U) (feq : IsEquiv f),
+        In@{u a i} O U.
   Proof.
-    intros [O|O]; [ exact (Os1.inO_equiv_inO_internal@{u a i} O)
-                  | exact (Os2.inO_equiv_inO_internal@{u a i} O) ].
+    intros [O|O]; [ exact (Os1.inO_equiv_inO@{u a i} O)
+                  | exact (Os2.inO_equiv_inO@{u a i} O) ].
   Defined.
 
-  Definition hprop_inO_internal
+  Definition hprop_inO
   : Funext -> forall (O : Modality@{u a}) (T : Type@{i}),
-                IsHProp (inO_internal@{u a i} O T).
+                IsHProp (In@{u a i} O T).
   Proof.
-    intros ? [O|O]; [ exact (Os1.hprop_inO_internal@{u a i} _ O)
-                    | exact (Os2.hprop_inO_internal@{u a i} _ O) ].
+    intros ? [O|O]; [ exact (Os1.hprop_inO@{u a i} _ O)
+                    | exact (Os2.hprop_inO@{u a i} _ O) ].
   Defined.
 
   Definition O_ind_internal
   : forall (O : Modality@{u a})
            (A : Type2le@{i a}) (B : O_reflector O A -> Type2le@{j a})
-           (B_inO : forall oa, inO_internal@{u a j} O (B oa)),
+           (B_inO : forall oa, In@{u a j} O (B oa)),
       (forall a, B (to O A a)) -> forall a, B a.
   Proof.
     intros [O|O]; [ exact (Os1.O_ind_internal@{u a i j k} O)
@@ -1206,7 +1219,7 @@ Module Modalities_FamUnion (Os1 Os2 : Modalities)
   Definition O_ind_beta_internal
   : forall (O : Modality@{u a})
            (A : Type@{i}) (B : O_reflector O A -> Type@{j})
-           (B_inO : forall oa, inO_internal@{u a j} O (B oa))
+           (B_inO : forall oa, In@{u a j} O (B oa))
            (f : forall a : A, B (to O A a)) (a:A),
       O_ind_internal@{u a i j k} O A B B_inO f (to O A a) = f a.
   Proof.
@@ -1216,8 +1229,8 @@ Module Modalities_FamUnion (Os1 Os2 : Modalities)
 
   Definition minO_paths
   : forall (O : Modality@{u a})
-           (A : Type2le@{i a}) (A_inO : inO_internal@{u a i} O A) (z z' : A),
-      inO_internal@{u a i} O (z = z').
+           (A : Type2le@{i a}) (A_inO : In@{u a i} O A) (z z' : A),
+      In@{u a i} O (z = z').
   Proof.
     intros [O|O]; [ exact (Os1.minO_paths@{u a i} O)
                   | exact (Os2.minO_paths@{u a i} O) ].

--- a/theories/Modalities/Nullification.v
+++ b/theories/Modalities/Nullification.v
@@ -63,15 +63,15 @@ Module Nullification_Modalities <: Modalities.
   Module LocRSUTh := ReflectiveSubuniverses_Theory LocRSU.
 
   Definition O_reflector := LocRSU.O_reflector.
-  Definition inO_internal := LocRSU.inO_internal.
-  Definition O_inO_internal := LocRSU.O_inO_internal.
+  Definition In := LocRSU.In.
+  Definition O_inO := @LocRSU.O_inO.
   Definition to := LocRSU.to.
-  Definition inO_equiv_inO_internal := LocRSU.inO_equiv_inO_internal.
-  Definition hprop_inO_internal := LocRSU.hprop_inO_internal.
+  Definition inO_equiv_inO := @LocRSU.inO_equiv_inO.
+  Definition hprop_inO := LocRSU.hprop_inO.
 
   Definition O_ind_internal (O : Modality@{u a}) (A : Type@{i})
              (B : O_reflector@{u a i} O A -> Type@{j})
-             (B_inO : forall oa : O_reflector@{u a i} O A, inO_internal@{u a j} O (B oa))
+             (B_inO : forall oa : O_reflector@{u a i} O A, In@{u a j} O (B oa))
              (g : forall a : A, B (to@{u a i} O A a))
   : forall x, B x.
   Proof.
@@ -87,14 +87,14 @@ Module Nullification_Modalities <: Modalities.
 
   Definition O_ind_beta_internal (O : Modality@{u a}) (A : Type@{i})
              (B : O_reflector@{u a i} O A -> Type@{j})
-             (B_inO : forall oa : O_reflector O A, inO_internal@{u a j} O (B oa))
+             (B_inO : forall oa : O_reflector O A, In@{u a j} O (B oa))
              (f : forall a : A, B (to O A a)) (a : A)
   : O_ind_internal@{u a i j k} O A B B_inO f (to O A a) = f a
     := 1.
 
   Definition minO_paths (O : Modality@{u a}) (A : Type@{i})
-             (A_inO : inO_internal@{u a i} O A) (z z' : A)
-  : inO_internal@{u a i} O (z = z').
+             (A_inO : In@{u a i} O A) (z z' : A)
+  : In@{u a i} O (z = z').
   Proof.
     apply (LocRSUTh.inO_paths@{u a i i}); assumption.
   Defined.
@@ -119,13 +119,13 @@ Notation IsNull f := (In (Nul f)).
 Module Accessible_Nullification
   <: Accessible_Modalities Nullification_Modalities.
 
-  Import Nullification_Modalities.
+  Module Import Os_Theory := Modalities_Theory Nullification_Modalities.
 
   Definition acc_gen : Modality -> NullGenerators
     := unNul.
 
-  Definition inO_iff_isnull_internal (O : Modality@{u a}) (X : Type@{i})
-  : iff@{i i i} (inO_internal@{u a i} O X) (IsNull (acc_gen O) X)
+  Definition inO_iff_isnull (O : Modality@{u a}) (X : Type@{i})
+  : iff@{i i i} (In@{u a i} O X) (IsNull (acc_gen O) X)
     := (idmap , idmap).
 
 End Accessible_Nullification.

--- a/theories/Modalities/Open.v
+++ b/theories/Modalities/Open.v
@@ -112,14 +112,16 @@ Defined.
 
 Module Accessible_OpenModalities <: Accessible_Modalities OpenModalities.
 
+  Module Import Os_Theory := Modalities_Theory OpenModalities.
+
   Definition acc_gen
     := fun (O : OpenModalities.Modality@{u a}) =>
          Build_NullGenerators@{a} Unit@{a} (fun _ => unOp O).
 
-  Definition inO_iff_isnull_internal
+  Definition inO_iff_isnull
              (O : OpenModalities.Modality@{u a}) (X : Type@{i})
   : iff@{i i i}
-      (OpenModalities.inO_internal@{u a i} O X)
+      (OpenModalities.In@{u a i} O X)
       (IsNull (acc_gen O) X).
   Proof.
     pose (funext_Op O); split.

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -109,35 +109,35 @@ Module Type ReflectiveSubuniverses.
   Check O_reflector@{u a i}.    (** Verify that we have the right number of universes *)
 
   (** For reflective subuniverses (and hence also modalities), it will turn out that [In O T] is equivalent to [IsEquiv (O_unit T)].  We could define the former as the latter, and it would simplify some of the general theory.  However, in many examples there is a "more basic" definition of [In O] which is equivalent, but not definitionally identical, to [IsEquiv (O_unit T)].  Thus, including [In O] as data makes more things turn out to be judgmentally what we would expect. *)
-  Parameter inO_internal : forall (O : ReflectiveSubuniverse@{u a}),
-                             Type2le@{i a} -> Type2le@{i a}.
-  Check inO_internal@{u a i}.
+  Parameter In : forall (O : ReflectiveSubuniverse@{u a}),
+                   Type2le@{i a} -> Type2le@{i a}.
+  Check In@{u a i}.
 
-  Parameter O_inO_internal : forall (O : ReflectiveSubuniverse@{u a}) (T : Type@{i}),
-                               inO_internal@{u a i} O (O_reflector@{u a i} O T).
-  Check O_inO_internal@{u a i}.
+  Parameter O_inO : forall (O : ReflectiveSubuniverse@{u a}) (T : Type@{i}),
+                               In@{u a i} O (O_reflector@{u a i} O T).
+  Check O_inO@{u a i}.
 
   Parameter to : forall (O : ReflectiveSubuniverse@{u a}) (T : Type@{i}),
                    T -> O_reflector@{u a i} O T.
   Check to@{u a i}.
 
-  Parameter inO_equiv_inO_internal :
+  Parameter inO_equiv_inO :
       forall (O : ReflectiveSubuniverse@{u a}) (T U : Type@{i})
-             (T_inO : inO_internal@{u a i} O T) (f : T -> U) (feq : IsEquiv f),
-        inO_internal@{u a i} O U.
-  Check inO_equiv_inO_internal@{u a i}.
+             (T_inO : In@{u a i} O T) (f : T -> U) (feq : IsEquiv f),
+        In@{u a i} O U.
+  Check inO_equiv_inO@{u a i}.
 
   (** In most examples, [Funext] is necessary to prove that the predicate of being in the subuniverse is an hprop.  To avoid needing to assume [Funext] as a global hypothesis when constructing such examples, and since [Funext] is often not needed for any of the rest of the theory, we add it as a hypothesis to this specific field. *)
-  Parameter hprop_inO_internal
+  Parameter hprop_inO
   : Funext -> forall (O : ReflectiveSubuniverse@{u a}) (T : Type@{i}),
-                IsHProp (inO_internal@{u a i} O T).
-  Check hprop_inO_internal@{u a i}.
+                IsHProp (In@{u a i} O T).
+  Check hprop_inO@{u a i}.
 
   (** We express the universal property using the representation [ooExtendableAlong] of precomposition equivalences.  This has the advantage that it avoids the funext redexes that otherwise infect the theory, thereby simplifying the proofs and proof terms.  We never have to worry about whether we have a path between functions or a homotopy; we use only homotopies, with no need for [ap10] or [path_arrow] to mediate.  Furthermore, the data in [ooExtendableAlong] are all special cases of the induction principle of a modality.  Thus, all the theorems we prove about reflective subuniverses will, when interpreted for a modality (coerced as above to a reflective subuniverse), reduce definitionally to "the way we would have proved them directly for a modality".  *)
-  Parameter extendable_to_O_internal
-  : forall (O : ReflectiveSubuniverse@{u a}) {P : Type2le@{i a}} {Q : Type2le@{j a}} {Q_inO : inO_internal@{u a j} O Q},
+  Parameter extendable_to_O
+  : forall (O : ReflectiveSubuniverse@{u a}) {P : Type2le@{i a}} {Q : Type2le@{j a}} {Q_inO : In@{u a j} O Q},
       ooExtendableAlong@{i i j k} (to O P) (fun _ => Q).
-  Check extendable_to_O_internal@{u a i j k}.
+  Check extendable_to_O@{u a i j k}.
 
 End ReflectiveSubuniverses.
 
@@ -146,11 +146,8 @@ End ReflectiveSubuniverses.
 Module ReflectiveSubuniverses_Theory (Os : ReflectiveSubuniverses).
 Export Os.
 
-(** We now give new names or identities to all the "internal" fields.  This serves several purposes.  Firstly, it allows us to make "being in the subuniverse" into a typeclass. *)
-Class In (O : ReflectiveSubuniverse@{u a}) (T : Type@{i}) :=
-  in_inO_internal : inO_internal@{u a i} O T.
-
-Typeclasses Transparent In.
+(** Membership in the subuniverse is a typeclass. *)
+Existing Class In.
 
 (** The type of types in the subuniverse *)
 Definition Type_ (O : ReflectiveSubuniverse@{u a}) : Type@{j}
@@ -168,22 +165,15 @@ Module Export Coercions.
 
 End Coercions.
 
-(** With this given, we now essentially have to redefine almost all the other fields so that they refer explicitly to the class [In] rather than to [inO_internal], so that Coq is willing to do typeclass inference for them. *)
-
 (** We assumed repleteness of the subuniverse in the definition.  Of course, with univalence this would be automatic, but we include it as a hypothesis since this is the only appearance of univalence in the theory of reflective subuniverses and non-lex modalities, and most or all examples can be shown to be replete without using univalence. *)
-Definition inO_equiv_inO {O : ReflectiveSubuniverse}
-           T {U} {T_inO : In O T} (f : T -> U) {feq : IsEquiv f}
-: In O U
-:= inO_equiv_inO_internal O T U T_inO f feq.
+Arguments inO_equiv_inO {O} T {U} {_} f {_}.
 
 (** Being in the subuniverse is a mere predicate (by hypothesis) *)
-Global Instance hprop_inO {fs : Funext} {O : ReflectiveSubuniverse} (T : Type)
-  : IsHProp (In O T)
-  := hprop_inO_internal fs O T.
+Global Existing Instance hprop_inO.
 
 (** [O T] is always in the subuniverse (by hypothesis).  This needs a universe annotation to become sufficiently polymorphic. *)
-Global Instance O_inO {O : ReflectiveSubuniverse} (T : Type) : In O (O T)
-  := O_inO_internal O T.
+Arguments O_inO {O} T.
+Global Existing Instance O_inO.
 
 (** The second component of [TypeO] is unique *)
 Definition path_TypeO {fs : Funext} O (T T' : Type_ O) (p : T.1 = T'.1)
@@ -202,7 +192,7 @@ Global Instance inO_TypeO {O : ReflectiveSubuniverse} (A : Type_ O)
 Definition extendable_to_O (O : ReflectiveSubuniverse)
            {P Q : Type} {Q_inO : In O Q}
 : ooExtendableAlong (to O P) (fun _ => Q)
-  := @extendable_to_O_internal O P Q Q_inO.
+  := @extendable_to_O O P Q Q_inO.
 
 (** We now extract the recursion principle and the restricted induction principles for paths. *)
 Section ORecursion.
@@ -774,6 +764,8 @@ Section Reflective_Subuniverse.
     : In O (B x).
     Proof.
       refine (inO_equiv_inO _ (hfiber_fibration x B)^-1).
+      (** TODO: Why doesn't Coq find this instance? *)
+      refine (inO_hfiber pr1 x); assumption.
     Defined.
 
     Hint Immediate inO_unsigma : typeclass_instances.
@@ -978,18 +970,18 @@ Module ReflectiveSubuniverses_Restriction
 
   Definition O_reflector (O : ReflectiveSubuniverse@{u a})
     := Os.O_reflector@{u a i} (Res.ReflectiveSubuniverses_restriction O).
-  Definition inO_internal (O : ReflectiveSubuniverse@{u a})
-    := Os.inO_internal@{u a i} (Res.ReflectiveSubuniverses_restriction O).
-  Definition O_inO_internal (O : ReflectiveSubuniverse@{u a})
-    := Os.O_inO_internal@{u a i} (Res.ReflectiveSubuniverses_restriction O).
+  Definition In (O : ReflectiveSubuniverse@{u a})
+    := Os.In@{u a i} (Res.ReflectiveSubuniverses_restriction O).
+  Definition O_inO (O : ReflectiveSubuniverse@{u a})
+    := Os.O_inO@{u a i} (Res.ReflectiveSubuniverses_restriction O).
   Definition to (O : ReflectiveSubuniverse@{u a})
     := Os.to@{u a i} (Res.ReflectiveSubuniverses_restriction O).
-  Definition inO_equiv_inO_internal (O : ReflectiveSubuniverse@{u a})
-    := Os.inO_equiv_inO_internal@{u a i} (Res.ReflectiveSubuniverses_restriction O).
-  Definition hprop_inO_internal (H : Funext) (O : ReflectiveSubuniverse@{u a})
-    := Os.hprop_inO_internal@{u a i} H (Res.ReflectiveSubuniverses_restriction O).
-  Definition extendable_to_O_internal (O : ReflectiveSubuniverse@{u a})
-    := @Os.extendable_to_O_internal@{u a i j k} (Res.ReflectiveSubuniverses_restriction@{u a} O).
+  Definition inO_equiv_inO (O : ReflectiveSubuniverse@{u a})
+    := Os.inO_equiv_inO@{u a i} (Res.ReflectiveSubuniverses_restriction O).
+  Definition hprop_inO (H : Funext) (O : ReflectiveSubuniverse@{u a})
+    := Os.hprop_inO@{u a i} H (Res.ReflectiveSubuniverses_restriction O).
+  Definition extendable_to_O (O : ReflectiveSubuniverse@{u a})
+    := @Os.extendable_to_O@{u a i j k} (Res.ReflectiveSubuniverses_restriction@{u a} O).
 
 End ReflectiveSubuniverses_Restriction.
 
@@ -1012,19 +1004,19 @@ Module ReflectiveSubuniverses_FamUnion
                   | exact (Os2.O_reflector@{u a i} O) ].
   Defined.
 
-  Definition inO_internal : forall (O : ReflectiveSubuniverse@{u a}),
+  Definition In : forall (O : ReflectiveSubuniverse@{u a}),
                              Type2le@{i a} -> Type2le@{i a}.
   Proof.
-    intros [O|O]; [ exact (Os1.inO_internal@{u a i} O)
-                  | exact (Os2.inO_internal@{u a i} O) ].
+    intros [O|O]; [ exact (Os1.In@{u a i} O)
+                  | exact (Os2.In@{u a i} O) ].
   Defined.
 
-  Definition O_inO_internal
+  Definition O_inO
   : forall (O : ReflectiveSubuniverse@{u a}) (T : Type@{i}),
-      inO_internal@{u a i} O (O_reflector@{u a i} O T).
+      In@{u a i} O (O_reflector@{u a i} O T).
   Proof.
-    intros [O|O]; [ exact (Os1.O_inO_internal@{u a i} O)
-                  | exact (Os2.O_inO_internal@{u a i} O) ].
+    intros [O|O]; [ exact (Os1.O_inO@{u a i} O)
+                  | exact (Os2.O_inO@{u a i} O) ].
   Defined.
 
   Definition to : forall (O : ReflectiveSubuniverse@{u a}) (T : Type@{i}),
@@ -1034,29 +1026,29 @@ Module ReflectiveSubuniverses_FamUnion
                   | exact (Os2.to@{u a i} O) ].
   Defined.
 
-  Definition inO_equiv_inO_internal :
+  Definition inO_equiv_inO :
       forall (O : ReflectiveSubuniverse@{u a}) (T U : Type@{i})
-             (T_inO : inO_internal@{u a i} O T) (f : T -> U) (feq : IsEquiv f),
-        inO_internal@{u a i} O U.
+             (T_inO : In@{u a i} O T) (f : T -> U) (feq : IsEquiv f),
+        In@{u a i} O U.
   Proof.
-    intros [O|O]; [ exact (Os1.inO_equiv_inO_internal@{u a i} O)
-                  | exact (Os2.inO_equiv_inO_internal@{u a i} O) ].
+    intros [O|O]; [ exact (Os1.inO_equiv_inO@{u a i} O)
+                  | exact (Os2.inO_equiv_inO@{u a i} O) ].
   Defined.
 
-  Definition hprop_inO_internal
+  Definition hprop_inO
   : Funext -> forall (O : ReflectiveSubuniverse@{u a}) (T : Type@{i}),
-                IsHProp (inO_internal@{u a i} O T).
+                IsHProp (In@{u a i} O T).
   Proof.
-    intros ? [O|O]; [ exact (Os1.hprop_inO_internal@{u a i} _ O)
-                    | exact (Os2.hprop_inO_internal@{u a i} _ O) ].
+    intros ? [O|O]; [ exact (Os1.hprop_inO@{u a i} _ O)
+                    | exact (Os2.hprop_inO@{u a i} _ O) ].
   Defined.
 
-  Definition extendable_to_O_internal
-  : forall (O : ReflectiveSubuniverse@{u a}) {P : Type2le@{i a}} {Q : Type2le@{j a}} {Q_inO : inO_internal@{u a j} O Q},
+  Definition extendable_to_O
+  : forall (O : ReflectiveSubuniverse@{u a}) {P : Type2le@{i a}} {Q : Type2le@{j a}} {Q_inO : In@{u a j} O Q},
       ooExtendableAlong@{i i j k} (to O P) (fun _ => Q).
   Proof.
-    intros [O|O]; [ exact (@Os1.extendable_to_O_internal@{u a i j k} O)
-                  | exact (@Os2.extendable_to_O_internal@{u a i j k} O) ].
+    intros [O|O]; [ exact (@Os1.extendable_to_O@{u a i j k} O)
+                  | exact (@Os2.extendable_to_O@{u a i j k} O) ].
   Defined.
 
 End ReflectiveSubuniverses_FamUnion.

--- a/theories/Modalities/Topological.v
+++ b/theories/Modalities/Topological.v
@@ -19,7 +19,7 @@ Module Topological_Modalities_Theory
 
   (** ** Topological modalities are lex *)
 
-  (** We prove left-exactness by proving that the universe of modal types is modal.  Of course, this require univalence. *)
+  (** We prove left-exactness by proving that the universe of modal types is modal.  Of course, this requires univalence. *)
 
   Global Instance lex_topological `{Univalence}
          (O : Modality) `{Topological O}
@@ -48,7 +48,7 @@ Module Topological_Modalities_Theory
       apply path_TypeO, path_universe_uncurried.
       unfold composeD; simpl.
       pose (e := isequiv_ooextendable _ _
-                                      (fst (inO_iff_isnull O (B tt)) _ i)).
+                                      (fst (inO_iff_isnull O (B tt)) (inO_TypeO (B tt)) i)).
       unfold composeD in e; simpl in e.
       refine (equiv_compose' _ (equiv_inverse (BuildEquiv _ _ _ e))).
       exact (equiv_contr_forall _).

--- a/theories/hit/Truncations.v
+++ b/theories/hit/Truncations.v
@@ -62,29 +62,29 @@ Module Truncation_Modalities <: Modalities.
 
   Definition O_reflector (n : Modality@{u u'}) A := Trunc n A.
 
-  Definition inO_internal (n : Modality@{u u'}) A := IsTrunc n A.
+  Definition In (n : Modality@{u u'}) A := IsTrunc n A.
 
-  Definition O_inO_internal (n : Modality@{u u'}) A : inO_internal n (O_reflector n A).
+  Definition O_inO (n : Modality@{u u'}) A : In n (O_reflector n A).
   Proof.
-    unfold inO_internal, O_reflector; exact _.
+    unfold In, O_reflector; exact _.
   Defined.
 
   Definition to (n : Modality@{u u'}) A := @tr n A.
 
-  Definition inO_equiv_inO_internal (n : Modality@{u u'})
+  Definition inO_equiv_inO (n : Modality@{u u'})
              (A B : Type@{i}) Atr f feq
   := @trunc_equiv A B f n Atr feq.
 
-  Definition hprop_inO_internal `{Funext} (n : Modality@{u u'}) A
-  : IsHProp (inO_internal n A).
+  Definition hprop_inO `{Funext} (n : Modality@{u u'}) A
+  : IsHProp (In n A).
   Proof.
-    unfold inO_internal; exact _.
+    unfold In; exact _.
   Defined.
 
   Definition O_ind_internal
   : forall (n : Modality@{u a})
            (A : Type@{i}) (B : O_reflector n A -> Type@{j})
-           (B_inO : forall oa, inO_internal@{u a j} n (B oa)),
+           (B_inO : forall oa, In@{u a j} n (B oa)),
       let gei := ((fun x => x) : Type@{i} -> Type@{k}) in
       let gej := ((fun x => x) : Type@{j} -> Type@{k}) in
       (forall a, B (to n A a)) -> forall a, B a
@@ -96,10 +96,10 @@ Module Truncation_Modalities <: Modalities.
     := 1.
 
   Definition minO_paths (n : Modality@{u a})
-             (A : Type@{i}) (Atr : inO_internal@{u a i} n A) (a a' : A)
-  : inO_internal@{u a i} n (a = a').
+             (A : Type@{i}) (Atr : In@{u a i} n A) (a a' : A)
+  : In@{u a i} n (a = a').
   Proof.
-    unfold inO_internal in *; exact _.
+    unfold In in *; exact _.
   Defined.
 
 End Truncation_Modalities.


### PR DESCRIPTION
With `Existing Class In` we can get rid of the need for most of the `_internal` fields for reflective subuniverses and modalities.  Unfortunately, I wasn't able to get rid of `O_ind_internal` and `O_ind_beta_internal` for modalities, since we need to have them already in order to prove that modalities are reflective subuniverses so that we can refer to the correct typeclass `In`.  (Suggestions are welcome...)