### PR TITLE
Remove a nested comment to make proviola happy

### DIFF
--- a/theories/HIT/Suspension.v
+++ b/theories/HIT/Suspension.v
@@ -252,7 +252,6 @@ Module Book_Loop_Susp_Adjunction.
       reflexivity.
     - cbn.
       Fail reflexivity.
-      (** ...but this goal is pretty intractable. *)
   Abort.
 >>
    *)


### PR DESCRIPTION
As you can see here: http://hott.github.io/HoTT/coqdoc-html/HoTT.HIT.Suspension.html
The nested comment just before [loop_susp_unit](http://hott.github.io/HoTT/proviola-html/HoTT.HIT.Suspension.html#loop_susp_unit) is badly handled and make the whole file corrupted.

As this comment is redundant, I propose to remove it.