### PR TITLE
Factor all notation levels through a common file

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -3,6 +3,7 @@
 COQC = hoqc
 
 theories/Basics/Notations.v
+theories/Basics/Utf8.v
 theories/Basics/Overture.v
 theories/Basics/UniverseLevel.v
 theories/Basics/PathGroupoids.v

--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -1,7 +1,7 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 (** * Equivalences *)
 
-Require Import Overture PathGroupoids.
+Require Import Overture PathGroupoids Basics.Notations.
 Local Open Scope path_scope.
 
 (** We now give many ways to construct equivalences.  In each case, we define an instance of the typeclass [IsEquiv] named [isequiv_X], followed by an element of the record type [Equiv] named [equiv_X].
@@ -59,7 +59,7 @@ Definition equiv_compose' {A B C : Type} (g : B <~> C) (f : A <~> B)
   := equiv_compose g f.
 
 (** We put [g] and [f] in [equiv_scope] explcitly.  This is a partial work-around for https://coq.inria.fr/bugs/show_bug.cgi?id=3990, which is that implicitly bound scopes don't nest well. *)
-Notation "g 'oE' f" := (equiv_compose' g%equiv f%equiv) (at level 40, left associativity) : equiv_scope.
+Notation "g 'oE' f" := (equiv_compose' g%equiv f%equiv) : equiv_scope.
 
 (* The TypeClass [Transitive] has a different order of parameters than [equiv_compose].  Thus in declaring the instance we have to switch the order of arguments. *)
 Global Instance transitive_equiv : Transitive Equiv | 0 :=
@@ -149,7 +149,7 @@ Proof.
   apply isequiv_inverse.
 Defined.
 
-Notation "e ^-1" := (@equiv_inverse _ _ e) (at level 3, format "e '^-1'") : equiv_scope.
+Notation "e ^-1" := (@equiv_inverse _ _ e) : equiv_scope.
 
 Global Instance symmetric_equiv : Symmetric Equiv | 0 := @equiv_inverse.
 

--- a/theories/Basics/Notations.v
+++ b/theories/Basics/Notations.v
@@ -1,4 +1,80 @@
-Reserved Notation "f ^*" (at level 20).
-Reserved Notation "g o*E f" (at level 40, left associativity).
-Reserved Notation "D '_f' g" (at level 10).
+(** To reserve this notation, we must first bootstrap, and preserve the underlying [forall] notation *)
+Notation "'forall'  x .. y , P" := (forall x , .. (forall y, P) ..) (at level 200, x binder, y binder, right associativity).
+
+(** Work around bug 5569, https://coq.inria.fr/bugs/show_bug.cgi?id=5569, Warning skip-spaces-curly,parsing seems bogus *)
+Local Set Warnings Append "-skip-spaces-curly".
+Reserved Infix "@*" (at level 30).
+Reserved Infix "-|" (at level 60, right associativity).
+Reserved Infix "<~=~>" (at level 70, no associativity).
+Reserved Infix "==*" (at level 70, no associativity).
+Reserved Infix "<~>*" (at level 85).
+Reserved Infix "->*" (at level 99).
+Reserved Infix "=n" (at level 70, no associativity).
+Reserved Infix "o*" (at level 40).
+Reserved Infix "oL" (at level 40, left associativity).
+Reserved Infix "oR" (at level 40, left associativity).
+Reserved Notation "-1" (at level 0).
+Reserved Notation "-2" (at level 0).
+Reserved Notation "~~ A" (at level 75, right associativity, only parsing).
+Reserved Notation "A <~> B" (at level 85).
+Reserved Notation "a // 'CAT'" (at level 40, left associativity).
+Reserved Notation "a \\ 'CAT'" (at level 40, left associativity).
+Reserved Notation "a \ C" (at level 40, left associativity).
+Reserved Notation "a <=_{ x } b" (at level 70, no associativity).
+Reserved Notation "'CAT' // a" (at level 40, left associativity).
+Reserved Notation "'CAT' \\ a" (at level 40, left associativity).
+Reserved Notation "C ^op" (at level 3, format "C '^op'").
 Reserved Notation "D1 ~d~ D2" (at level 65).
+Reserved Notation "D '_f' g" (at level 10).
+Reserved Notation "F '_0' x" (at level 10, no associativity).
+Reserved Notation "F '_0' x" (at level 10, no associativity, only parsing).
+Reserved Notation "f ^-1" (at level 3, format "f '^-1'").
+Reserved Notation "F '_1' m" (at level 10, no associativity).
+Reserved Notation "f ^*" (at level 20).
+Reserved Notation "f *E g" (at level 40, no associativity).
+Reserved Notation "f +E g" (at level 50, left associativity).
+Reserved Notation "f == g" (at level 70, no associativity).
+Reserved Notation "F ^op" (at level 3, format "F ^op").
+Reserved Notation "'forall'  x .. y , P" (at level 200, x binder, y binder, right associativity).
+Reserved Notation "g ^*'" (at level 20).
+Reserved Notation "g 'oD' f" (at level 40, left associativity).
+Reserved Notation "g 'oE' f" (at level 40, left associativity).
+Reserved Notation "g o*E f" (at level 40, left associativity).
+Reserved Notation "g 'o' f" (at level 40, left associativity).
+Reserved Notation "m ^-1" (at level 3, format "m '^-1'").
+Reserved Notation "m -2+ n" (at level 50, left associativity).
+Reserved Notation "m <= n" (at level 70, no associativity).
+Reserved Notation "n .+1" (at level 2, left associativity, format "n .+1").
+Reserved Notation "n .+2" (at level 2, left associativity, format "n .+2").
+Reserved Notation "n .+3" (at level 2, left associativity, format "n .+3").
+Reserved Notation "n .+4" (at level 2, left associativity, format "n .+4").
+Reserved Notation "n .+5" (at level 2, left associativity, format "n .+5").
+Reserved Notation "n -Type" (at level 1).
+Reserved Notation "p ..1" (at level 3).
+Reserved Notation "p ..2" (at level 3).
+Reserved Notation "p ^" (at level 3, format "p '^'").
+Reserved Notation "!! P" (at level 75, right associativity).
+Reserved Notation "p @ q" (at level 20).
+Reserved Notation "p @@ q" (at level 20).
+Reserved Notation "p @' q" (at level 21, left associativity, format "'[v' p '/' '@''  q ']'").
+Reserved Notation "p # x" (right associativity, at level 65).
+Reserved Notation "p # x" (right associativity, at level 65, only parsing).
+Reserved Notation "T ^op" (at level 3, format "T ^op").
+Reserved Notation "[ u ]" (at level 9).
+Reserved Notation "u ~~ v" (at level 30).
+Reserved Notation " [ u , v ] " (at level 9).
+Reserved Notation "x .1" (at level 3, format "x '.1'").
+Reserved Notation "x .2" (at level 3, format "x '.2'").
+Reserved Notation "! x" (at level 3, format "'!' x").
+Reserved Notation "x \\ F" (at level 40, left associativity).
+Reserved Notation "x // F" (at level 40, left associativity).
+Reserved Notation "{ { xL | xR // xcut } }" (at level 0, xR at level 39, format "{ {  xL  |  xR  //  xcut  } }").
+Reserved Notation "x \ F" (at level 40, left associativity).
+Reserved Notation "x / F" (at level 40, left associativity).
+Reserved Notation "x <> y" (at level 70, no associativity).
+Reserved Notation "x ->> y" (at level 99, right associativity, y at level 200).
+Reserved Notation "x -|-> y" (at level 99, right associativity, y at level 200).
+Reserved Notation "x --> y" (at level 99, right associativity, y at level 200).
+Reserved Notation "x (-> y" (at level 99, right associativity, y at level 200).
+Reserved Notation "x <> y  :>  T" (at level 70, y at next level, no associativity).
+Reserved Notation "Z ** W" (at level 40, no associativity).

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -1,6 +1,8 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 
 (** * Basic definitions of homotopy type theory, particularly the groupoid structure of identity types. *)
+(** Import the file of reserved notations so we maintain consistent level notations throughout the library *)
+Require Export Basics.Notations.
 
 (** Change in introduction patterns not adding an implicit [] *)
 Global Unset Bracketing Last Introduction Pattern.
@@ -147,9 +149,9 @@ Bind Scope fibration_scope with sigT.
 Notation pr1 := projT1.
 Notation pr2 := projT2.
 
-(** The following notation is very convenient, although it unfortunately clashes with Proof General's "electric period".  We add [format] specifiers so that it will display without an extra space, as [x.1] rather than as [x .1]. *)
-Notation "x .1" := (pr1 x) (at level 3, format "x '.1'") : fibration_scope.
-Notation "x .2" := (pr2 x) (at level 3, format "x '.2'") : fibration_scope.
+(** The following notation is very convenient, although it unfortunately clashes with Proof General's "electric period".  We have added [format] specifiers in Notations.v so that it will display without an extra space, as [x.1] rather than as [x .1]. *)
+Notation "x .1" := (pr1 x) : fibration_scope.
+Notation "x .2" := (pr2 x) : fibration_scope.
 
 (** Composition of functions. *)
 
@@ -159,7 +161,7 @@ Notation compose := (fun g f x => g (f x)).
 
 (** We allow writing [(f o g)%function] to force [function_scope] over, e.g., [morphism_scope]. *)
 
-Notation "g 'o' f" := (compose g%function f%function) (at level 40, left associativity) : function_scope.
+Notation "g 'o' f" := (compose g%function f%function) : function_scope.
 
 (** Composition of logical equivalences *)
 Instance iff_compose : Transitive iff | 1
@@ -182,7 +184,7 @@ Global Arguments composeD {A B C}%type_scope (g f)%function_scope x.
 
 Hint Unfold composeD.
 
-Notation "g 'oD' f" := (composeD g f) (at level 40, left associativity) : function_scope.
+Notation "g 'oD' f" := (composeD g f) : function_scope.
 
 (** ** The groupoid structure of identity types. *)
 
@@ -280,15 +282,14 @@ Notation "1" := idpath : path_scope.
 
 (** The composition of two paths. *)
 (** We put [p] and [q] in [path_scope] explcitly.  This is a partial work-around for https://coq.inria.fr/bugs/show_bug.cgi?id=3990, which is that implicitly bound scopes don't nest well. *)
-Notation "p @ q" := (concat p%path q%path) (at level 20) : path_scope.
+Notation "p @ q" := (concat p%path q%path) : path_scope.
 
 (** The inverse of a path. *)
 (** See above about explicitly placing [p] in [path_scope]. *)
-Notation "p ^" := (inverse p%path) (at level 3, format "p '^'") : path_scope.
+Notation "p ^" := (inverse p%path) : path_scope.
 
-(** An alternative notation which puts each path on its own line.  Useful as a temporary device during proofs of equalities between very long composites; to turn it on inside a section, say [Open Scope long_path_scope]. *)
-Notation "p @' q" := (concat p q) (at level 21, left associativity,
-  format "'[v' p '/' '@''  q ']'") : long_path_scope.
+(** An alternative notation which puts each path on its own line, via the [format] specification in Notations.v.  Useful as a temporary device during proofs of equalities between very long composites; to turn it on inside a section, say [Open Scope long_path_scope]. *)
+Notation "p @' q" := (concat p q) : long_path_scope.
 
 
 (** An important instance of [paths_ind] is that given any dependent type, one can _transport_ elements of instances of the type along equalities in the base.
@@ -302,7 +303,7 @@ Arguments transport {A}%type_scope P%function_scope {x y} p%path_scope u : simpl
 
 (** Transport is very common so it is worth introducing a parsing notation for it.  However, we do not use the notation for output because it hides the fibration, and so makes it very hard to read involved transport expression.*)
 
-Notation "p # x" := (transport _ p x) (right associativity, at level 65, only parsing) : path_scope.
+Notation "p # x" := (transport _ p x) (only parsing) : path_scope.
 
 (** Having defined transport, we can use it to talk about what a homotopy theorist might see as "paths in a fibration over paths in the base"; and what a type theorist might see as "heterogeneous eqality in a dependent type".
 
@@ -330,7 +331,7 @@ Global Arguments pointwise_paths {A}%type_scope {P} (f g)%function_scope.
 
 Hint Unfold pointwise_paths : typeclass_instances.
 
-Notation "f == g" := (pointwise_paths f g) (at level 70, no associativity) : type_scope.
+Notation "f == g" := (pointwise_paths f g) : type_scope.
 
 Definition apD10 {A} {B:A->Type} {f g : forall x, B x} (h:f=g)
   : f == g
@@ -418,11 +419,11 @@ Arguments equiv_isequiv {A B} _.
 
 Bind Scope equiv_scope with Equiv.
 
-Notation "A <~> B" := (Equiv A B) (at level 85) : type_scope.
+Notation "A <~> B" := (Equiv A B) : type_scope.
 
 (** A notation for the inverse of an equivalence.  We can apply this to a function as long as there is a typeclass instance asserting it to be an equivalence.  We can also apply it to an element of [A <~> B], since there is an implicit coercion to [A -> B] and also an existing instance of [IsEquiv]. *)
 
-Notation "f ^-1" := (@equiv_inv _ _ f _) (at level 3, format "f '^-1'") : function_scope.
+Notation "f ^-1" := (@equiv_inv _ _ f _) : function_scope.
 
 (** ** Applying paths between equivalences like functions *)
 
@@ -477,16 +478,16 @@ Arguments trunc_S _%trunc_scope.
 
 (** Include the basic numerals, so we don't need to go through the coercion from [nat], and so that we get the right binding with [trunc_scope]. *)
 (** Note that putting the negative numbers at level 0 allows us to override the [- _] notation for negative numbers. *)
-Notation "n .+1" := (trunc_S n) (at level 2, left associativity, format "n .+1") : trunc_scope.
-Notation "n .+1" := (S n) (at level 2, left associativity, format "n .+1") : nat_scope.
-Notation "n .+2" := (n.+1.+1)%trunc (at level 2, left associativity, format "n .+2") : trunc_scope.
-Notation "n .+2" := (n.+1.+1)%nat (at level 2, left associativity, format "n .+2") : nat_scope.
-Notation "n .+3" := (n.+1.+2)%trunc (at level 2, left associativity, format "n .+3") : trunc_scope.
-Notation "n .+3" := (n.+1.+2)%nat (at level 2, left associativity, format "n .+3") : nat_scope.
-Notation "n .+4" := (n.+1.+3)%trunc (at level 2, left associativity, format "n .+4") : trunc_scope.
-Notation "n .+4" := (n.+1.+3)%nat (at level 2, left associativity, format "n .+4") : nat_scope.
-Notation "n .+5" := (n.+1.+4)%trunc (at level 2, left associativity, format "n .+5") : trunc_scope.
-Notation "n .+5" := (n.+1.+4)%nat (at level 2, left associativity, format "n .+5") : nat_scope.
+Notation "n .+1" := (trunc_S n) : trunc_scope.
+Notation "n .+1" := (S n) : nat_scope.
+Notation "n .+2" := (n.+1.+1)%trunc : trunc_scope.
+Notation "n .+2" := (n.+1.+1)%nat   : nat_scope.
+Notation "n .+3" := (n.+1.+2)%trunc : trunc_scope.
+Notation "n .+3" := (n.+1.+2)%nat   : nat_scope.
+Notation "n .+4" := (n.+1.+3)%trunc : trunc_scope.
+Notation "n .+4" := (n.+1.+3)%nat   : nat_scope.
+Notation "n .+5" := (n.+1.+4)%trunc : trunc_scope.
+Notation "n .+5" := (n.+1.+4)%nat   : nat_scope.
 Local Open Scope trunc_scope.
 Notation "-2" := minus_two (at level 0) : trunc_scope.
 Notation "-1" := (-2.+1) (at level 0) : trunc_scope.
@@ -621,10 +622,10 @@ Definition Empty_rect := Empty_ind.
 
 Definition not (A:Type) : Type := A -> Empty.
 Notation "~ x" := (not x) : type_scope.
+Notation "~~ x" := (~ ~x) : type_scope.
 Hint Unfold not: core.
-Notation "x <> y  :>  T" := (not (x = y :> T))
-(at level 70, y at next level, no associativity) : type_scope.
-Notation "x <> y" := (x <> y :> _) (at level 70, no associativity) : type_scope.
+Notation "x <> y  :>  T" := (not (x = y :> T)) : type_scope.
+Notation "x <> y" := (x <> y :> _) : type_scope.
 
 Definition symmetric_neq {A} {x y : A} : x <> y -> y <> x
   := fun np p => np (p^).

--- a/theories/Basics/PathGroupoids.v
+++ b/theories/Basics/PathGroupoids.v
@@ -927,13 +927,13 @@ Definition concat2 {A} {x y z : A} {p p' : x = y} {q q' : y = z} (h : p = p') (h
   : p @ q = p' @ q'
 := match h, h' with idpath, idpath => 1 end.
 
-Notation "p @@ q" := (concat2 p q)%path (at level 20) : path_scope.
+Notation "p @@ q" := (concat2 p q)%path : path_scope.
 
 Arguments concat2 : simpl nomatch.
 
-Lemma concat2_ap_ap {A B : Type} {x' y' z' : B} 
+Lemma concat2_ap_ap {A B : Type} {x' y' z' : B}
            (f : A -> (x' = y')) (g : A -> (y' = z'))
-           {x y : A} (p : x = y) 
+           {x y : A} (p : x = y)
 : (ap f p) @@ (ap g p) = ap (fun u => f u @ g u) p.
 Proof.
     by path_induction.
@@ -1044,17 +1044,17 @@ Definition concat2_1p {A : Type} {x y : A} {p q : x = y} (h : p = q) :
   :=
   match h with idpath => 1 end.
 
-Definition cancel2L {A : Type} {x y z : A} {p p' : x = y} {q q' : y = z} 
+Definition cancel2L {A : Type} {x y z : A} {p p' : x = y} {q q' : y = z}
            (g : p = p') (h k : q = q')
 : (g @@ h = g @@ k) -> (h = k).
 Proof.
   intro r. induction g, p, q.
-  refine ((whiskerL_1p h)^ @ _). refine (_ @ (whiskerL_1p k)). 
+  refine ((whiskerL_1p h)^ @ _). refine (_ @ (whiskerL_1p k)).
   refine (whiskerR _ _). refine (whiskerL _ _).
   apply r.
 Defined.
 
-Definition cancel2R {A : Type} {x y z : A} {p p' : x = y} {q q' : y = z} 
+Definition cancel2R {A : Type} {x y z : A} {p p' : x = y} {q q' : y = z}
            (g h : p = p') (k : q = q')
 : (g @@ k = h @@ k) -> (g = h).
 Proof.
@@ -1193,7 +1193,7 @@ Definition apD02 {A : Type} {B : A -> Type} {x y : A} {p q : x = y}
   := match r with idpath => (concat_1p _)^ end.
 
 Definition apD02_const {A B : Type} (f : A -> B) {x y : A} {p q : x = y} (r : p = q)
-: apD02 f r = (apD_const f p) 
+: apD02 f r = (apD_const f p)
               @ (transport2_const r (f x) @@ ap02 f r)
               @ (concat_p_pp _ _ _)^
               @ (whiskerL (transport2 _ r (f x)) (apD_const f q)^)

--- a/theories/Basics/Trunc.v
+++ b/theories/Basics/Trunc.v
@@ -7,14 +7,15 @@ Local Open Scope path_scope.
 Generalizable Variables A B m n f.
 
 (** ** Arithmetic on truncation-levels. *)
-
+Open Scope trunc_scope.
+Check -2.
 Fixpoint trunc_index_add (m n : trunc_index) : trunc_index
   := match m with
        | -2 => n
        | m'.+1 => (trunc_index_add m' n).+1
      end.
 
-Notation "m -2+ n" := (trunc_index_add m n) (at level 50, left associativity) : trunc_scope.
+Notation "m -2+ n" := (trunc_index_add m n) : trunc_scope.
 
 Fixpoint trunc_index_leq (m n : trunc_index) : Type0
   := match m, n with
@@ -23,7 +24,7 @@ Fixpoint trunc_index_leq (m n : trunc_index) : Type0
        | m'.+1, n'.+1 => trunc_index_leq m' n'
      end.
 
-Notation "m <= n" := (trunc_index_leq m n) (at level 70, no associativity) : trunc_scope.
+Notation "m <= n" := (trunc_index_leq m n) : trunc_scope.
 
 Fixpoint trunc_index_inc (n : nat) (k : trunc_index) : trunc_index
   := match n with O => k | S m => (trunc_index_inc m k).+1 end.
@@ -116,7 +117,7 @@ Arguments istrunc_trunctype_type [_] _.
 Coercion trunctype_type : TruncType >-> Sortclass.
 Global Existing Instance istrunc_trunctype_type.
 
-Notation "n -Type" := (TruncType n) (at level 1) : type_scope.
+Notation "n -Type" := (TruncType n) : type_scope.
 Notation hProp := (-1)-Type.
 Notation hSet := 0-Type.
 

--- a/theories/Basics/Utf8.v
+++ b/theories/Basics/Utf8.v
@@ -1,0 +1,45 @@
+Require Export Basics.Notations.
+
+Reserved Infix "∙" (at level 20, only parsing).
+Reserved Infix "∘" (at level 40, left associativity).
+Reserved Infix "∘ˡ" (at level 40, left associativity).
+Reserved Infix "∘ʳ" (at level 40, left associativity).
+Reserved Infix "⊣" (at level 60, right associativity).
+Reserved Infix "≅" (at level 70, no associativity).
+Reserved Notation "A 'ᵒᵖ'" (at level 3).
+Reserved Notation "A × B" (at level 40, left associativity).
+Reserved Notation "a ≤ b" (at level 70, no associativity).
+Reserved Notation "A ≃ B" (at level 85).
+Reserved Notation "a ⇓ 'CAT'" (at level 40, left associativity).
+Reserved Notation "a ⇑ 'CAT'" (at level 40, left associativity).
+Reserved Notation "a ≤_{ x } b" (at level 70, no associativity).
+Reserved Notation "C ↓ a" (at level 70, no associativity).
+Reserved Notation "'CAT' ⇓ a" (at level 40, left associativity).
+Reserved Notation "'CAT' ⇑ a" (at level 40, left associativity).
+Reserved Notation "C 'ᵒᵖ'" (at level 3).
+Reserved Notation "C → D" (at level 99, D at level 200, right associativity).
+Reserved Notation "f '⁻¹'" (at level 3, format "f '⁻¹'").
+Reserved Notation "f ×ᴱ g" (at level 40, no associativity).
+Reserved Notation "f *ᴱ g" (at level 40, no associativity).
+Reserved Notation "f +ᴱ g" (at level 50, left associativity).
+Reserved Notation "F ₁ m" (at level 10, no associativity).
+Reserved Notation "F ₀ x" (at level 10, no associativity).
+Reserved Notation "g ∘ f" (at level 40, left associativity).
+Reserved Notation "g ∘ᴱ f" (at level 40, left associativity).
+Reserved Notation "m ⁻¹" (at level 3, format "m '⁻¹'").
+Reserved Notation "m ≤ n" (at level 70, no associativity).
+Reserved Notation "p '⁻¹'" (at level 3, format "p '⁻¹'").
+Reserved Notation "p • q" (at level 20).
+Reserved Notation "p •' q" (at level 21, left associativity, format "'[v' p '/' '•''  q ']'").
+Reserved Notation "x ₁" (at level 3).
+Reserved Notation "x ₂" (at level 3).
+Reserved Notation "¬ x" (at level 75, right associativity).
+Reserved Notation "x ⇓ F" (at level 40, left associativity).
+Reserved Notation "x ⇑ F" (at level 40, left associativity).
+Reserved Notation "x ∈ v" (at level 30).
+Reserved Notation "x ⊆ y" (at level 30).
+Reserved Notation "x ≠ y" (at level 70).
+Reserved Notation "x ⇸ y" (at level 99, right associativity, y at level 200).
+Reserved Notation "x ↠ y" (at level 99, right associativity, y at level 200).
+Reserved Notation "x ↪ y" (at level 99, right associativity, y at level 200).
+Reserved Notation "∀  x .. y , P" (at level 200, x binder, y binder, right associativity).

--- a/theories/Categories/Adjoint/Core.v
+++ b/theories/Categories/Adjoint/Core.v
@@ -1,8 +1,9 @@
 (** * Adjunctions *)
 Require Import Adjoint.UnitCounit.
+Require Import Basics.Notations.
 
 Notation Adjunction := AdjunctionUnitCounit.
 
 Module Export AdjointCoreNotations.
-  Infix "-|" := Adjunction (at level 60, right associativity) : type_scope.
+  Infix "-|" := Adjunction : type_scope.
 End AdjointCoreNotations.

--- a/theories/Categories/Adjoint/Dual.v
+++ b/theories/Categories/Adjoint/Dual.v
@@ -25,7 +25,7 @@ Definition opposite
        (unit_counit_equation_2 A)
        (unit_counit_equation_1 A).
 
-Local Notation "A ^op" := (opposite A) (at level 3, format "A '^op'") : adjunction_scope.
+Local Notation "A ^op" := (opposite A) : adjunction_scope.
 
 Local Open Scope adjunction_scope.
 
@@ -35,5 +35,5 @@ Definition opposite_involutive C D (F : Functor C D) (G : Functor D C) (A : F -|
   := idpath.
 
 Module Export AdjointDualNotations.
-  Notation "A ^op" := (opposite A) (at level 3, format "A '^op'") : adjunction_scope.
+  Notation "A ^op" := (opposite A) : adjunction_scope.
 End AdjointDualNotations.

--- a/theories/Categories/Adjoint/Utf8.v
+++ b/theories/Categories/Adjoint/Utf8.v
@@ -1,10 +1,11 @@
 Require Import Adjoint.Core Adjoint.Dual Adjoint.Composition.Core.
 Require Export Adjoint.Notations.
+Require Import Basics.Utf8.
 
-Infix "⊣" := Adjunction (at level 60, right associativity) : type_scope.
+Infix "⊣" := Adjunction : type_scope.
 
-Infix "∘" := compose (at level 40, left associativity) : adjunction_scope.
+Infix "∘" := compose : adjunction_scope.
 
 (** It would be nice to put [, format "A 'ᵒᵖ'"] here, but that would
     make this notation unparseable. *)
-Notation "A 'ᵒᵖ'" := (opposite A) (at level 3) : adjunction_scope.
+Notation "A 'ᵒᵖ'" := (opposite A) : adjunction_scope.

--- a/theories/Categories/Category/Core.v
+++ b/theories/Categories/Category/Core.v
@@ -1,5 +1,5 @@
 (** * Definition of a [PreCategory] *)
-Require Export Overture.
+Require Export Overture Basics.Notations.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.
@@ -83,7 +83,7 @@ Arguments compose {!C%category} / {s d d'}%object (m1 m2)%morphism : rename.
 Local Infix "o" := compose : morphism_scope.
 (** Perhaps we should consider making this notation more global. *)
 (** Perhaps we should pre-reserve all of the notations. *)
-Local Notation "x --> y" := (morphism _ x y) (at level 99, right associativity, y at level 200) : type_scope.
+Local Notation "x --> y" := (morphism _ x y) : type_scope.
 Local Notation "1" := (identity _) : morphism_scope.
 
 (** Define a convenience wrapper for building a precategory without
@@ -145,8 +145,8 @@ Module Export CategoryCoreNotations.
   Infix "o" := compose : morphism_scope.
   (** Perhaps we should consider making this notation more global. *)
   (** Perhaps we should pre-reserve all of the notations. *)
-  Local Notation "x --> y" := (@morphism _ x y) (at level 99, right associativity, y at level 200) : type_scope.
-  Local Notation "x --> y" := (morphism _ x y) (at level 99, right associativity, y at level 200) : type_scope.
+  Local Notation "x --> y" := (@morphism _ x y) : type_scope.
+  Local Notation "x --> y" := (morphism _ x y) : type_scope.
   Notation "1" := (identity _) : morphism_scope.
 End CategoryCoreNotations.
 

--- a/theories/Categories/Category/Dual.v
+++ b/theories/Categories/Category/Dual.v
@@ -24,7 +24,7 @@ Definition opposite (C : PreCategory) : PreCategory
        (@identity_identity C)
        _.
 
-Local Notation "C ^op" := (opposite C) (at level 3, format "C '^op'") : category_scope.
+Local Notation "C ^op" := (opposite C) : category_scope.
 
 (** ** [ᵒᵖ] is judgmentally involutive *)
 Definition opposite_involutive C : (C^op)^op = C := idpath.
@@ -45,5 +45,5 @@ Section DualObjects.
 End DualObjects.
 
 Module Export CategoryDualNotations.
-  Notation "C ^op" := (opposite C) (at level 3, format "C '^op'") : category_scope.
+  Notation "C ^op" := (opposite C) : category_scope.
 End CategoryDualNotations.

--- a/theories/Categories/Category/Morphisms.v
+++ b/theories/Categories/Category/Morphisms.v
@@ -20,7 +20,7 @@ Class IsIsomorphism {C : PreCategory} {s d} (m : morphism C s d) :=
 
 Arguments morphism_inverse {C s d} m {_}.
 
-Local Notation "m ^-1" := (morphism_inverse m) (at level 3, format "m '^-1'") : morphism_scope.
+Local Notation "m ^-1" := (morphism_inverse m) : morphism_scope.
 
 Hint Resolve left_inverse right_inverse : category morphism.
 Hint Rewrite @left_inverse @right_inverse : category.
@@ -36,7 +36,7 @@ Class Isomorphic {C : PreCategory} s d :=
 Coercion morphism_isomorphic : Isomorphic >-> morphism.
 Coercion isisomorphism_isomorphic : Isomorphic >-> IsIsomorphism.
 
-Local Infix "<~=~>" := Isomorphic (at level 70, no associativity) : category_scope.
+Local Infix "<~=~>" := Isomorphic : category_scope.
 
 Global Existing Instance isisomorphism_isomorphic.
 
@@ -262,10 +262,8 @@ Record Monomorphism {C} x y :=
 
 Global Existing Instances Epimorphism_IsEpimorphism Monomorphism_IsMonomorphism.
 
-Local Notation "x ->> y" := (Epimorphism x y)
-                              (at level 99, right associativity, y at level 200).
-Local Notation "x (-> y" := (Monomorphism x y)
-                              (at level 99, right associativity, y at level 200).
+Local Notation "x ->> y" := (Epimorphism x y).
+Local Notation "x (-> y" := (Monomorphism x y).
 
 Class IsSectionOf C x y (s : morphism C x y) (r : morphism C y x)
   := is_sect_morphism : r o s = identity _.
@@ -665,12 +663,10 @@ Section associativity_composition.
 End associativity_composition.
 
 Module Export CategoryMorphismsNotations.
-  Notation "m ^-1" := (morphism_inverse m) (at level 3, format "m '^-1'") : morphism_scope.
+  Notation "m ^-1" := (morphism_inverse m) : morphism_scope.
 
-  Infix "<~=~>" := Isomorphic (at level 70, no associativity) : category_scope.
+  Infix "<~=~>" := Isomorphic : category_scope.
 
-  Notation "x ->> y" := (Epimorphism x y)
-                          (at level 99, right associativity, y at level 200).
-  Notation "x (-> y" := (Monomorphism x y)
-                          (at level 99, right associativity, y at level 200).
+  Notation "x ->> y" := (Epimorphism x y).
+  Notation "x (-> y" := (Monomorphism x y).
 End CategoryMorphismsNotations.

--- a/theories/Categories/Category/Pi.v
+++ b/theories/Categories/Category/Pi.v
@@ -33,12 +33,8 @@ Section pi.
   Defined.
 End pi.
 
-Local Notation "'forall'  x .. y , P" := (forall x, .. (forall y, P) ..)
-  (at level 200, x binder, y binder, right associativity).
-Local Notation "'forall'  x .. y , P" := (forall x, .. (forall y, P) ..)
-  (at level 200, x binder, y binder, right associativity) : type_scope.
-Local Notation "'forall'  x .. y , P" := (pi (fun x => .. (pi (fun y => P)) .. ))
-  (at level 200, x binder, y binder, right associativity) : category_scope.
+Local Notation "'forall'  x .. y , P" := (forall x, .. (forall y, P) ..) : type_scope.
+Local Notation "'forall'  x .. y , P" := (pi (fun x => .. (pi (fun y => P)) .. )) : category_scope.
 
 (** ** The product of strict categories is strict *)
 Global Instance isstrict_category_pi
@@ -51,10 +47,6 @@ Qed.
 
 Local Set Warnings Append "-notation-overridden".
 Module Export CategoryPiNotations.
-  Notation "'forall'  x .. y , P" := (forall x, .. (forall y, P) ..)
-                                       (at level 200, x binder, y binder, right associativity).
-  Notation "'forall'  x .. y , P" := (forall x, .. (forall y, P) ..)
-                                       (at level 200, x binder, y binder, right associativity) : type_scope.
-  Notation "'forall'  x .. y , P" := (pi (fun x => .. (pi (fun y => P)) .. ))
-                                       (at level 200, x binder, y binder, right associativity) : category_scope.
+  Notation "'forall'  x .. y , P" := (forall x, .. (forall y, P) ..)%type : type_scope.
+  Notation "'forall'  x .. y , P" := (pi (fun x => .. (pi (fun y => P)) .. )) : category_scope.
 End CategoryPiNotations.

--- a/theories/Categories/Category/Utf8.v
+++ b/theories/Categories/Category/Utf8.v
@@ -3,22 +3,18 @@ Require Import Category.Core Category.Morphisms Category.Dual Category.Prod Cate
 Local Set Warnings Append "-notation-overridden".
 Require Export Category.Notations.
 Local Set Warnings Append "notation-overridden".
+Require Import Basics.Utf8.
 
-Infix "∘" := compose (at level 40, left associativity) : morphism_scope.
-Notation "m ⁻¹" := (morphism_inverse m) (at level 3, format "m '⁻¹'") : morphism_scope.
-Infix "≅" := Isomorphic (at level 70, no associativity) : category_scope.
-Notation "x ↠ y" := (Epimorphism x y)
-                      (at level 99, right associativity, y at level 200).
-Notation "x ↪ y" := (Monomorphism x y)
-                      (at level 99, right associativity, y at level 200).
+Infix "∘" := compose : morphism_scope.
+Notation "m ⁻¹" := (morphism_inverse m) : morphism_scope.
+Infix "≅" := Isomorphic : category_scope.
+Notation "x ↠ y" := (Epimorphism x y).
+Notation "x ↪ y" := (Monomorphism x y).
 
 (** It would be nice to put [, format "C 'ᵒᵖ'"] here, but that makes
     this notation unparseable. *)
-Notation "C 'ᵒᵖ'" := (opposite C) (at level 3) : category_scope.
+Notation "C 'ᵒᵖ'" := (opposite C) : category_scope.
 
-Notation "∀  x .. y , P" := (forall x, .. (forall y, P) ..)
-                              (at level 200, x binder, y binder, right associativity).
-Notation "∀  x .. y , P" := (forall x, .. (forall y, P) ..)
-                              (at level 200, x binder, y binder, right associativity) : type_scope.
-Notation "∀  x .. y , P" := (pi (fun x => .. (pi (fun y => P)) .. ))
-                              (at level 200, x binder, y binder, right associativity) : category_scope.
+Notation "∀  x .. y , P" := (forall x, .. (forall y, P) ..).
+Notation "∀  x .. y , P" := (forall x, .. (forall y, P) ..) : type_scope.
+Notation "∀  x .. y , P" := (pi (fun x => .. (pi (fun y => P)) .. )) : category_scope.

--- a/theories/Categories/Comma/Core.v
+++ b/theories/Categories/Comma/Core.v
@@ -5,6 +5,7 @@ Require Functor.Identity.
 Require Import Category.Strict.
 Require Import Types.Record Types.Paths Types.Sigma Trunc HoTT.Tactics HProp.
 Import Functor.Identity.FunctorIdentityNotations.
+Require Import Basics.Notations.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.
@@ -349,7 +350,7 @@ Module Export CommaCoreNotations.
   (** We really want to use infix [↓] for comma categories, but that's unicode.  Infix [,] might also be reasonable, but I can't seem to get it to work without destroying the [(_, _)] notation for ordered pairs.  So I settle for the ugly ASCII rendition [/] of [↓]. *)
   (** Set some notations for printing *)
   Notation "C / a" := (@slice_category_over C a) (only printing) : category_scope.
-  Notation "a \ C" := (@coslice_category_over C a) (at level 40, left associativity) : category_scope.
+  Notation "a \ C" := (@coslice_category_over C a) : category_scope.
   Notation "a / C" := (@coslice_category_over C a) (only printing) : category_scope.
   Notation "x / F" := (coslice_category x F) (only printing) : category_scope.
   Notation "F / x" := (slice_category x F) (only printing) : category_scope.

--- a/theories/Categories/Comma/Utf8.v
+++ b/theories/Categories/Comma/Utf8.v
@@ -2,9 +2,10 @@
 Local Set Warnings Append "-notation-overridden".
 Require Import Comma.Core.
 Require Export Comma.Notations.
+Require Import Basics.Utf8.
 
 (** Set some notations for printing *)
-Notation "C ↓ a" := (@slice_category_over C a) (at level 70, no associativity, only printing) : category_scope.
+Notation "C ↓ a" := (@slice_category_over C a) (only printing) : category_scope.
 Notation "a ↓ C" := (@coslice_category_over C a) (only printing) : category_scope.
 Notation "x ↓ F" := (coslice_category x F) (only printing) : category_scope.
 Notation "F ↓ x" := (slice_category x F) (only printing) : category_scope.

--- a/theories/Categories/Functor/Core.v
+++ b/theories/Categories/Functor/Core.v
@@ -54,9 +54,9 @@ Arguments identity_of [C D] F _ : rename.
 
 Module Export FunctorCoreNotations.
   (** Perhaps we should consider making this more global? *)
-  Local Notation "C --> D" := (Functor C D) (at level 99, right associativity) : type_scope.
-  Notation "F '_0' x" := (object_of F x) (at level 10, no associativity, only parsing) : object_scope.
-  Notation "F '_1' m" := (morphism_of F m) (at level 10, no associativity) : morphism_scope.
+  Local Notation "C --> D" := (Functor C D) : type_scope.
+  Notation "F '_0' x" := (object_of F x) : object_scope.
+  Notation "F '_1' m" := (morphism_of F m) : morphism_scope.
 End FunctorCoreNotations.
 
 Hint Resolve @composition_of @identity_of : category functor.

--- a/theories/Categories/Functor/Dual.v
+++ b/theories/Categories/Functor/Dual.v
@@ -18,7 +18,7 @@ Definition opposite C D (F : Functor C D) : Functor C^op D^op
                    (fun d' d s m1 m2 => composition_of F s d d' m2 m1)
                    (identity_of F).
 
-Local Notation "F ^op" := (opposite F) (at level 3, format "F ^op") : functor_scope.
+Local Notation "F ^op" := (opposite F) : functor_scope.
 
 Local Open Scope functor_scope.
 
@@ -27,5 +27,5 @@ Definition opposite_involutive C D (F : Functor C D) : (F^op)^op = F
   := idpath.
 
 Module Export FunctorDualNotations.
-  Notation "F ^op" := (opposite F) (at level 3, format "F ^op") : functor_scope.
+  Notation "F ^op" := (opposite F) : functor_scope.
 End FunctorDualNotations.

--- a/theories/Categories/Functor/Notations.v
+++ b/theories/Categories/Functor/Notations.v
@@ -1,4 +1,5 @@
 (** * Notations for functors *)
+Require Import Basics.Notations.
 Require Functor.Composition.
 Require Functor.Core.
 Require Functor.Dual.

--- a/theories/Categories/Functor/Utf8.v
+++ b/theories/Categories/Functor/Utf8.v
@@ -1,15 +1,10 @@
 (** * Unicode notations for functors *)
 Require Export Category.Notations Category.Utf8 Functor.Notations.
 Require Import Functor.Core Functor.Composition.Core Functor.Sum Functor.Dual Functor.Identity.
+Require Import Basics.Utf8.
 
 Infix "∘" := compose : functor_scope.
 
-Notation "F ₀ x" := (object_of F x) (at level 10, no associativity) : object_scope.
-Notation "F ₁ m" := (morphism_of F m) (at level 10, no associativity) : morphism_scope.
-
-(* This notation should be [only parsing] for now, because otherwise
-   copy/paste doesn't work, because the parser doesn't recognize the
-   unicode characters [ᵒᵖ].  So, really, this notation is just a
-   reminder to do something when Coq's parser is better. *)
-
-Notation "F 'ᵒᵖ'" := (opposite F) (only parsing) : functor_scope.
+Notation "F ₀ x" := (object_of F x) : object_scope.
+Notation "F ₁ m" := (morphism_of F m) : morphism_scope.
+Notation "F 'ᵒᵖ'" := (opposite F) : functor_scope.

--- a/theories/Categories/FunctorCategory/Utf8.v
+++ b/theories/Categories/FunctorCategory/Utf8.v
@@ -1,7 +1,7 @@
 (** * Unicode notations for functor categories *)
 Require Export Category.Utf8 Functor.Utf8 NaturalTransformation.Utf8.
 Require Import FunctorCategory.Core FunctorCategory.Morphisms.
+Require Import Basics.Utf8.
 
-Notation "C → D" := (functor_category C D)
-  (at level 99, D at level 200, right associativity) : category_scope.
+Notation "C → D" := (functor_category C D) : category_scope.
 Infix "≅" := NaturalIsomorphism : natural_transformation_scope.

--- a/theories/Categories/InitialTerminalCategory/Functors.v
+++ b/theories/Categories/InitialTerminalCategory/Functors.v
@@ -53,7 +53,7 @@ Definition from_1 C c : Functor 1 C
 Definition from_0 C : Functor 0 C
   := Eval simpl in from_initial C.
 
-Local Notation "! x" := (@from_terminal _ terminal_category _ _ _ x) (at level 3, format "'!' x") : functor_scope.
+Local Notation "! x" := (@from_terminal _ terminal_category _ _ _ x) : functor_scope.
 
 (** *** Uniqueness principles about initial and terminal categories and functors *)
 Section unique.
@@ -108,5 +108,5 @@ Section unique.
 End unique.
 
 Module Export InitialTerminalCategoryFunctorsNotations.
-  Notation "! x" := (@from_terminal _ terminal_category _ _ _ x) (at level 3, format "'!' x") : functor_scope.
+  Notation "! x" := (@from_terminal _ terminal_category _ _ _ x) : functor_scope.
 End InitialTerminalCategoryFunctorsNotations.

--- a/theories/Categories/InitialTerminalCategory/Pseudofunctors.v
+++ b/theories/Categories/InitialTerminalCategory/Pseudofunctors.v
@@ -61,8 +61,8 @@ Definition from_1 `{Funext} c : Pseudofunctor 1
 Definition from_0 `{Funext} : Pseudofunctor 0
   := Eval simpl in from_initial.
 
-Local Notation "! x" := (@from_terminal _ terminal_category _ _ _ x) (at level 3, format "'!' x") : pseudofunctor_scope.
+Local Notation "! x" := (@from_terminal _ terminal_category _ _ _ x) : pseudofunctor_scope.
 
 Module Export InitialTerminalCategoryPseudofunctorsNotations.
-  Notation "! x" := (@from_terminal _ terminal_category _ _ _ x) (at level 3, format "'!' x") : pseudofunctor_scope.
+  Notation "! x" := (@from_terminal _ terminal_category _ _ _ x) : pseudofunctor_scope.
 End InitialTerminalCategoryPseudofunctorsNotations.

--- a/theories/Categories/LaxComma/Core.v
+++ b/theories/Categories/LaxComma/Core.v
@@ -14,6 +14,9 @@ Require Import NaturalTransformation.Composition.Laws.
 Require Import FunctorCategory.Morphisms.
 Require LaxComma.CoreLaws.
 Require Import Types.Record Trunc HoTT.Tactics Types.Paths Types.Sigma.
+Local Set Warnings Append "-notation-overridden".
+Require Import Basics.Notations.
+Local Set Warnings Append "notation-overridden".
 
 Import Functor.Identity.FunctorIdentityNotations.
 Import Pseudofunctor.Identity.PseudofunctorIdentityNotations.
@@ -252,17 +255,17 @@ Module Export LaxCommaCoreNotations.
 
   (** We really want to use infix [⇓] and [⇑] for lax comma categories, but that's unicode.  Infix [,] might also be reasonable, but I can't seem to get it to work without destroying the [(_, _)] notation for ordered pairs.  So I settle for the ugly ASCII rendition [//] of [⇓] and [\\] for [⇑]. *)
   (** Set some notations for printing *)
-  Notation "'CAT' // a" := (@lax_slice_category_over _ _ _ a _) (at level 40, left associativity) : category_scope.
-  Notation "a // 'CAT'" := (@lax_coslice_category_over _ _ _ a _) (at level 40, left associativity) : category_scope.
-  Notation "x // F" := (lax_coslice_category x F) (at level 40, left associativity, only printing) : category_scope.
+  Notation "'CAT' // a" := (@lax_slice_category_over _ _ _ a _) : category_scope.
+  Notation "a // 'CAT'" := (@lax_coslice_category_over _ _ _ a _) : category_scope.
+  Notation "x // F" := (lax_coslice_category x F) (only printing) : category_scope.
   Notation "F // x" := (lax_slice_category x F) (only printing) : category_scope.
   Notation "S // T" := (lax_comma_category S T) (only printing) : category_scope.
   (** Set the notation for parsing; typeclasses will automatically decide which of the arguments are functors and which are objects, i.e., functors from the terminal category. *)
   Notation "S // T" := (get_LCC S T) : category_scope.
 
-  Notation "'CAT' \\ a" := (@oplax_slice_category_over _ _ _ a _) (at level 40, left associativity) : category_scope.
-  Notation "a \\ 'CAT'" := (@oplax_coslice_category_over _ _ _ a _) (at level 40, left associativity) : category_scope.
-  Notation "x \\ F" := (oplax_coslice_category x F) (at level 40, left associativity, only printing) : category_scope.
+  Notation "'CAT' \\ a" := (@oplax_slice_category_over _ _ _ a _) : category_scope.
+  Notation "a \\ 'CAT'" := (@oplax_coslice_category_over _ _ _ a _) : category_scope.
+  Notation "x \\ F" := (oplax_coslice_category x F) (only printing) : category_scope.
   Notation "F \\ x" := (oplax_slice_category x F) (only printing) : category_scope.
   Notation "S \\ T" := (oplax_comma_category S T) (only printing) : category_scope.
   (** Set the notation for parsing; typeclasses will automatically decide which of the arguments are functors and which are objects, i.e., functors from the terminal category. *)

--- a/theories/Categories/LaxComma/Utf8.v
+++ b/theories/Categories/LaxComma/Utf8.v
@@ -2,19 +2,20 @@
 Local Set Warnings Append "-notation-overridden".
 Require Import LaxComma.Core.
 Require Export LaxComma.Notations.
+Require Import Basics.Utf8.
 
 (** Set some notations for printing *)
-Notation "'CAT' ⇓ a" := (@lax_slice_category_over _ _ _ a _) (at level 40, left associativity) : category_scope.
-Notation "a ⇓ 'CAT'" := (@lax_coslice_category_over _ _ _ a _) (at level 40, left associativity) : category_scope.
-Notation "x ⇓ F" := (lax_coslice_category x F) (at level 40, left associativity, only printing) : category_scope.
+Notation "'CAT' ⇓ a" := (@lax_slice_category_over _ _ _ a _) : category_scope.
+Notation "a ⇓ 'CAT'" := (@lax_coslice_category_over _ _ _ a _) : category_scope.
+Notation "x ⇓ F" := (lax_coslice_category x F) (only printing) : category_scope.
 Notation "F ⇓ x" := (lax_slice_category x F) (only printing) : category_scope.
 Notation "S ⇓ T" := (lax_comma_category S T) (only printing) : category_scope.
 (** Set the notation for parsing; typeclasses will automatically decide which of the arguments are functors and which are objects, i.e., functors from the terminal category. *)
 Notation "S ⇓ T" := (get_LCC S T) : category_scope.
 
-Notation "'CAT' ⇑ a" := (@oplax_slice_category_over _ _ _ a _) (at level 40, left associativity) : category_scope.
-Notation "a ⇑ 'CAT'" := (@oplax_coslice_category_over _ _ _ a _) (at level 40, left associativity) : category_scope.
-Notation "x ⇑ F" := (oplax_coslice_category x F) (at level 40, left associativity, only printing) : category_scope.
+Notation "'CAT' ⇑ a" := (@oplax_slice_category_over _ _ _ a _) : category_scope.
+Notation "a ⇑ 'CAT'" := (@oplax_coslice_category_over _ _ _ a _) : category_scope.
+Notation "x ⇑ F" := (oplax_coslice_category x F) (only printing) : category_scope.
 Notation "F ⇑ x" := (oplax_slice_category x F) (only printing) : category_scope.
 Notation "S ⇑ T" := (oplax_comma_category S T) (only printing) : category_scope.
 (** Set the notation for parsing; typeclasses will automatically decide which of the arguments are functors and which are objects, i.e., functors from the terminal category. *)

--- a/theories/Categories/NatCategory.v
+++ b/theories/Categories/NatCategory.v
@@ -6,6 +6,7 @@ Set Universe Polymorphism.
 Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
+Local Open Scope nat_scope.
 
 Module Export Core.
   (** ** [Fin n] types, or [CardinalityRepresentative] *)

--- a/theories/Categories/NaturalTransformation/Composition/Core.v
+++ b/theories/Categories/NaturalTransformation/Composition/Core.v
@@ -152,6 +152,6 @@ End composition.
 
 Module Export NaturalTransformationCompositionCoreNotations.
   Infix "o" := compose : natural_transformation_scope.
-  Infix "oL" := whisker_l (at level 40, left associativity) : natural_transformation_scope.
-  Infix "oR" := whisker_r (at level 40, left associativity) : natural_transformation_scope.
+  Infix "oL" := whisker_l : natural_transformation_scope.
+  Infix "oR" := whisker_r : natural_transformation_scope.
 End NaturalTransformationCompositionCoreNotations.

--- a/theories/Categories/NaturalTransformation/Dual.v
+++ b/theories/Categories/NaturalTransformation/Dual.v
@@ -21,7 +21,7 @@ Definition opposite
                                   (fun s d => commutes_sym T d s)
                                   (fun s d => commutes T d s).
 
-Local Notation "T ^op" := (opposite T) (at level 3, format "T ^op") : natural_transformation_scope.
+Local Notation "T ^op" := (opposite T) : natural_transformation_scope.
 
 (** ** [ᵒᵖ] is judgmentally involutive *)
 Local Open Scope natural_transformation_scope.
@@ -31,5 +31,5 @@ Definition opposite_involutive C D (F G : Functor C D) (T : NaturalTransformatio
   := idpath.
 
 Module Export NaturalTransformationDualNotations.
-  Notation "T ^op" := (opposite T) (at level 3, format "T ^op") : natural_transformation_scope.
+  Notation "T ^op" := (opposite T) : natural_transformation_scope.
 End NaturalTransformationDualNotations.

--- a/theories/Categories/NaturalTransformation/Utf8.v
+++ b/theories/Categories/NaturalTransformation/Utf8.v
@@ -1,14 +1,9 @@
 (** * Unicode notations for natural transformations *)
 Require Export Category.Utf8 Functor.Utf8.
 Require Import NaturalTransformation.Core NaturalTransformation.Composition.Core NaturalTransformation.Dual.
+Require Import Basics.Utf8.
 
 Infix "∘" := compose : natural_transformation_scope.
-Infix "∘ˡ" := whisker_l (at level 40, left associativity) : natural_transformation_scope.
-Infix "∘ʳ" := whisker_r (at level 40, left associativity) : natural_transformation_scope.
-
-(* This notation should be [only parsing] for now, because otherwise
-   copy/paste doesn't work, because the parser doesn't recognize the
-   unicode characters [ᵒᵖ].  So, really, this notation is just a
-   reminder to do something when Coq's parser is better. *)
-
-Notation "T 'ᵒᵖ'" := (opposite T) (only parsing) : natural_transformation_scope.
+Infix "∘ˡ" := whisker_l : natural_transformation_scope.
+Infix "∘ʳ" := whisker_r : natural_transformation_scope.
+Notation "T 'ᵒᵖ'" := (opposite T) : natural_transformation_scope.

--- a/theories/Categories/Notations.v
+++ b/theories/Categories/Notations.v
@@ -1,4 +1,5 @@
 (** * Notations for categories *)
+Require Import Basics.Notations.
 Require Export Category.Notations.
 Require Export Functor.Notations.
 Require Export NaturalTransformation.Notations.

--- a/theories/Categories/Profunctor/Core.v
+++ b/theories/Categories/Profunctor/Core.v
@@ -1,5 +1,8 @@
 (** * Profunctors *)
 Require Import Category.Core Functor.Core Category.Prod Category.Dual Functor.Prod.Core SetCategory.Core.
+Local Set Warnings Append "-notation-overridden".
+Require Import Basics.Notations.
+Local Set Warnings Append "notation-overridden".
 
 Set Universe Polymorphism.
 Set Implicit Arguments.
@@ -33,7 +36,5 @@ End profunctor.
 Bind Scope profunctor_scope with Profunctor.
 
 Module Export ProfunctorCoreNotations.
-  Notation "x -|-> y" := (Profunctor x y)
-                           (at level 99, right associativity, y at level 200)
-                         : type_scope.
+  Notation "x -|-> y" := (Profunctor x y) : type_scope.
 End ProfunctorCoreNotations.

--- a/theories/Categories/Profunctor/Utf8.v
+++ b/theories/Categories/Profunctor/Utf8.v
@@ -1,7 +1,6 @@
 (** * Unicode notations for profunctors *)
 Require Import Profunctor.Core.
 Require Export Profunctor.Notations.
+Require Import Basics.Utf8.
 
-Notation "x ⇸ y" := (Profunctor x y)
-                      (at level 99, right associativity, y at level 200)
-                    : type_scope.
+Notation "x ⇸ y" := (Profunctor x y) : type_scope.

--- a/theories/Categories/Structure/Core.v
+++ b/theories/Categories/Structure/Core.v
@@ -1,6 +1,7 @@
 (** * Notions of Structure *)
 Require Import Category.Core.
 Require Import HProp HSet Types.Sigma Types.Record Trunc.
+Require Import Basics.Notations.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.
@@ -112,7 +113,7 @@ Hint Resolve is_structure_homomorphism_identity is_structure_homomorphism_compos
 
 *)
 
-Local Notation "a <=_{ x } b" := (is_structure_homomorphism _ x x (identity x) a b) (at level 70, no associativity) : long_structure_scope.
+Local Notation "a <=_{ x } b" := (is_structure_homomorphism _ x x (identity x) a b) : long_structure_scope.
 Local Notation "a <= b" := (a <=_{ _ } b)%long_structure : structure_scope.
 
 (** By (iii) and (iv), this is a preorder with [P x] its type of objects. *)
@@ -248,6 +249,6 @@ Section precategory.
 End precategory.
 
 Module Export StructureCoreNotations.
-  Notation "a <=_{ x } b" := (is_structure_homomorphism _ x x (identity x) a b) (at level 70, no associativity) : long_structure_scope.
+  Notation "a <=_{ x } b" := (is_structure_homomorphism _ x x (identity x) a b) : long_structure_scope.
   Notation "a <= b" := (a <=_{ _ } b)%long_structure : structure_scope.
 End StructureCoreNotations.

--- a/theories/Categories/Structure/Utf8.v
+++ b/theories/Categories/Structure/Utf8.v
@@ -1,5 +1,6 @@
 Require Import Structure.Core.
 Require Export Structure.Notations.
+Require Import Basics.Utf8.
 
-Notation "a ≤_{ x } b" := (a <=_{ x } b)%long_structure (at level 70, no associativity) : long_structure_scope.
-Notation "a ≤ b" := (a <= b)%structure (at level 70, no associativity) : structure_scope.
+Notation "a ≤_{ x } b" := (a <=_{ x } b)%long_structure : long_structure_scope.
+Notation "a ≤ b" := (a <= b)%structure : structure_scope.

--- a/theories/DProp.v
+++ b/theories/DProp.v
@@ -147,8 +147,7 @@ Infix "&&" := dhand : dhprop_scope.
 Infix "||" := dor : dprop_scope.
 Infix "||" := dhor : dhprop_scope.
 Infix "->" := dimpl : dprop_scope.
-Notation "!! P" := (dneg P) (at level 75, right associativity)
-                   : dprop_scope.
+Notation "!! P" := (dneg P) : dprop_scope.
 
 Delimit Scope dprop_scope with dprop.
 Bind Scope dprop_scope with DProp.

--- a/theories/EquivalenceVarieties.v
+++ b/theories/EquivalenceVarieties.v
@@ -5,6 +5,7 @@ Require Import HoTT.Basics HoTT.Types.
 Require Import HProp.
 Require Import HoTT.Tactics.
 
+Local Open Scope nat_scope.
 Local Open Scope path_scope.
 
 Generalizable Variables A B f.

--- a/theories/Extensions.v
+++ b/theories/Extensions.v
@@ -6,6 +6,7 @@ Require Import HoTT.Basics HoTT.Types.
 Require Import HProp EquivalenceVarieties.
 Require Import HoTT.Tactics.
 
+Local Open Scope nat_scope.
 Local Open Scope path_scope.
 
 (** Given [C : B -> Type] and [f : A -> B], an extension of [g : forall a, C (f a)] along [f] is a section [h : forall b, C b] such that [h (f a) = g a] for all [a:A].  This is equivalently the existence of fillers for commutative squares, restricted to the case where the bottom of the square is the identity; type-theoretically, this approach is sometimes more convenient.  In this file we study the type of such extensions.  One of its crucial properties is that a path between extensions is equivalently an extension in a fibration of paths.

--- a/theories/HIT/Colimits/MappingTelescope.v
+++ b/theories/HIT/Colimits/MappingTelescope.v
@@ -1,5 +1,6 @@
 Require Import HoTT.Basics HoTT.Types.Bool HoTT.Types.Paths.
 Require Import Colimits.Diagram Colimits.Colimit.
+Local Open Scope nat_scope.
 Local Open Scope path.
 
 (** * Mapping telescope *)

--- a/theories/HIT/V.v
+++ b/theories/HIT/V.v
@@ -2,10 +2,11 @@
 
 (** * The cumulative hierarchy [V]. *)
 
-Require Import HoTT.Basics.
+Require Import HoTT.Basics HoTT.Basics.Notations HoTT.Basics.Utf8.
 Require Import Types.Unit Types.Bool Types.Universe Types.Sigma Types.Arrow Types.Forall.
 Require Import HProp HSet UnivalenceImpliesFunext TruncType.
 Require Import HIT.Truncations HIT.quotient.
+Local Open Scope nat_scope.
 Local Open Scope path_scope.
 
 
@@ -258,8 +259,7 @@ Proof.
     intros [a p']. exists a. transitivity (g b); auto with path_hints.
 Defined.
 
-Notation "x ∈ v" := (mem x v)
-  (at level 30) : set_scope.
+Notation "x ∈ v" := (mem x v) : set_scope.
 Open Scope set_scope.
 
 (** ** Subset relation *)
@@ -267,8 +267,7 @@ Open Scope set_scope.
 Definition subset (x : V) (y : V) : hProp
 := BuildhProp (forall z : V, z ∈ x -> z ∈ y).
 
-Notation "x ⊆ y" := (subset x y)
-  (at level 30) : set_scope.
+Notation "x ⊆ y" := (subset x y) : set_scope.
 
 
 (** ** Bisimulation relation *)
@@ -326,8 +325,7 @@ Proof.
       intros [a p]. exists a. exact ((ap10 p^ (h c)) # H3).
 Defined.
 
-Notation "u ~~ v" := (bisimulation u v)
-  (at level 30) : set_scope.
+Notation "u ~~ v" := (bisimulation u v) : set_scope.
 
 Global Instance reflexive_bisimulation : Reflexive bisimulation.
 Proof.
@@ -456,8 +454,7 @@ Defined.
 
 Definition type_of_members (u : V) : Type := pr1 (monic_set_present u).
 
-Notation "[ u ]" := (type_of_members u)
-  (at level 20) : set_scope.
+Notation "[ u ]" := (type_of_members u) : set_scope.
 
 Definition func_of_members {u : V} : [u] -> V := pr1 (pr2 (monic_set_present u)) : [u] -> V.
 
@@ -565,8 +562,7 @@ Defined.
 (** The ordered pair (u,v) *)
 Definition V_pair_ord (u : V) (v : V) : V := V_pair (V_singleton u) (V_pair u v).
 
-Notation " [ u , v ] " := (V_pair_ord u v)
-  (at level 20) : set_scope.
+Notation " [ u , v ] " := (V_pair_ord u v) : set_scope.
 
 Lemma path_pair_ord {a b c d : V} : [a, b] = [c, d] <-> (a = c) * (b = d).
 Proof.
@@ -608,11 +604,10 @@ Defined.
 Definition V_cart_prod (a : V) (b : V) : V
 := set (fun x : [a] * [b] => [func_of_members (fst x), func_of_members (snd x)]).
 
-Notation " a × b " := (V_cart_prod a b)
-  (at level 25) : set_scope.
+Notation " a × b " := (V_cart_prod a b) : set_scope.
 
 (** f is a function with domain a and codomain b *)
-Definition V_is_func (a : V) (b : V) (f : V) := f ⊆ a × b
+Definition V_is_func (a : V) (b : V) (f : V) := f ⊆ (a × b)
  * (forall x, x ∈ a -> hexists (fun y => y ∈ b * [x,y] ∈ f))
  * (forall x y y', [x,y] ∈ f * [x,y'] ∈ f -> y = y').
 

--- a/theories/Idempotents.v
+++ b/theories/Idempotents.v
@@ -3,6 +3,7 @@ Require Import HoTT.Basics HoTT.Types.
 Require Import Fibrations UnivalenceImpliesFunext EquivalenceVarieties Constant.
 Require Import HIT.Truncations.
 
+Local Open Scope nat_scope.
 Local Open Scope path_scope.
 
 Local Set Universe Minimization ToSet.

--- a/theories/Modalities/Accessible.v
+++ b/theories/Modalities/Accessible.v
@@ -6,6 +6,7 @@ Require Import HoTT.Basics HoTT.Types HoTT.Tactics.
 Require Import Extensions NullHomotopy EquivalenceVarieties.
 Require Import ReflectiveSubuniverse Modality.
 
+Local Open Scope nat_scope.
 Local Open Scope path_scope.
 
 

--- a/theories/Modalities/Closed.v
+++ b/theories/Modalities/Closed.v
@@ -5,6 +5,7 @@ Require Import HProp TruncType Extensions.
 Require Import Modality Accessible Nullification Lex Topological.
 Require Import HIT.Pushout HIT.Join.
 
+Local Open Scope nat_scope.
 Local Open Scope path_scope.
 
 

--- a/theories/Modalities/Localization.v
+++ b/theories/Modalities/Localization.v
@@ -5,6 +5,7 @@ Require Import HoTT.Basics HoTT.Types.
 Require Import Extensions EquivalenceVarieties.
 Require Import ReflectiveSubuniverse Accessible.
 
+Local Open Scope nat_scope.
 Local Open Scope path_scope.
 
 (** Suppose given a family of maps [f : forall (i:I), S i -> T i].  A type [X] is said to be [f]-local if for all [i:I], the map [(T i -> X) -> (S i -> X)] given by precomposition with [f i] is an equivalence.  Our goal is to show that the [f]-local types form a reflective subuniverse, with a reflector constructed by localization.  That is, morally we want to say

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -5,6 +5,7 @@ Require Import HoTT.Tactics.
 Require Import HIT.Coeq.
 Require Import Tactics.RewriteModuloAssociativity.
 
+Local Open Scope nat_scope.
 Local Open Scope path_scope.
 
 

--- a/theories/Pointed.v
+++ b/theories/Pointed.v
@@ -73,7 +73,7 @@ Record pMap (A B : pType) :=
 Arguments point_eq {A B} f : rename.
 Coercion pointed_fun : pMap >-> Funclass.
 
-Infix "->*" := pMap (at level 99) : pointed_scope.
+Infix "->*" := pMap : pointed_scope.
 Local Open Scope pointed_scope.
 
 Definition pmap_idmap (A : pType): A ->* A
@@ -85,7 +85,7 @@ Definition pmap_compose {A B C : pType}
   := Build_pMap A C (g o f)
                 (ap g (point_eq f) @ point_eq g).
 
-Infix "o*" := pmap_compose (at level 40) : pointed_scope.
+Infix "o*" := pmap_compose : pointed_scope.
 
 (** Another option would be
 <<
@@ -107,7 +107,7 @@ Arguments pointed_htpy {A B f g} p x.
 
 Coercion pointed_htpy : pHomotopy >-> pointwise_paths.
 
-Infix "==*" := pHomotopy (at level 70, no associativity) : pointed_scope.
+Infix "==*" := pHomotopy : pointed_scope.
 
 (** The following tactic often allows us to "pretend" that pointed maps and homotopies preserve basepoints strictly.  We have carefully defined [pMap] and [pHomotopy] so that when destructed, their second components are paths with right endpoints free, to which we can apply Paulin-Morhing path-induction. *)
 Ltac pointed_reduce :=
@@ -211,7 +211,7 @@ Proof.
   - apply concat_p1.
 Qed.
 
-Infix "@*" := phomotopy_compose (at level 30) : pointed_scope.
+Infix "@*" := phomotopy_compose : pointed_scope.
 
 Definition phomotopy_inverse {A B : pType} {f g : A ->* B}
 : (f ==* g) -> (g ==* f).
@@ -302,7 +302,7 @@ Record pEquiv (A B : pType) :=
     pointed_isequiv : IsEquiv pointed_equiv_fun
   }.
 
-Infix "<~>*" := pEquiv (at level 85) : pointed_scope.
+Infix "<~>*" := pEquiv : pointed_scope.
 
 Coercion pointed_equiv_fun : pEquiv >-> pMap.
 Global Existing Instance pointed_isequiv.

--- a/theories/Pullback.v
+++ b/theories/Pullback.v
@@ -90,7 +90,7 @@ Definition pullback_along' {A B C} (g : C -> A) (f : B -> A)
 
 Arguments pullback_along' / .
 
-Notation "g ^*'" := (pullback_along' g) (at level 20) : function_scope.
+Notation "g ^*'" := (pullback_along' g) : function_scope.
 
 Definition hfiber_pullback_along' {A B C} (g : C -> A) (f : B -> A) (c:C)
 : hfiber (g ^*' f) c <~> hfiber f (g c).

--- a/theories/Spaces/BAut/Bool.v
+++ b/theories/Spaces/BAut/Bool.v
@@ -220,9 +220,7 @@ First we define the function that will be the equivalence. *)
     exact (path_universe equiv_bool_aut_bool).
   Defined.
 
-  Notation "Z ** W" := (baut_bool_pairing Z W)
-                         (at level 40, no associativity)
-                       : baut_bool_scope.
+  Notation "Z ** W" := (baut_bool_pairing Z W) : baut_bool_scope.
   Local Open Scope baut_bool_scope.
 
   Local Notation pt := (point (BAut Bool)).

--- a/theories/Spaces/Cantor.v
+++ b/theories/Spaces/Cantor.v
@@ -1,6 +1,7 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 Require Import HoTT.Basics HoTT.Types.
 
+Local Open Scope nat_scope.
 Local Open Scope path_scope.
 
 

--- a/theories/Spaces/Nat.v
+++ b/theories/Spaces/Nat.v
@@ -71,7 +71,7 @@ Fixpoint code_nat (m n : nat) {struct m} : DHProp :=
     | _, _ => False
   end.
 
-Infix "=n" := code_nat (at level 70, no associativity) : nat_scope.
+Infix "=n" := code_nat : nat_scope.
 
 Fixpoint idcode_nat {n} : (n =n n) :=
   match n as n return (n =n n) with

--- a/theories/Spaces/No.v
+++ b/theories/Spaces/No.v
@@ -1098,8 +1098,7 @@ Section Addition.
       refine (Conway_theorem0_ii_r _ _ _ _ _ (inl r)) ).
   Defined.
 
-  (** Oddly, without the universe annotations here, Coq turns all these [No]s into [No@{Set}}. *)
-  Definition plus (x y : No@{i}) : No@{i}
+  Definition plus (x y : No) : No
     := (plus_outer.1 x).1 y.
 
   Infix "+" := plus : surreal_scope.

--- a/theories/Spaces/No.v
+++ b/theories/Spaces/No.v
@@ -4,6 +4,7 @@ Require Import UnivalenceImpliesFunext TruncType HSet.
 Require Import HIT.Truncations.
 Import TrM.
 
+Local Open Scope nat_scope.
 Local Open Scope path_scope.
 
 (** * The surreal numbers *)
@@ -86,7 +87,7 @@ Module Export Surreals.
                 (isno _ _ _ _ (isno_game_of o xL)
                       (isno_game_of o xR) xcut).
 
-  Local Notation "{{ xL | xR // xcut }}" := (No_cut xL xR xcut) : surreal_scope.
+  Local Notation "{ { xL | xR // xcut } }" := (No_cut xL xR xcut) : surreal_scope.
 
   Axiom path_No : forall (x y : No), (x <= y) -> (y <= x) -> (x = y).
   Arguments path_No {x y} _ _.
@@ -283,7 +284,7 @@ End Surreals.
 
 (** We put this in a module so that it doesn't prevent other people from using notations with double `}}`, e.g. nested sigma-types.  Apparently just putting it in a closed scope is not good enough for that.  Anyone else who wants to use this notation can import this module. *)
 Module Import Surreal_Cut_Notation.
-  Notation "{{ xL | xR // xcut }}" := (No_cut xL xR xcut) : surreal_scope.
+  Notation "{ { xL | xR // xcut } }" := (No_cut xL xR xcut) : surreal_scope.
 End Surreal_Cut_Notation.
 
 (** ** A few surreal numbers *)
@@ -1097,7 +1098,7 @@ Section Addition.
       refine (Conway_theorem0_ii_r _ _ _ _ _ (inl r)) ).
   Defined.
 
-  (** Oddly, without the universe annotations here, Coq turns all these [No]s into [No@{Set}]. *)
+  (** Oddly, without the universe annotations here, Coq turns all these [No]s into [No@{Set}}. *)
   Definition plus (x y : No@{i}) : No@{i}
     := (plus_outer.1 x).1 y.
 

--- a/theories/Spectra/Spectrum.v
+++ b/theories/Spectra/Spectrum.v
@@ -7,6 +7,7 @@ Require Import HoTT.Tactics.
 Require Import Pointed.
 Require Import HIT.Truncations.
 Import TrM.
+Local Open Scope nat_scope.
 Local Open Scope path_scope.
 Local Open Scope equiv_scope.
 Local Open Scope pointed_scope.

--- a/theories/Types/Prod.v
+++ b/theories/Types/Prod.v
@@ -240,7 +240,7 @@ Proof.
   exact _.
 Defined.
 
-Notation "f *E g" := (equiv_functor_prod' f g) (at level 40, no associativity) : equiv_scope.
+Notation "f *E g" := (equiv_functor_prod' f g) : equiv_scope.
 
 Definition equiv_functor_prod_l {A B B' : Type} (g : B <~> B')
   : A * B <~> A * B'

--- a/theories/Types/Sigma.v
+++ b/theories/Types/Sigma.v
@@ -105,14 +105,14 @@ Definition pr1_path `{P : A -> Type} {u v : sigT P} (p : u = v)
     ap pr1 p.
 (* match p with idpath => 1 end. *)
 
-Notation "p ..1" := (pr1_path p) (at level 3) : fibration_scope.
+Notation "p ..1" := (pr1_path p) : fibration_scope.
 
 Definition pr2_path `{P : A -> Type} {u v : sigT P} (p : u = v)
 : p..1 # u.2 = v.2
   := (transport_compose P pr1 p u.2)^
      @ (@apD {x:A & P x} _ pr2 _ _ p).
 
-Notation "p ..2" := (pr2_path p) (at level 3) : fibration_scope.
+Notation "p ..2" := (pr2_path p) : fibration_scope.
 
 (** Now we show how these things compute. *)
 

--- a/theories/Types/Sum.v
+++ b/theories/Types/Sum.v
@@ -484,7 +484,7 @@ Definition equiv_functor_sum' {A A' B B' : Type} (f : A <~> A') (g : B <~> B')
 : A + B <~> A' + B'
   := equiv_functor_sum (f := f) (g := g).
 
-Notation "f +E g" := (equiv_functor_sum' f g) (at level 50, left associativity) : equiv_scope.
+Notation "f +E g" := (equiv_functor_sum' f g) : equiv_scope.
 
 Definition equiv_functor_sum_l {A B B' : Type} (g : B <~> B')
 : A + B <~> A + B'

--- a/theories/Utf8.v
+++ b/theories/Utf8.v
@@ -1,4 +1,5 @@
 Require Export Coq.Unicode.Utf8.
+Require Export HoTT.Basics.Utf8.
 Require Import HoTT.Basics HoTT.Types.Arrow HoTT.Types.Prod HoTT.Types.Sum.
 Require Import Modalities.Identity.
 Require Import HIT.Circle HIT.TwoSphere HIT.Truncations HIT.Suspension.
@@ -8,31 +9,30 @@ Notation pr₁ := pr1.
 Notation pr₂ := pr2.
 Local Open Scope fibration_scope.
 (*Notation "f → g" := (f -> g)%equiv : equiv_scope.*)
-Notation "x ₁" := (x.1) (at level 3) : fibration_scope.
-Notation "x ₂" := (x.2) (at level 3) : fibration_scope.
-Notation "g ∘ f" := (g o f)%function (at level 40, left associativity) : function_scope.
-Notation "g ∘ᴱ f" := (g oE f)%equiv (at level 40, left associativity) : equiv_scope.
-Notation "f *ᴱ g" := (f *E g)%equiv (at level 40, no associativity) : equiv_scope.
-Notation "f ×ᴱ g" := (f *E g)%equiv (at level 40, no associativity) : equiv_scope.
-Notation "A × B" := (A * B)%type (at level 40, no associativity) : type_scope.
-Notation "f +ᴱ g" := (f +E g)%equiv (at level 50, left associativity) : equiv_scope.
+Notation "x ₁" := (x.1) : fibration_scope.
+Notation "x ₂" := (x.2) : fibration_scope.
+Notation "g ∘ f" := (g o f)%function : function_scope.
+Notation "g ∘ᴱ f" := (g oE f)%equiv : equiv_scope.
+Notation "f *ᴱ g" := (f *E g)%equiv : equiv_scope.
+Notation "f ×ᴱ g" := (f *E g)%equiv : equiv_scope.
+Notation "A × B" := (A * B)%type : type_scope.
+Notation "f +ᴱ g" := (f +E g)%equiv : equiv_scope.
 (** We copy the HoTT-Agda library with regard to path concatenation. *)
-Notation "p • q" := (p @ q)%path (at level 20) : path_scope.
-Notation "p '⁻¹'" := (p^)%path (at level 3, format "p '⁻¹'") : path_scope.
-Notation "p •' q" := (p @ q)%path (at level 21, left associativity,
-                                   format "'[v' p '/' '•''  q ']'") : long_path_scope.
+Notation "p • q" := (p @ q)%path : path_scope.
+Notation "p '⁻¹'" := (p^)%path : path_scope.
+Notation "p •' q" := (p @ q)%path : long_path_scope.
 (** Add error messages so people aren't intensely confused by using an almost identical character. *)
-Infix "∙" := ltac:(fail "You used '∙' (BULLET OPERATOR, #x2219) when you probably meant to use '•' (BULLET, #x2022)") (at level 20, only parsing) : path_scope.
+Infix "∙" := ltac:(fail "You used '∙' (BULLET OPERATOR, #x2219) when you probably meant to use '•' (BULLET, #x2022)") (only parsing) : path_scope.
 (*Notation "p # x" := (transport _ p x) (right associativity, at level 65, only parsing) : path_scope.*)
 (*Notation "f == g" := (pointwise_paths f g) (at level 70, no associativity) : type_scope.*)
-Notation "A ≃ B" := (A <~> B) (at level 85) : type_scope.
-Notation "f '⁻¹'" := (f^-1)%function (at level 3, format "f '⁻¹'") : function_scope.
-Notation "f '⁻¹'" := (f^-1)%equiv (at level 3, format "f '⁻¹'") : equiv_scope.
-Notation "¬ x" := (~x) (at level 75, right associativity) : type_scope.
-Notation "x ≠ y" := (x <> y) (at level 70) : type_scope.
+Notation "A ≃ B" := (A <~> B) : type_scope.
+Notation "f '⁻¹'" := (f^-1)%function : function_scope.
+Notation "f '⁻¹'" := (f^-1)%equiv : equiv_scope.
+Notation "¬ x" := (~x) : type_scope.
+Notation "x ≠ y" := (x <> y) : type_scope.
 (*Notation "p @@ q" := (concat2 p q)%path (at level 20) : path_scope.*)
 
-Notation "m ≤ n" := (m <= n)%trunc (at level 70, no associativity) : trunc_scope.
+Notation "m ≤ n" := (m <= n)%trunc : trunc_scope.
 
 (*Infix "||" := orb : bool_scope.*)
 (*Infix "&&" := andb : bool_scope.*)


### PR DESCRIPTION
This allows us to ensure that notation levels don't conflict (some of them did), and fail fast if they do.  I had to adjust some notations a bit, e.g., I replaced `{{ xL | xR // xcut }}` with `{ { xL | xR // xcut } }` so that it doesn't conflict with `{x : Type@{i}}`, and adjusted the level of `xR` so that it doesn't conflict with the `//` notation for lax comma categories.

For some unknown reason, a number of files now need `Local Open Scope nat_scope` to not get confused about `nat_scope` vs `trunc_scope`.