### PR TITLE
Add `contrib` directory to default `LoadPath` of `hoqtop`, `hoqc`, etc.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -225,7 +225,7 @@ $(MAIN_VFILES:.v=.vi) : %.vi : %.v $(STD_VOFILES) coq-HoTT
 # The deps file, for graphs
 HoTT.deps: $(ALL_VFILES)
 	$(VECHO) COQDEP > $@
-	$(Q) "$(COQDEP)" -nois -coqlib "$(SRCCOQLIB)" -R "$(srcdir)/theories" HoTT -R "$(SRCCOQLIB)/theories" Coq $(ALL_VFILES) | sed s'#\\#/#g' >$@
+	$(Q) "$(COQDEP)" -nois -coqlib "$(SRCCOQLIB)" -R "$(srcdir)/theories" HoTT -Q "$(srcdir)/contrib" "" -R "$(SRCCOQLIB)/theories" Coq $(ALL_VFILES) | sed s'#\\#/#g' >$@
 
 HoTTCore.deps: $(CORE_VFILES)
 	$(VECHO) COQDEP > $@
@@ -238,7 +238,7 @@ HoTTCore.deps: $(CORE_VFILES)
 html-done.timestamp: $(ALL_GLOBFILES) $(ALL_VFILES)
 	- $(mkdir_p) html
 	touch html-done.timestamp
-	"$(COQDOC)" -toc -interpolate -utf8 -html --coqlib_path "$(SRCCOQLIB)" --no-externals -R "$(srcdir)/theories" HoTT -R "$(SRCCOQLIB)/theories" Coq -d html $(ALL_VFILES)
+	"$(COQDOC)" -toc -interpolate -utf8 -html --coqlib_path "$(SRCCOQLIB)" --no-externals -R "$(srcdir)/theories" HoTT -Q "$(srcdir)/contrib" "" -R "$(SRCCOQLIB)/theories" Coq -d html $(ALL_VFILES)
 
 html:
 	rm -f html-done.timestamp
@@ -368,7 +368,7 @@ TAGS : $(TAGS_FILES)
 # Dependency files
 $(MAIN_DEPFILES) : %.d : %.v
 	$(VECHO) COQDEP $<
-	$(Q) "$(COQDEP)" -nois -coqlib "$(SRCCOQLIB)" -R "$(srcdir)/theories" HoTT -R "$(SRCCOQLIB)/theories" Coq $< | sed s'#\\#/#g' >$@
+	$(Q) "$(COQDEP)" -nois -coqlib "$(SRCCOQLIB)" -R "$(srcdir)/theories" HoTT -Q "$(srcdir)/contrib" "" -R "$(SRCCOQLIB)/theories" Coq $< | sed s'#\\#/#g' >$@
 
 $(STD_DEPFILES) : %.d : %.v
 	$(VECHO) COQDEP $<

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,4 +1,5 @@
 -R theories HoTT
+-Q contrib ""
 COQC = hoqc
 
 theories/Basics/Notations.v

--- a/etc/dpdgraph-0.4alpha/hoqthmdep
+++ b/etc/dpdgraph-0.4alpha/hoqthmdep
@@ -41,4 +41,4 @@ fi
 # or using more evil (but portable) 'eval', do
 # $ eval 'exec "$COQTOP" '"$COQ_ARGS"' "$@"'
 # Instead, we duplicate code, because it's simpler.
-exec "$mythmdepdir/coqthmdep" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -R "$HOTTCONTRIB" "" -indices-matter "$@"
+exec "$mythmdepdir/coqthmdep" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -Q "$HOTTCONTRIB" "" -indices-matter "$@"

--- a/etc/dpdgraph-0.4alpha/hoqthmdep
+++ b/etc/dpdgraph-0.4alpha/hoqthmdep
@@ -41,4 +41,4 @@ fi
 # or using more evil (but portable) 'eval', do
 # $ eval 'exec "$COQTOP" '"$COQ_ARGS"' "$@"'
 # Instead, we duplicate code, because it's simpler.
-exec "$mythmdepdir/coqthmdep" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -indices-matter "$@"
+exec "$mythmdepdir/coqthmdep" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -R "$HOTTCONTRIB" "" -indices-matter "$@"

--- a/hoq-config.in
+++ b/hoq-config.in
@@ -43,7 +43,7 @@ if test -d "$mydir/coq/theories"
 then
   export COQLIB="$mydir/coq"
   export HOTTLIB="$mydir/theories"
-  export HOTTCONTRIB="${prefix}/contrib"
+  export HOTTCONTRIB="$mydir/contrib"
 else
   export COQLIB="${prefix}/share/hott/coq"
   export HOTTLIB="${prefix}/share/hott/theories"

--- a/hoq-config.in
+++ b/hoq-config.in
@@ -43,8 +43,10 @@ if test -d "$mydir/coq/theories"
 then
   export COQLIB="$mydir/coq"
   export HOTTLIB="$mydir/theories"
+  export HOTTCONTRIB="${prefix}/contrib"
 else
-  export COQLIB="@hottdir@/coq"
-  export HOTTLIB="@hottdir@/theories"
+  export COQLIB="${prefix}/share/hott/coq"
+  export HOTTLIB="${prefix}/share/hott/theories"
+  export HOTTCONTRIB="${prefix}/share/hott/contrib"
 fi
-#export COQ_ARGS=(-no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -indices-matter)
+#export COQ_ARGS=(-no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" -R "$HOTTCONTRIB" "" -indices-matter)

--- a/hoq-config.in
+++ b/hoq-config.in
@@ -49,4 +49,4 @@ else
   export HOTTLIB="${prefix}/share/hott/theories"
   export HOTTCONTRIB="${prefix}/share/hott/contrib"
 fi
-#export COQ_ARGS=(-no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" -R "$HOTTCONTRIB" "" -indices-matter)
+#export COQ_ARGS=(-no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -Q "$HOTTCONTRIB" "" -indices-matter)

--- a/hoq-config.in
+++ b/hoq-config.in
@@ -45,8 +45,8 @@ then
   export HOTTLIB="$mydir/theories"
   export HOTTCONTRIB="$mydir/contrib"
 else
-  export COQLIB="${prefix}/share/hott/coq"
-  export HOTTLIB="${prefix}/share/hott/theories"
-  export HOTTCONTRIB="${prefix}/share/hott/contrib"
+  export COQLIB="@hottdir@/coq"
+  export HOTTLIB="@hottdir@/theories"
+  export HOTTCONTRIB="@hottdir@/contrib"
 fi
 #export COQ_ARGS=(-no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -Q "$HOTTCONTRIB" "" -indices-matter)

--- a/hoqc
+++ b/hoqc
@@ -46,4 +46,4 @@ fi
 # or using more evil (but portable) 'eval', do
 # $ eval 'exec "$COQC" '"$COQ_ARGS"' "$@"'
 # Instead, we duplicate code, because it's simpler.
-exec "$COQC" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -R "$HOTTCONTRIB" "" -indices-matter "$@"
+exec "$COQC" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -Q "$HOTTCONTRIB" "" -indices-matter "$@"

--- a/hoqc
+++ b/hoqc
@@ -46,4 +46,4 @@ fi
 # or using more evil (but portable) 'eval', do
 # $ eval 'exec "$COQC" '"$COQ_ARGS"' "$@"'
 # Instead, we duplicate code, because it's simpler.
-exec "$COQC" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -indices-matter "$@"
+exec "$COQC" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -R "$HOTTCONTRIB" "" -indices-matter "$@"

--- a/hoqdep
+++ b/hoqdep
@@ -46,4 +46,4 @@ fi
 # or using more evil (but portable) 'eval', do
 # $ eval 'exec "$COQDEP" '"$COQ_ARGS"' "$@"'
 # Instead, we duplicate code, because it's simpler.
-exec "$COQDEP" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -indices-matter "$@"
+exec "$COQDEP" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -Q "$HOTTCONTRIB" "" -indices-matter "$@"

--- a/hoqide
+++ b/hoqide
@@ -46,4 +46,4 @@ fi
 # or using more evil (but portable) 'eval', do
 # $ eval 'exec "$COQIDE" '"$COQ_ARGS"' "$@"'
 # Instead, we duplicate code, because it's simpler.
-exec "$COQIDE" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -indices-matter "$@"
+exec "$COQIDE" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -R "$HOTTCONTRIB" "" -indices-matter "$@"

--- a/hoqide
+++ b/hoqide
@@ -46,4 +46,4 @@ fi
 # or using more evil (but portable) 'eval', do
 # $ eval 'exec "$COQIDE" '"$COQ_ARGS"' "$@"'
 # Instead, we duplicate code, because it's simpler.
-exec "$COQIDE" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -R "$HOTTCONTRIB" "" -indices-matter "$@"
+exec "$COQIDE" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -Q "$HOTTCONTRIB" "" -indices-matter "$@"

--- a/hoqtop
+++ b/hoqtop
@@ -46,4 +46,4 @@ fi
 # or using more evil (but portable) 'eval', do
 # $ eval 'exec "$COQTOP" '"$COQ_ARGS"' "$@"'
 # Instead, we duplicate code, because it's simpler.
-exec "$COQTOP" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -indices-matter "$@"
+exec "$COQTOP" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -R "$HOTTCONTRIB" "" -indices-matter "$@"

--- a/hoqtop
+++ b/hoqtop
@@ -46,4 +46,4 @@ fi
 # or using more evil (but portable) 'eval', do
 # $ eval 'exec "$COQTOP" '"$COQ_ARGS"' "$@"'
 # Instead, we duplicate code, because it's simpler.
-exec "$COQTOP" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -R "$HOTTCONTRIB" "" -indices-matter "$@"
+exec "$COQTOP" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -Q "$HOTTCONTRIB" "" -indices-matter "$@"

--- a/hoqtop.byte
+++ b/hoqtop.byte
@@ -46,4 +46,4 @@ fi
 # or using more evil (but portable) 'eval', do
 # $ eval 'exec "$COQTOP.byte" '"$COQ_ARGS"' "$@"'
 # Instead, we duplicate code, because it's simpler.
-exec "$COQTOP.byte" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -R "$HOTTCONTRIB" "" -indices-matter "$@"
+exec "$COQTOP.byte" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -Q "$HOTTCONTRIB" "" -indices-matter "$@"

--- a/hoqtop.byte
+++ b/hoqtop.byte
@@ -46,4 +46,4 @@ fi
 # or using more evil (but portable) 'eval', do
 # $ eval 'exec "$COQTOP.byte" '"$COQ_ARGS"' "$@"'
 # Instead, we duplicate code, because it's simpler.
-exec "$COQTOP.byte" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -indices-matter "$@"
+exec "$COQTOP.byte" -no-native-compiler -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -R "$HOTTCONTRIB" "" -indices-matter "$@"


### PR DESCRIPTION
In standard coq, there is a `user-contrib` directory where additional libraries can be installed, and this is available automatically at the top level of the initial `LoadPath`, so that contributed libraries can be loaded by their own names, with no additional prefix.  This gives a canonical way for contributed libraries to invoke each other.

Currently, there doesn’t seem to be an analogous canonical place to install further libraries over the `HoTT` library.  The repo provides a `contrib` directory (currently containing three individual `.v` files), but this is not by default available in the `LoadPath`.

This pull request adds that `contrib` directory to the default `LoadPath` in `hoqtop` (and other scripts), making its contents available with no additional toplevel prefix, just like the situation over standard `coq`.  So, for instance, the library `…/contrib/HoTTBook.vo` can now be loaded in any `hoqtop` session by `Require Import HoTTBook.`  Moreover, users can install further libraries in this directory, and load them by their names.

(There is probably a larger discussion to be had here about how we should best set things up for independent installation and management of libraries based over HoTT. This pull request is just intended as a minimal first step, making usable the directory that we already have.)
