### PR TITLE
Make Lex_Reflective_Subuniverses actually instantiate SigmaClosed

### DIFF
--- a/theories/Fibrations.v
+++ b/theories/Fibrations.v
@@ -148,12 +148,12 @@ Section UnstableOctahedral.
     unfold hfiber, hfiber_compose_map.
     refine (_ oE (equiv_sigma_assoc _ _)^-1).
     refine (equiv_functor_sigma' 1 _); intros a; simpl.
-    transitivity ({p : g (f a) = g b & {q : f a = b & transport (fun y => g y = g b) q p = 1}}).
-    - refine (equiv_functor_sigma' 1
-                (fun p => (equiv_path_sigma _ _ _)^-1)).
+    refine (equiv_compose' (B := {p : g (f a) = g b & {q : f a = b & transport (fun y => g y = g b) q p = 1}}) _ _).
     - refine (_ oE equiv_sigma_symm _).
       apply equiv_sigma_contr; intros p.
       destruct p; simpl; exact _.
+    - refine (equiv_functor_sigma' 1
+                (fun p => (equiv_path_sigma _ _ _)^-1)).
   Defined.
 
   Definition hfiber_compose (c : C)

--- a/theories/Modalities/Closed.v
+++ b/theories/Modalities/Closed.v
@@ -68,11 +68,13 @@ Module ClosedModalities <: Modalities.
   : T -> O_reflector@{u a i} O T
     := fun x => push (inr x).
 
-  Definition inO_equiv_inO (O : Modality@{u a}) (T U : Type@{i})
-     (T_inO : In@{u a i} O T) (f : T -> U) (feq : IsEquiv@{i i} f)
-  : In@{u a i} O U.
+  Definition inO_equiv_inO (O : Modality@{u a}) (T : Type@{i}) (U : Type@{j})
+     (T_inO : In@{u a i} O T) (f : T -> U) (feq : IsEquiv f)
+  : let gei := ((fun x => x) : Type@{i} -> Type@{k}) in
+    let gej := ((fun x => x) : Type@{j} -> Type@{k}) in
+    In@{u a j} O U.
   Proof.
-    intros u; pose (T_inO u).
+    cbn; intros u; pose (T_inO u).
     refine (contr_equiv _ f); exact _.
   Defined.
 

--- a/theories/Modalities/Identity.v
+++ b/theories/Modalities/Identity.v
@@ -34,9 +34,11 @@ Module Identity_Modalities <: Modalities.
     := fun O X x => x.
 
   Definition inO_equiv_inO :
-      forall (O : Modality@{u a}) (T U : Type@{i})
+      forall (O : Modality@{u a}) (T : Type@{i}) (U : Type@{j})
              (T_inO : In@{u a i} O T) (f : T -> U) (feq : IsEquiv f),
-        In@{u a i} O U
+        let gei := ((fun x => x) : Type@{i} -> Type@{k}) in
+        let gej := ((fun x => x) : Type@{j} -> Type@{k}) in
+        In@{u a j} O U
     := fun O T U _ _ _ => tt.
 
   Definition hprop_inO

--- a/theories/Modalities/Lex.v
+++ b/theories/Modalities/Lex.v
@@ -195,10 +195,9 @@ Module Type Preserves_Fibers (Os : ReflectiveSubuniverses).
 
 End Preserves_Fibers.
 
-(** We omit the module type as with [ReflectiveSubuniverses_to_Modalities]; see below. *)
 Module Lex_Reflective_Subuniverses
-       (Os : ReflectiveSubuniverses) (Opf : Preserves_Fibers Os).
-  (** <: SigmaClosed Os. *)
+       (Os : ReflectiveSubuniverses) (Opf : Preserves_Fibers Os)
+  <: SigmaClosed Os.
 
   Import Opf.
 
@@ -208,27 +207,31 @@ Module Lex_Reflective_Subuniverses
              (B_inO : forall a, In@{u a j} O (B a))
   : In@{u a k} O {x:A & B x}.
   Proof.
-    pose (g := O_rec pr1 : O {x : A & B x} -> A).
+    pose (g := O_rec@{u a k i k k i} pr1 : O {x : A & B x} -> A).
     transparent assert (p : (forall x, g (to O _ x) = x.1)).
     { intros x; subst g; apply O_rec_beta. }
-    apply inO_isequiv_to_O.
+    apply inO_isequiv_to_O@{u a k k}.
     apply isequiv_fcontr; intros x.
-    refine (contr_equiv' _ (hfiber_hfiber_compose_map _ g x)).
+    refine (contr_equiv' _ (hfiber_hfiber_compose_map@{k k i k k k k k k} _ g x)).
     apply fcontr_isequiv.
     unfold hfiber_compose_map.
-    transparent assert (h : (hfiber (@pr1 A B) (g x) <~> hfiber g (g x))).
-    { refine (_ oE equiv_to_O O _).
-      - refine (_ oE BuildEquiv _ _ (O_functor_hfiber O (@pr1 A B) (g x)) _).
+    transparent assert (h : (Equiv@{k k} (hfiber@{k i} (@pr1 A B) (g x))
+                                         (hfiber@{k i} g (g x)))).
+    { refine (_ oE equiv_to_O@{u a k k} O _).
+      - refine (_ oE BuildEquiv _ _
+                  (O_functor_hfiber@{u a k i k k i k irrelevant k k k k k k}
+                                   O (@pr1 A B) (g x)) _).
         unfold hfiber.
         refine (equiv_functor_sigma' 1 _). intros y; cbn.
         refine (_ oE (equiv_moveR_equiv_V _ _)).
         apply equiv_concat_l.
         apply moveL_equiv_V.
         unfold g, O_functor.
-        revert y; apply O_indpaths; intros [a q]; cbn.
+        revert y; apply O_indpaths@{u a k i i k k}; intros [a q]; cbn.
         refine (_ @ (O_rec_beta _ _)^).
         apply ap, O_rec_beta.
-      - refine (inO_equiv_inO _ (hfiber_fibration (g x) B)). }
+      - refine (inO_equiv_inO@{dwim1 dwim2 dwim3 dwim4 k} _
+                 (hfiber_fibration@{i j k k} (g x) B)). }
     refine (isequiv_homotopic (h oE equiv_hfiber_homotopic _ _ p (g x)) _).
     intros [[a b] q]; cbn. clear h.
     unfold O_functor_hfiber.
@@ -249,7 +252,6 @@ Module Lex_Reflective_Subuniverses
     Close Scope long_path_scope.
   Qed.
 
-(** As with [ReflectiveSubuniverses_to_Modalities], Coq won't actually accept this as a module of type [SigmaClosed Os] because the above proof introduces way too many universe parameters.  It might be possible to bring it down to become acceptable with heavy use of universe annotations, but this is probably not worthwhile bothering about because the only point of [SigmaClosed] is to be passed to [ReflectiveSubuniverses_to_Modalities], which in turn can't actually instantiate [Modalities] for more fundamental reasons.  *)
 End Lex_Reflective_Subuniverses.
 
 (** ** Accessible lex modalities *)

--- a/theories/Modalities/Localization.v
+++ b/theories/Modalities/Localization.v
@@ -253,12 +253,19 @@ Qed.
 Import IsLocal_Internal.
 
 Definition islocal_equiv_islocal (f : LocalGenerators@{a})
-           (X : Type@{i}) {Y : Type@{i}}
-           (Xloc : IsLocal@{i i a} f X)
+           (X : Type@{i}) {Y : Type@{j}}
+           (Xloc : IsLocal@{i i' a} f X)
            (g : X -> Y) `{IsEquiv@{i j} _ _ g}
-: IsLocal@{j j a} f Y
-  := fun i => ooextendable_postcompose _ _ (f i) (fun _ => g) (Xloc i).
-
+: IsLocal@{j j' a} f Y.
+Proof.
+  intros i.
+  (** We have to fiddle with the max universes to get this to work, since [ooextendable_postcompose] requires the max universe in both cases to be the same, whereas we don't want to assume that the hypothesis and conclusion are related in any way. *)
+  apply lift_ooextendablealong@{a a j k j'}.
+  refine (ooextendable_postcompose@{a a i j k k k k k k k}
+            _ _ (f i) (fun _ => g) _).
+  apply lift_ooextendablealong@{a a i i' k}.
+  apply Xloc.
+Defined.
 
 (** ** Localization as a HIT *)
 
@@ -359,9 +366,10 @@ Module Localization_ReflectiveSubuniverses <: ReflectiveSubuniverses.
     := fun O => @loc@{a i} (unLoc O).
 
   Definition inO_equiv_inO :
-    forall (O : ReflectiveSubuniverse@{u a}) (T U : Type@{i}),
-      In@{u a i} O T -> forall f : T -> U, IsEquiv f -> In@{u a i} O U
-    := fun O => islocal_equiv_islocal@{a i i} (unLoc O).
+    forall (O : ReflectiveSubuniverse@{u a}) (T : Type@{i}) (U : Type@{j}),
+      In@{u a i} O T -> forall f : T -> U, IsEquiv f ->
+      In@{u a j} O U
+    := fun O => islocal_equiv_islocal@{a i j i j k} (unLoc O).
 
   Definition hprop_inO `{Funext}
              (O : ReflectiveSubuniverse@{u a}) (T : Type@{i})

--- a/theories/Modalities/Modality.v
+++ b/theories/Modalities/Modality.v
@@ -31,10 +31,13 @@ Module Type Modalities.
   Check to@{u a i}.
 
   Parameter inO_equiv_inO :
-      forall (O : Modality@{u a}) (T U : Type@{i})
+      forall (O : Modality@{u a}) (T : Type@{i}) (U : Type@{j})
              (T_inO : In@{u a i} O T) (f : T -> U) (feq : IsEquiv f),
-        In@{u a i} O U.
-  Check inO_equiv_inO@{u a i}.
+        (** We add an extra universe parameter that's bigger than both [i] and [j].  This seems to be necessary for the proof of repleteness in some examples, such as easy modalities. *)
+        let gei := ((fun x => x) : Type@{i} -> Type@{k}) in
+        let gej := ((fun x => x) : Type@{j} -> Type@{k}) in
+        In@{u a j} O U.
+  Check inO_equiv_inO@{u a i j k}.
 
   Parameter hprop_inO
   : Funext -> forall (O : Modality@{u a}) (T : Type@{i}),
@@ -110,10 +113,10 @@ Module Modalities_to_ReflectiveSubuniverses
     := O_inO@{u a i}.
   Definition to := to.
   Definition inO_equiv_inO :
-      forall (O : ReflectiveSubuniverse@{u a}) (T U : Type@{i})
+      forall (O : ReflectiveSubuniverse@{u a}) (T : Type@{i}) (U : Type@{j})
              (T_inO : In@{u a i} O T) (f : T -> U) (feq : IsEquiv f),
-        In@{u a i} O U
-    := inO_equiv_inO@{u a i}.
+        In@{u a j} O U
+    := inO_equiv_inO@{u a i j k}.
   Definition hprop_inO
   : Funext -> forall (O : ReflectiveSubuniverse@{u a}) (T : Type@{i}),
                 IsHProp (In@{u a i} O T)
@@ -159,7 +162,7 @@ Module ReflectiveSubuniverses_to_Modalities
   Definition In := In@{u a i}.
   Definition O_inO := @O_inO@{u a i}.
   Definition to := to.
-  Definition inO_equiv_inO := @inO_equiv_inO@{u a i}.
+  Definition inO_equiv_inO := @inO_equiv_inO@{u a i j k}.
   Definition hprop_inO := hprop_inO@{u a i}.
 
   (** The reason Coq won't actually accept this as a module of type [Modalities] is that the following definitions of [O_ind_internal] and [O_ind_beta_internal] have an extra universe parameter [k] that's at least as large as both [i] and [j].  This is because [extendable_to_O] has such a parameter, which in turn is because [ooExtendableAlong] does.  Unfortunately, we can't directly instantiate [k] to [max(i,j)] because Coq doesn't allow "algebraic universes" in arbitrary position.  We could probably work around it by defining [ExtendableAlong] inductively rather than recursively, but given the non-usefulness of this construction in practice, that doesn't seem to be worth the trouble at the moment. *)
@@ -290,9 +293,9 @@ Module EasyModalities_to_Modalities (Os : EasyModalities)
   Defined.
 
   (** It seems to be surprisingly hard to show repleteness (without univalence).  We basically have to manually develop enough functoriality of [O] and naturality of [to O]. *)
-  Definition inO_equiv_inO (O : Modality@{u a}) (A B : Type@{i})
+  Definition inO_equiv_inO (O : Modality@{u a}) (A : Type@{i}) (B : Type@{j})
     (A_inO : In@{u a i} O A) (f : A -> B) (feq : IsEquiv f)
-  : In@{u a i} O B.
+  : In@{u a j} O B.
   Proof.
     refine (isequiv_commsq (to O A) (to O B) f
              (O_ind_internal O A (fun _ => O_reflector O B) _ (fun a => to O B (f a))) _).
@@ -1130,7 +1133,7 @@ Module Modalities_Restriction
   Definition to (O : Modality@{u a})
     := Os.to@{u a i} (Res.Modalities_restriction O).
   Definition inO_equiv_inO (O : Modality@{u a})
-    := Os.inO_equiv_inO@{u a i} (Res.Modalities_restriction O).
+    := Os.inO_equiv_inO@{u a i j k} (Res.Modalities_restriction O).
   Definition hprop_inO (H : Funext) (O : Modality@{u a})
     := Os.hprop_inO@{u a i} H (Res.Modalities_restriction O).
   Definition O_ind_internal (O : Modality@{u a})
@@ -1182,12 +1185,12 @@ Module Modalities_FamUnion (Os1 Os2 : Modalities)
   Defined.
 
   Definition inO_equiv_inO :
-      forall (O : Modality@{u a}) (T U : Type@{i})
+      forall (O : Modality@{u a}) (T : Type@{i}) (U : Type@{j})
              (T_inO : In@{u a i} O T) (f : T -> U) (feq : IsEquiv f),
-        In@{u a i} O U.
+        In@{u a j} O U.
   Proof.
-    intros [O|O]; [ exact (Os1.inO_equiv_inO@{u a i} O)
-                  | exact (Os2.inO_equiv_inO@{u a i} O) ].
+    intros [O|O]; [ exact (Os1.inO_equiv_inO@{u a i j k} O)
+                  | exact (Os2.inO_equiv_inO@{u a i j k} O) ].
   Defined.
 
   Definition hprop_inO

--- a/theories/Modalities/Nullification.v
+++ b/theories/Modalities/Nullification.v
@@ -66,7 +66,7 @@ Module Nullification_Modalities <: Modalities.
   Definition In := LocRSU.In.
   Definition O_inO := @LocRSU.O_inO.
   Definition to := LocRSU.to.
-  Definition inO_equiv_inO := @LocRSU.inO_equiv_inO.
+  Definition inO_equiv_inO := @LocRSU.inO_equiv_inO@{u a i j k}.
   Definition hprop_inO := LocRSU.hprop_inO.
 
   Definition O_ind_internal (O : Modality@{u a}) (A : Type@{i})

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -277,11 +277,12 @@ Section Reflective_Subuniverse.
   Defined.
 
   (** If [T] is in the subuniverse, then [to O T] is an equivalence. *)
-  Global Instance isequiv_to_O_inO (T : Type) `{In O T} : IsEquiv (to O T).
+  Global Instance isequiv_to_O_inO (T : Type@{i}) `{In O T} : IsEquiv@{i i} (to O T).
   Proof.
-    pose (g := O_rec idmap).
+    (** Using universe annotations to reduce superfluous universes *)
+    pose (g := O_rec@{u a i i i i i} idmap).
     refine (isequiv_adjointify (to O T) g _ _).
-    - refine (O_indpaths (to O T o g) idmap _).
+    - refine (O_indpaths@{u a i i i i i} (to O T o g) idmap _).
       intros x.
       apply ap.
       apply O_rec_beta.

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -124,10 +124,13 @@ Module Type ReflectiveSubuniverses.
   Check to@{u a i}.
 
   Parameter inO_equiv_inO :
-      forall (O : ReflectiveSubuniverse@{u a}) (T U : Type@{i})
+      forall (O : ReflectiveSubuniverse@{u a}) (T : Type@{i}) (U : Type@{j})
              (T_inO : In@{u a i} O T) (f : T -> U) (feq : IsEquiv f),
-        In@{u a i} O U.
-  Check inO_equiv_inO@{u a i}.
+        (** We add an extra universe parameter that's bigger than both [i] and [j].  This seems to be necessary for the proof of repleteness in some examples, such as easy modalities. *)
+        let gei := ((fun x => x) : Type@{i} -> Type@{k}) in
+        let gej := ((fun x => x) : Type@{j} -> Type@{k}) in
+        In@{u a j} O U.
+  Check inO_equiv_inO@{u a i j k}.
 
   (** In most examples, [Funext] is necessary to prove that the predicate of being in the subuniverse is an hprop.  To avoid needing to assume [Funext] as a global hypothesis when constructing such examples, and since [Funext] is often not needed for any of the rest of the theory, we add it as a hypothesis to this specific field. *)
   Parameter hprop_inO
@@ -1162,7 +1165,7 @@ Module ReflectiveSubuniverses_Restriction
   Definition to (O : ReflectiveSubuniverse@{u a})
     := Os.to@{u a i} (Res.ReflectiveSubuniverses_restriction O).
   Definition inO_equiv_inO (O : ReflectiveSubuniverse@{u a})
-    := Os.inO_equiv_inO@{u a i} (Res.ReflectiveSubuniverses_restriction O).
+    := Os.inO_equiv_inO@{u a i j k} (Res.ReflectiveSubuniverses_restriction O).
   Definition hprop_inO (H : Funext) (O : ReflectiveSubuniverse@{u a})
     := Os.hprop_inO@{u a i} H (Res.ReflectiveSubuniverses_restriction O).
   Definition extendable_to_O (O : ReflectiveSubuniverse@{u a})
@@ -1212,12 +1215,12 @@ Module ReflectiveSubuniverses_FamUnion
   Defined.
 
   Definition inO_equiv_inO :
-      forall (O : ReflectiveSubuniverse@{u a}) (T U : Type@{i})
+      forall (O : ReflectiveSubuniverse@{u a}) (T : Type@{i}) (U : Type@{j})
              (T_inO : In@{u a i} O T) (f : T -> U) (feq : IsEquiv f),
-        In@{u a i} O U.
+        In@{u a j} O U.
   Proof.
-    intros [O|O]; [ exact (Os1.inO_equiv_inO@{u a i} O)
-                  | exact (Os2.inO_equiv_inO@{u a i} O) ].
+    intros [O|O]; [ exact (Os1.inO_equiv_inO@{u a i j k} O)
+                  | exact (Os2.inO_equiv_inO@{u a i j k} O) ].
   Defined.
 
   Definition hprop_inO

--- a/theories/hit/Truncations.v
+++ b/theories/hit/Truncations.v
@@ -72,7 +72,10 @@ Module Truncation_Modalities <: Modalities.
   Definition to (n : Modality@{u u'}) A := @tr n A.
 
   Definition inO_equiv_inO (n : Modality@{u u'})
-             (A B : Type@{i}) Atr f feq
+             (A : Type@{i}) (B : Type@{j}) Atr f feq
+  : let gei := ((fun x => x) : Type@{i} -> Type@{k}) in
+    let gej := ((fun x => x) : Type@{j} -> Type@{k}) in
+    In n B
   := @trunc_equiv A B f n Atr feq.
 
   Definition hprop_inO `{Funext} (n : Modality@{u u'}) A


### PR DESCRIPTION
There was one too-big universe coming from an application of `transitivity` to `Equiv` elsewhere, which I got rid of.  The collapsing of universes was due to repleteness not being able to move between universes, which seems like a serious bug in its own right, so I fixed it (though I had to introduce an extra "max" universe everywhere).  And in order to track those down I pretty much had to get rid of all the redundant universes anyway, so now it actually works.