### PR TITLE
S2 <~> Sphere 2

### DIFF
--- a/contrib/Freudenthal.v
+++ b/contrib/Freudenthal.v
@@ -197,7 +197,7 @@ Definition FST_Codes_transportD (x1 : X) (p : No = No) (rr : FST_Codes No p)
 Proof.
   refine (transportD_as_apD _ _ _ _ _ @ _).
   unfold transportD'.
-  unfold FST_Codes. rewrite (Susp_comp_merid _ _ _ _ x1); simpl.
+  unfold FST_Codes. rewrite (Susp_ind_beta_merid _ _ _ _ x1); simpl.
     rewrite (@ap10_path_forall (fst funext_large)).
   unfold FST_Codes_transportD_concrete.
   rewrite ! transport_pp.

--- a/theories/Basics/PathGroupoids.v
+++ b/theories/Basics/PathGroupoids.v
@@ -858,6 +858,14 @@ Notation "p @@ q" := (concat2 p q)%path (at level 20) : path_scope.
 
 Arguments concat2 : simpl nomatch.
 
+Lemma concat2_ap_ap {A B : Type} {x' y' z' : B} 
+           (f : A -> (x' = y')) (g : A -> (y' = z'))
+           {x y : A} (p : x = y) 
+: (ap f p) @@ (ap g p) = ap (fun u => f u @ g u) p.
+Proof.
+    by path_induction.
+Defined.
+
 (** 2-dimensional path inversion *)
 Definition inverse2 {A : Type} {x y : A} {p q : x = y} (h : p = q)
   : p^ = q^


### PR DESCRIPTION
Construct an equivalence S2 <~> Sphere 2. Rename beta principles for suspensions to match other HITs.  The compile time for Spheres.v is up to 3.3s, but this is as fast as I could get it.
