### PR TITLE
Add some notations for equivalences (for composition, idmap, and inverse)

### DIFF
--- a/contrib/Freudenthal.v
+++ b/contrib/Freudenthal.v
@@ -8,7 +8,7 @@ Require Import hit.Connectedness hit.Suspension hit.Truncations.
 Import TrM.
 Local Open Scope trunc_scope.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 Generalizable Variables X A B f g n.
 
 (* ** Connectedness of the suspension *)

--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -26,7 +26,6 @@
 Require Import HoTT Coq.Init.Peano.
 
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
 
 (* END OF PREAMBLE *)
 (* ================================================== ex:composition *)
@@ -373,7 +372,7 @@ Proof.
   intro isHProp_A.
   exists idmap.
   apply path_ishprop. (* automagically, from IsHProp A *)
-  intro contr_AA. 
+  intro contr_AA.
   apply hprop_allpath; intros a1 a2.
   exact (ap10 (path_contr (fun x:A => a1) (fun x:A => a2)) a1).
 Defined.
@@ -390,19 +389,19 @@ Lemma Book_3_6_solution_1 `{Funext} (A : Type) : IsHProp A -> IsHProp (A + ~A).
 Proof.
   intro isHProp_A.
   apply hprop_allpath. intros x y.
-  destruct x as [a1|n1]; destruct y as [a2|n2]; apply path_sum; try apply path_ishprop. 
+  destruct x as [a1|n1]; destruct y as [a2|n2]; apply path_sum; try apply path_ishprop.
   exact (n2 a1). exact (n1 a2).
 Defined.
 
 (* ================================================== ex:disjoint-or *)
 (** Exercise 3.7 *)
 
-Lemma Book_3_7_solution_1 (A B: Type) : 
+Lemma Book_3_7_solution_1 (A B: Type) :
   IsHProp A -> IsHProp B -> ~(A*B) -> IsHProp (A+B).
 Proof.
   intros isHProp_A isProp_B nab.
   apply hprop_allpath. intros x y.
-  destruct x as [a1|b1]; destruct y as [a2|b2]; apply path_sum; try apply path_ishprop. 
+  destruct x as [a1|b1]; destruct y as [a2|b2]; apply path_sum; try apply path_ishprop.
   exact (nab (a1,b2)). exact (nab (a2,b1)).
 Defined.
 
@@ -426,7 +425,7 @@ Proof.
   - unfold Sect. intros []; simpl.
     + unfold LEM_hProp_Bool. elim (lem Unit_hp _).
       * exact (fun _ => 1).
-      * intro nUnit. elim (nUnit tt). 
+      * intro nUnit. elim (nUnit tt).
     + unfold LEM_hProp_Bool. elim (lem False_hp _).
       * intro fals. elim fals.
       * exact (fun _ => 1).
@@ -1347,6 +1346,3 @@ Definition Book_7_13_part_ii := @HoTT.Modalities.Closed.Cl.
 
 (* ================================================== ex:pseudo-ordinals *)
 (** Exercise 11.18 *)
-
-
-

--- a/theories/Basics/Contractible.v
+++ b/theories/Basics/Contractible.v
@@ -3,7 +3,6 @@
 
 Require Import Overture PathGroupoids.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
 
 (** Naming convention: we consistently abbreviate "contractible" as "contr".  A theorem about a space [X] being contractible (which will usually be an instance of the typeclass [Contr]) is called [contr_X]. *)
 

--- a/theories/Basics/Decidable.v
+++ b/theories/Basics/Decidable.v
@@ -1,6 +1,5 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 Require Import Overture PathGroupoids Contractible Equivalences Trunc.
-Local Open Scope equiv_scope.
 Local Open Scope trunc_scope.
 Local Open Scope path_scope.
 

--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -3,7 +3,6 @@
 
 Require Import Overture PathGroupoids.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
 
 (** We now give many ways to construct equivalences.  In each case, we define an instance of the typeclass [IsEquiv] named [isequiv_X], followed by an element of the record type [Equiv] named [equiv_X].
 
@@ -19,7 +18,11 @@ Global Instance isequiv_idmap (A : Type) : IsEquiv idmap | 0 :=
 
 Definition equiv_idmap (A : Type) : A <~> A := BuildEquiv A A idmap _.
 
-Global Instance reflexive_equiv : Reflexive Equiv | 0 := equiv_idmap.
+Arguments equiv_idmap {A} , A.
+
+Notation "1" := equiv_idmap : equiv_scope.
+
+Global Instance reflexive_equiv : Reflexive Equiv | 0 := @equiv_idmap.
 
 (** The composition of equivalences is an equivalence. *)
 Global Instance isequiv_compose `{IsEquiv A B f} `{IsEquiv B C g}
@@ -54,6 +57,8 @@ Definition equiv_compose {A B C : Type} (g : B -> C) (f : A -> B)
 Definition equiv_compose' {A B C : Type} (g : B <~> C) (f : A <~> B)
   : A <~> C
   := equiv_compose g f.
+
+Notation "g 'o' f" := (equiv_compose' g f) (at level 40, left associativity) : equiv_scope.
 
 (* The TypeClass [Transitive] has a different order of parameters than [equiv_compose].  Thus in declaring the instance we have to switch the order of arguments. *)
 Global Instance transitive_equiv : Transitive Equiv | 0 :=
@@ -142,6 +147,8 @@ Proof.
   exists (e^-1).
   apply isequiv_inverse.
 Defined.
+
+Notation "e ^-1" := (@equiv_inverse _ _ e) (at level 3, format "e '^-1'") : equiv_scope.
 
 Global Instance symmetric_equiv : Symmetric Equiv | 0 := @equiv_inverse.
 
@@ -239,6 +246,9 @@ Section Adjointify.
     := BuildEquiv A B f isequiv_adjointify.
 
 End Adjointify.
+
+Arguments isequiv_adjointify {A B}%type_scope (f g)%function_scope isretr issect.
+Arguments equiv_adjointify {A B}%type_scope (f g)%function_scope isretr issect.
 
 (** An involution is an endomap that is its own inverse. *)
 Definition isequiv_involution {X : Type} (f : X -> X) (isinvol : Sect f f)

--- a/theories/Basics/FunextVarieties.v
+++ b/theories/Basics/FunextVarieties.v
@@ -32,7 +32,7 @@ Definition Funext_implies_NaiveFunext : Funext_type -> NaiveFunext.
 Proof.
   intros fe A P f g h.
   unfold Funext_type in *.
-  exact ((@apD10 A P f g)^-1 h)%equiv.
+  exact ((@apD10 A P f g)^-1 h).
 Defined.
 
 Definition NaiveFunext_implies_WeakFunext : NaiveFunext -> WeakFunext.

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -286,6 +286,8 @@ Notation ap01 := ap (only parsing).
 Definition pointwise_paths {A} {P:A->Type} (f g:forall x:A, P x)
   := forall x:A, f x = g x.
 
+Arguments pointwise_paths {A}%type_scope {P} (f g)%function_scope.
+
 Hint Unfold pointwise_paths : typeclass_instances.
 
 Notation "f == g" := (pointwise_paths f g) (at level 70, no associativity) : type_scope.
@@ -348,9 +350,10 @@ Class IsEquiv {A B : Type} (f : A -> B) := BuildIsEquiv {
   eisadj : forall x : A, eisretr (f x) = ap f (eissect x)
 }.
 
-Arguments eisretr {A B} f {_} _.
-Arguments eissect {A B} f {_} _.
-Arguments eisadj {A B} f {_} _.
+Arguments eisretr {A B}%type_scope f%function_scope {_} _.
+Arguments eissect {A B}%type_scope f%function_scope {_} _.
+Arguments eisadj {A B}%type_scope f%function_scope {_} _.
+Arguments IsEquiv {A B}%type_scope f%function_scope.
 
 (** A record that includes all the data of an adjoint equivalence. *)
 Record Equiv A B := BuildEquiv {
@@ -366,13 +369,14 @@ Arguments equiv_fun {A B} _ _.
 Arguments equiv_isequiv {A B} _.
 
 Delimit Scope equiv_scope with equiv.
-Local Open Scope equiv_scope.
 
-Notation "A <~> B" := (Equiv A B) (at level 85) : equiv_scope.
+Bind Scope equiv_scope with Equiv.
+
+Notation "A <~> B" := (Equiv A B) (at level 85) : type_scope.
 
 (** A notation for the inverse of an equivalence.  We can apply this to a function as long as there is a typeclass instance asserting it to be an equivalence.  We can also apply it to an element of [A <~> B], since there is an implicit coercion to [A -> B] and also an existing instance of [IsEquiv]. *)
 
-Notation "f ^-1" := (@equiv_inv _ _ f _) (at level 3, format "f '^-1'") : equiv_scope.
+Notation "f ^-1" := (@equiv_inv _ _ f _) (at level 3, format "f '^-1'") : function_scope.
 
 (** ** Applying paths between equivalences like functions *)
 

--- a/theories/Basics/Pointed.v
+++ b/theories/Basics/Pointed.v
@@ -4,7 +4,6 @@
 Require Import Overture PathGroupoids Equivalences.
 
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
 
 (** Allow ourselves to implicitly generalize over types [A] and [B], and a function [f]. *)
 Generalizable Variables A B f.

--- a/theories/Basics/Trunc.v
+++ b/theories/Basics/Trunc.v
@@ -2,7 +2,6 @@
 (** * Truncatedness *)
 
 Require Import Overture PathGroupoids Contractible Equivalences.
-Local Open Scope equiv_scope.
 Local Open Scope trunc_scope.
 Local Open Scope path_scope.
 Generalizable Variables A B m n f.

--- a/theories/Constant.v
+++ b/theories/Constant.v
@@ -4,9 +4,8 @@ Require Import Extensions Factorization Modalities.Modality.
 Require Import hit.Truncations hit.Connectedness.
 Import TrM.
 
-Open Scope path_scope.
-Open Scope equiv_scope.
-Open Scope trunc_scope.
+Local Open Scope path_scope.
+Local Open Scope trunc_scope.
 
 (** * Varieties of constant function *)
 

--- a/theories/DProp.v
+++ b/theories/DProp.v
@@ -5,7 +5,7 @@
 Require Import HoTT.Basics HoTT.Types.
 Require Import TruncType HProp UnivalenceImpliesFunext.
 Require Import hit.Truncations.
-Local Open Scope equiv_scope.
+
 Local Open Scope path_scope.
 
 (** ** Definitions *)

--- a/theories/EquivalenceVarieties.v
+++ b/theories/EquivalenceVarieties.v
@@ -5,7 +5,6 @@ Require Import HoTT.Basics HoTT.Types.
 Require Import HProp.
 Require Import HoTT.Tactics.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
 
 Generalizable Variables A B f.
 
@@ -214,7 +213,7 @@ Proof.
 Defined.
 
 (** ** n-Path-split maps.
- 
+
 A map is n-path-split if its induced maps on the first n iterated path-spaces are split surjections.  Thus every map is 0-path-split, the 1-path-split maps are the split surjections, and so on.  It turns out that for n>1, being n-path-split is the same as being an equivalence. *)
 
 Fixpoint PathSplit (n : nat) `(f : A -> B) : Type

--- a/theories/Extensions.v
+++ b/theories/Extensions.v
@@ -6,7 +6,7 @@ Require Import HoTT.Basics HoTT.Types.
 Require Import HProp EquivalenceVarieties.
 Require Import HoTT.Tactics.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 (** Given [C : B -> Type] and [f : A -> B], an extension of [g : forall a, C (f a)] along [f] is a section [h : forall b, C b] such that [h (f a) = g a] for all [a:A].  This is equivalently the existence of fillers for commutative squares, restricted to the case where the bottom of the square is the identity; type-theoretically, this approach is sometimes more convenient.  In this file we study the type of such extensions.  One of its crucial properties is that a path between extensions is equivalently an extension in a fibration of paths.
 

--- a/theories/Factorization.v
+++ b/theories/Factorization.v
@@ -6,7 +6,7 @@ Require Import HoTT.Basics HoTT.Types.
 Require Import HProp UnivalenceImpliesFunext Extensions.
 Require Import HoTT.Tactics.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 (** ** Factorizations *)
 

--- a/theories/Fibrations.v
+++ b/theories/Fibrations.v
@@ -4,7 +4,7 @@
 Require Import HoTT.Basics Types.Sigma Types.Paths.
 Require Import EquivalenceVarieties.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 (* ** Homotopy fibers *)
 

--- a/theories/Functorish.v
+++ b/theories/Functorish.v
@@ -1,6 +1,6 @@
 Require Import HoTT.Basics Types.Universe TruncType UnivalenceImpliesFunext.
-Open Scope equiv.
-Open Scope path.
+
+Local Open Scope path_scope.
 
 Section Functorish.
 Context `{Univalence}.

--- a/theories/HProp.v
+++ b/theories/HProp.v
@@ -2,7 +2,7 @@
 (** * HPropositions *)
 
 Require Import HoTT.Basics HoTT.Types.
-Local Open Scope equiv_scope.
+
 Local Open Scope path_scope.
 
 Generalizable Variables A B.

--- a/theories/HSet.v
+++ b/theories/HSet.v
@@ -4,7 +4,7 @@
 Require Import HoTT.Basics.
 Require Import Types.Paths Types.Sigma Types.Empty Types.Record Types.Unit Types.Arrow HProp.
 
-Local Open Scope equiv_scope.
+
 Local Open Scope path_scope.
 
 (** A type is a set if and only if it satisfies Axiom K. *)

--- a/theories/Idempotents.v
+++ b/theories/Idempotents.v
@@ -4,7 +4,7 @@ Require Import Fibrations UnivalenceImpliesFunext EquivalenceVarieties.
 Require Import hit.Truncations.
 
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 (** * Idempotents and their splittings *)
 

--- a/theories/Misc.v
+++ b/theories/Misc.v
@@ -10,6 +10,6 @@
 
 Require Import HoTT.Basics HoTT.Types.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 (** Currently there is nothing here. *)

--- a/theories/Modalities/Accessible.v
+++ b/theories/Modalities/Accessible.v
@@ -7,7 +7,7 @@ Require Import Extensions NullHomotopy.
 Require Import ReflectiveSubuniverse Modality.
 
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 (** ** Accessible reflective subuniverses *)
 

--- a/theories/Modalities/Closed.v
+++ b/theories/Modalities/Closed.v
@@ -6,7 +6,7 @@ Require Import Modality Accessible Nullification Lex Topological.
 Require Import hit.Pushout hit.Join.
 
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 (** * Closed modalities *)
 

--- a/theories/Modalities/Fracture.v
+++ b/theories/Modalities/Fracture.v
@@ -5,7 +5,7 @@ Require Import Modality Lex Open Closed Nullification.
 Require Import HoTT.Tactics.
 
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 (** * The lex-modal fracture theorem *)
 

--- a/theories/Modalities/Identity.v
+++ b/theories/Modalities/Identity.v
@@ -3,7 +3,7 @@ Require Import HoTT.Basics HoTT.Types.
 Require Import Modality Accessible Nullification.
 
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 (** * The identity modality *)
 

--- a/theories/Modalities/Lex.v
+++ b/theories/Modalities/Lex.v
@@ -5,7 +5,7 @@ Require Import Modality Accessible.
 Require Import HoTT.Tactics.
 
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 (** * Lex modalities *)
 

--- a/theories/Modalities/Localization.v
+++ b/theories/Modalities/Localization.v
@@ -4,7 +4,7 @@
 Require Import HoTT.Basics HoTT.Types.
 Require Import Extensions EquivalenceVarieties.
 Require Import ReflectiveSubuniverse Accessible.
-Local Open Scope equiv_scope.
+
 Local Open Scope path_scope.
 
 (** Suppose given a family of maps [f : forall (i:I), S i -> T i].  A type [X] is said to be [f]-local if for all [i:I], the map [(T i -> X) -> (S i -> X)] given by precomposition with [f i] is an equivalence.  Our goal is to show that the [f]-local types form a reflective subuniverse, with a reflector constructed by localization.  That is, morally we want to say

--- a/theories/Modalities/Modality.v
+++ b/theories/Modalities/Modality.v
@@ -5,7 +5,7 @@ Require Export ReflectiveSubuniverse. (* [Export] because many of the lemmas and
 Require Import HoTT.Tactics.
 
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 (** * Modalities *)
 

--- a/theories/Modalities/Notnot.v
+++ b/theories/Modalities/Notnot.v
@@ -3,7 +3,7 @@ Require Import HoTT.Basics HoTT.Types.
 Require Import Modality.
 
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 (** * The double negation modality *)
 

--- a/theories/Modalities/Nullification.v
+++ b/theories/Modalities/Nullification.v
@@ -5,7 +5,7 @@ Require Import HoTT.Basics HoTT.Types.
 Require Import Extensions.
 Require Import Modality Accessible.
 Require Export Localization.    (** Nullification is a special case of localization *)
-Local Open Scope equiv_scope.
+
 Local Open Scope path_scope.
 
 (** Nullification is the special case of localization where the codomains of the generating maps are all [Unit].  In this case, we get a modality and not just a reflective subuniverse. *)

--- a/theories/Modalities/Open.v
+++ b/theories/Modalities/Open.v
@@ -5,7 +5,7 @@ Require Import HProp TruncType Extensions.
 Require Import Modality Accessible Nullification Lex.
 
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 (** * Open modalities *)
 

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -4,7 +4,7 @@ Require Import UnivalenceImpliesFunext EquivalenceVarieties Extensions Fibration
 Require Import HoTT.Tactics.
 
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 (** * Reflective Subuniverses *)
 

--- a/theories/Modalities/Topological.v
+++ b/theories/Modalities/Topological.v
@@ -4,7 +4,7 @@ Require Import Extensions.
 Require Import Modality Accessible Lex Nullification.
 
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 (** * Topological localizations *)
 

--- a/theories/NullHomotopy.v
+++ b/theories/NullHomotopy.v
@@ -2,7 +2,7 @@
 Require Import HoTT.Basics.
 Require Import Types.Sigma Types.Forall.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 (** * Null homotopies of maps *)
 Section NullHomotopy.

--- a/theories/ObjectClassifier.v
+++ b/theories/ObjectClassifier.v
@@ -5,7 +5,7 @@ This equivalence is close to the existence of an object classifier.
 Require Import HoTT.Basics.
 Require Import Types.Universe Types.Sigma Types.Arrow.
 Require Import Fibrations HProp EquivalenceVarieties UnivalenceImpliesFunext Pullback.
-Local Open Scope equiv_scope.
+
 Local Open Scope path_scope.
 
 Section AssumeUnivalence.

--- a/theories/PType.v
+++ b/theories/PType.v
@@ -3,7 +3,7 @@
 Require Import HoTT.Basics HoTT.Types.
 Require Import hit.Truncations.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 Local Open Scope pointed_scope.
 
 (** * More about pointed types *)

--- a/theories/Pullback.v
+++ b/theories/Pullback.v
@@ -3,7 +3,7 @@ Require Import HoTT.Basics HoTT.Types.
 Require Import Fibrations.
 
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 (** * Pullbacks *)
 

--- a/theories/Spaces/BAut.v
+++ b/theories/Spaces/BAut.v
@@ -4,8 +4,7 @@ Require Import Constant Factorization UnivalenceImpliesFunext.
 Require Import Modalities.Modality hit.Truncations hit.Connectedness.
 Import TrM.
 
-Open Scope path_scope.
-Open Scope equiv_scope.
+Local Open Scope path_scope.
 
 (** * BAut(X) *)
 

--- a/theories/Spaces/BAut/Bool.v
+++ b/theories/Spaces/BAut/Bool.v
@@ -5,8 +5,8 @@ Require Import Modalities.Modality hit.Truncations hit.Connectedness.
 Import TrM.
 Require Import Spaces.BAut.
 
-Open Scope path_scope.
-Open Scope equiv_scope.
+Local Open Scope trunc_scope.
+Local Open Scope path_scope.
 
 (** * BAut(Bool) *)
 
@@ -14,9 +14,9 @@ Section AssumeUnivalence.
   Context `{Univalence}.
 
   (** ** Nontrivial central homotopy *)
-  
+
   (** The equivalence [Bool <~> (Bool <~> Bool)], and particularly its consequence [abelian_aut_bool], implies that [BAut Bool] has a nontrivial center.  *)
-  
+
   Definition negb_center_baut_bool
   : forall (Z:BAut Bool), Z = Z.
   Proof.
@@ -24,7 +24,7 @@ Section AssumeUnivalence.
     exists equiv_negb.
     intros g; apply abelian_aut_bool.
   Defined.
-  
+
   Definition nontrivial_negb_center_baut_bool
   : negb_center_baut_bool <> (fun Z => idpath Z).
   Proof.
@@ -34,11 +34,11 @@ Section AssumeUnivalence.
                   (oops @ (id_center_baut Bool)^))..1 true).
     exact (false_ne_true p).
   Defined.
-  
+
   (** In particular, every element of [BAut Bool] has a canonical flip automorphism.  *)
   Definition negb_baut_bool (Z : BAut Bool) : Z <~> Z
     := equiv_path Z Z (negb_center_baut_bool Z)..1.
-  
+
   Definition negb_baut_bool_ne_idmap (Z : BAut Bool)
   : negb_baut_bool Z <> equiv_idmap Z.
   Proof.
@@ -56,7 +56,7 @@ Section AssumeUnivalence.
       refine (eisretr (equiv_path_sigma_hprop Z Z) _).
     - apply moveR_equiv_M; reflexivity.
   Defined.
-  
+
   (** If [Z] is [Bool], then the flip is the usual one. *)
   Definition negb_baut_bool_bool_negb
   : negb_baut_bool (point _) = equiv_negb.
@@ -67,14 +67,14 @@ Section AssumeUnivalence.
       contradiction.
     - assumption.
   Defined.
-  
+
   Definition ap_pr1_negb_baut_bool_bool
   : (negb_center_baut_bool (point _))..1 = path_universe negb.
   Proof.
     apply moveL_equiv_V.
     apply negb_baut_bool_bool_negb.
   Defined.
-  
+
   (** Moreover, we can show that every automorphism of a [Z : BAut Bool] must be either the flip or the identity. *)
   Definition aut_baut_bool_idmap_or_negb (Z : BAut Bool) (e : Z <~> Z)
   : (e = equiv_idmap Z) + (e = negb_baut_bool Z).
@@ -88,9 +88,9 @@ Section AssumeUnivalence.
     - intros q; apply inr.
       exact (q @ negb_baut_bool_bool_negb^).
   Defined.
-  
+
   (** ** Connectedness *)
-  
+
   Global Instance isminusoneconnected_baut_bool `{Funext} (Z : BAut Bool)
   : IsConnected -1 Z.
   Proof.
@@ -98,13 +98,13 @@ Section AssumeUnivalence.
     apply contr_inhabited_hprop; try exact _.
     exact (tr true).
   Defined.
-  
+
   Definition merely_inhab_baut_bool `{Funext} (Z : BAut Bool)
   : merely Z
     := center (merely Z).
-  
+
   (** ** Equivalence types *)
-  
+
   (** As soon as an element of [BAut Bool] is inhabited, it is (purely) equivalent to [Bool].  (Of course, every element of [BAut Bool] is *merely* inhabited, since [Bool] is.)  In fact, it is equivalent in two canonical ways.
 
 First we define the function that will be the equivalence. *)
@@ -115,7 +115,7 @@ First we define the function that will be the equivalence. *)
                   if b then z else negb_baut_bool Z z
                 else
                   if b then negb_baut_bool Z z else z.
-  
+
   (** We compute this in the case when [Z] is [Bool]. *)
   Definition inhab_baut_bool_from_bool_bool (t : Bool)
   : inhab_baut_bool_from_bool t (point _) =
@@ -131,33 +131,33 @@ First we define the function that will be the equivalence. *)
     try reflexivity;
     try apply (ap10_equiv negb_baut_bool_bool_negb).
   Defined.
-  
+
   (** Now we show that it is an equivalence. *)
   Global Instance isequiv_inhab_baut_bool_from_bool (t : Bool)
          (Z : BAut Bool) (z : Z)
   : IsEquiv (inhab_baut_bool_from_bool t Z z).
   Proof.
     baut_reduce.
-    refine (transport IsEquiv (ap10 (inhab_baut_bool_from_bool_bool t)^ z) _). 
+    refine (transport IsEquiv (ap10 (inhab_baut_bool_from_bool_bool t)^ z) _).
     simpl in z; destruct z, t; simpl.
     - refine (isequiv_homotopic idmap _); intros []; reflexivity.
     - apply isequiv_negb.
     - apply isequiv_negb.
     - refine (isequiv_homotopic idmap _); intros []; reflexivity.
   Defined.
-  
+
   Definition equiv_inhab_baut_bool_bool (t : Bool)
              (Z : BAut Bool) (z : Z)
   : Bool <~> Z
     := BuildEquiv _ _ (inhab_baut_bool_from_bool t Z z) _.
-  
+
   Definition path_baut_bool_inhab (Z : BAut Bool) (z : Z)
   : (point (BAut Bool)) = Z.
   Proof.
     apply path_baut.
     exact (equiv_inhab_baut_bool_bool true Z z). (** [true] is a choice! *)
   Defined.
-  
+
   (** In fact, the map sending [z:Z] to this equivalence [Bool <~> Z] is also an equivalence.  To assist with computing the result when [Z] is [Bool], we prove it with an extra parameter first. *)
   Definition isequiv_equiv_inhab_baut_bool_bool_lemma
              (t : Bool) (Z : BAut Bool) (m : merely (point _ = Z))
@@ -177,7 +177,7 @@ First we define the function that will be the equivalence. *)
       refine (ap10 (ap10 (inhab_baut_bool_from_bool_bool t) z) t @ _).
       destruct t; reflexivity.
   Defined.
-  
+
   Global Instance isequiv_equiv_inhab_baut_bool_bool
          (t : Bool) (Z : BAut Bool)
   : IsEquiv (equiv_inhab_baut_bool_bool t Z).
@@ -185,13 +185,13 @@ First we define the function that will be the equivalence. *)
     exact (isequiv_equiv_inhab_baut_bool_bool_lemma t Z
             (merely_path_baut _ _)).
   Defined.
-  
+
   (** The names are getting pretty ridiculous; below we suggest a better name for this. *)
   Definition equiv_equiv_inhab_baut_bool_bool (t : Bool)
              (Z : BAut Bool)
   : Z <~> (Bool <~> Z)
     := BuildEquiv _ _ (equiv_inhab_baut_bool_bool t Z) _.
-  
+
   (** We compute its inverse in the case of [Bool]. *)
   Definition equiv_equiv_inhab_baut_bool_bool_bool_inv (t : Bool)
              (e : Bool <~> Bool)
@@ -206,11 +206,11 @@ First we define the function that will be the equivalence. *)
       apply path_ishprop. }
     exact (ap10_equiv (ap equiv_inverse p) e).
   Defined.
-  
+
   (** ** Group structure *)
-  
+
   (** Homotopically, [BAut Bool] is a [K(Z/2,1)].  In particular, it has a (coherent) abelian group structure induced from that of [Z/2].  With our definition of [BAut Bool], we can construct this operation as follows. *)
-  
+
   Definition baut_bool_pairing : BAut Bool -> BAut Bool -> BAut Bool.
   Proof.
     intros Z W.
@@ -219,38 +219,38 @@ First we define the function that will be the equivalence. *)
     apply tr, symmetry.
     exact (path_universe equiv_bool_aut_bool).
   Defined.
-  
+
   Notation "Z ** W" := (baut_bool_pairing Z W)
                          (at level 40, no associativity)
                        : baut_bool_scope.
   Local Open Scope baut_bool_scope.
-  
+
   Local Notation pt := (point (BAut Bool)).
-  
+
   (** Now [equiv_equiv_inhab_baut_bool_bool] is revealed as simply the left unit law of this pairing. *)
   Definition baut_bool_pairing_1Z Z : pt ** Z = Z.
   Proof.
     apply path_baut, equiv_inverse, equiv_equiv_inhab_baut_bool_bool.
     exact true.                   (** This is a choice! *)
   Defined.
-  
+
   (** The pairing is obviously symmetric. *)
   Definition baut_bool_pairing_symm Z W : Z ** W = W ** Z.
   Proof.
     apply path_baut, equiv_equiv_inverse.
   Defined.
-  
+
   (** Whence we get the right unit law as well. *)
   Definition baut_bool_pairing_Z1 Z : Z ** pt = Z
     := baut_bool_pairing_symm Z pt @ baut_bool_pairing_1Z Z.
-  
+
   (** Every element is its own inverse. *)
   Definition baut_bool_pairing_ZZ Z : Z ** Z = pt.
   Proof.
     apply symmetry, path_baut_bool_inhab.
     apply equiv_idmap.            (** A choice!  Could be the flip. *)
   Defined.
-  
+
   (** Associativity is easiest to think about in terms of "curried 2-variable equivalences".  We start with some auxiliary lemmas. *)
   Definition baut_bool_pairing_ZZ_Z_symm_part1 {Y Z W}
              (e : Y ** (Z ** W)) (z : Z)
@@ -274,7 +274,7 @@ First we define the function that will be the equivalence. *)
       destruct (path_baut_bool_inhab Y y).
       destruct (path_baut_bool_inhab Z z).
       destruct (path_baut_bool_inhab W (e y z)).
-      simpl. 
+      simpl.
       case (dec (z = e y z)); intros p; apply moveR_equiv_V;
       destruct (aut_bool_idmap_or_negb (e y)) as [q|q].
       * symmetry; assumption.
@@ -340,7 +340,7 @@ First we define the function that will be the equivalence. *)
                  (path_ishprop _ (tr y)) @ _).
       simpl. refine (eissect _ _).
   Defined.
-  
+
   Definition baut_bool_pairing_ZZ_Z_symm_inv Y Z W
   : baut_bool_pairing_ZZ_Z_symm_map Y Z W
     o baut_bool_pairing_ZZ_Z_symm_map Z Y W
@@ -351,7 +351,7 @@ First we define the function that will be the equivalence. *)
     apply path_equiv, path_arrow; intros y.
     reflexivity.
   Defined.
-  
+
   Definition baut_bool_pairing_ZZ_Z_symm Y Z W
   : Y ** (Z ** W) <~> Z ** (Y ** W).
   Proof.
@@ -361,7 +361,7 @@ First we define the function that will be the equivalence. *)
               (baut_bool_pairing_ZZ_Z_symm_inv Y Z W)
               (baut_bool_pairing_ZZ_Z_symm_inv Z Y W)).
   Defined.
-  
+
   (** Finally, we can prove associativity. *)
   Definition baut_bool_pairing_ZZ_Z Z W Y
   : (Z ** W) ** Y = Z ** (W ** Y).
@@ -370,13 +370,13 @@ First we define the function that will be the equivalence. *)
     refine (_ @ ap (fun X => Z ** X) (baut_bool_pairing_symm Y W)).
     apply path_baut, baut_bool_pairing_ZZ_Z_symm.
   Defined.
-  
+
   (** Since [BAut Bool] is not a set, we ought to have some coherence for these operations too, but we'll leave that for another time. *)
-  
+
   (** ** Automorphisms of [BAut Bool] *)
-  
+
   (** Interestingly, like [Bool] itself, [BAut Bool] is equivalent to its own automorphism group. *)
-  
+
   (** An initial lemma: every automorphism of [BAut Bool] and its inverse are "adjoint" with respect to the pairing. *)
   Definition aut_baut_bool_moveR_pairing_V
              (e : BAut Bool <~> BAut Bool) (Z W : BAut Bool)
@@ -438,9 +438,9 @@ First we define the function that will be the equivalence. *)
   Defined.
 
   (** ** [BAut (BAut Bool)]  *)
-  
+
   (** Putting all of this together, we can construct a nontrivial 2-central element of [BAut (BAut Bool)]. *)
-  
+
   Definition center_baut_bool_central
              (g : BAut Bool <~> BAut Bool) (W : BAut Bool)
   : ap g (negb_center_baut_bool W) = negb_center_baut_bool (g W).

--- a/theories/Spaces/BAut/Bool/IncoherentIdempotent.v
+++ b/theories/Spaces/BAut/Bool/IncoherentIdempotent.v
@@ -3,8 +3,7 @@ Require Import HoTT.Basics HoTT.Types.
 Require Import EquivalenceVarieties Idempotents.
 Require Import Spaces.BAut Spaces.BAut.Bool.
 
-Open Scope path_scope.
-Open Scope equiv_scope.
+Local Open Scope path_scope.
 
 (** * An incoherent quasi-idempotent on [BAut (BAut Bool)]. *)
 
@@ -53,4 +52,3 @@ Section IncoherentQuasiIdempotent.
   (** These results show only that not *every* quasi-idempotence witness is coherent.  "Clearly" the nontrivial quasi-idempotence witness [nontrivial_qidem_baut_baut_bool] should be the one that is not coherent.  To show this, we would probably need to show that [isqidem_idmap] *is* in the image of [s], and this seems rather annoying to do based on our construction of [splitting_preidem_retractof_qidem]. *)
 
 End IncoherentQuasiIdempotent.
-

--- a/theories/Spaces/BAut/Cantor.v
+++ b/theories/Spaces/BAut/Cantor.v
@@ -4,7 +4,7 @@ Require Import Idempotents.
 Require Import hit.Truncations Spaces.BAut Spaces.Cantor.
 
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 (** * BAut(Cantor) *)
 

--- a/theories/Spaces/Cantor.v
+++ b/theories/Spaces/Cantor.v
@@ -2,7 +2,7 @@
 Require Import HoTT.Basics HoTT.Types.
 
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 (** * Cantor space 2^N *)
 

--- a/theories/Spaces/Finite.v
+++ b/theories/Spaces/Finite.v
@@ -6,7 +6,7 @@ Import TrM.
 Require Import Spaces.Nat.
 
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 Local Open Scope nat_scope.
 

--- a/theories/Spaces/Nat.v
+++ b/theories/Spaces/Nat.v
@@ -5,7 +5,7 @@ Require Import HoTT.Basics.
 Require Import HoTT.Types.Bool HoTT.Types.Nat.
 Require Import HoTT.TruncType HoTT.DProp.
 
-Local Open Scope equiv_scope.
+
 
 (** Much of the layout of this file is adapted from ssreflect *)
 

--- a/theories/Spaces/No.v
+++ b/theories/Spaces/No.v
@@ -5,7 +5,6 @@ Require Import hit.Truncations.
 Import TrM.
 
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
 
 (** * The surreal numbers *)
 
@@ -56,7 +55,7 @@ Module Export Surreals.
   Arguments game_le_lr {L R} xL xR {L' R'} yL yR _ _.
   Arguments game_lt_l {L R} xL xR {L' R'} yL yR l _.
   Arguments game_lt_r {L R} xL xR {L' R'} yL yR r _.
-  
+
   (** *** Now the surreals *)
 
   Private Inductive is_surreal : Game@{i} -> Type :=
@@ -624,7 +623,7 @@ Section NoCodes.
             intros r' yR_le_z [h1 h2] x_le_y;
             apply h2; exact (snd x_le_y r') ).
     Defined.
-  
+
     Local Definition inner (y : No) : A' y
       := inner_package.1 y.
 
@@ -644,7 +643,7 @@ Section NoCodes.
       (hor {l':L' & fst (inner (yL l')).1}
            {r:R & (xR_let r).1 {{ yL | yR // ycut }} })
       := 1.
-        
+
     Local Definition inner_le y z p : A'le y z p (inner y) (inner z)
       := fst (inner_package.2) y z p.
 

--- a/theories/TruncType.v
+++ b/theories/TruncType.v
@@ -3,7 +3,7 @@
 
 Require Import HoTT.Basics HoTT.Types.
 Require Import HProp UnivalenceImpliesFunext.
-Local Open Scope equiv_scope.
+
 
 Generalizable Variables A B n f.
 

--- a/theories/Types/Arrow.v
+++ b/theories/Types/Arrow.v
@@ -4,7 +4,7 @@
 Require Import HoTT.Basics.
 Require Import Types.Paths Types.Forall.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 Generalizable Variables A B C D f g n.
 

--- a/theories/Types/Bool.v
+++ b/theories/Types/Bool.v
@@ -3,7 +3,7 @@
 
 Require Import HoTT.Basics.
 Require Import Types.Prod Types.Equiv.
-Local Open Scope equiv_scope.
+
 Local Open Scope path_scope.
 
 (* coq calls it "bool", we call it "Bool" *)

--- a/theories/Types/Equiv.v
+++ b/theories/Types/Equiv.v
@@ -3,7 +3,7 @@
 Require Import HoTT.Basics.
 Require Import Types.Prod Types.Sigma Types.Forall Types.Arrow Types.Paths Types.Record.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 (** * Equivalences *)
 

--- a/theories/Types/Forall.v
+++ b/theories/Types/Forall.v
@@ -5,7 +5,7 @@ Require Import HoTT.Basics.
 Require Import Types.Paths.
 
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 Generalizable Variables A B f g e n.
 

--- a/theories/Types/Nat.v
+++ b/theories/Types/Nat.v
@@ -12,7 +12,7 @@ Global Open Scope core_scope.
 (** But in this file, we want to be able to use the usual symbols for natural number arithmetic. *)
 Local Open Scope nat_scope.
 
-Local Open Scope equiv_scope.
+
 
 Scheme nat_ind := Induction for nat Sort Type.
 Scheme nat_rec := Minimality for nat Sort Type.

--- a/theories/Types/Paths.v
+++ b/theories/Types/Paths.v
@@ -3,7 +3,7 @@
 
 Require Import HoTT.Basics.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 Generalizable Variables A B f x y z.
 

--- a/theories/Types/Prod.v
+++ b/theories/Types/Prod.v
@@ -4,7 +4,7 @@
 Require Import HoTT.Basics.
 Require Import Types.Empty Types.Unit.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 Generalizable Variables X A B f g n.
 
 Scheme prod_ind := Induction for prod Sort Type.

--- a/theories/Types/Record.v
+++ b/theories/Types/Record.v
@@ -4,7 +4,7 @@
 Require Import HoTT.Basics.
 Require Import Types.Sigma Types.Forall.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 (** The following tactic proves automatically that a two-component record type is equivalent to a Sigma-type.  Specifically, it proves a goal that looks like
 <<

--- a/theories/Types/Sigma.v
+++ b/theories/Types/Sigma.v
@@ -4,7 +4,7 @@
 Require Import HoTT.Basics.
 Require Import Types.Arrow Types.Prod Types.Paths Types.Unit.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 Generalizable Variables X A B C f g n.
 

--- a/theories/Types/Sum.v
+++ b/theories/Types/Sum.v
@@ -7,7 +7,7 @@ Require Import Types.Empty Types.Prod Types.Sigma.
 Require Import Types.Bool Types.Forall.
 Local Open Scope trunc_scope.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 Generalizable Variables X A B f g n.
 
 Scheme sum_ind := Induction for sum Sort Type.

--- a/theories/Types/Unit.v
+++ b/theories/Types/Unit.v
@@ -3,7 +3,7 @@
 
 Require Import HoTT.Basics.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 Generalizable Variables A.
 
 (** ** Eta conversion *)

--- a/theories/Types/Universe.v
+++ b/theories/Types/Universe.v
@@ -4,7 +4,7 @@
 Require Import HoTT.Basics.
 Require Import Types.Sigma Types.Forall Types.Arrow Types.Paths Types.Equiv.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 Generalizable Variables A B f.
 

--- a/theories/UnivalenceImpliesFunext.v
+++ b/theories/UnivalenceImpliesFunext.v
@@ -21,7 +21,7 @@ Section UnivalenceImpliesFunext.
     unfold Univalence_type in *.
     refine (isequiv_adjointify
               (fun (g:C->A) => w o g)
-              (fun (g:C->B) => w^-1 o g)%equiv
+              (fun (g:C->B) => w^-1 o g)
               _
               _);
     intro;
@@ -30,7 +30,7 @@ Section UnivalenceImpliesFunext.
     change w with (@equiv_fun _ _ w');
     clearbody w'; clear H0 w;
     rewrite <- (@eisretr _ _ (@equiv_path A B) (ua A B) w');
-    generalize ((@equiv_inv _ _ (equiv_path A B) (ua A B)) w')%equiv;
+    generalize ((@equiv_inv _ _ (equiv_path A B) (ua A B)) w');
     intro p;
     clear w';
     destruct p;

--- a/theories/Utf8.v
+++ b/theories/Utf8.v
@@ -9,7 +9,8 @@ Notation pr₂ := pr2.
 Local Open Scope fibration_scope.
 Notation "x ₁" := (x.1) (at level 3) : fibration_scope.
 Notation "x ₂" := (x.2) (at level 3) : fibration_scope.
-Notation "g ∘ f" := (g o f) (at level 40, left associativity) : function_scope.
+Notation "g ∘ f" := (g o f)%function (at level 40, left associativity) : function_scope.
+Notation "g ∘ f" := (g o f)%equiv (at level 40, left associativity) : equiv_scope.
 (** We copy the HoTT-Agda library with regard to path concatenation. *)
 Notation "p • q" := (p @ q)%path (at level 20) : path_scope.
 Notation "p '⁻¹'" := (p^)%path (at level 3, format "p '⁻¹'") : path_scope.
@@ -19,7 +20,8 @@ Notation "p •' q" := (p @ q)%path (at level 21, left associativity,
 Infix "∙" := $(fail "You used '∙' (BULLET OPERATOR, #x2219) when you probably meant to use '•' (BULLET, #x2022)")$ (at level 20, only parsing) : path_scope.
 (*Notation "p # x" := (transport _ p x) (right associativity, at level 65, only parsing) : path_scope.*)
 (*Notation "f == g" := (pointwise_paths f g) (at level 70, no associativity) : type_scope.*)
-Notation "A ≃ B" := (A <~> B)%equiv (at level 85) : equiv_scope.
+Notation "A ≃ B" := (A <~> B) (at level 85) : type_scope.
+Notation "f '⁻¹'" := (f^-1)%function (at level 3, format "f '⁻¹'") : function_scope.
 Notation "f '⁻¹'" := (f^-1)%equiv (at level 3, format "f '⁻¹'") : equiv_scope.
 Notation "¬ x" := (~x) (at level 75, right associativity) : type_scope.
 Notation "x ≠ y" := (x <> y) (at level 70) : type_scope.

--- a/theories/categories/Adjoint/Hom.v
+++ b/theories/categories/Adjoint/Hom.v
@@ -14,7 +14,7 @@ Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
 
-Local Open Scope equiv_scope.
+
 Local Open Scope morphism_scope.
 Local Open Scope category_scope.
 Local Open Scope functor_scope.

--- a/theories/categories/Adjoint/HomCoercions.v
+++ b/theories/categories/Adjoint/HomCoercions.v
@@ -17,7 +17,7 @@ Generalizable All Variables.
 Set Asymmetric Patterns.
 
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 Local Open Scope morphism_scope.
 Local Open Scope category_scope.
 Local Open Scope functor_scope.

--- a/theories/categories/Adjoint/Paths.v
+++ b/theories/categories/Adjoint/Paths.v
@@ -20,7 +20,7 @@ Section path_adjunction.
   Variable F : Functor C D.
   Variable G : Functor D C.
 
-  Local Open Scope equiv_scope.
+
 
   Notation adjunction_sigT :=
     { eta : NaturalTransformation 1 (G o F)

--- a/theories/categories/Category/Dual.v
+++ b/theories/categories/Category/Dual.v
@@ -6,7 +6,7 @@ Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
 
-Local Open Scope equiv_scope.
+
 Local Open Scope morphism_scope.
 Local Open Scope category_scope.
 

--- a/theories/categories/Category/Morphisms.v
+++ b/theories/categories/Category/Morphisms.v
@@ -44,7 +44,7 @@ Global Existing Instance isisomorphism_isomorphic.
 Section iso_contr.
   Variable C : PreCategory.
 
-  Local Open Scope equiv_scope.
+
 
   Variables s d : C.
 

--- a/theories/categories/Category/Paths.v
+++ b/theories/categories/Category/Paths.v
@@ -14,7 +14,7 @@ Local Open Scope category_scope.
 
 Section path_category.
   Local Open Scope path_scope.
-  Local Open Scope equiv_scope.
+
 
   (** We add a prime ([']) as an arbitrary convention to denote that
       we are talking about equality of functions (less convenient for

--- a/theories/categories/Category/Sigma/Univalent.v
+++ b/theories/categories/Category/Sigma/Univalent.v
@@ -13,7 +13,7 @@ Local Notation pr1_type := Overture.pr1 (only parsing).
 
 Local Open Scope path_scope.
 Local Open Scope morphism_scope.
-Local Open Scope equiv_scope.
+
 Local Open Scope function_scope.
 
 (** TODO: Following a comment from Mike Shulman
@@ -297,7 +297,7 @@ Section on_both.
                  | [ |- transport (?f o ?g) _ _ = _ ] => rewrite (@transport_compose _ _ _ _ f g)
                  | [ |- transport (fun x => ?f (?g x)) _ _ = _ ] => rewrite (@transport_compose _ _ _ _ f g)
                  | [ |- context[ap (@morphism_isomorphic ?a ?b ?c) (path_isomorphic ?i ?j ?x)] ]
-                   => change (ap (@morphism_isomorphic a b c)) with ((path_isomorphic i j)^-1%equiv);
+                   => change (ap (@morphism_isomorphic a b c)) with ((path_isomorphic i j)^-1%function);
                      rewrite (@eissect _ _ (path_isomorphic i j) _ x)
                  | [ |- context[ap (fun e : Isomorphic _ _ => @morphism_inverse ?C ?s ?d _ _) (path_isomorphic ?i ?j ?x)] ]
                    => rewrite (@ap_morphism_inverse_path_isomorphic C s d i j x 1)

--- a/theories/categories/CategoryOfSections/Core.v
+++ b/theories/categories/CategoryOfSections/Core.v
@@ -11,7 +11,7 @@ Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
 
-Local Open Scope equiv_scope.
+
 Local Open Scope functor_scope.
 
 Section FunctorSectionCategory.

--- a/theories/categories/Comma/Core.v
+++ b/theories/categories/Comma/Core.v
@@ -11,7 +11,7 @@ Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
 
-Local Open Scope equiv_scope.
+
 Local Open Scope morphism_scope.
 Local Open Scope category_scope.
 

--- a/theories/categories/Comma/Functorial.v
+++ b/theories/categories/Comma/Functorial.v
@@ -15,7 +15,7 @@ Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
 
-Local Open Scope equiv_scope.
+
 Local Open Scope morphism_scope.
 Local Open Scope category_scope.
 

--- a/theories/categories/Functor/Attributes.v
+++ b/theories/categories/Functor/Attributes.v
@@ -92,7 +92,7 @@ Section fully_faithful_helpers.
         `{H' : IsEquiv _ _ m}
   : IsIsomorphism (m : morphism set_cat x y).
   Proof.
-    exists (m^-1)%equiv;
+    exists (m^-1)%core;
     apply path_forall; intro;
     destruct H';
     simpl in *;

--- a/theories/categories/Functor/Paths.v
+++ b/theories/categories/Functor/Paths.v
@@ -16,7 +16,7 @@ Section path_functor.
 
   Variables C D : PreCategory.
 
-  Local Open Scope equiv_scope.
+
 
   Local Notation functor_sig_T :=
     { OO : C -> D

--- a/theories/categories/FundamentalPreGroupoidCategory.v
+++ b/theories/categories/FundamentalPreGroupoidCategory.v
@@ -8,7 +8,7 @@ Generalizable All Variables.
 Set Asymmetric Patterns.
 
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 Local Open Scope category_scope.
 
 (** Quoting the HoTT Book:

--- a/theories/categories/GroupoidCategory/Core.v
+++ b/theories/categories/GroupoidCategory/Core.v
@@ -7,7 +7,7 @@ Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
 
-Local Open Scope equiv_scope.
+
 Local Open Scope category_scope.
 
 (** A groupoid is a precategory where every morphism is an isomorphism.  Since 1-types are 1-groupoids, we can construct the category corresponding to the 1-groupoid of a 1-type. *)

--- a/theories/categories/GroupoidCategory/Morphisms.v
+++ b/theories/categories/GroupoidCategory/Morphisms.v
@@ -7,7 +7,7 @@ Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
 
-Local Open Scope equiv_scope.
+
 Local Open Scope category_scope.
 
 Section groupoid_category.

--- a/theories/categories/HomotopyPreCategory.v
+++ b/theories/categories/HomotopyPreCategory.v
@@ -8,7 +8,7 @@ Generalizable All Variables.
 Set Asymmetric Patterns.
 
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 Local Open Scope category_scope.
 
 (** Quoting the HoTT Book:

--- a/theories/categories/LaxComma/Core.v
+++ b/theories/categories/LaxComma/Core.v
@@ -24,7 +24,7 @@ Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
 
-Local Open Scope equiv_scope.
+
 Local Open Scope morphism_scope.
 Local Open Scope category_scope.
 

--- a/theories/categories/LaxComma/CoreLaws.v
+++ b/theories/categories/LaxComma/CoreLaws.v
@@ -17,7 +17,7 @@ Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
 
-Local Open Scope equiv_scope.
+
 Local Open Scope morphism_scope.
 Local Open Scope category_scope.
 

--- a/theories/categories/LaxComma/CoreParts.v
+++ b/theories/categories/LaxComma/CoreParts.v
@@ -15,7 +15,7 @@ Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
 
-Local Open Scope equiv_scope.
+
 Local Open Scope morphism_scope.
 Local Open Scope category_scope.
 

--- a/theories/categories/Limits/Core.v
+++ b/theories/categories/Limits/Core.v
@@ -12,7 +12,7 @@ Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
 
-Local Open Scope equiv_scope.
+
 Local Open Scope functor_scope.
 Local Open Scope category_scope.
 

--- a/theories/categories/NaturalTransformation/Paths.v
+++ b/theories/categories/NaturalTransformation/Paths.v
@@ -16,7 +16,7 @@ Section path_natural_transformation.
   Variables C D : PreCategory.
   Variables F G : Functor C D.
 
-  Local Open Scope equiv_scope.
+
 
   (** ** Equivalence between record and sigma versions of natural transformation *)
   Lemma equiv_sig_natural_transformation

--- a/theories/categories/SetCategory/Morphisms.v
+++ b/theories/categories/SetCategory/Morphisms.v
@@ -11,7 +11,7 @@ Generalizable All Variables.
 Set Asymmetric Patterns.
 
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 Local Open Scope morphism_scope.
 Local Open Scope category_scope.
 
@@ -43,7 +43,7 @@ Section equiv_iso_set_cat.
   : IsIsomorphism m
     := Build_IsIsomorphism
          set_cat s d
-         m m^-1%equiv
+         m m^-1%function
          (path_forall _ _ (eissect m))
          (path_forall _ _ (eisretr m)).
 
@@ -98,7 +98,7 @@ Section equiv_iso_prop_cat.
   : IsIsomorphism m
     := Build_IsIsomorphism
          prop_cat s d
-         m m^-1%equiv
+         m m^-1%function
          (path_forall _ _ (eissect m))
          (path_forall _ _ (eisretr m)).
 

--- a/theories/categories/Structure/Core.v
+++ b/theories/categories/Structure/Core.v
@@ -170,7 +170,7 @@ Defined.
     (iii) and (iv) ensure that these lift to [A]. *)
 
 Module PreCategoryOfStructures.
-  Local Open Scope equiv_scope.
+
   Section precategory.
     (** We use [Records] because they are faster than sigma types. *)
 

--- a/theories/hit/Circle.v
+++ b/theories/hit/Circle.v
@@ -6,7 +6,7 @@ Require Import HoTT.Basics.
 Require Import Types.Paths Types.Forall Types.Arrow Types.Universe Types.Empty Types.Unit.
 Require Import HSet UnivalenceImpliesFunext.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 Generalizable Variables X A B f g n.
 
 (* ** Definition of the circle. *)

--- a/theories/hit/Connectedness.v
+++ b/theories/hit/Connectedness.v
@@ -6,7 +6,7 @@ Require Import TruncType UnivalenceImpliesFunext HProp EquivalenceVarieties Exte
 Require Export Modality.        (* [Export] since the actual definitions of connectednes appear there, in the generality of a modality. *)
 Require Import hit.Truncations.
 Import TrM.
-Local Open Scope equiv_scope.
+
 Local Open Scope path_scope.
 Local Open Scope trunc_scope.
 

--- a/theories/hit/Flattening.v
+++ b/theories/hit/Flattening.v
@@ -5,7 +5,7 @@
 Require Import HoTT.Basics UnivalenceImpliesFunext.
 Require Import Types.Paths Types.Forall Types.Sigma Types.Arrow Types.Universe.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 
 (** First we define the general non-recursive HIT. *)

--- a/theories/hit/Interval.v
+++ b/theories/hit/Interval.v
@@ -5,7 +5,7 @@
 Require Import HoTT.Basics.
 Require Import Types.Sigma Types.Forall Types.Paths.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 Module Export Interval.
 

--- a/theories/hit/Join.v
+++ b/theories/hit/Join.v
@@ -4,7 +4,6 @@ Require Import HoTT.Basics HoTT.Types.
 Require Import HProp HSet.
 Require Import hit.Pushout.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
 
 (** * Joins *)
 

--- a/theories/hit/Pushout.v
+++ b/theories/hit/Pushout.v
@@ -4,7 +4,7 @@ Require Import Types.Paths Types.Forall Types.Sigma Types.Arrow Types.Universe T
 Require Import HSet TruncType.
 Require Import hit.Truncations.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 (** * Homotopy Pushouts *)
 

--- a/theories/hit/Spheres.v
+++ b/theories/hit/Spheres.v
@@ -8,7 +8,7 @@ Require Import HProp NullHomotopy.
 Require Import hit.Suspension hit.Circle.
 Local Open Scope trunc_scope.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 Generalizable Variables X A B f g n.
 
 (** ** Definition, by iterated suspension. *)

--- a/theories/hit/Suspension.v
+++ b/theories/hit/Suspension.v
@@ -5,7 +5,7 @@
 Require Import HoTT.Basics HoTT.Types.
 Require Import PType NullHomotopy.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 Local Open Scope pointed_scope.
 Generalizable Variables X A B f g n.
 

--- a/theories/hit/Truncations.v
+++ b/theories/hit/Truncations.v
@@ -5,7 +5,7 @@
 Require Import HoTT.Basics Types.Sigma Types.Universe TruncType HProp.
 Require Import Modalities.Modality Modalities.Identity.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 Generalizable Variables A X n.
 
 (** ** Definition. *)

--- a/theories/hit/TwoSphere.v
+++ b/theories/hit/TwoSphere.v
@@ -5,7 +5,7 @@
 Require Import HoTT.Basics HSet.
 Require Import Types.Paths Types.Forall Types.Arrow Types.Universe Types.Empty Types.Unit.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 Generalizable Variables X A B f g n.
 
 (* ** Definition of the 2-sphere. *)

--- a/theories/hit/V.v
+++ b/theories/hit/V.v
@@ -7,7 +7,7 @@ Require Import Types.Unit Types.Bool Types.Universe Types.Sigma Types.Arrow Type
 Require Import HProp HSet UnivalenceImpliesFunext TruncType.
 Require Import hit.Truncations hit.quotient.
 Local Open Scope path_scope.
-Local Open Scope equiv_scope.
+
 
 
 (** ** Pushout with respect to a relation *)

--- a/theories/hit/epi.v
+++ b/theories/hit/epi.v
@@ -3,9 +3,7 @@ Require Import Types.Universe Types.Unit Types.Forall Types.Arrow Types.Sigma Ty
 Require Import HProp HSet TruncType UnivalenceImpliesFunext.
 Require Import hit.Pushout hit.Truncations hit.Connectedness.
 
-Open Local Scope path_scope.
-Open Local Scope equiv_scope.
-
+Local Open Scope path_scope.
 
 Section AssumingUA.
 Context `{ua:Univalence}.

--- a/theories/hit/iso.v
+++ b/theories/hit/iso.v
@@ -3,8 +3,7 @@ Require Import Types.Universe.
 Require Import HSet UnivalenceImpliesFunext TruncType.
 Require Import hit.epi hit.unique_choice hit.Truncations.
 
-Open Local Scope path_scope.
-Open Local Scope equiv_scope.
+Local Open Scope path_scope.
 
 (** We prove that [epi + mono <-> IsEquiv] *)
 Section iso.

--- a/theories/hit/quotient.v
+++ b/theories/hit/quotient.v
@@ -4,8 +4,7 @@ Require Import Types.Universe Types.Arrow Types.Sigma.
 Require Import HSet HProp UnivalenceImpliesFunext TruncType.
 Require Import hit.epi hit.Truncations hit.Connectedness.
 
-Open Local Scope path_scope.
-Open Local Scope equiv_scope.
+Local Open Scope path_scope.
 
 (** * Quotient of a Type by an hprop-valued relation
 


### PR DESCRIPTION
Also, correct equiv_scope.  The new rule for [equiv_scope] is that it
should match [function_scope], [morphism_scope], [type_scope]:
[equiv_scope] is for things that build [Equiv]s (just like [type_scope]
is for things that build [Type]s).

This permits and necessitates removing many [Local Open Scope
equiv_scope]; things that expect [Equiv] now get the notations
automatically, and since [<~>] is in [type_scope] and [^-1] is in
[function_scope], we don't need [equiv_scope] for those.  We also must
not have [equiv_scope] on top of [function_scope], or else we'll pick up
the wrong [o].