### PR TITLE
Also install .glob files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -123,10 +123,8 @@ ALL_DOTFILES=$(ALL_DPDFILES:.dpd=.dot)
 
 # Definitions that let autoconf know how to install things.
 nobase_hott_DATA = \
-	$(STD_VOFILES) \
-	$(CORE_VOFILES) \
-	$(CATEGORY_VOFILES) \
-	$(CONTRIB_VOFILES) \
+	$(ALL_VOFILES) \
+	$(ALL_GLOBFILES) \
 	$(STDLIB_EXTRA_DIST) \
 	$(shell find "$(SRCCOQLIB)/theories" -name "README.txt")
 


### PR DESCRIPTION
This allows hyperlinking in pide to work correctly.

I've replaced the list of `*_VOFILES` with the single `ALL_VOFILES`; they expand to the same thing, and this one is less typing.