### PR TITLE
Fix hoqide on Windows

### DIFF
--- a/hoq-config.in
+++ b/hoq-config.in
@@ -38,6 +38,7 @@ function readlink_f() {
 # script, then use that one, otherwise use the global one. This trick
 # allows hoqc to work "in place" on the source files.
 mydir="$(dirname "$(readlink_f "${BASH_SOURCE[0]}")")"
+which cygpath 2>/dev/null >/dev/null && mydir="$(cygpath -m "$mydir")"
 if test -d "$mydir/coq/theories"
 then
   export COQLIB="$mydir/coq"


### PR DESCRIPTION
Do this by checking for the existence of `cygpath`, and Windowsifying
the paths if it exists.  This breaks machines with a `cygpath` in
`PATH` which don't support Windows paths, but such machines are rare,
I believe.