### PR TITLE
V8.6

### DIFF
--- a/coq/theories/Init/Notations.v
+++ b/coq/theories/Init/Notations.v
@@ -76,9 +76,14 @@ Reserved Notation "{ x : A  & P }" (at level 0, x at level 99).
 Reserved Notation "{ x : A  & P  & Q }" (at level 0, x at level 99).
 
 Delimit Scope type_scope with type.
+Delimit Scope function_scope with function.
 Delimit Scope core_scope with core.
 
+Bind Scope type_scope with Sortclass.
+Bind Scope function_scope with Funclass.
+
 Open Scope core_scope.
+Open Scope function_scope.
 Open Scope type_scope.
 
 (** ML Tactic Notations *)

--- a/coq/theories/Init/Notations.v
+++ b/coq/theories/Init/Notations.v
@@ -85,8 +85,7 @@ Open Scope type_scope.
 
 Declare ML Module "coretactics".
 Declare ML Module "extratactics".
-Declare ML Module "eauto".
+Declare ML Module "g_auto".
 Declare ML Module "g_class".
 Declare ML Module "g_eqdecide".
 Declare ML Module "g_rewrite".
-Declare ML Module "tauto".

--- a/coq/theories/Program/Tactics.v
+++ b/coq/theories/Program/Tactics.v
@@ -258,7 +258,7 @@ Ltac autoinjection tac := idtac.
 
 Ltac inject H := progress (inversion H ; subst*; clear_dups) ; clear H.
 
-Ltac autoinjections := repeat (clear_dups ; autoinjection ltac:inject).
+Ltac autoinjections := repeat (clear_dups ; autoinjection ltac:(inject)).
 
 (** Destruct an hypothesis by first copying it to avoid dependencies. *)
 

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -22,6 +22,9 @@ Global Unset Strict Universe Declaration.
 (** This command makes it so that when we say something like [IsHSet nat] we get [IsHSet@{i} nat] instead of [IsHSet@{Set} nat]. *)
 Global Unset Universe Minimization ToSet.
 
+(** Change in introduction patterns not adding an implicit [] *)
+Global Unset Bracketing Last Introduction Pattern.
+
 Definition relation (A : Type) := A -> A -> Type.
 
 Class Reflexive {A} (R : relation A) :=

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -508,6 +508,8 @@ Fixpoint IsTrunc_internal (n : trunc_index) (A : Type) : Type :=
     | n'.+1 => forall (x y : A), IsTrunc_internal n' (x = y)
   end.
 
+Existing Class IsTrunc_internal.
+
 Arguments IsTrunc_internal n A : simpl nomatch.
 
 Class IsTrunc (n : trunc_index) (A : Type) : Type :=
@@ -523,7 +525,11 @@ Global Instance istrunc_paths (A : Type) n `{H : IsTrunc n.+1 A} (x y : A)
 : IsTrunc n (x = y)
   := H x y. (* but do fold [IsTrunc] *)
 
-Hint Extern 0 => progress change IsTrunc_internal with IsTrunc in * : typeclass_instances. (* Also fold [IsTrunc_internal] *)
+Existing Class IsTrunc_internal.
+
+Hint Extern 0 (IsTrunc_internal _ _) => progress change IsTrunc_internal with IsTrunc in * : typeclass_instances. (* Also fold [IsTrunc_internal] *)
+
+Hint Extern 0 (IsTrunc _ _) => progress change IsTrunc_internal with IsTrunc in * : typeclass_instances. (* Also fold [IsTrunc_internal] *)
 
 (** Picking up the [forall x y, IsTrunc n (x = y)] instances in the hypotheses is much tricker.  We could do something evil where we declare an empty typeclass like [IsTruncSimplification] and use the typeclass as a proxy for allowing typeclass machinery to factor nested [forall]s into the [IsTrunc] via backward reasoning on the type of the hypothesis... but, that's rather complicated, so we instead explicitly list out a few common cases.  It should be clear how to extend the pattern. *)
 Hint Extern 10 =>

--- a/theories/Categories/Adjoint/Functorial/Laws.v
+++ b/theories/Categories/Adjoint/Functorial/Laws.v
@@ -38,7 +38,7 @@ Section laws.
     match goal with
       | _ => reflexivity
       | _ => progress rewrite ?identity_of, ?Category.Core.left_identity, ?Category.Core.right_identity
-      | _ => try_various_ways ltac:f_ap
+      | _ => try_various_ways ltac:(f_ap)
       | [ |- context[components_of ?T ?x] ]
         => try_various_ways ltac:(simpl rewrite <- (commutes T))
       | [ |- context[unit ?A] ]

--- a/theories/Categories/Pseudofunctor/FromFunctor.v
+++ b/theories/Categories/Pseudofunctor/FromFunctor.v
@@ -47,7 +47,7 @@ Section of_functor.
     unfold natural_transformation_of_natural_isomorphism;
     rewrite ?idtoiso_whisker_r, ?idtoiso_whisker_l;
     repeat (
-        let C := match goal with |- @paths (@NaturalTransformation ?C ?D ?F ?G) _ _ => constr:(C -> D)%category end in
+        let C := match goal with |- @paths (@NaturalTransformation ?C ?D ?F ?G) _ _ => constr:((C -> D)%category) end in
         first [ eapply (@iso_moveL_pV C)
               | eapply (@iso_moveL_Vp C)
               | eapply (@iso_moveL_pM C)

--- a/theories/Categories/Pseudofunctor/RewriteLaws.v
+++ b/theories/Categories/Pseudofunctor/RewriteLaws.v
@@ -39,7 +39,8 @@ Section lemmas.
                              o (@morphism_isomorphic _ _ _ (Category.Morphisms.idtoiso (p2 -> p1) (ap f0 (Category.Core.associativity C w x y z f g h))))))))%natural_transformation.
   Proof.
     simpl in *.
-    let C := match goal with |- @paths (@NaturalTransformation ?C ?D ?F ?G) _ _ => constr:(C -> D)%category end in
+    let C := match goal with |- @paths (@NaturalTransformation ?C ?D ?F ?G) _ _ =>
+                             constr:((C -> D)%category) end in
     apply (@iso_moveL_Vp C);
       apply (@iso_moveL_Mp C _ _ _ _ _ _ (iso_whisker_l _ _ _ _ _ _ _)).
     path_natural_transformation.

--- a/theories/Modalities/Accessible.v
+++ b/theories/Modalities/Accessible.v
@@ -256,7 +256,7 @@ Module Accessible_Modalities_from_ReflectiveSubuniverses
     Definition inO_iff_isnull@{u a i} (O : Modality@{u a}) (X : Type@{i})
     : iff@{i i i} (In@{u a i} O X) (IsNull@{a i} (acc_gen O) X).
     Proof.
-      pose proof (@conn_map_to_O@{u a a a i a a a}).
+      pose proof (@conn_map_to_O@{u a a a i a a a a a}).
       split.
       - intros X_inO [ [i x] | [i x] ];
           exact (ooextendable_const_isconnected_inO@{u a a i i} O _ _ ).

--- a/theories/Modalities/Accessible.v
+++ b/theories/Modalities/Accessible.v
@@ -256,13 +256,14 @@ Module Accessible_Modalities_from_ReflectiveSubuniverses
     Definition inO_iff_isnull@{u a i} (O : Modality@{u a}) (X : Type@{i})
     : iff@{i i i} (In@{u a i} O X) (IsNull@{a i} (acc_gen O) X).
     Proof.
-      pose proof (@conn_map_to_O@{u a a a i a a a a a}).
+      pose proof (@conn_map_to_O@{u a a a a}).
       split.
       - intros X_inO [ [i x] | [i x] ];
-          exact (ooextendable_const_isconnected_inO@{u a a i i} O _ _ ).
+          exact (ooextendable_const_isconnected_inO@{u a a i i} O _ _).
+          (* MS: annotation can be dropped *)
       - intros Xnull.
         apply (snd (inO_iff_islocal O X)); intros i.
-        refine (cancelL_ooextendable@{a a a i i i i i i i}
+        refine (cancelL_ooextendable@{a a a i i i i i i}
                   (fun _ => X) (Acc.acc_gen O i)
                   (to O (lgen_codomain (Acc.acc_gen O) i)) _ _).
         + apply ooextendable_isnull_fibers@{a a i i a a i a a a}; intros x.

--- a/theories/Modalities/Lex.v
+++ b/theories/Modalities/Lex.v
@@ -212,14 +212,15 @@ Module Lex_Reflective_Subuniverses
     { intros x; subst g; apply O_rec_beta. }
     apply inO_isequiv_to_O@{u a k k}.
     apply isequiv_fcontr; intros x.
-    refine (contr_equiv' _ (hfiber_hfiber_compose_map@{k k i k k k k k k} _ g x)).
+    refine (contr_equiv' _ (hfiber_hfiber_compose_map@{k k i k k k k k} _ g x)).
     apply fcontr_isequiv.
     unfold hfiber_compose_map.
     transparent assert (h : (Equiv@{k k} (hfiber@{k i} (@pr1 A B) (g x))
                                          (hfiber@{k i} g (g x)))).
     { refine (_ oE equiv_to_O@{u a k k} O _).
       - refine (_ oE BuildEquiv _ _
-                  (O_functor_hfiber@{u a k i k k i k k (* <- this k is irrelevant *) k k k k}
+                  (O_functor_hfiber@{u a k i k k i k k k}
+                                   (* MS: Annotation can be dropped now *)
                                    O (@pr1 A B) (g x)) _).
         unfold hfiber.
         refine (equiv_functor_sigma' 1 _). intros y; cbn.
@@ -231,7 +232,7 @@ Module Lex_Reflective_Subuniverses
         refine (_ @ (O_rec_beta _ _)^).
         apply ap, O_rec_beta.
       - refine (inO_equiv_inO@{u (*dwim1*) a (*dwim2*) j (*dwim3*) k (* <- dwim4 *) k} _
-                 (hfiber_fibration@{i j k k} (g x) B)). }
+                 (hfiber_fibration@{i j k} (g x) B)). }
     refine (isequiv_homotopic (h oE equiv_hfiber_homotopic _ _ p (g x)) _).
     intros [[a b] q]; cbn. clear h.
     unfold O_functor_hfiber.

--- a/theories/Modalities/Localization.v
+++ b/theories/Modalities/Localization.v
@@ -263,7 +263,7 @@ Proof.
   intros i.
   (** We have to fiddle with the max universes to get this to work, since [ooextendable_postcompose] requires the max universe in both cases to be the same, whereas we don't want to assume that the hypothesis and conclusion are related in any way. *)
   apply lift_ooextendablealong@{a a j k j'}.
-  refine (ooextendable_postcompose@{a a i j k k k k k k k k}
+  refine (ooextendable_postcompose@{a a i j k k k k k k}
             _ _ (f i) (fun _ => g) _).
   apply lift_ooextendablealong@{a a i i' k}.
   apply Xloc.
@@ -386,7 +386,7 @@ Module Localization_ReflectiveSubuniverses <: ReflectiveSubuniverses.
              {Q : Type@{j}} {Q_inO : In@{u a j} O Q}
   : ooExtendableAlong@{i i j k} (to O P) (fun _ => Q).
   Proof.
-    apply ext_localize_ind@{a i j i k i k}; intros ?.
+    apply ext_localize_ind@{a i j i k}; intros ?.
     apply ooextendable_over_const.
     apply Q_inO.
   Defined.

--- a/theories/Modalities/Modality.v
+++ b/theories/Modalities/Modality.v
@@ -94,7 +94,7 @@ Module Modalities_to_ReflectiveSubuniverses
 
   Definition ReflectiveSubuniverse := Modality.
 
-  Definition O_reflector := O_reflector.
+  Definition O_reflector@{u a i} := O_reflector@{u a i}.
   (** Work around https://coq.inria.fr/bugs/show_bug.cgi?id=3807 *)
   Definition In@{u a i} : forall (O : ReflectiveSubuniverse@{u a}),
                    Type2le@{i a} -> Type2le@{i a}
@@ -102,7 +102,7 @@ Module Modalities_to_ReflectiveSubuniverses
   Definition O_inO@{u a i} : forall (O : ReflectiveSubuniverse@{u a}) (T : Type@{i}),
                                In@{u a i} O (O_reflector@{u a i} O T)
     := O_inO@{u a i}.
-  Definition to := to.
+  Definition to@{u a i} := to@{u a i}.
   Definition inO_equiv_inO@{u a i j k} :
       forall (O : ReflectiveSubuniverse@{u a}) (T : Type@{i}) (U : Type@{j})
              (T_inO : In@{u a i} O T) (f : T -> U) (feq : IsEquiv f),
@@ -147,11 +147,11 @@ Module ReflectiveSubuniverses_to_Modalities
 
   Definition Modality := ReflectiveSubuniverse.
 
-  Definition O_reflector := O_reflector.
+  Definition O_reflector@{u a i} := O_reflector@{u a i}.
   (** Work around https://coq.inria.fr/bugs/show_bug.cgi?id=3807 *)
   Definition In@{u a i} := In@{u a i}.
   Definition O_inO@{u a i} := @O_inO@{u a i}.
-  Definition to := to.
+  Definition to@{u a i} := to@{u a i}.
   Definition inO_equiv_inO@{u a i j k} := @inO_equiv_inO@{u a i j k}.
   Definition hprop_inO@{u a i} := hprop_inO@{u a i}.
 
@@ -160,7 +160,7 @@ Module ReflectiveSubuniverses_to_Modalities
              (A : Type@{i}) (B : O_reflector@{u a i} O A -> Type@{j})
              (B_inO : forall oa, In@{u a j} O (B oa))
   : (forall a, B (to O A a)) -> forall a, B a
-  := fun g => pr1 ((O_ind_from_inO_sigma@{u a i j j j k k} O (inO_sigma O))
+  := fun g => pr1 ((O_ind_from_inO_sigma@{u a i j j k k} O (inO_sigma O))
                      A B B_inO g).
 
   Definition O_ind_beta_internal@{u a i j k} (O : Modality@{u a})
@@ -168,7 +168,7 @@ Module ReflectiveSubuniverses_to_Modalities
              (B_inO : forall oa, In@{u a j} O (B oa))
              (f : forall a : A, B (to O A a)) (a:A)
   : O_ind_internal O A B B_inO f (to O A a) = f a
-  := pr2 ((O_ind_from_inO_sigma@{u a i j j j k k} O (inO_sigma O))
+  := pr2 ((O_ind_from_inO_sigma@{u a i j j k k} O (inO_sigma O))
                      A B B_inO f) a.
 
   Definition minO_paths@{u a i} (O : Modality@{u a})
@@ -525,7 +525,7 @@ Section ConnectedTypes.
       exists (fun _ : Unit => (isconnected_elim@{i j j k i} C f).1); intros a.
       symmetry; apply ((isconnected_elim@{i j j k i} C f).2).
     - intros h k.
-      refine (extendable_postcompose'@{i i j j j j l l l l l l} n _ _ _ _ (IHn (h tt = k tt) (inO_paths@{Ou Oa j m} _ _ _ _))).
+      refine (extendable_postcompose'@{i i j j j j l l l l} n _ _ _ _ (IHn (h tt = k tt) (inO_paths@{Ou Oa j m} _ _ _ _))).
       intros []; apply equiv_idmap.
   Defined.
 

--- a/theories/Modalities/Nullification.v
+++ b/theories/Modalities/Nullification.v
@@ -62,12 +62,12 @@ Module Nullification_Modalities <: Modalities.
 
   Module LocRSUTh := ReflectiveSubuniverses_Theory LocRSU.
 
-  Definition O_reflector := LocRSU.O_reflector.
-  Definition In := LocRSU.In.
-  Definition O_inO := @LocRSU.O_inO.
-  Definition to := LocRSU.to.
+  Definition O_reflector@{u a i} := LocRSU.O_reflector@{u a i}.
+  Definition In@{u a i} := LocRSU.In@{u a i}.
+  Definition O_inO@{u a i} := @LocRSU.O_inO@{u a i}.
+  Definition to@{u a i} := LocRSU.to@{u a i}.
   Definition inO_equiv_inO := @LocRSU.inO_equiv_inO@{u a i j k}.
-  Definition hprop_inO := LocRSU.hprop_inO.
+  Definition hprop_inO@{u a i} := LocRSU.hprop_inO@{u a i}.
 
   Definition O_ind_internal@{u a i j k} (O : Modality@{u a}) (A : Type@{i})
              (B : O_reflector@{u a i} O A -> Type@{j})
@@ -78,7 +78,8 @@ Module Nullification_Modalities <: Modalities.
     refine (Localize_ind@{a i j k}
              (null_to_local_generators@{a a} (unNul O)) A B g _); intros i.
     apply (ooextendable_over_unit@{a i j a k}); intros c.
-    refine (ooextendable_postcompose@{a a j j k j j j k j k k}
+    refine (ooextendable_postcompose@{a a j j k k k k k k}
+                                    (* MS: Can be dropped *)
               (fun (_:Unit) => B (c tt)) _ _
               (fun u => transport@{i j} B (ap c (path_unit@{a} tt u))) _).
     refine (ooextendable_islocal _ i).

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -827,7 +827,7 @@ Section Reflective_Subuniverse.
         { refine (O_indpaths _ _ _); simpl.
           intro v; exact v. }
         exact (p u).
-      - hnf.
+      - simpl.
         rewrite O_indpaths_beta; reflexivity.
     Qed.
     Global Existing Instance inO_paths.

--- a/theories/Tactics/EquivalenceInduction.v
+++ b/theories/Tactics/EquivalenceInduction.v
@@ -346,10 +346,10 @@ Ltac equiv_induction p :=
   generalize dependent p;
   let p' := fresh in
   intro p';
-    let y := match type of p' with ?x <~> ?y => constr:y end in
+    let y := match type of p' with ?x <~> ?y => constr:(y) end in
     move p' at top;
       generalize dependent y;
-      let P := match goal with |- forall y p, @?P y p => constr:P end in
+      let P := match goal with |- forall y p, @?P y p => constr:(P) end in
       (* We use [(fun x => x) _] to block automatic typeclass resolution in the hole for the equivalence respectful proof. *)
       refine ((fun g H B e => (@respects_equivalenceL _ P H).1 B e g) _ (_ : (fun x => x) _));
         [ intros | repeat step_respects_equiv ].

--- a/theories/Tactics/RewriteModuloAssociativity.v
+++ b/theories/Tactics/RewriteModuloAssociativity.v
@@ -47,7 +47,7 @@ Module Export Compose.
     match T with
       | context G[?g o ?f] => let T' := context G[compose g f] in
                               to_compose T'
-      | ?T' => constr:T'
+      | ?T' => constr:(T')
     end.
 
   (** Turns a lemma of type [f = g] into [forall h, h o f = h o g] *)
@@ -57,7 +57,7 @@ Module Export Compose.
                                                                let T := type of H' in
                                                                let T' := to_compose T in
                                                                pose proof (fun src (g : _ -> src) => @ap _ _ (fun f => compose g f) _ _ (H' : T')) as H))
-                                                      ltac:idtac H in
+                                                      ltac:(idtac) H in
     let T := type of ret in
     let T' := (eval cbv beta in T) in
     constr:(ret : T').
@@ -109,44 +109,44 @@ Module Export Compose.
            end.
 
   Tactic Notation "rewriteoA" constr(lem) :=
-    rewriteA_using_helper ltac:(fun lem' => rewrite lem') lem ltac:precompose_any ltac:left_associate_compose ltac:left_associate_compose_in; after_rewrite.
+    rewriteA_using_helper ltac:(fun lem' => rewrite lem') lem ltac:(precompose_any) ltac:(left_associate_compose) ltac:(left_associate_compose_in); after_rewrite.
   Tactic Notation "rewriteoA" "->" constr(lem) :=
-    rewriteA_using_helper ltac:(fun lem' => rewrite -> lem') lem ltac:precompose_any ltac:left_associate_compose ltac:left_associate_compose_in; after_rewrite.
+    rewriteA_using_helper ltac:(fun lem' => rewrite -> lem') lem ltac:(precompose_any) ltac:(left_associate_compose) ltac:(left_associate_compose_in); after_rewrite.
   Tactic Notation "rewriteoA" "<-" constr(lem) :=
-    rewriteA_using_helper ltac:(fun lem' => rewrite <- lem') lem ltac:precompose_any ltac:left_associate_compose ltac:left_associate_compose_in; after_rewrite.
+    rewriteA_using_helper ltac:(fun lem' => rewrite <- lem') lem ltac:(precompose_any) ltac:(left_associate_compose) ltac:(left_associate_compose_in); after_rewrite.
   Tactic Notation "rewriteoA" "!" constr(lem) :=
-    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => progress rewrite ?lem', ?lem'') lem ltac:precompose_any ltac:left_associate_compose ltac:left_associate_compose_in; after_rewrite.
+    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => progress rewrite ?lem', ?lem'') lem ltac:(precompose_any) ltac:(left_associate_compose) ltac:(left_associate_compose_in); after_rewrite.
   Tactic Notation "rewriteoA" "?" constr(lem) :=
-    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => rewrite ?lem', ?lem'') lem ltac:precompose_any ltac:left_associate_compose ltac:left_associate_compose_in; after_rewrite.
+    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => rewrite ?lem', ?lem'') lem ltac:(precompose_any) ltac:(left_associate_compose) ltac:(left_associate_compose_in); after_rewrite.
   Tactic Notation "rewriteoA" "->" "!" constr(lem) :=
-    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => progress rewrite -> ?lem', -> ?lem'') lem ltac:precompose_any ltac:left_associate_compose ltac:left_associate_compose_in; after_rewrite.
+    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => progress rewrite -> ?lem', -> ?lem'') lem ltac:(precompose_any) ltac:(left_associate_compose) ltac:(left_associate_compose_in); after_rewrite.
   Tactic Notation "rewriteoA" "<-" "!" constr(lem) :=
-    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => progress rewrite <- ?lem', <- ?lem'') lem ltac:precompose_any ltac:left_associate_compose ltac:left_associate_compose_in; after_rewrite.
+    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => progress rewrite <- ?lem', <- ?lem'') lem ltac:(precompose_any) ltac:(left_associate_compose) ltac:(left_associate_compose_in); after_rewrite.
   Tactic Notation "rewriteoA" "->" "?" constr(lem) :=
-    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => rewrite -> ?lem', -> ?lem'') lem ltac:precompose_any ltac:left_associate_compose ltac:left_associate_compose_in; after_rewrite.
+    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => rewrite -> ?lem', -> ?lem'') lem ltac:(precompose_any) ltac:(left_associate_compose) ltac:(left_associate_compose_in); after_rewrite.
   Tactic Notation "rewriteoA" "<-" "?" constr(lem) :=
-    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => rewrite <- ?lem', <- ?lem'') lem ltac:precompose_any ltac:left_associate_compose ltac:left_associate_compose_in; after_rewrite.
+    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => rewrite <- ?lem', <- ?lem'') lem ltac:(precompose_any) ltac:(left_associate_compose) ltac:(left_associate_compose_in); after_rewrite.
 
 
 
   Tactic Notation "erewriteoA" constr(lem) :=
-    rewriteA_using_helper ltac:(fun lem' => erewrite lem') lem ltac:precompose_any ltac:left_associate_compose ltac:left_associate_compose_in; after_rewrite.
+    rewriteA_using_helper ltac:(fun lem' => erewrite lem') lem ltac:(precompose_any) ltac:(left_associate_compose) ltac:(left_associate_compose_in); after_rewrite.
   Tactic Notation "erewriteoA" "->" constr(lem) :=
-    rewriteA_using_helper ltac:(fun lem' => erewrite -> lem') lem ltac:precompose_any ltac:left_associate_compose ltac:left_associate_compose_in; after_rewrite.
+    rewriteA_using_helper ltac:(fun lem' => erewrite -> lem') lem ltac:(precompose_any) ltac:(left_associate_compose) ltac:(left_associate_compose_in); after_rewrite.
   Tactic Notation "erewriteoA" "<-" constr(lem) :=
-    rewriteA_using_helper ltac:(fun lem' => erewrite <- lem') lem ltac:precompose_any ltac:left_associate_compose ltac:left_associate_compose_in; after_rewrite.
+    rewriteA_using_helper ltac:(fun lem' => erewrite <- lem') lem ltac:(precompose_any) ltac:(left_associate_compose) ltac:(left_associate_compose_in); after_rewrite.
   Tactic Notation "erewriteoA" "!" constr(lem) :=
-    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => progress erewrite ?lem', ?lem'') lem ltac:precompose_any ltac:left_associate_compose ltac:left_associate_compose_in; after_rewrite.
+    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => progress erewrite ?lem', ?lem'') lem ltac:(precompose_any) ltac:(left_associate_compose) ltac:(left_associate_compose_in); after_rewrite.
   Tactic Notation "erewriteoA" "?" constr(lem) :=
-    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => erewrite ?lem', ?lem'') lem ltac:precompose_any ltac:left_associate_compose ltac:left_associate_compose_in; after_rewrite.
+    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => erewrite ?lem', ?lem'') lem ltac:(precompose_any) ltac:(left_associate_compose) ltac:(left_associate_compose_in); after_rewrite.
   Tactic Notation "erewriteoA" "->" "!" constr(lem) :=
-    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => progress erewrite -> ?lem', -> ?lem'') lem ltac:precompose_any ltac:left_associate_compose ltac:left_associate_compose_in; after_rewrite.
+    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => progress erewrite -> ?lem', -> ?lem'') lem ltac:(precompose_any) ltac:(left_associate_compose) ltac:(left_associate_compose_in); after_rewrite.
   Tactic Notation "erewriteoA" "<-" "!" constr(lem) :=
-    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => progress erewrite <- ?lem', <- ?lem'') lem ltac:precompose_any ltac:left_associate_compose ltac:left_associate_compose_in; after_rewrite.
+    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => progress erewrite <- ?lem', <- ?lem'') lem ltac:(precompose_any) ltac:(left_associate_compose) ltac:(left_associate_compose_in); after_rewrite.
   Tactic Notation "erewriteoA" "->" "?" constr(lem) :=
-    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => erewrite -> ?lem', -> ?lem'') lem ltac:precompose_any ltac:left_associate_compose ltac:left_associate_compose_in; after_rewrite.
+    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => erewrite -> ?lem', -> ?lem'') lem ltac:(precompose_any) ltac:(left_associate_compose) ltac:(left_associate_compose_in); after_rewrite.
   Tactic Notation "erewriteoA" "<-" "?" constr(lem) :=
-    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => erewrite <- ?lem', <- ?lem'') lem ltac:precompose_any ltac:left_associate_compose ltac:left_associate_compose_in; after_rewrite.
+    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => erewrite <- ?lem', <- ?lem'') lem ltac:(precompose_any) ltac:(left_associate_compose) ltac:(left_associate_compose_in); after_rewrite.
 
 
   Tactic Notation "rewrite∘A" constr(lem) := rewriteoA lem.
@@ -178,7 +178,7 @@ Module Export Concat.
     let ret := make_tac_under_binders_using_in ltac:(fun H => (let H' := fresh in
                                                                rename H into H';
                                                                pose proof (fun dst (g : dst = _) => @ap _ _ (fun f => g @ f) _ _ H') as H))
-                                                      ltac:idtac H in
+                                                      ltac:(idtac) H in
     let T := type of ret in
     let T' := (eval cbv beta in T) in
     constr:(ret : T').
@@ -224,44 +224,44 @@ Module Export Concat.
         clear H'.
 
   Tactic Notation "rewrite@A" constr(lem) :=
-    rewriteA_using_helper ltac:(fun lem' => rewrite lem') lem ltac:preconcat_any ltac:left_associate_concat ltac:left_associate_concat_in_hyp.
+    rewriteA_using_helper ltac:(fun lem' => rewrite lem') lem ltac:(preconcat_any) ltac:(left_associate_concat) ltac:(left_associate_concat_in_hyp).
   Tactic Notation "rewrite@A" "->" constr(lem) :=
-    rewriteA_using_helper ltac:(fun lem' => rewrite -> lem') lem ltac:preconcat_any ltac:left_associate_concat ltac:left_associate_concat_in_hyp.
+    rewriteA_using_helper ltac:(fun lem' => rewrite -> lem') lem ltac:(preconcat_any) ltac:(left_associate_concat) ltac:(left_associate_concat_in_hyp).
   Tactic Notation "rewrite@A" "<-" constr(lem) :=
-    rewriteA_using_helper ltac:(fun lem' => rewrite <- lem') lem ltac:preconcat_any ltac:left_associate_concat ltac:left_associate_concat_in_hyp.
+    rewriteA_using_helper ltac:(fun lem' => rewrite <- lem') lem ltac:(preconcat_any) ltac:(left_associate_concat) ltac:(left_associate_concat_in_hyp).
   Tactic Notation "rewrite@A" "!" constr(lem) :=
-    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => progress rewrite ?lem', ?lem'') lem ltac:preconcat_any ltac:left_associate_concat ltac:left_associate_concat_in_hyp.
+    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => progress rewrite ?lem', ?lem'') lem ltac:(preconcat_any) ltac:(left_associate_concat) ltac:(left_associate_concat_in_hyp).
   Tactic Notation "rewrite@A" "?" constr(lem) :=
-    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => rewrite ?lem', ?lem'') lem ltac:preconcat_any ltac:left_associate_concat ltac:left_associate_concat_in_hyp.
+    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => rewrite ?lem', ?lem'') lem ltac:(preconcat_any) ltac:(left_associate_concat) ltac:(left_associate_concat_in_hyp).
   Tactic Notation "rewrite@A" "->" "!" constr(lem) :=
-    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => progress rewrite -> ?lem', -> ?lem'') lem ltac:preconcat_any ltac:left_associate_concat ltac:left_associate_concat_in_hyp.
+    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => progress rewrite -> ?lem', -> ?lem'') lem ltac:(preconcat_any) ltac:(left_associate_concat) ltac:(left_associate_concat_in_hyp).
   Tactic Notation "rewrite@A" "<-" "!" constr(lem) :=
-    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => progress rewrite <- ?lem', <- ?lem'') lem ltac:preconcat_any ltac:left_associate_concat ltac:left_associate_concat_in_hyp.
+    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => progress rewrite <- ?lem', <- ?lem'') lem ltac:(preconcat_any) ltac:(left_associate_concat) ltac:(left_associate_concat_in_hyp).
   Tactic Notation "rewrite@A" "->" "?" constr(lem) :=
-    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => rewrite -> ?lem', -> ?lem'') lem ltac:preconcat_any ltac:left_associate_concat ltac:left_associate_concat_in_hyp.
+    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => rewrite -> ?lem', -> ?lem'') lem ltac:(preconcat_any) ltac:(left_associate_concat) ltac:(left_associate_concat_in_hyp).
   Tactic Notation "rewrite@A" "<-" "?" constr(lem) :=
-    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => rewrite <- ?lem', <- ?lem'') lem ltac:preconcat_any ltac:left_associate_concat ltac:left_associate_concat_in_hyp.
+    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => rewrite <- ?lem', <- ?lem'') lem ltac:(preconcat_any) ltac:(left_associate_concat) ltac:(left_associate_concat_in_hyp).
 
 
 
   Tactic Notation "erewrite@A" constr(lem) :=
-    rewriteA_using_helper ltac:(fun lem' => erewrite lem') lem ltac:preconcat_any ltac:left_associate_concat ltac:left_associate_concat_in_hyp.
+    rewriteA_using_helper ltac:(fun lem' => erewrite lem') lem ltac:(preconcat_any) ltac:(left_associate_concat) ltac:(left_associate_concat_in_hyp).
   Tactic Notation "erewrite@A" "->" constr(lem) :=
-    rewriteA_using_helper ltac:(fun lem' => erewrite -> lem') lem ltac:preconcat_any ltac:left_associate_concat ltac:left_associate_concat_in_hyp.
+    rewriteA_using_helper ltac:(fun lem' => erewrite -> lem') lem ltac:(preconcat_any) ltac:(left_associate_concat) ltac:(left_associate_concat_in_hyp).
   Tactic Notation "erewrite@A" "<-" constr(lem) :=
-    rewriteA_using_helper ltac:(fun lem' => erewrite <- lem') lem ltac:preconcat_any ltac:left_associate_concat ltac:left_associate_concat_in_hyp.
+    rewriteA_using_helper ltac:(fun lem' => erewrite <- lem') lem ltac:(preconcat_any) ltac:(left_associate_concat) ltac:(left_associate_concat_in_hyp).
   Tactic Notation "erewrite@A" "!" constr(lem) :=
-    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => progress erewrite ?lem', ?lem'') lem ltac:preconcat_any ltac:left_associate_concat ltac:left_associate_concat_in_hyp.
+    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => progress erewrite ?lem', ?lem'') lem ltac:(preconcat_any) ltac:(left_associate_concat) ltac:(left_associate_concat_in_hyp).
   Tactic Notation "erewrite@A" "?" constr(lem) :=
-    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => erewrite ?lem', ?lem'') lem ltac:preconcat_any ltac:left_associate_concat ltac:left_associate_concat_in_hyp.
+    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => erewrite ?lem', ?lem'') lem ltac:(preconcat_any) ltac:(left_associate_concat) ltac:(left_associate_concat_in_hyp).
   Tactic Notation "erewrite@A" "->" "!" constr(lem) :=
-    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => progress erewrite -> ?lem', -> ?lem'') lem ltac:preconcat_any ltac:left_associate_concat ltac:left_associate_concat_in_hyp.
+    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => progress erewrite -> ?lem', -> ?lem'') lem ltac:(preconcat_any) ltac:(left_associate_concat) ltac:(left_associate_concat_in_hyp).
   Tactic Notation "erewrite@A" "<-" "!" constr(lem) :=
-    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => progress erewrite <- ?lem', <- ?lem'') lem ltac:preconcat_any ltac:left_associate_concat ltac:left_associate_concat_in_hyp.
+    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => progress erewrite <- ?lem', <- ?lem'') lem ltac:(preconcat_any) ltac:(left_associate_concat) ltac:(left_associate_concat_in_hyp).
   Tactic Notation "erewrite@A" "->" "?" constr(lem) :=
-    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => erewrite -> ?lem', -> ?lem'') lem ltac:preconcat_any ltac:left_associate_concat ltac:left_associate_concat_in_hyp.
+    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => erewrite -> ?lem', -> ?lem'') lem ltac:(preconcat_any) ltac:(left_associate_concat) ltac:(left_associate_concat_in_hyp).
   Tactic Notation "erewrite@A" "<-" "?" constr(lem) :=
-    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => erewrite <- ?lem', <- ?lem'') lem ltac:preconcat_any ltac:left_associate_concat ltac:left_associate_concat_in_hyp.
+    repeat_rewriteA_using_helper ltac:(fun lem' lem'' => erewrite <- ?lem', <- ?lem'') lem ltac:(preconcat_any) ltac:(left_associate_concat) ltac:(left_associate_concat_in_hyp).
 
   Tactic Notation "rewrite•A" constr(lem) := rewrite@A lem.
   Tactic Notation "rewrite•A" "->" constr(lem) := rewrite@A -> lem.


### PR DESCRIPTION
This PR shows the changes necessary to compile with the current 8.6 branch, soon to be beta1, once we resolve the following issues:
- symmetry shadowing (I patched by using apply symmetry everywhere)
- Arguments foo /. fails currently, but I think we'll backtrack on making this an error
- One real bug in typeclasses.

In the end only the next-to-last patch should apply, which is about universe annotations consistent with the fixed minimization which is now insensitive to redundant constraints in the graph (see https://github.com/coq/coq/pull/315) for the patched Coq that goes with this.
