### PR TITLE
Prove saturatedness - Grothendieck of F : C -> Set

### DIFF
--- a/Makefile_targets.mk
+++ b/Makefile_targets.mk
@@ -330,6 +330,9 @@ CATEGORY_VFILES = \
 	\
 	$(srcdir)/theories/categories/Grothendieck.v \
 	$(srcdir)/theories/categories/Grothendieck/ToSet.v \
+	$(srcdir)/theories/categories/Grothendieck/ToSet/Core.v \
+	$(srcdir)/theories/categories/Grothendieck/ToSet/Morphisms.v \
+	$(srcdir)/theories/categories/Grothendieck/ToSet/Univalent.v \
 	$(srcdir)/theories/categories/Grothendieck/PseudofunctorToCat.v \
 	$(srcdir)/theories/categories/Grothendieck/ToCat.v \
 	\

--- a/theories/categories/Grothendieck/ToSet.v
+++ b/theories/categories/Grothendieck/ToSet.v
@@ -1,117 +1,12 @@
 (** * Grothendieck Construction of a functor to Set *)
-Require Import Category.Core Functor.Core.
-Require Import SetCategory.Core.
-Require Import Basics.Trunc HSet Types.Sigma TruncType.
+(** We want to have the following as subdirectories/modules, not at top level.  Unfortunately, namespacing in Coq is kind-of broken (see, e.g., https://coq.inria.fr/bugs/show_bug.cgi?id=3676), so we don't get the ability to rename subfolders by [Including] into other modules. *)
+(** ** construction *)
+Require Grothendieck.ToSet.Core.
 
-Set Universe Polymorphism.
-Set Implicit Arguments.
-Generalizable All Variables.
-Set Asymmetric Patterns.
+(** ** classification of morphisms *)
+Require Grothendieck.ToSet.Morphisms.
 
-Local Open Scope morphism_scope.
+(** ** preservation of saturation *)
+Require Grothendieck.ToSet.Univalent.
 
-Section Grothendieck.
-  Context `{Funext}.
-
-  (**
-     Quoting Wikipedia:
-
-     The Grothendieck construction is an auxiliary construction used
-     in the mathematical field of category theory.
-
-     Let
-
-<<
-     F : C → Set
->>
-
-     be a functor from any small category to the category of sets.
-     The Grothendieck construct for [F] is the category [Γ F] whose
-     objects are pairs [(c, x)], where [c : C] is an object and [x : F
-     c] is an element, and for which the set [Hom (Γ F) (c1, x1) (c2,
-     x2)] is the set of morphisms [f : c1 → c2] in [C] such that
-     [F₁ f x1 = x2].  *)
-
-  Variable C : PreCategory.
-  Variable F : Functor C set_cat.
-
-  Record Pair :=
-    {
-      c : C;
-      x : F c
-    }.
-
-  Local Notation morphism s d :=
-    { f : morphism C s.(c) d.(c)
-    | morphism_of F f s.(x) = d.(x) }.
-
-  Definition compose_H s d d'
-             (m1 : morphism d d')
-             (m2 : morphism s d)
-  : (F _1 (m1 .1 o m2 .1)) s.(x) = d'.(x).
-  Proof.
-    etransitivity; [ | exact (m1.2) ].
-    etransitivity; [ | apply ap; exact (m2.2) ].
-    match goal with
-      | [ |- ?f ?x = ?g (?h ?x) ] => change (f x = (g o h) x)
-    end.
-    match goal with
-      | [ |- ?f ?x = ?g ?x ] => apply (@apD10 _ _ f g)
-    end.
-    apply (composition_of F).
-  Defined.
-
-  Definition compose s d d'
-             (m1 : morphism d d')
-             (m2 : morphism s d)
-  : morphism s d'.
-  Proof.
-    exists (m1.1 o m2.1).
-    apply compose_H.
-  Defined.
-
-  Definition identity_H s
-    := apD10 (identity_of F s.(c)) s.(x).
-
-  Definition identity s : morphism s s.
-  Proof.
-    exists 1.
-    apply identity_H.
-  Defined.
-
-  Global Arguments compose_H : simpl never.
-  Global Arguments identity_H : simpl never.
-  Global Arguments identity _ / .
-  Global Arguments compose _ _ _ _ _ / .
-
-  (** ** Category of elements *)
-  Definition category : PreCategory.
-  Proof.
-    refine (@Build_PreCategory
-              Pair
-              (fun s d => morphism s d)
-              identity
-              compose
-              _
-              _
-              _
-              _);
-    abstract (
-        repeat intro;
-        apply path_sigma_uncurried; simpl;
-        ((exists (associativity _ _ _ _ _ _ _ _))
-           || (exists (left_identity _ _ _ _))
-           || (exists (right_identity _ _ _ _)));
-        exact (center _)
-      ).
-  Defined.
-
-  (** ** First projection functor *)
-  Definition pr1 : Functor category C
-    := Build_Functor
-         category C
-         c
-         (fun s d => @pr1 _ _)
-         (fun _ _ _ _ _ => idpath)
-         (fun _ => idpath).
-End Grothendieck.
+Include Grothendieck.ToSet.Core.

--- a/theories/categories/Grothendieck/ToSet/Core.v
+++ b/theories/categories/Grothendieck/ToSet/Core.v
@@ -1,0 +1,122 @@
+(** * Grothendieck Construction of a functor to Set *)
+Require Import Category.Core Functor.Core.
+Require Import SetCategory.Core.
+Require Import Basics.Trunc HSet Types.Sigma TruncType Types.Record.
+
+Set Universe Polymorphism.
+Set Implicit Arguments.
+Generalizable All Variables.
+Set Asymmetric Patterns.
+
+Local Open Scope morphism_scope.
+
+Section Grothendieck.
+  Context `{Funext}.
+
+  (**
+     Quoting Wikipedia:
+
+     The Grothendieck construction is an auxiliary construction used
+     in the mathematical field of category theory.
+
+     Let
+
+<<
+     F : C → Set
+>>
+
+     be a functor from any small category to the category of sets.
+     The Grothendieck construct for [F] is the category [Γ F] whose
+     objects are pairs [(c, x)], where [c : C] is an object and [x : F
+     c] is an element, and for which the set [Hom (Γ F) (c1, x1) (c2,
+     x2)] is the set of morphisms [f : c1 → c2] in [C] such that
+     [F₁ f x1 = x2].  *)
+
+  Variable C : PreCategory.
+  Variable F : Functor C set_cat.
+
+  Record Pair :=
+    {
+      c : C;
+      x : F c
+    }.
+
+  Definition issig_pair : { c : C | F c } <~> Pair.
+  Proof.
+    issig Build_Pair c x.
+  Defined.
+
+  Local Notation morphism s d :=
+    { f : morphism C s.(c) d.(c)
+    | morphism_of F f s.(x) = d.(x) }.
+
+  Definition compose_H s d d'
+             (m1 : morphism d d')
+             (m2 : morphism s d)
+  : (F _1 (m1 .1 o m2 .1)) s.(x) = d'.(x).
+  Proof.
+    etransitivity; [ | exact (m1.2) ].
+    etransitivity; [ | apply ap; exact (m2.2) ].
+    match goal with
+      | [ |- ?f ?x = ?g (?h ?x) ] => change (f x = (g o h) x)
+    end.
+    match goal with
+      | [ |- ?f ?x = ?g ?x ] => apply (@apD10 _ _ f g)
+    end.
+    apply (composition_of F).
+  Defined.
+
+  Definition compose s d d'
+             (m1 : morphism d d')
+             (m2 : morphism s d)
+  : morphism s d'.
+  Proof.
+    exists (m1.1 o m2.1).
+    apply compose_H.
+  Defined.
+
+  Definition identity_H s
+    := apD10 (identity_of F s.(c)) s.(x).
+
+  Definition identity s : morphism s s.
+  Proof.
+    exists 1.
+    apply identity_H.
+  Defined.
+
+  Global Arguments compose_H : simpl never.
+  Global Arguments identity_H : simpl never.
+  Global Arguments identity _ / .
+  Global Arguments compose _ _ _ _ _ / .
+
+  (** ** Category of elements *)
+  Definition category : PreCategory.
+  Proof.
+    refine (@Build_PreCategory
+              Pair
+              (fun s d => morphism s d)
+              identity
+              compose
+              _
+              _
+              _
+              _);
+    abstract (
+        repeat intro;
+        apply path_sigma_uncurried; simpl;
+        ((exists (associativity _ _ _ _ _ _ _ _))
+           || (exists (left_identity _ _ _ _))
+           || (exists (right_identity _ _ _ _)));
+        exact (center _)
+      ).
+  Defined.
+
+  (** ** First projection functor *)
+  Definition pr1 : Functor category C
+    := Build_Functor
+         category C
+         c
+         (fun s d => @pr1 _ _)
+         (fun _ _ _ _ _ => idpath)
+         (fun _ => idpath).
+End Grothendieck.

--- a/theories/categories/Grothendieck/ToSet/Morphisms.v
+++ b/theories/categories/Grothendieck/ToSet/Morphisms.v
@@ -1,0 +1,46 @@
+(** * Classification of morphisms of the Grothendieck Construction of a functor to Set *)
+Require Import Category.Core Functor.Core.
+Require Import Category.Morphisms.
+Require Import SetCategory.Core.
+Require Import Grothendieck.ToSet.Core.
+Require Import HoTT.Basics.Equivalences HoTT.Types.Sigma.
+
+Set Universe Polymorphism.
+Set Implicit Arguments.
+Generalizable All Variables.
+Set Asymmetric Patterns.
+
+Local Open Scope morphism_scope.
+
+Section Grothendieck.
+  Context `{Funext}.
+  Context {C : PreCategory}
+          {F : Functor C set_cat}.
+
+  Definition isequiv_sigma_category_isomorphism {s d : category F}
+  : (s <~=~> d)%category <~> { e : (s.(c) <~=~> d.(c))%category | (F _1 e s.(x) = d.(x))%category }.
+  Proof.
+    refine (equiv_adjointify _ _ _ _).
+    { intro m.
+      refine (_; _).
+      { exists (m : morphism _ _ _).1.
+        exists (m^-1).1.
+        { exact (ap projT1 (@left_inverse _ _ _ m _)). }
+        { exact (ap projT1 (@right_inverse _ _ _ m _)). } }
+      { exact (m : morphism _ _ _).2. } }
+    { intro m.
+      exists (m.1 : morphism _ _ _ ; m.2).
+      eexists (m.1^-1;
+               ((ap (F _1 (m.1)^-1) m.2)^)
+                 @ (ap10 ((((composition_of F _ _ _ _ _)^)
+                             @ (ap (fun m => F _1 m) (@left_inverse _ _ _ m.1 _))
+                             @ (identity_of F _))
+                          : (F _1 (m.1 : morphism _ _ _)^-1) o F _1 m.1 = idmap) s.(x)));
+        apply path_sigma_hprop.
+      exact left_inverse.
+      exact right_inverse. }
+    { intro x; apply path_sigma_hprop; apply path_isomorphic.
+      reflexivity. }
+    { intro x; apply path_isomorphic; reflexivity. }
+  Defined.
+End Grothendieck.

--- a/theories/categories/Grothendieck/ToSet/Univalent.v
+++ b/theories/categories/Grothendieck/ToSet/Univalent.v
@@ -1,0 +1,57 @@
+(** * Saturation of the Grothendieck Construction of a functor to Set *)
+Require Import Category.Core Functor.Core.
+Require Import Category.Univalent.
+Require Import Category.Morphisms.
+Require Import SetCategory.Core.
+Require Import Grothendieck.ToSet.Core Grothendieck.ToSet.Morphisms.
+From HoTT.Basics Require Import Equivalences Trunc.
+From HoTT.Types Require Import Universe Paths Sigma.
+Require Import HoTT.UnivalenceImpliesFunext.
+
+Set Universe Polymorphism.
+Set Implicit Arguments.
+Generalizable All Variables.
+Set Asymmetric Patterns.
+
+Local Open Scope morphism_scope.
+
+Section Grothendieck.
+  Context `{Univalence}.
+
+  Variable C : PreCategory.
+  Context `{IsCategory C}.
+  Variable F : Functor C set_cat.
+
+  Definition category_isotoid_helper {s d} (a : c s = c d)
+  : (transport (fun c : C => F c) a (x s) = x d)
+      <~> (F _1 (idtoiso C a)) (x s) = x d.
+  Proof.
+    apply equiv_path.
+    apply ap10, ap.
+    destruct a; simpl.
+    exact (ap10 (identity_of F _)^ _).
+  Defined.
+
+  Arguments category_isotoid_helper : simpl never.
+
+  Definition category_isotoid {s d : category F}
+  : s = d <~> (s <~=~> d)%category.
+  Proof.
+    refine (isequiv_sigma_category_isomorphism^-1 oE _ oE (equiv_ap' (issig_pair F)^-1 s d)).
+    refine (_ oE (equiv_path_sigma _ _ _)^-1).
+    simpl.
+    refine (equiv_functor_sigma' _ _).
+    { exists (@idtoiso C _ _).
+      exact _. }
+    { exact category_isotoid_helper. }
+  Defined.
+
+  Global Instance preservation : IsCategory (category F).
+  Proof.
+    intros s d.
+    refine (@isequiv_homotopic _ _ category_isotoid (idtoiso (category F) (x:=s) (y:=d)) _ _).
+    intro x.
+    destruct x; apply path_isomorphic, path_sigma_hprop.
+    reflexivity.
+  Defined.
+End Grothendieck.


### PR DESCRIPTION
An answer to Mike's suspicion on the mailing list.

It seems to be much, much, much easier to construct an equivalence `(s = d) ≃ (s ≅ d)` and prove it's carrier function equal to `idtoiso`, than it is to directly construct a function `(s ≅ d) → (s = d)` and prove that it's a section and retraction of `idtoiso`.  Any ideas if this is an instance of a more general property?  (Or ideas for why this is the case?)

If anyone want's to try their hand at pseduofunctor "path" algebra, there are [a few `admit`s left in this branch that does this construction for the Grothendieck construction for a pseudofunctor to cat](https://github.com/HoTT/HoTT/compare/master...JasonGross:grothendieck-cat-univalent#diff-91e920f8e0ee250520376601b86f019eR39).