### PR TITLE
Give trunc_{contr,hprop,hset} only one universe

### DIFF
--- a/theories/Basics/Trunc.v
+++ b/theories/Basics/Trunc.v
@@ -58,14 +58,14 @@ Defined.
 
 (** In particular, a contractible type, hprop, or hset is truncated at all higher levels.  We don't allow these to be used as idmaps, since there would be no point to it. *)
 
-Definition trunc_contr {n} {A} `{Contr A} : IsTrunc n.+1 A
-  := (@trunc_leq -2 n.+1 tt _ _).
+Definition trunc_contr@{i} {n} {A} `{Contr A} : IsTrunc n.+1 A
+  := (@trunc_leq@{i i} -2 n.+1 tt _ _).
 
-Definition trunc_hprop {n} {A} `{IsHProp A} : IsTrunc n.+2 A
-  := (@trunc_leq -1 n.+2 tt _ _).
+Definition trunc_hprop@{i} {n} {A} `{IsHProp A} : IsTrunc n.+2 A
+  := (@trunc_leq@{i i} -1 n.+2 tt _ _).
 
-Definition trunc_hset {n} {A} `{IsHSet A} : IsTrunc n.+3 A
-  := (@trunc_leq 0 n.+3 tt _ _).
+Definition trunc_hset@{i} {n} {A} `{IsHSet A} : IsTrunc n.+3 A
+  := (@trunc_leq@{i i} 0 n.+3 tt _ _).
 
 (** Consider the preceding definitions as instances for typeclass search, but only if the requisite hypothesis is already a known assumption; otherwise they result in long or interminable searches. *)
 Hint Immediate trunc_contr : typeclass_instances.

--- a/theories/Basics/Trunc.v
+++ b/theories/Basics/Trunc.v
@@ -16,7 +16,7 @@ Fixpoint trunc_index_add (m n : trunc_index) : trunc_index
 
 Notation "m -2+ n" := (trunc_index_add m n) (at level 50, left associativity) : trunc_scope.
 
-Fixpoint trunc_index_leq (m n : trunc_index) : Type
+Fixpoint trunc_index_leq (m n : trunc_index) : Type0
   := match m, n with
        | -2, _ => Unit
        | m'.+1, -2 => Empty
@@ -58,14 +58,14 @@ Defined.
 
 (** In particular, a contractible type, hprop, or hset is truncated at all higher levels.  We don't allow these to be used as idmaps, since there would be no point to it. *)
 
-Definition trunc_contr@{i} {n} {A} `{Contr A} : IsTrunc n.+1 A
-  := (@trunc_leq@{i i} -2 n.+1 tt _ _).
+Definition trunc_contr {n} {A} `{Contr A} : IsTrunc n.+1 A
+  := (@trunc_leq -2 n.+1 tt _ _).
 
-Definition trunc_hprop@{i} {n} {A} `{IsHProp A} : IsTrunc n.+2 A
-  := (@trunc_leq@{i i} -1 n.+2 tt _ _).
+Definition trunc_hprop {n} {A} `{IsHProp A} : IsTrunc n.+2 A
+  := (@trunc_leq -1 n.+2 tt _ _).
 
-Definition trunc_hset@{i} {n} {A} `{IsHSet A} : IsTrunc n.+3 A
-  := (@trunc_leq@{i i} 0 n.+3 tt _ _).
+Definition trunc_hset {n} {A} `{IsHSet A} : IsTrunc n.+3 A
+  := (@trunc_leq 0 n.+3 tt _ _).
 
 (** Consider the preceding definitions as instances for typeclass search, but only if the requisite hypothesis is already a known assumption; otherwise they result in long or interminable searches. *)
 Hint Immediate trunc_contr : typeclass_instances.

--- a/theories/Modalities/Closed.v
+++ b/theories/Modalities/Closed.v
@@ -145,7 +145,7 @@ Module Accessible_ClosedModalities
     split.
     - intros X_inO u.
       pose (X_inO u).
-      apply ooextendable_contr@{a a i i a}; exact _.
+      apply ooextendable_contr@{a a i i}; exact _.
     - intros ext u.
       exists ((fst (ext u 1%nat) Empty_rec).1 tt); intros x.
       unfold const in ext.

--- a/theories/Modalities/Identity.v
+++ b/theories/Modalities/Identity.v
@@ -44,7 +44,7 @@ Module Identity_Modalities <: Modalities.
   Definition hprop_inO@{u a i}
   : Funext -> forall (O : Modality@{u a}) (T : Type@{i}),
                 IsHProp (In@{u a i} O T)
-    := fun _ O T => trunc_contr@{i a}.
+    := fun _ O T => trunc_contr@{i}.
 
   Definition O_ind_internal
   : forall (O : Modality@{u a})

--- a/theories/Modalities/Notnot.v
+++ b/theories/Modalities/Notnot.v
@@ -57,7 +57,7 @@ Module Notnot_Easy_Modalities <: EasyModalities.
   : IsEquiv@{i i} (to@{u a i} O (z = z')).
   Proof.
     pose (unNotnot O).
-    pose proof (hprop_Empty@{i});pose proof (@trunc_hprop@{i a}).
+    pose proof (hprop_Empty@{i});pose proof (@trunc_hprop@{i}).
     refine (isequiv_iff_hprop _ _).
     intros; apply path_ishprop.
   Defined.


### PR DESCRIPTION
This is part of an attempt to make the hpropresizing branch faster.  I'm not sure I picked the right universe to remove `theories/Modalities/Closed.v`; @mikeshulman, can you take a look at that change?