### PR TITLE
Make [equiv_induction] a bit more robust

### DIFF
--- a/theories/Tactics/EquivalenceInduction.v
+++ b/theories/Tactics/EquivalenceInduction.v
@@ -5,9 +5,9 @@ Require Import HoTT.Basics HoTT.Types.
 
 Local Open Scope equiv_scope.
 
-Class RespectsEquivalenceL A (P : forall B, (A <~> B) -> Type)
+Class RespectsEquivalenceL (A : Type@{i}) (P : forall (B : Type@{j}), (A <~> B) -> Type)
   := respects_equivalenceL : { e' : forall B (e : A <~> B), P A (equiv_idmap A) <~> P B e & Funext -> equiv_idmap _ = e' A (equiv_idmap _) }.
-Class RespectsEquivalenceR A (P : forall B, (B <~> A) -> Type)
+Class RespectsEquivalenceR (A : Type@{i}) (P : forall (B : Type@{j}), (B <~> A) -> Type)
   := respects_equivalenceR : { e' : forall B (e : B <~> A), P A (equiv_idmap A) <~> P B e & Funext -> equiv_idmap _ = e' A (equiv_idmap _) }.
 (** We use a sigma type rather than a record for two reasons:
 
@@ -350,8 +350,9 @@ Ltac equiv_induction p :=
     move p' at top;
       generalize dependent y;
       let P := match goal with |- forall y p, @?P y p => constr:P end in
-      refine ((fun g H B e => (@respects_equivalenceL _ P H).1 B e g) _ _);
-        [ | repeat step_respects_equiv ].
+      (* We use [(fun x => x) _] to block automatic typeclass resolution in the hole for the equivalence respectful proof. *)
+      refine ((fun g H B e => (@respects_equivalenceL _ P H).1 B e g) _ (_ : (fun x => x) _));
+        [ intros | repeat step_respects_equiv ].
 
 Goal forall `{Funext} A B (e : A <~> B), A -> { y : B & forall Q, Contr Q -> ((e^-1 y = e^-1 y) <~> (y = y)) * Q }.
   intros ? ? ? ? a.

--- a/theories/Tests.v
+++ b/theories/Tests.v
@@ -34,3 +34,34 @@ Module Foo (Os : ReflectiveSubuniverses).
     pose test.
   Admitted.
 End Foo.
+
+(** Test 1 from issue #754 *)
+Module Issue754_1.
+  Inductive nat : Type1 :=
+  | O : nat
+  | S : nat -> nat.
+  Fixpoint code_nat (m n : nat) {struct m} : DProp.DHProp :=
+    match m with
+      | O => match n with
+               | O => DProp.True
+               | S _ => DProp.False
+             end
+      | S m' => match n with
+                  | O => DProp.False
+                  | S n' => code_nat m' n'
+                end
+    end.
+
+  Notation "x =n y" := (code_nat x y) : nat_scope.
+  Bind Scope nat_scope with nat.
+  Axiom equiv_path_nat :
+    forall n m : nat,
+      Trunc.trunctype_type (DProp.dhprop_hprop (n =n m)) <~> n = m.
+
+  Definition nat_discr `{Funext} {n: nat}: O <> S n.
+  Proof.
+    intro H'.
+    equiv_induction (@equiv_path_nat O (S n)).
+    assumption.
+  Qed.
+End Issue754_1.


### PR DESCRIPTION
This makes `equiv_induction` work even when typeclass resolution fully solves the side-condition.

Also add a test case from #754.