### PR TITLE
Fix universe annotation that was silently ignored

### DIFF
--- a/theories/Modalities/Identity.v
+++ b/theories/Modalities/Identity.v
@@ -90,7 +90,7 @@ Module Accessible_Identity <: Accessible_Modalities Identity_Modalities.
   : forall (O : Modality@{u a}) (X : Type@{i}),
       iff@{i i i}
         (In@{u a i} O X)
-        (IsNull@{a i} (acc_gen O) X)
+        (IsNull@{u a i} (acc_gen O) X)
     := fun O X => (fun _ => Empty_ind _ , fun _ => tt).
 
 End Accessible_Identity.


### PR DESCRIPTION
And now produces the right length-mismatch error
with Coq's PR #168 (backward compatible change).