### PR TITLE
define TwoSphere recursion

### DIFF
--- a/theories/Basics/PathGroupoids.v
+++ b/theories/Basics/PathGroupoids.v
@@ -963,6 +963,27 @@ Definition concat2_1p {A : Type} {x y : A} {p q : x = y} (h : p = q) :
   :=
   match h with idpath => 1 end.
 
+Definition cancel2L {A : Type} {x y z : A} {p p' : x = y} {q q' : y = z} 
+           (g : p = p') (h k : q = q')
+: (g @@ h = g @@ k) -> (h = k).
+Proof.
+  intro r. induction g, p, q.
+  refine ((whiskerL_1p h)^ @ _). refine (_ @ (whiskerL_1p k)). 
+  refine (whiskerR _ _). refine (whiskerL _ _).
+  apply r.
+Defined.
+
+Definition cancel2R {A : Type} {x y z : A} {p p' : x = y} {q q' : y = z} 
+           (g h : p = p') (k : q = q')
+: (g @@ k = h @@ k) -> (g = h).
+Proof.
+  intro r. induction k, p, q.
+  refine ((whiskerR_p1 g)^ @ _). refine (_ @ (whiskerR_p1 h)).
+  refine (whiskerR _ _). refine (whiskerL _ _).
+  apply r.
+Defined.
+
+
 (** Whiskering and composition *)
 
 (* The naming scheme for these is a little unclear; should [pp] refer to concatenation of the 2-paths being whiskered or of the paths we are whiskering by? *)
@@ -1089,6 +1110,16 @@ Definition apD02 {A : Type} {B : A -> Type} {x y : A} {p q : x = y}
   (f : forall x, B x) (r : p = q)
   : apD f p = transport2 B r (f x) @ apD f q
   := match r with idpath => (concat_1p _)^ end.
+
+Definition apD02_const {A B : Type} (f : A -> B) {x y : A} {p q : x = y} (r : p = q)
+: apD02 f r = (apD_const f p) 
+              @ (transport2_const r (f x) @@ ap02 f r)
+              @ (concat_p_pp _ _ _)^
+              @ (whiskerL (transport2 _ r (f x)) (apD_const f q)^)
+:=
+  match r with idpath =>
+    match p with idpath => 1
+    end end.
 
 (* And now for a lemma whose statement is much longer than its proof. *)
 Definition apD02_pp {A} (B : A -> Type) (f : forall x:A, B x) {x y : A}

--- a/theories/hit/TwoSphere.v
+++ b/theories/hit/TwoSphere.v
@@ -17,30 +17,55 @@ Private Inductive S2 : Type0 :=
 
 Axiom surf : idpath base = idpath base.
 
-Definition S2_ind (P : S2 -> Type) (b : P base) (l : transport2 P surf b = idpath b)
+Definition S2_ind (P : S2 -> Type) (b : P base) (s : idpath b = transport2 P surf b)
   : forall (x:S2), P x
-  := fun x => match x with base => fun _ => b end l.
+  := fun x => match x with base => fun _ => b end s.
 
-Axiom S2_ind_beta_loop
-  : forall (P : S2 -> Type) (b : P base) (l : transport2 P surf b = idpath b),
-      apD02 (S2_ind P b l) surf = l^ @ (concat_p1 _)^.
+Axiom S2_ind_beta_surf
+  : forall (P : S2 -> Type) (b : P base) (s : idpath b = transport2 P surf b),
+      apD02 (S2_ind P b s) surf = s @ (concat_p1 _)^.
 
 End TwoSphere.
 
 (* ** The non-dependent eliminator *)
 
-Definition S2_rec (P : Type) (b : P) (l : idpath b = idpath b)
+Definition S2_rec (P : Type) (b : P) (s : idpath b = idpath b)
   : S2 -> P
-  := S2_ind (fun _ => P) b ((concat_p1 _)^ @ (transport2_const surf b)^ @ l).
+  := S2_ind (fun _ => P) b (s @ (transport2_const surf b) @ (concat_p1 _)).
 
-(** TODO: Write the non-dependent eliminator.  It's probably something like
-<<
-Definition S1_rec_beta_loop (P : Type) (b : P) (l : idpath b = idpath b)
-: ap02 (S2_rec P b l) surf = l^ @ (concat_p1 _)^.
+
+Definition S2_rec_beta_surf (P : Type) (b : P) (s : idpath b = idpath b)
+: ap02 (S2_rec P b s) surf = s.
 Proof.
-  unfold S2_rec.
-  refine (cancelL (transport2_const surf b)^ _ _ _).
-  refine (cancelL ((concat_p1 (transport2 (fun _ : S2 => P) surf b))^) _ _ _).
-...
->>
-*)
+  apply (cancel2L (transport2_const surf b)).
+  apply (cancelL (apD_const (S2_rec P b s) (idpath base))).
+  apply (cancelR _ _ (concat_p_pp _ (transport_const _ b) _)^).
+  apply (cancelR _ _ (whiskerL (transport2 _ surf b) (apD_const _ _)^)).
+  refine ((apD02_const (S2_rec P b s) surf)^ @ _).
+  refine ((S2_ind_beta_surf _ _ _) @ _).
+  refine (_ @ (ap (fun w => _ @ w) 
+                  (triangulator 
+                     (transport2 (fun _ : S2 => P) surf b) _))). 
+  cbn. refine (_ @ (ap (fun w => (w @ _) @ _) (concat_1p _)^)).
+  
+  refine (_ @ (concat_p_pp _ _ _)).
+  refine (_ @ (ap (fun w => _ @ w) (concat_pp_p _ _ _))).
+  refine (_ @ (ap (fun w => _ @ (w @ _)) (concat_Vp _)^)).
+  refine (_ @ (ap (fun w => _ @ (w @ _)) 
+                  (concat_pV (concat_p1 
+                                (transport2 (fun _ : S2 => P) surf b @ 1))))).
+  refine (_ @ (ap (fun w => _ @ w) (concat_p_pp _ _ _))).
+  refine (_ @ (concat_pp_p _ _ _)). apply moveR_pV.
+  refine (_ @ (concat_p_pp _ _ _)).
+  refine (_ @ (ap (fun w => _ @ w) (whiskerR_p1 _)^)). f_ap.
+  refine ((ap (fun w => w @ _) (whiskerL_1p_1 _)^) @ _).
+  refine ((ap (fun w => _ @ w) (whiskerR_p1 _)^) @ _). cbn.
+  refine ((concat_p_pp _ _ _) @ _). f_ap.
+  refine ((ap (fun w => _ @ w) (concat_1p _)) @ _).
+  refine ((concat_whisker 1 _ _ 1 (transport2_const surf b) s)^ @ _).
+  
+  symmetry.
+  refine ((ap (fun w => w @@ _) (concat_p1 _)^) @ _).
+  refine ((ap (fun w => _ @@ w) (concat_1p _)^) @ _).
+  refine ((concat_concat2 _ _ _ _)^ @ _). f_ap.
+Defined.


### PR DESCRIPTION
I changed the type of S2_ind to match Chapter 6 of the HoTT Book, and changed S2_ind_beta_loop to S2_ind_beta_surf. I added some lemmas used in the definition of S2_rec_beta_surf to PathGroupoids.v.

I also constructed an equivalence S2 <~> Sphere 2 ([here](https://github.com/jdoughertyii/HoTT/blob/spheres_with_S2/theories/hit/Spheres.v#L78)), but it's not included in this pull request because it takes a full minute and a half to compile.  I don't know if that's something that would be worth trying to improve and submit.