### PR TITLE
Better `make clean` target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -144,6 +144,9 @@ all-am: Makefile $(SCRIPTS) $(DATA) $(MAKEFILE_TARGETS_FILE)
 
 .PHONY: stdlib hottlib hott-core hott-categories contrib clean html proviola timing-html clean-local install-data-local proviola-all proviola-xml svg-file-dep-graphs svg-aggregate-dep-graphs svg-dep-graphs clean-dpdgraph strict strict-test strict-no-axiom quick vi2vo checkproofs
 
+# targets that we don't need to run coqdep for
+FAST_TARGETS = clean clean-local clean-dpdgraph TAGS
+
 if install_stdlib_symlinks
 install-data-local:
 	$(MKDIR_P) "$(hottdir)/coq"
@@ -379,4 +382,4 @@ clean:
 	rm -f $(EXTRA_CLEANFILES)
 	find "$(SRCCOQLIB)/theories" $(srcdir)/theories -name \*.vo -o -name \*.glob -o -name \*.timing | xargs rm -f
 
--include $(ALL_DEPFILES)
+@include_snippet@

--- a/Makefile.am
+++ b/Makefile.am
@@ -362,23 +362,35 @@ $(STD_DEPFILES) : %.d : %.v
 	$(VECHO) COQDEP $<
 	$(Q) "$(COQDEP)" -nois -coqlib "$(SRCCOQLIB)" -R "$(SRCCOQLIB)/theories" Coq $< | sed s'#\\#/#g' >$@
 
-clean-dpdgraph:
+clean-dpdgraph::
 	(cd etc/dpdgraph-0.4alpha && $(MAKE) clean)
 
 # We separate things to work around `make: execvp: /bin/bash: Argument list too long`
-clean:
-	rm -f $(ALL_VOFILES)
-	rm -f $(ALL_VFILES:.v=.vi)
-	rm -f $(ALL_GLOBFILES)
-	rm -f $(ALL_DEPFILES)
-	rm -f $(ALL_HTMLFILES)
-	rm -f $(ALL_XMLFILES)
-	rm -f $(ALL_PROVIOLA_HTMLFILES)
-	rm -f $(ALL_TIMINGFILES)
-	rm -f $(ALL_TIMING_HTMLFILES)
-	rm -f $(ALL_SVGFILES)
-	rm -f $(ALL_DPDFILES)
-	rm -f $(ALL_DOTFILES)
+clean::
+	$(VECHO) "RM *.VO"
+	$(Q)rm -f $(ALL_VOFILES)
+	$(VECHO) "RM *.VIO"
+	$(Q)rm -f $(ALL_VFILES:.v=.vio)
+	$(VECHO) "RM *.GLOB"
+	$(Q)rm -f $(ALL_GLOBFILES)
+	$(VECHO) "RM *.V.D"
+	$(Q)rm -f $(ALL_DEPFILES)
+	$(VECHO) "RM *.HTML"
+	$(Q)rm -f $(ALL_HTMLFILES)
+	$(VECHO) "RM *.XML"
+	$(Q)rm -f $(ALL_XMLFILES)
+	$(VECHO) "RM *.HTML"
+	$(Q)rm -f $(ALL_PROVIOLA_HTMLFILES)
+	$(VECHO) "RM *.TIMING"
+	$(Q)rm -f $(ALL_TIMINGFILES)
+	$(VECHO) "RM *.TIMING.HTML"
+	$(Q)rm -f $(ALL_TIMING_HTMLFILES)
+	$(VECHO) "RM *.SVG"
+	$(Q)rm -f $(ALL_SVGFILES)
+	$(VECHO) "RM *.DPD"
+	$(Q)rm -f $(ALL_DPDFILES)
+	$(VECHO) "RM *.DOT"
+	$(Q)rm -f $(ALL_DOTFILES)
 	rm -f $(EXTRA_CLEANFILES)
 	find "$(SRCCOQLIB)/theories" $(srcdir)/theories -name \*.vo -o -name \*.glob -o -name \*.timing | xargs rm -f
 

--- a/configure.ac
+++ b/configure.ac
@@ -195,6 +195,21 @@ AS_IF([test "$coqtop_out" = 0],
 
 AM_CONDITIONAL(install_stdlib_symlinks, [test "$coqtop_out" = 0])
 
+# create a snippet to get a Makefile conditional through automake,
+# from http://stackoverflow.com/a/8643550/377022 and
+# http://stackoverflow.com/a/28652045/377022
+include_snippet='
+ifneq ($(filter-out $(FAST_TARGETS),$(MAKECMDGOALS)),)
+-include $(ALL_DEPFILES)
+else
+ifeq ($(MAKECMDGOALS),)
+-include $(ALL_DEPFILES)
+endif
+endif
+'
+AC_SUBST([include_snippet])
+AM_SUBST_NOTMAKE([include_snippet])
+
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([hoq-config])
 


### PR DESCRIPTION
With a bit of help from stackoverflow, it's possible to not run coqdep when we run `make clean`.