### PR TITLE
Bugfix #4527 Add universe annotations

### DIFF
--- a/theories/Extensions.v
+++ b/theories/Extensions.v
@@ -29,7 +29,7 @@ Section Extensions.
       - >= max(A,P).
     The following [Check] verifies that this is in fact the case. *)
   (** We would like to say [Check], but because of bug #4517, https://coq.inria.fr/bugs/show_bug.cgi?id=4517, we can't. *)
-  Definition check_ExtensionAlong@{a b p m n} : True.
+  Definition check_ExtensionAlong@{a b p m n} : True@{Set}.
   Proof.
     Check ExtensionAlong@{a b p m n}.
   Abort.
@@ -109,7 +109,7 @@ Section Extensions.
       - size of C
       - size of result (>= A,B,C) *)
   (** We would like to say [Check], but because of bug #4517, https://coq.inria.fr/bugs/show_bug.cgi?id=4517, we can't. *)
-  Definition check_ExtendableAlong@{a b c r} : True.
+  Definition check_ExtendableAlong@{a b c r} : True@{Set}.
   Proof.
     Check ExtendableAlong@{a b c r}.
   Abort.
@@ -129,7 +129,7 @@ Section Extensions.
       + intros h k; exact (IH _ (snd ext h k)).
   Defined.
   (** We would like to say [Check], but because of bug #4517, https://coq.inria.fr/bugs/show_bug.cgi?id=4517, we can't. *)
-  Definition check_lift_extendablealong@{i j k l1 l2} : True.
+  Definition check_lift_extendablealong@{i j k l1 l2} : True@{Set}.
   Proof.
     Check lift_extendablealong@{i j k l1 l2}.
   Abort.
@@ -329,7 +329,7 @@ Section Extensions.
     := forall n, ExtendableAlong@{i j k l} n f C.
   (** Universe parameters are the same as for [ExtendableAlong]. *)
   (** We would like to say [Check], but because of bug #4517, https://coq.inria.fr/bugs/show_bug.cgi?id=4517, we can't. *)
-  Definition check_ooExtendableAlong@{a b c r} : True.
+  Definition check_ooExtendableAlong@{a b c r} : True@{Set}.
   Proof.
     Check ooExtendableAlong@{a b c r}.
   Abort.
@@ -343,7 +343,7 @@ Section Extensions.
   : ooExtendableAlong@{i j k l1} f C -> ooExtendableAlong@{i j k l2} f C
     := fun ext n => lift_extendablealong n f C (ext n).
   (** We would like to say [Check], but because of bug #4517, https://coq.inria.fr/bugs/show_bug.cgi?id=4517, we can't. *)
-  Definition check_ooextendablealong@{i j k l1 l2} : True.
+  Definition check_ooextendablealong@{i j k l1 l2} : True@{Set}.
   Proof.
     Check lift_ooextendablealong@{i j k l1 l2}.
   Abort.

--- a/theories/Modalities/Modality.v
+++ b/theories/Modalities/Modality.v
@@ -300,7 +300,7 @@ Module EasyModalities_to_Modalities (Os : EasyModalities)
 
   Definition minO_paths@{u a i} (O : Modality@{u a})
              (A : Type@{i}) (A_inO : In@{u a i} O A) (a a' : A)
-  : In O (a = a').
+  : In@{u a i} O (a = a').
   Proof.
     simple refine (inO_equiv_inO O (to O A a = to O A a') _ _
                           (@ap _ _ (to O A) a a')^-1 _).


### PR DESCRIPTION
To be compatible with the new semantics of explicit universe
declarations in lemma statements (Coq pr #177, forward compatible).