### PR TITLE
Add a local admit tactic to contrib/Frudenthal.v

### DIFF
--- a/contrib/Freudenthal.v
+++ b/contrib/Freudenthal.v
@@ -11,6 +11,8 @@ Local Open Scope path_scope.
 
 Generalizable Variables X A B f g n.
 
+(** [proof_admitted] is used to implement the admit tactic, as in Coq 8.5 beta 1. *)
+Local Axiom proof_admitted : False.
 Local Ltac admit := case proof_admitted.
 
 (* ** Connectedness of the suspension *)

--- a/contrib/Freudenthal.v
+++ b/contrib/Freudenthal.v
@@ -11,6 +11,8 @@ Local Open Scope path_scope.
 
 Generalizable Variables X A B f g n.
 
+Local Ltac admit := case proof_admitted.
+
 (* ** Connectedness of the suspension *)
 
 Global Instance isconn_susp {n : trunc_index} {X : Type} `{H : IsConnected n X}

--- a/coq/theories/Init/Logic.v
+++ b/coq/theories/Init/Logic.v
@@ -28,9 +28,6 @@ Inductive True : Type :=
 (** [False] is the empty type. *)
 Inductive False : Type :=.
 
-(** [proof_admitted] is used to implement the admit tactic *)
-Axiom proof_admitted : False.
-
 (** [not A], written [~A], is the negation of [A] *)
 Definition not (A:Type) : Type := A -> False.
 


### PR DESCRIPTION
In 8.5beta2, the built-in [admit] which uses [proof_admitted] is
replaced by one aliased to [shelve]; we bring it back so we can use it
in transparent proofs, in contrib/Freudenthal.v.