### PR TITLE
Put Empty and Unit in Type0

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -724,6 +724,12 @@ universes.  One solution is to alter the proofs of those instances as
 described above; another is to call the instance(s) you need
 explicitly, rather than relying on typeclass inference to find them.
 
+Sometimes binders without type annotation, like `forall n, foo n`
+where `foo : nat -> Type0`, will produce a fresh universe for
+the variable's type, eg `forall n : (? : Type@{fresh}), foo n`,
+which will remain in the definition as a phantom type:
+`fresh |= forall n : nat, foo n`. Annotating the binder will get rid of it.
+
 ### Lifting and lowering ###
 
 The file `Basics/UniverseLevel` contains an operation `Lift` which

--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -517,7 +517,8 @@ Section Book_3_14.
       apply hprop_allpath.
       intros x' y'.
       etransitivity; [ symmetry; apply (p x x y' x') | ].
-     (* Without this it somehow proves [H'] using the wrong universe for hprop_Empty and fails when we do [Defined]. *)
+     (* Without this it somehow proves [H'] using the wrong universe for hprop_Empty and fails when we do [Defined].
+        See Coq #4862. *)
       set (path := path_ishprop x x).
       assert (H' : idpath = path) by apply path_ishprop.
       destruct H'.

--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -505,8 +505,6 @@ Section Book_3_14.
   Context `{Funext}.
   Hypothesis LEM : forall A : Type, IsHProp A -> A + ~A.
 
-  Local Set Universe Minimization ToSet.
-
   Definition Book_3_14
   : forall A (P : ~~A -> Type),
     (forall a, P (fun na => na a))
@@ -519,7 +517,9 @@ Section Book_3_14.
       apply hprop_allpath.
       intros x' y'.
       etransitivity; [ symmetry; apply (p x x y' x') | ].
-      assert (H' : idpath = path_ishprop x x) by apply path_ishprop.
+     (* Without this it somehow proves [H'] using the wrong universe for hprop_Empty and fails when we do [Defined]. *)
+      set (path := path_ishprop x x).
+      assert (H' : idpath = path) by apply path_ishprop.
       destruct H'.
       reflexivity.
     - destruct (LEM (P nna) _) as [pnna|npnna]; trivial.
@@ -529,8 +529,6 @@ Section Book_3_14.
       apply npnna.
       exact (transport P (path_ishprop _ _) (base a)).
   Defined.
-
-  Local Unset Universe Minimization ToSet.
 
   Lemma Book_3_14_equiv A : merely A <~> ~~A.
   Proof.

--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -505,6 +505,8 @@ Section Book_3_14.
   Context `{Funext}.
   Hypothesis LEM : forall A : Type, IsHProp A -> A + ~A.
 
+  Local Set Universe Minimization ToSet.
+
   Definition Book_3_14
   : forall A (P : ~~A -> Type),
     (forall a, P (fun na => na a))
@@ -527,6 +529,8 @@ Section Book_3_14.
       apply npnna.
       exact (transport P (path_ishprop _ _) (base a)).
   Defined.
+
+  Local Unset Universe Minimization ToSet.
 
   Lemma Book_3_14_equiv A : merely A <~> ~~A.
   Proof.

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -19,6 +19,9 @@ Global Unset Refine Instance Mode.
 (** This command makes it so that you don't have to declare universes explicitly when mentioning them in the type.  (Without this command, if you want to say [Definition foo := Type@{i}.], you must instead say [Definition foo@{i} := Type@{i}.]. *)
 Global Unset Strict Universe Declaration.
 
+(** This command makes it so that when we say something like [IsHSet nat] we get [IsHSet@{i} nat] instead of [IsHSet@{Set} nat]. *)
+Global Unset Universe Minimization ToSet.
+
 Definition relation (A : Type) := A -> A -> Type.
 
 Class Reflexive {A} (R : relation A) :=
@@ -603,7 +606,7 @@ Ltac path_via mid :=
   apply @concat with (y := mid); auto with path_hints.
 
 (** We put [Empty] here, instead of in [Empty.v], because [Ltac done] uses it. *)
-Inductive Empty : Type1 := .
+Inductive Empty : Type0 := .
 
 Scheme Empty_ind := Induction for Empty Sort Type.
 Scheme Empty_rec := Minimality for Empty Sort Type.
@@ -631,7 +634,7 @@ Class Asymmetric {A} (R : relation A) :=
   asymmetry : forall {x y}, R x y -> (complement R y x : Type).
 
 (** Likewise, we put [Unit] here, instead of in [Unit.v], because [Trunc] uses it. *)
-Inductive Unit : Type1 :=
+Inductive Unit : Type0 :=
     tt : Unit.
 
 Scheme Unit_ind := Induction for Unit Sort Type.

--- a/theories/Extensions.v
+++ b/theories/Extensions.v
@@ -97,7 +97,7 @@ Section Extensions.
            (n : nat) {A : Type@{i}} {B : Type@{j}}
            (f : A -> B) (C : B -> Type@{k}) : Type@{l}
     := match n with
-         | 0 => Unit@{l}
+         | 0 => Unit
          | S n => (forall (g : forall a, C (f a)),
                      ExtensionAlong@{i j k l l} f C g) *
                   forall (h k : forall b, C b),
@@ -326,7 +326,7 @@ Section Extensions.
   Definition ooExtendableAlong@{i j k l}
              {A : Type@{i}} {B : Type@{j}}
              (f : A -> B) (C : B -> Type@{k}) : Type@{l}
-    := forall n, ExtendableAlong@{i j k l} n f C.
+    := forall n : nat, ExtendableAlong@{i j k l} n f C.
   (** Universe parameters are the same as for [ExtendableAlong]. *)
   (** We would like to say [Check], but because of bug #4517, https://coq.inria.fr/bugs/show_bug.cgi?id=4517, we can't. *)
   Definition check_ooExtendableAlong@{a b c r} : True@{Set}.

--- a/theories/Idempotents.v
+++ b/theories/Idempotents.v
@@ -5,6 +5,7 @@ Require Import hit.Truncations.
 
 Local Open Scope path_scope.
 
+Local Set Universe Minimization ToSet.
 
 (** * Idempotents and their splittings *)
 
@@ -428,7 +429,7 @@ Section Splitting.
 
   (** The splitting will be the sequential limit of the sequence [... -> X -> X -> X]. *)
   Definition split_idem : Type
-    := { a : nat -> X & forall n, f (a n.+1) = a n }.
+    := { a : nat -> X & forall n : nat, f (a n.+1) = a n }.
 
   Definition split_idem_pr1 : split_idem -> (nat -> X)
     := pr1.
@@ -457,7 +458,7 @@ Section Splitting.
 
   Definition path_split_idem {a a' : split_idem}
     (p : a.1 == a'.1)
-    (q : forall n, a.2 n @ p n = ap f (p n.+1) @ a'.2 n)
+    (q : forall n : nat, a.2 n @ p n = ap f (p n.+1) @ a'.2 n)
   : a = a'.
   Proof.
     simple refine (path_sigma' _ _ _).

--- a/theories/Idempotents.v
+++ b/theories/Idempotents.v
@@ -429,7 +429,7 @@ Section Splitting.
 
   (** The splitting will be the sequential limit of the sequence [... -> X -> X -> X]. *)
   Definition split_idem : Type
-    := { a : nat -> X & forall n : nat, f (a n.+1) = a n }.
+    := { a : nat -> X & forall n, f (a n.+1) = a n }.
 
   Definition split_idem_pr1 : split_idem -> (nat -> X)
     := pr1.
@@ -458,7 +458,7 @@ Section Splitting.
 
   Definition path_split_idem {a a' : split_idem}
     (p : a.1 == a'.1)
-    (q : forall n : nat, a.2 n @ p n = ap f (p n.+1) @ a'.2 n)
+    (q : forall n, a.2 n @ p n = ap f (p n.+1) @ a'.2 n)
   : a = a'.
   Proof.
     simple refine (path_sigma' _ _ _).

--- a/theories/Modalities/Accessible.v
+++ b/theories/Modalities/Accessible.v
@@ -125,7 +125,7 @@ Defined.
 
 Definition ooextendable_isnull_fibers {A B} (f : A -> B) (C : B -> Type)
 : (forall b, ooExtendableAlong (@const (hfiber f b) Unit tt)
-                               (fun _ : Unit => C b))
+                               (fun _ => C b))
   -> ooExtendableAlong f C
 := fun null n => extendable_isnull_fibers n f C null.
 

--- a/theories/Modalities/Accessible.v
+++ b/theories/Modalities/Accessible.v
@@ -96,7 +96,7 @@ Record NullGenerators :=
 Coercion ngen_type : NullGenerators >-> Funclass.
 
 Definition null_to_local_generators : NullGenerators@{a1} -> LocalGenerators@{a2}
-  := fun S => Build_LocalGenerators (ngen_indices S) (ngen_type S) (fun _ => Unit@{a2}) (fun _ _ => tt).
+  := fun S => Build_LocalGenerators (ngen_indices S) (ngen_type S) (fun _ => Unit) (fun _ _ => tt).
 
 (** As with [IsLocal], the real version of this notation will be defined in [Nullification]. *)
 Module Import IsNull_Internal.
@@ -125,7 +125,7 @@ Defined.
 
 Definition ooextendable_isnull_fibers {A B} (f : A -> B) (C : B -> Type)
 : (forall b, ooExtendableAlong (@const (hfiber f b) Unit tt)
-                               (fun _ => C b))
+                               (fun _ : Unit => C b))
   -> ooExtendableAlong f C
 := fun null n => extendable_isnull_fibers n f C null.
 
@@ -256,6 +256,7 @@ Module Accessible_Modalities_from_ReflectiveSubuniverses
     Definition inO_iff_isnull@{u a i} (O : Modality@{u a}) (X : Type@{i})
     : iff@{i i i} (In@{u a i} O X) (IsNull@{a i} (acc_gen O) X).
     Proof.
+      pose proof (@conn_map_to_O@{u a a a i a a a}).
       split.
       - intros X_inO [ [i x] | [i x] ];
           exact (ooextendable_const_isconnected_inO@{u a a i i} O _ _ ).
@@ -264,7 +265,7 @@ Module Accessible_Modalities_from_ReflectiveSubuniverses
         refine (cancelL_ooextendable@{a a a i i i i i i i}
                   (fun _ => X) (Acc.acc_gen O i)
                   (to O (lgen_codomain (Acc.acc_gen O) i)) _ _).
-        + apply ooextendable_isnull_fibers@{a a i i a i a}; intros x.
+        + apply ooextendable_isnull_fibers@{a a i i a a i a a a}; intros x.
           exact (Xnull (inr (i;x))).
         + refine (ooextendable_homotopic _
                    (O_functor O (Acc.acc_gen O i)
@@ -272,7 +273,7 @@ Module Accessible_Modalities_from_ReflectiveSubuniverses
           1:apply to_O_natural.
           apply ooextendable_compose@{a a a i i i i}.
           * apply ooextendable_equiv, O_inverts_generators.
-          * apply ooextendable_isnull_fibers; intros x.
+          * apply ooextendable_isnull_fibers@{a a i i a a i a a a}; intros x.
             exact (Xnull (inl (i;x))).
     Defined.
 

--- a/theories/Modalities/Closed.v
+++ b/theories/Modalities/Closed.v
@@ -134,9 +134,9 @@ Module Accessible_ClosedModalities
 
   Definition acc_gen
     := fun (O : ClosedModalities.Modality@{u a}) =>
-         Build_NullGenerators@{a} (unCl O) (fun _ => Empty@{a}).
+         Build_NullGenerators@{a} (unCl O) (fun _ => Empty).
 
-  Definition inO_iff_isnull
+  Definition inO_iff_isnull@{u a i}
              (O : ClosedModalities.Modality@{u a}) (X : Type@{i})
   : iff@{i i i}
       (ClosedModalities.In@{u a i} O X)
@@ -145,7 +145,7 @@ Module Accessible_ClosedModalities
     split.
     - intros X_inO u.
       pose (X_inO u).
-      apply ooextendable_contr; exact _.
+      apply ooextendable_contr@{a a i i a}; exact _.
     - intros ext u.
       exists ((fst (ext u 1%nat) Empty_rec).1 tt); intros x.
       unfold const in ext.

--- a/theories/Modalities/Identity.v
+++ b/theories/Modalities/Identity.v
@@ -90,13 +90,9 @@ Module Accessible_Identity <: Accessible_Modalities Identity_Modalities.
   : forall (O : Modality@{u a}) (X : Type@{i}),
       iff@{i i i}
         (In@{u a i} O X)
-        (IsNull@{u a i} (acc_gen@{u a} O) X).
-  Proof.
-  intros O X.
-  split.
-  - intros ?.
-    exact (Empty_ind _).
-  - intros ?;exact tt.
-  Defined.
+        (IsNull@{u a i} (acc_gen@{u a} O) X)
+  := fun O X => @pair _ (_ -> Unit)
+     (fun _ => Empty_ind _)
+     (fun _ => tt).
 
 End Accessible_Identity.

--- a/theories/Modalities/Identity.v
+++ b/theories/Modalities/Identity.v
@@ -23,7 +23,7 @@ Module Identity_Modalities <: Modalities.
 
   Definition In : forall (O : Modality@{u a}),
                              Type@{i} -> Type@{i}
-    := fun O X => Unit@{i}.
+    := fun O X => Unit.
 
   Definition O_inO : forall (O : Modality@{u a}) (T : Type@{i}),
                                In@{u a i} O (O_reflector@{u a i} O T)
@@ -41,10 +41,10 @@ Module Identity_Modalities <: Modalities.
         In@{u a j} O U
     := fun O T U _ _ _ => tt.
 
-  Definition hprop_inO
+  Definition hprop_inO@{u a i}
   : Funext -> forall (O : Modality@{u a}) (T : Type@{i}),
                 IsHProp (In@{u a i} O T)
-    := fun _ O T => _.
+    := fun _ O T => trunc_contr@{i a}.
 
   Definition O_ind_internal
   : forall (O : Modality@{u a})
@@ -84,13 +84,19 @@ Module Accessible_Identity <: Accessible_Modalities Identity_Modalities.
   Module Import Os_Theory := Modalities_Theory Identity_Modalities.
 
   Definition acc_gen : Modality@{u a} -> NullGenerators@{a}
-    := fun _ => Build_NullGenerators Empty@{a} (fun _ => Empty@{a}).
+    := fun _ => Build_NullGenerators Empty (fun _ => Empty).
 
-  Definition inO_iff_isnull
+  Definition inO_iff_isnull@{u a i}
   : forall (O : Modality@{u a}) (X : Type@{i}),
       iff@{i i i}
         (In@{u a i} O X)
-        (IsNull@{u a i} (acc_gen O) X)
-    := fun O X => (fun _ => Empty_ind _ , fun _ => tt).
+        (IsNull@{u a i} (acc_gen@{u a} O) X).
+  Proof.
+  intros O X.
+  split.
+  - intros ?.
+    exact (Empty_ind _).
+  - intros ?;exact tt.
+  Defined.
 
 End Accessible_Identity.

--- a/theories/Modalities/Identity.v
+++ b/theories/Modalities/Identity.v
@@ -90,7 +90,7 @@ Module Accessible_Identity <: Accessible_Modalities Identity_Modalities.
   : forall (O : Modality@{u a}) (X : Type@{i}),
       iff@{i i i}
         (In@{u a i} O X)
-        (IsNull@{u a i} (acc_gen@{u a} O) X)
+        (IsNull@{u a i} (acc_gen O) X)
   := fun O X => @pair _ (_ -> Unit)
      (fun _ => Empty_ind _)
      (fun _ => tt).

--- a/theories/Modalities/Lex.v
+++ b/theories/Modalities/Lex.v
@@ -219,7 +219,7 @@ Module Lex_Reflective_Subuniverses
                                          (hfiber@{k i} g (g x)))).
     { refine (_ oE equiv_to_O@{u a k k} O _).
       - refine (_ oE BuildEquiv _ _
-                  (O_functor_hfiber@{u a k i k k i k k (* <- this k is irrelevant *) k k k k k k}
+                  (O_functor_hfiber@{u a k i k k i k k (* <- this k is irrelevant *) k k k k}
                                    O (@pr1 A B) (g x)) _).
         unfold hfiber.
         refine (equiv_functor_sigma' 1 _). intros y; cbn.

--- a/theories/Modalities/Localization.v
+++ b/theories/Modalities/Localization.v
@@ -51,7 +51,7 @@ Fixpoint ExtendableAlong_Over@{a b c d m}
          (ext : ExtendableAlong@{a b c m} n f C)
 : Type@{m}
   := match n return ExtendableAlong@{a b c m} n f C -> Type@{m} with
-       | 0 => fun _ => Unit@{m}
+       | 0 => fun _ => Unit
        | S n => fun ext' =>
                 (forall (g : forall a, C (f a)) (g' : forall a, D (f a) (g a)),
                   sig@{m m}     (** Control universe parameters *)
@@ -263,7 +263,7 @@ Proof.
   intros i.
   (** We have to fiddle with the max universes to get this to work, since [ooextendable_postcompose] requires the max universe in both cases to be the same, whereas we don't want to assume that the hypothesis and conclusion are related in any way. *)
   apply lift_ooextendablealong@{a a j k j'}.
-  refine (ooextendable_postcompose@{a a i j k k k k k k k}
+  refine (ooextendable_postcompose@{a a i j k k k k k k k k}
             _ _ (f i) (fun _ => g) _).
   apply lift_ooextendablealong@{a a i i' k}.
   apply Xloc.
@@ -373,12 +373,12 @@ Module Localization_ReflectiveSubuniverses <: ReflectiveSubuniverses.
       In@{u a j} O U
     := fun O => islocal_equiv_islocal@{a i j i j k} (unLoc O).
 
-  Definition hprop_inO `{Funext}
+  Definition hprop_inO@{u a i} `{Funext}
              (O : ReflectiveSubuniverse@{u a}) (T : Type@{i})
   : IsHProp (In@{u a i} O T).
   Proof.
     apply (@trunc_forall@{a i i} _); intros i.
-    apply ishprop_ooextendable@{a a i i i i i}.
+    apply ishprop_ooextendable@{a a i i i i i i i i i i}.
   Defined.
 
   Definition extendable_to_O

--- a/theories/Modalities/Modality.v
+++ b/theories/Modalities/Modality.v
@@ -516,16 +516,16 @@ Section ConnectedTypes.
              (** Work around https://coq.inria.fr/bugs/show_bug.cgi?id=3811 *)
              (A : Type@{i}) {conn_A : IsConnected@{Ou Oa i} O A}
              (C : Type@{j}) `{In@{Ou Oa j} O C}
-  : ExtendableAlong@{i i j j} n (@const A Unit@{i} tt) (fun _ => C).
+  : ExtendableAlong@{i i j j} n (@const@{i i} A Unit tt) (fun _ => C).
   Proof.
     generalize dependent C;
       simple_induction n n IHn; intros C ?;
       [ exact tt | split ].
     - intros f.
-      exists (fun _ => (isconnected_elim@{i j j k i} C f).1); intros a.
+      exists (fun _ : Unit => (isconnected_elim@{i j j k i} C f).1); intros a.
       symmetry; apply ((isconnected_elim@{i j j k i} C f).2).
     - intros h k.
-      refine (extendable_postcompose'@{i i j j j l l l l l l} n _ _ _ _ (IHn (h tt = k tt) (inO_paths@{Ou Oa j m} _ _ _ _))).
+      refine (extendable_postcompose'@{i i j j j j l l l l l l} n _ _ _ _ (IHn (h tt = k tt) (inO_paths@{Ou Oa j m} _ _ _ _))).
       intros []; apply equiv_idmap.
   Defined.
 

--- a/theories/Modalities/Notnot.v
+++ b/theories/Modalities/Notnot.v
@@ -22,43 +22,42 @@ Module Notnot_Easy_Modalities <: EasyModalities.
 
   Definition O_reflector : Modality@{u a} -> Type@{i} -> Type@{i}
     (** We call [not] explicitly with universe annotations so that [O_reflector] has the right number of universe parameters to satisfy the module type. *)
-    := fun O X => not@{i i i} (not@{i i i} X).
+    := fun O X => not@{i i} (not@{i i} X).
 
   Definition to (O : Modality@{u a}) (T : Type@{i})
   : T -> O_reflector@{u a i} O T
   := fun x nx => nx x.
 
-  Definition O_indO (O : Modality@{u a}) (A : Type@{i})
+  Definition O_indO@{u a i j} (O : Modality@{u a}) (A : Type@{i})
              (B : O_reflector@{u a i} O A -> Type@{j})
   : (forall a : A, O_reflector@{u a j} O (B (to O A a))) ->
     forall z : O_reflector@{u a i} O A, O_reflector@{u a j} O (B z).
   Proof.
     intros f z nBz.
     pose (unNotnot O).          (** Access the [Funext] hypothesis *)
-    (** The goal is [Empty@{j}], whereas [z] has codomain [Empty@{i}].  Thus, simply applying [z] would collapse the universe parameters undesirably, so we first alter the goal to be [Empty@{i}]. *)
-    cut (Empty@{i}); [ intros [] | ].
     apply z; intros a.
-    (** Now the goal is [Empty@{i}], whereas [f] has codomain [Empty@{j}]. *)
-    cut (Empty@{j}); [ intros [] | ].
-    exact (f a (transport (fun x => not@{j j j} (B x))
+    pose proof (hprop_Empty@{i}).
+    exact (f a (transport (fun x => not@{j j} (B x))
                           (path_ishprop _ _)
                           nBz)).
   Defined.
 
-  Definition O_indO_beta (O : Modality@{u a}) (A : Type@{i})
+  Definition O_indO_beta@{u a i j} (O : Modality@{u a}) (A : Type@{i})
              (B : O_reflector@{u a i} O A -> Type@{j})
              (f : forall a, O_reflector@{u a j} O (B (to O A a))) (a:A)
   : O_indO O A B f (to O A a) = f a.
   Proof.
     pose (unNotnot O).
+    pose proof (hprop_Empty@{j}).
     apply path_ishprop.
   Defined.
 
-  Definition minO_pathsO (O : Modality@{u a}) (A : Type@{i})
+  Definition minO_pathsO@{u a i} (O : Modality@{u a}) (A : Type@{i})
              (z z' : O_reflector@{u a i} O A)
   : IsEquiv@{i i} (to@{u a i} O (z = z')).
   Proof.
     pose (unNotnot O).
+    pose proof (hprop_Empty@{i});pose proof (@trunc_hprop@{i a}).
     refine (isequiv_iff_hprop _ _).
     intros; apply path_ishprop.
   Defined.

--- a/theories/Modalities/Nullification.v
+++ b/theories/Modalities/Nullification.v
@@ -13,7 +13,7 @@ Local Open Scope path_scope.
 (** The hypotheses of this lemma may look slightly odd (why are we bothering to talk about type families dependent over [Unit]?), but they seem to be the most convenient to make the induction go through.  *)
 
 Definition extendable_over_unit (n : nat)
-  (A : Type@{a}) (C : Unit@{a} -> Type@{i}) (D : forall u, C u -> Type@{j})
+  (A : Type@{a}) (C : Unit -> Type@{i}) (D : forall u, C u -> Type@{j})
   (ext : ExtendableAlong@{a a i k} n (@const A Unit tt) C)
   (ext' : forall (c : forall u, C u),
             ExtendableAlong@{a a j k} n (@const A Unit tt) (fun u => (D u (c u))))
@@ -33,9 +33,9 @@ Proof.
     exact (snd (ext' k) (fun u => g u # h' u) k').
 Defined.
 
-Definition ooextendable_over_unit
-  (A : Type) (C : Unit -> Type) (D : forall u, C u -> Type)
-  (ext : ooExtendableAlong (@const A Unit tt) C)
+Definition ooextendable_over_unit@{i j k l m}
+  (A : Type@{i}) (C : Unit -> Type@{j}) (D : forall u, C u -> Type@{k})
+  (ext : ooExtendableAlong@{l l j m} (@const@{l l} A Unit tt) C)
   (ext' : forall (c : forall u, C u),
             ooExtendableAlong (@const A Unit tt) (fun u => (D u (c u))))
 : ooExtendableAlong_Over (@const A Unit tt) C D ext
@@ -69,7 +69,7 @@ Module Nullification_Modalities <: Modalities.
   Definition inO_equiv_inO := @LocRSU.inO_equiv_inO@{u a i j k}.
   Definition hprop_inO := LocRSU.hprop_inO.
 
-  Definition O_ind_internal (O : Modality@{u a}) (A : Type@{i})
+  Definition O_ind_internal@{u a i j k} (O : Modality@{u a}) (A : Type@{i})
              (B : O_reflector@{u a i} O A -> Type@{j})
              (B_inO : forall oa : O_reflector@{u a i} O A, In@{u a j} O (B oa))
              (g : forall a : A, B (to@{u a i} O A a))
@@ -78,9 +78,9 @@ Module Nullification_Modalities <: Modalities.
     refine (Localize_ind@{a i j k}
              (null_to_local_generators@{a a} (unNul O)) A B g _); intros i.
     apply (ooextendable_over_unit@{a i j a k}); intros c.
-    refine (ooextendable_postcompose@{a a j j k j j j k j k}
+    refine (ooextendable_postcompose@{a a j j k j j j k j k k}
               (fun (_:Unit) => B (c tt)) _ _
-              (fun u => transport@{i j} B (ap c (path_unit tt u))) _).
+              (fun u => transport@{i j} B (ap c (path_unit@{a} tt u))) _).
     refine (ooextendable_islocal _ i).
     apply B_inO.
   Defined.

--- a/theories/Modalities/Open.v
+++ b/theories/Modalities/Open.v
@@ -132,10 +132,14 @@ Module Accessible_OpenModalities <: Accessible_Modalities OpenModalities.
     - intros ext; specialize (ext tt).
       refine (isequiv_compose (f := (fun x => unit_name x))
                               (g := (fun h => h o (@const (unOp O) Unit tt)))).
-      refine (isequiv_ooextendable (fun _ => X) (@const (unOp O) Unit tt) ext).
+      refine (isequiv_ooextendable@{a a i i i i i i} (fun _ => X) (@const@{i a} (unOp O) Unit tt) ext).
   Defined.
 
-  Definition inO_iff_isnull@{u a i} := inO_iff_isnull'@{u a i i i i i i i i i i i i i i}.
+  (* Phantom universes (ie not appearing in the term) are produced by some un-annotated functions and foralls.
+     For instance if we explicitate [(B:=(Unit -> _))] in the [isequiv_compose] use above only one extra is produced.
+     I can't figure out where the last extra is coming from so we have to manually identify it with [i].
+     Since we have to do this manual identification step we might as well use it for the universe from [B] too. *)
+  Definition inO_iff_isnull@{u a i} := inO_iff_isnull'@{u a i i i}.
 
 End Accessible_OpenModalities.
 

--- a/theories/Modalities/Open.v
+++ b/theories/Modalities/Open.v
@@ -116,9 +116,9 @@ Module Accessible_OpenModalities <: Accessible_Modalities OpenModalities.
 
   Definition acc_gen
     := fun (O : OpenModalities.Modality@{u a}) =>
-         Build_NullGenerators@{a} Unit@{a} (fun _ => unOp O).
+         Build_NullGenerators@{a} Unit (fun _ => unOp O).
 
-  Definition inO_iff_isnull
+  Definition inO_iff_isnull'
              (O : OpenModalities.Modality@{u a}) (X : Type@{i})
   : iff@{i i i}
       (OpenModalities.In@{u a i} O X)
@@ -126,7 +126,7 @@ Module Accessible_OpenModalities <: Accessible_Modalities OpenModalities.
   Proof.
     pose (funext_Op O); split.
     - intros X_inO u.
-      apply (equiv_inverse (equiv_ooextendable_isequiv@{a a i i i i i} _ _)).
+      apply (equiv_inverse (equiv_ooextendable_isequiv@{a a i i i i i i i i i i i} _ _)).
       refine (cancelR_isequiv (fun x (u:Unit) => x)).
       apply X_inO.
     - intros ext; specialize (ext tt).
@@ -134,6 +134,8 @@ Module Accessible_OpenModalities <: Accessible_Modalities OpenModalities.
                               (g := (fun h => h o (@const (unOp O) Unit tt)))).
       refine (isequiv_ooextendable (fun _ => X) (@const (unOp O) Unit tt) ext).
   Defined.
+
+  Definition inO_iff_isnull@{u a i} := inO_iff_isnull'@{u a i i i i i i i i i i i i i i}.
 
 End Accessible_OpenModalities.
 

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -742,7 +742,7 @@ Section Reflective_Subuniverse.
       simpl in *.
       specialize (H ({x:A & B x}) (fun x => B (h x)) _ g).
       destruct H as [f q].
-      apply inO_to_O_retract@{i j} with (mu := fun w => (h w; f w)).
+      apply inO_to_O_retract@{i} with (mu := fun w => (h w; f w)).
       intros [x1 x2].
       simple refine (path_sigma B _ _ _ _); simpl.
       - apply p.
@@ -822,7 +822,7 @@ Section Reflective_Subuniverse.
     Definition inO_paths@{i j} (S : Type@{i}) {S_inO : In@{Ou Oa i} O S} (x y : S)
     : In@{Ou Oa i} O (x=y).
     Proof.
-      simple refine (inO_to_O_retract@{i j} _ _ _); intro u.
+      simple refine (inO_to_O_retract@{i} _ _ _); intro u.
       - assert (p : (fun _ : O (x=y) => x) == (fun _=> y)).
         { refine (O_indpaths _ _ _); simpl.
           intro v; exact v. }

--- a/theories/Types/Unit.v
+++ b/theories/Types/Unit.v
@@ -66,12 +66,12 @@ Global Instance isequiv_unit_rec `{Funext} (A : Type)
 (* For various reasons, it is typically more convenient to define functions out of the unit as constant maps, rather than [Unit_ind]. *)
 Notation unit_name x := (fun (_ : Unit) => x).
 
-Global Instance isequiv_unit_name `{Funext} (A : Type)
-: IsEquiv (fun (a:A) => unit_name a).
+Global Instance isequiv_unit_name `{Funext} (A : Type@{i})
+: @IsEquiv@{i j} _ (Unit -> _) (fun (a:A) => unit_name a).
 Proof.
-  refine (isequiv_adjointify _ (fun f => f tt) _ _).
-  - intros f; apply path_forall; intros x.
-    apply ap, path_unit.
+  refine (isequiv_adjointify _ (fun f : Unit -> _ => f tt) _ _).
+  - intros f; apply path_forall@{i i j}; intros x.
+    apply ap@{i i}, path_unit.
   - intros a; reflexivity.
 Defined.
 

--- a/theories/Types/Unit.v
+++ b/theories/Types/Unit.v
@@ -66,7 +66,7 @@ Global Instance isequiv_unit_rec `{Funext} (A : Type)
 (* For various reasons, it is typically more convenient to define functions out of the unit as constant maps, rather than [Unit_ind]. *)
 Notation unit_name x := (fun (_ : Unit) => x).
 
-Global Instance isequiv_unit_name `{Funext} (A : Type@{i})
+Global Instance isequiv_unit_name@{i j} `{Funext} (A : Type@{i})
 : @IsEquiv@{i j} _ (Unit -> _) (fun (a:A) => unit_name a).
 Proof.
   refine (isequiv_adjointify _ (fun f : Unit -> _ => f tt) _ _).


### PR DESCRIPTION
The only complicated fixing was in Modalities which needed changes in the universe annotations.
Universe minimization to Set is globally disabled so that we get lemmas like `Contr@{i} Unit` for all `i`. If Coq had cumulative inductive types like in http://advent-project.eu/pubs/cit-ictac15.pdf it might not be needed.
It is locally re-enabled in Idempotents to avoid a blowup in the number of universes (IsIdempotent goes from 4 to 51 universes), and for `Book_3_14` in the exercises to avoid some error.