### PR TITLE
Fix travis testing of no-autoconf building

### DIFF
--- a/etc/ci/before_script.sh
+++ b/etc/ci/before_script.sh
@@ -13,9 +13,9 @@ then
 fi
 # (un)install autoreconf
 if [ ! -z "$WITH_AUTORECONF" ]; then
-    sudo apt-get install -q dh-autoreconf
+    sudo apt-get install -q autoconf
 else
-    sudo apt-get remove -q dh-autoreconf
+    sudo apt-get remove -q autoconf
 fi
 # install coq
 if [ ! -z "$UPDATE_QUICK_DOC" ]; then


### PR DESCRIPTION
dh-autoreconf is a debhelper (dh) package, what HoTT uses is autoconf which is preinstalled on travis.

Latest build on master at the time of this PR with `WITH_AUTORECONF=""`: https://travis-ci.org/HoTT/HoTT/jobs/234410119
```
$ ./autogen.sh && ./configure && if [ -z "$UPDATE_QUICK_DOC" ]; then make strict-test && ./etc/coq-scripts/timing/make-pretty-timed.sh V=1 -j2 && make && ./etc/ci/test-install-target.sh && cat ./time-of-build-pretty.log && echo; fi && ./etc/ci/after_success.sh

autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I etc
autoreconf: configure.ac: tracing
autoreconf: configure.ac: not using Libtool
autoreconf: running: /usr/bin/autoconf --force
autoreconf: configure.ac: not using Autoheader
autoreconf: running: automake --add-missing --copy --force-missing
configure.ac:12: installing 'etc/install-sh'
configure.ac:12: installing 'etc/missing'
autoreconf: Leaving directory `.'
```

First job to have `WITH_AUTORECONF=""`: https://travis-ci.org/HoTT/HoTT/jobs/10635031
```
$ ./autogen.sh && ./configure && make
autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I etc
autoreconf: configure.ac: tracing
autoreconf: configure.ac: not using Libtool
autoreconf: running: /usr/bin/autoconf --force
autoreconf: configure.ac: not using Autoheader
autoreconf: running: automake --add-missing --copy --force-missing
configure.ac:14: installing `etc/install-sh'
configure.ac:14: installing `etc/missing'
autoreconf: Leaving directory `.'
```

Expected: `Warning: autoreconf failed.  Falling back on git`.