### PR TITLE
Disable file-dep-graphs/hott-all.svg on travis

### DIFF
--- a/etc/ci/generate_and_push_dep_graphs.sh
+++ b/etc/ci/generate_and_push_dep_graphs.sh
@@ -34,7 +34,9 @@ export MESSAGE="Autoupdate documentation with dpdgraphs"
 echo '$ make svg-file-dep-graphs svg-aggregate-dep-graphs'
 make etc/dpdgraph-0.4alpha/coqthmdep || exit $?
 make svg-file-dep-graphs -k || exit $?
-make svg-aggregate-dep-graphs -k || exit $?
+# `dot` hates file-dep-graphs/hott-all.dot, because it's too big, and
+# makes `dot` spin for over a dozen minutes.  So disable it for now.
+#make svg-aggregate-dep-graphs -k || exit $?
 make file-dep-graphs/index.html -k || exit $?
 
 mv file-dep-graphs file-dep-graphs-bak


### PR DESCRIPTION
It seems that `dot` is just bad at gigantic files.  Hopefully this will
fix #692.