### PR TITLE
Use functor notations [F _0 x] and [F _1 m] more

### DIFF
--- a/theories/Categories/Adjoint/Composition/LawsTactic.v
+++ b/theories/Categories/Adjoint/Composition/LawsTactic.v
@@ -24,17 +24,17 @@ Ltac law_t :=
   rewrite !transport_forall_constant;
   repeat
     match goal with
-      | [ |- context[transport (fun y => ?f (@object_of ?C ?D y ?x))] ]
+      | [ |- context[transport (fun y : Functor ?C ?D => ?f (y _0 ?x)%object)] ]
         => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (y' x)) (@object_of C D))
-      | [ |- context[transport (fun y => ?f (?g (@object_of ?C ?D y ?x)))] ]
+      | [ |- context[transport (fun y : Functor ?C ?D => ?f (?g (y _0 ?x)%object))] ]
         => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (g (y' x))) (@object_of C D))
-      | [ |- context[transport (fun y => ?f (?g (?h (?i (@object_of ?C ?D y ?x)))))] ]
+      | [ |- context[transport (fun y : Functor ?C ?D => ?f (?g (?h (?i (y _0 ?x)%object))))] ]
         => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (g (h (i (y' x))))) (@object_of C D))
-      | [ |- context[transport (fun y => ?f (@object_of ?C ?D y ?x) ?z)] ]
+      | [ |- context[transport (fun y : Functor ?C ?D => ?f (y _0 ?x)%object ?z)] ]
         => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (y' x) z) (@object_of C D))
-      | [ |- context[transport (fun y => ?f (?g (@object_of ?C ?D y ?x)) ?z)] ]
+      | [ |- context[transport (fun y : Functor ?C ?D => ?f (?g (y _0 ?x)%object) ?z)] ]
         => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (g (y' x)) z) (@object_of C D))
-      | [ |- context[transport (fun y => ?f (?g (?h (?i (@object_of ?C ?D y ?x)))) ?z)] ]
+      | [ |- context[transport (fun y : Functor ?C ?D => ?f (?g (?h (?i (y _0 ?x)%object))) ?z)] ]
         => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (g (h (i (y' x)))) z) (@object_of C D))
     end;
   unfold symmetry, symmetric_paths;

--- a/theories/Categories/Adjoint/UnitCounit.v
+++ b/theories/Categories/Adjoint/UnitCounit.v
@@ -264,12 +264,12 @@ Section Adjunction.
         : forall Y : C, (*ε (F Y) ∘ F ₁ (η Y) = identity (F Y);*)
             Category.Core.compose (C := D) (s := F Y) (d := F (G (F Y))) (d' := F Y)
                                   (counit (F Y))
-                                  (morphism_of F (s := Y) (d := G (F Y)) (unit Y))
+                                  (F _1 (unit Y : morphism _ Y (G (F Y))))
             = 1;
         unit_counit_equation_2
         : forall X : D, (* G ₁ (ε X) ∘ η (G X) = identity (G X) *)
             Category.Core.compose (C := C) (s := G X) (d := G (F (G X))) (d' := G X)
-                                  (morphism_of G (s := F (G X)) (d := X) (counit X))
+                                  (G _1 (counit X : morphism _ (F (G X)) X))
                                   (unit (G X))
             = 1
       }.

--- a/theories/Categories/Category/Morphisms.v
+++ b/theories/Categories/Category/Morphisms.v
@@ -447,16 +447,16 @@ Section iso_lemmas.
   (** *** [idtoiso] respects application of functors on morphisms and objects *)
   Lemma idtoiso_functor (C D : PreCategory) (s d : C) (m : s = d)
         (F : Functor C D)
-  : morphism_of F (idtoiso _ m) = idtoiso _ (ap (object_of F) m).
+  : F _1 (idtoiso _ m) = idtoiso _ (ap (object_of F) m).
   Proof.
     path_induction; simpl; apply identity_of.
   Defined.
 
   (** *** Functors preserve isomorphisms *)
   Global Instance iso_functor C D (F : Functor C D) `(@IsIsomorphism C s d m)
-  : IsIsomorphism (morphism_of F m).
+  : IsIsomorphism (F _1 m).
   Proof.
-    refine ({| morphism_inverse := morphism_of F m^-1 |}).
+    refine ({| morphism_inverse := F _1 m^-1 |}).
     abstract (rewrite <- composition_of, ?left_inverse, ?right_inverse, identity_of; reflexivity).
     abstract (rewrite <- composition_of, ?left_inverse, ?right_inverse, identity_of; reflexivity).
   Defined.

--- a/theories/Categories/ExponentialLaws/Law4/Functors.v
+++ b/theories/Categories/ExponentialLaws/Law4/Functors.v
@@ -99,11 +99,7 @@ Section law4.
         refine (Build_Functor
                   C2 D
                   (fun c2 => F (c1, c2))
-                  (fun s2 d2 m2 => morphism_of
-                                     F
-                                     (s := (c1, s2))
-                                     (d := (c1, d2))
-                                     (identity c1, m2))
+                  (fun s2 d2 m2 => F _1 ((identity c1, m2) : morphism (_ * _) (c1, s2) (c1, d2)))
                   _
                   _);
           abstract do_exponential4_inverse.
@@ -118,11 +114,7 @@ Section law4.
         refine (Build_NaturalTransformation
                   (inverse_object_of_object_of s)
                   (inverse_object_of_object_of d)
-                  (fun c => morphism_of
-                              F
-                              (s := (s, c))
-                              (d := (d, c))
-                              (m, identity c))
+                  (fun c => F _1 ((m, identity c) : morphism (_ * _) (s, c) (d, c)))
                   _);
         abstract do_exponential4_inverse.
       Defined.

--- a/theories/Categories/ExponentialLaws/Tactics.v
+++ b/theories/Categories/ExponentialLaws/Tactics.v
@@ -50,15 +50,15 @@ Ltac exp_laws_handle_transport' :=
     | _ => progress rewrite ?transport_forall_constant, ?path_forall_2_beta, ?transport_const, ?transport_path_prod
     | [ |- context [path_functor_uncurried ?F ?G (?x; ?y)] ] (* https://coq.inria.fr/bugs/show_bug.cgi?id=3768 *)
       => rewrite (@path_functor_uncurried_fst _ _ _ F G x y)
-    | [ |- context[transport (fun y => ?f (@object_of ?C ?D y ?x))] ]
+    | [ |- context[transport (fun y : Functor ?C ?D => ?f (y _0 ?x)%object)] ]
       => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (y' x)) (@object_of C D))
-    | [ |- context[transport (fun y => ?f (@object_of ?C ?D y ?x) ?z)] ]
+    | [ |- context[transport (fun y : Functor ?C ?D => ?f (y _0 ?x)%object ?z)] ]
       => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (y' x) z) (@object_of C D))
-    | [ |- context[transport (fun y => ?f (@object_of ?C ?D y ?x) ?z)] ]
+    | [ |- context[transport (fun y : Functor ?C ?D => ?f (y _0 ?x)%object ?z)] ]
       => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (y' x) z) (@object_of C D))
-    | [ |- context[transport (fun y => ?f (?g (@object_of ?C ?D y ?x)))] ]
+    | [ |- context[transport (fun y : Functor ?C ?D => ?f (?g (y _0 ?x)%object))] ]
       => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (g (y' x))) (@object_of C D))
-    | [ |- context[transport (fun y => ?f (?g (@object_of ?C ?D y ?x)) ?z)] ]
+    | [ |- context[transport (fun y : Functor ?C ?D => ?f (?g (y _0 ?x)%object) ?z)] ]
       => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (g (y' x)) z) (@object_of C D))
     | _ => progress transport_path_forall_hammer
     | [ |- context[components_of (transport ?P ?p ?z)] ]

--- a/theories/Categories/Functor/Attributes.v
+++ b/theories/Categories/Functor/Attributes.v
@@ -22,8 +22,7 @@ Section full_faithful.
     refine (Build_NaturalTransformation
               (hom_functor C)
               (hom_functor D o (F^op, F))
-              (fun sd : object (C^op * C) =>
-                 morphism_of F (s := _) (d := _))
+              (fun (sd : object (C^op * C)) m => (F _1 m)%morphism)
               _
            ).
     abstract (

--- a/theories/Categories/Functor/Composition/Core.v
+++ b/theories/Categories/Functor/Composition/Core.v
@@ -16,25 +16,25 @@ Section composition.
   (** We usually don't want to see the proofs of composition in functors, because the proofs are hProps, and so we don't care about them.  But occasionally, we want to be able to reduce the proofs.  Having the proofs transparent allows the composition of the identity functor with itself to be judgementally the identity.  Since the only way to hide something from within a proof is [abstract], and that makes the definitions opaque, we need to define the laws separately. *)
 
   Local Notation c_object_of c := (G (F c)) (only parsing).
-  Local Notation c_morphism_of m := (morphism_of G (morphism_of F m)) (only parsing).
+  Local Notation c_morphism_of m := (G _1 (F _1 m)) (only parsing).
   Definition compose_composition_of s d d'
       (m1 : morphism C s d) (m2 : morphism C d d')
   : c_morphism_of (m2 o m1) = c_morphism_of m2 o c_morphism_of m1
     := transport (@paths _ (c_morphism_of (m2 o m1)))
                  (composition_of G _ _ _ _ _)
-                 (ap (@morphism_of _ _ G _ _) (composition_of F _ _ _ m1 m2)).
+                 (ap (fun m => G _1 m) (composition_of F _ _ _ m1 m2)).
 
   Definition compose_identity_of x
   : c_morphism_of (identity x) = identity (c_object_of x)
     := transport (@paths _ _)
                  (identity_of G _)
-                 (ap (@morphism_of _ _ G _ _) (identity_of F x)).
+                 (ap (fun m => G _1 m) (identity_of F x)).
 
   Definition compose : Functor C E
     := Build_Functor
          C E
          (fun c => G (F c))
-         (fun _ _ m => morphism_of G (morphism_of F m))
+         (fun _ _ m => G _1 (F _1 m))
          compose_composition_of
          compose_identity_of.
 End composition.

--- a/theories/Categories/Functor/Dual.v
+++ b/theories/Categories/Functor/Dual.v
@@ -14,7 +14,7 @@ Local Open Scope category_scope.
 Definition opposite C D (F : Functor C D) : Functor C^op D^op
   := Build_Functor (C^op) (D^op)
                    (object_of F)
-                   (fun s d => morphism_of F (s := d) (d := s))
+                   (fun s d (m : morphism C^op s d) => (F _1 m)%morphism)
                    (fun d' d s m1 m2 => composition_of F s d d' m2 m1)
                    (identity_of F).
 

--- a/theories/Categories/Functor/Paths.v
+++ b/theories/Categories/Functor/Paths.v
@@ -111,7 +111,7 @@ Section path_functor.
                           (path_forall _ _ HO)
                           (morphism_of F)
                           s d m
-                = morphism_of G m)
+                = G _1 m)
   : F = G.
   Proof.
     refine (path_functor F G (path_forall _ _ HO) _).

--- a/theories/Categories/Functor/Sum.v
+++ b/theories/Categories/Functor/Sum.v
@@ -47,11 +47,11 @@ Section sum.
               (fun s d
                => match s, d with
                     | type_inl cs, type_inl cd
-                      => morphism_of F (s := cs) (d := cd)
+                      => fun m : morphism _ cs cd => F _1 m
                     | type_inr c's, type_inr c'd
-                      => morphism_of F' (s := c's) (d := c'd)
+                      => fun m : morphism _ c's c'd => F' _1 m
                     | _, _ => fun m => match m with end
-                  end)
+                  end%morphism)
               _
               _);
     abstract (

--- a/theories/Categories/Grothendieck/PseudofunctorToCat.v
+++ b/theories/Categories/Grothendieck/PseudofunctorToCat.v
@@ -104,10 +104,10 @@ Section Grothendieck.
                      | try_associativity_quick (f_ap; []) ];
         match goal with
           | _ => reflexivity
-          | [ |- context[morphism_of ?F ?m o components_of ?T ?x] ]
+          | [ |- context[?F _1 ?m o components_of ?T ?x] ]
             => simpl rewrite <- (commutes T _ _ m);
               try reflexivity
-          | [ |- context[components_of ?T ?x o morphism_of ?F ?m] ]
+          | [ |- context[components_of ?T ?x o ?F _1 ?m] ]
             => simpl rewrite (commutes T _ _ m);
               try reflexivity
         end.

--- a/theories/Categories/Grothendieck/ToSet/Core.v
+++ b/theories/Categories/Grothendieck/ToSet/Core.v
@@ -48,7 +48,7 @@ Section Grothendieck.
 
   Local Notation morphism s d :=
     { f : morphism C s.(c) d.(c)
-    | morphism_of F f s.(x) = d.(x) }.
+    | F _1 f s.(x) = d.(x) }.
 
   Definition compose_H s d d'
              (m1 : morphism d d')

--- a/theories/Categories/NaturalTransformation/Composition/Core.v
+++ b/theories/Categories/NaturalTransformation/Composition/Core.v
@@ -61,7 +61,7 @@ Section composition.
     Local Notation CO c := (T' c o T c).
 
     Definition compose_commutes s d (m : morphism C s d)
-    : CO d o morphism_of F m = morphism_of F'' m o CO s
+    : CO d o F _1 m = F'' _1 m o CO s
       := (associativity _ _ _ _ _ _ _ _)
            @ ap (fun x => _ o x) (commutes T _ _ m)
            @ (associativity_sym _ _ _ _ _ _ _ _)
@@ -70,7 +70,7 @@ Section composition.
 
     (** We define the symmetrized version separately so that we can get more unification in the functor [(C → D)ᵒᵖ → (Cᵒᵖ → Dᵒᵖ)] *)
     Definition compose_commutes_sym s d (m : morphism C s d)
-    : morphism_of F'' m o CO s = CO d o morphism_of F m
+    : F'' _1 m o CO s = CO d o F _1 m
       := (associativity_sym _ _ _ _ _ _ _ _)
            @ ap (fun x => x o _) (commutes_sym T' _ _ m)
            @ (associativity _ _ _ _ _ _ _ _)
@@ -97,7 +97,7 @@ Section composition.
       Variables G G' : Functor C D.
       Variable T : NaturalTransformation G G'.
 
-      Local Notation CO c := (morphism_of F (T c)).
+      Local Notation CO c := (F _1 (T c)).
 
       Definition whisker_l_commutes s d (m : morphism C s d)
       : F _1 (T d) o (F o G) _1 m = (F o G') _1 m o F _1 (T s)

--- a/theories/Categories/NaturalTransformation/Identity.v
+++ b/theories/Categories/NaturalTransformation/Identity.v
@@ -31,14 +31,14 @@ Section identity.
                                       (identity (F c))).
 
     Definition generalized_identity_commutes s d (m : morphism C s d)
-    : CO d o morphism_of F m = morphism_of G m o CO s.
+    : CO d o F _1 m = G _1 m o CO s.
     Proof.
       case HM. case HO.
       exact (left_identity _ _ _ _ @ (right_identity _ _ _ _)^).
     Defined.
 
     Definition generalized_identity_commutes_sym s d (m : morphism C s d)
-    : morphism_of G m o CO s = CO d o morphism_of F m.
+    : G _1 m o CO s = CO d o F _1 m.
     Proof.
       case HM. case HO.
       exact (right_identity _ _ _ _ @ (left_identity _ _ _ _)^).

--- a/theories/Categories/Pseudofunctor/FromFunctor.v
+++ b/theories/Categories/Pseudofunctor/FromFunctor.v
@@ -148,7 +148,7 @@ intros.
     := Build_Pseudofunctor
          C
          (fun x => pr1 (F x))
-         (fun s d m => morphism_of F m)
+         (fun s d m => F _1 m)
          (fun s d d' m0 m1 => Category.Morphisms.idtoiso (_ -> _) (composition_of F _ _ _ m1 m0))
          (fun x => Category.Morphisms.idtoiso (_ -> _) (identity_of F x))
          (fun w x y z _ _ _ => pseudofunctor_of_functor__composition_of (F w).2 (F z).2 (F y).2 (F x).2)

--- a/theories/Categories/SetCategory/Functors/SetProp.v
+++ b/theories/Categories/SetCategory/Functors/SetProp.v
@@ -33,7 +33,7 @@ Section set_coercions.
   Definition to_prop2set (F : to_prop C) : to_set C :=
     Build_Functor C set_cat
                   (fun x => BuildhSet (F x))
-                  (fun s d m => morphism_of F m)
+                  (fun s d m => (F _1 m)%morphism)
                   (fun s d d' m m' => composition_of F s d d' m m')
                   (fun x => identity_of F x).
 
@@ -41,10 +41,10 @@ Section set_coercions.
   Definition from_set2prop (F : from_set C) : from_prop C
     := Build_Functor prop_cat C
                      (fun x => F (BuildhSet x))
-                     (fun s d m => morphism_of F (m : morphism
-                                                        set_cat
-                                                        (BuildhSet s)
-                                                        (BuildhSet d)))
+                     (fun s d m => (F _1 (m : morphism
+                                                set_cat
+                                                (BuildhSet s)
+                                                (BuildhSet d)))%morphism)
                      (fun s d d' m m' => composition_of F
                                                         (BuildhSet s)
                                                         (BuildhSet d)

--- a/theories/Categories/UniversalProperties.v
+++ b/theories/Categories/UniversalProperties.v
@@ -75,7 +75,7 @@ Section UniversalMorphism.
                  (UniversalProperty
                   : forall (A' : D) (p' : morphism C X (U A')),
                       Contr { m : morphism D A A'
-                            | morphism_of U m o p = p' })
+                            | U _1 m o p = p' })
       : IsInitialMorphism Ap.
       Proof.
         intro x.
@@ -98,9 +98,9 @@ Section UniversalMorphism.
                  (m : forall (A' : D) (p' : morphism C X (U A')),
                         morphism D A A')
                  (H : forall (A' : D) (p' : morphism C X (U A')),
-                        morphism_of U (m A' p') o p = p')
+                        U _1 (m A' p') o p = p')
                  (H' : forall (A' : D) (p' : morphism C X (U A')) m',
-                         morphism_of U m' o p = p'
+                         U _1 m' o p = p'
                          -> m A' p' = m')
       : IsInitialMorphism Ap
         := Build_IsInitialMorphism
@@ -125,9 +125,9 @@ Section UniversalMorphism.
                        | let Ap := CommaCategory.Build_object !X U tt A p in
                          forall (A' : D) (p' : morphism C X (U A')),
                            { m : morphism D A A'
-                           | { H : morphism_of U m o p = p'
+                           | { H : U _1 m o p = p'
                              | forall m',
-                                 morphism_of U m' o p = p'
+                                 U _1 m' o p = p'
                                  -> m = m' }}}})
         := @Build_IsInitialMorphism_curried
              (univ.1)
@@ -178,9 +178,9 @@ Section UniversalMorphism.
                     | let Ap := CommaCategory.Build_object !X U tt A p in
                       forall (A' : D) (p' : morphism C X (U A')),
                         { m : morphism D A A'
-                        | { H : morphism_of U m o p = p'
+                        | { H : U _1 m o p = p'
                           | forall m',
-                              morphism_of U m' o p = p'
+                              U _1 m' o p = p'
                               -> m = m' }}}}),
           IsInitialMorphism (CommaCategory.Build_object !X U tt univ.1 univ.2.1)
         := @make_uncurried
@@ -209,7 +209,7 @@ Section UniversalMorphism.
       Definition IsInitialMorphism_property_morphism_property
                  (M : IsInitialMorphism Ap)
                  (Y : D) (f : morphism C X (U Y))
-      : (morphism_of U (IsInitialMorphism_property_morphism M Y f))
+      : (U _1 (IsInitialMorphism_property_morphism M Y f))
           o IsInitialMorphism_morphism M = f
         := concat
              (CommaCategory.p
@@ -219,7 +219,7 @@ Section UniversalMorphism.
                  (M : IsInitialMorphism Ap)
                  (Y : D) (f : morphism C X (U Y))
                  m'
-                 (H : morphism_of U m' o IsInitialMorphism_morphism M = f)
+                 (H : U _1 m' o IsInitialMorphism_morphism M = f)
       : IsInitialMorphism_property_morphism M Y f = m'
         := ap
              (@CommaCategory.h _ _ _ _ _ _ _)
@@ -232,7 +232,7 @@ Section UniversalMorphism.
                  (M : IsInitialMorphism Ap)
                  (Y : D) (f : morphism C X (U Y))
       : Contr { m : morphism D (IsInitialMorphism_object M) Y
-              | morphism_of U m o IsInitialMorphism_morphism M = f }
+              | U _1 m o IsInitialMorphism_morphism M = f }
         := {| center := (IsInitialMorphism_property_morphism M Y f;
                          IsInitialMorphism_property_morphism_property M Y f);
               contr m' := path_sigma
@@ -306,7 +306,7 @@ Section UniversalMorphism.
           (UniversalProperty
            : forall (A' : D) (p' : morphism C (U A') X),
                Contr { m : morphism D A' A
-                     | p o morphism_of U m = p' }),
+                     | p o U _1 m = p' }),
           IsTerminalMorphism Ap
         := @Build_IsInitialMorphism
              (C^op)
@@ -322,9 +322,9 @@ Section UniversalMorphism.
           (m : forall (A' : D) (p' : morphism C (U A') X),
                  morphism D A' A)
           (H : forall (A' : D) (p' : morphism C (U A') X),
-                 p o morphism_of U (m A' p') = p')
+                 p o U _1 (m A' p') = p')
           (H' : forall (A' : D) (p' : morphism C (U A') X) m',
-                  p o morphism_of U m' = p'
+                  p o U _1 m' = p'
                   -> m A' p' = m'),
           IsTerminalMorphism Ap
         := @Build_IsInitialMorphism_curried
@@ -340,9 +340,9 @@ Section UniversalMorphism.
                     | let Ap := CommaCategory.Build_object U !X A tt p in
                       forall (A' : D) (p' : morphism C (U A') X),
                         { m : morphism D A' A
-                        | { H : p o morphism_of U m = p'
+                        | { H : p o U _1 m = p'
                           | forall m',
-                              p o morphism_of U m' = p'
+                              p o U _1 m' = p'
                               -> m = m' }}}}),
           IsTerminalMorphism (CommaCategory.Build_object U !X univ.1 tt univ.2.1)
         := @Build_IsInitialMorphism_uncurried
@@ -365,7 +365,7 @@ Section UniversalMorphism.
       Definition IsTerminalMorphism_property
       : forall (Y : D) (f : morphism C (U Y) X),
           Contr { m : morphism D Y IsTerminalMorphism_object
-                | IsTerminalMorphism_morphism o morphism_of U m = f }
+                | IsTerminalMorphism_morphism o U _1 m = f }
         := @IsInitialMorphism_property C^op D^op X U^op (op_object Ap) M.
       Definition IsTerminalMorphism_property_morphism
       : forall (Y : D) (f : morphism C (U Y) X),
@@ -375,14 +375,14 @@ Section UniversalMorphism.
       Definition IsTerminalMorphism_property_morphism_property
       : forall (Y : D) (f : morphism C (U Y) X),
           IsTerminalMorphism_morphism
-            o (morphism_of U (IsTerminalMorphism_property_morphism Y f))
+            o (U _1 (IsTerminalMorphism_property_morphism Y f))
           = f
         := @IsInitialMorphism_property_morphism_property
              C^op D^op X U^op (op_object Ap) M.
       Definition IsTerminalMorphism_property_morphism_unique
       : forall (Y : D) (f : morphism C (U Y) X)
                m'
-               (H : IsTerminalMorphism_morphism o morphism_of U m' = f),
+               (H : IsTerminalMorphism_morphism o U _1 m' = f),
           IsTerminalMorphism_property_morphism Y f = m'
         := @IsInitialMorphism_property_morphism_unique
              C^op D^op X U^op (op_object Ap) M.

--- a/theories/Categories/Yoneda.v
+++ b/theories/Categories/Yoneda.v
@@ -193,7 +193,7 @@ Section coyoneda_lemma.
     let G0 := match goal with |- NaturalTransformation ?F ?G => constr:(G) end in
     refine (Build_NaturalTransformation
               F0 G0
-              (fun a' : A => (fun f : morphism A a a' => morphism_of F f Fa))
+              (fun a' : A => (fun f : morphism A a a' => F _1 f Fa))
               _
            ).
     simpl.


### PR DESCRIPTION
This paves the way for making `Functor C D` unify with `Functor C' D'` so long as the fields unify.  See #849.