### PR TITLE
Retry `cabal update` 10 times

### DIFF
--- a/etc/ci/install_coq_dot_deps.sh
+++ b/etc/ci/install_coq_dot_deps.sh
@@ -5,5 +5,12 @@ set -x
 
 sudo apt-get update -qq
 sudo apt-get install -q ghc cabal-install libgraphviz4 graphviz
-cabal update
+# http://unix.stackexchange.com/questions/82598/how-do-i-write-a-retry-logic-in-script-to-keep-retrying-to-run-it-upto-5-times
+n=0
+until [ $n -ge 10 ]
+do
+    cabal update && break
+    n=$[$n+1]
+    sleep 10
+done
 cabal install graphviz text


### PR DESCRIPTION
`cabal update` sometimes errors with
  Downloading the latest package list from hackage.haskell.org
  cabal: <socket: 3>: resource vanished
Now we retry multiple times.