### PR TITLE
Factor out part of accessible lex modalities

### DIFF
--- a/theories/Modalities/Lex.v
+++ b/theories/Modalities/Lex.v
@@ -385,7 +385,7 @@ Module Accessible_Lex_Modalities_Theory
     apply (snd (inO_iff_isnull O _)); intros i n; simpl in *.
     destruct n; [ exact tt | split ].
     - intros P.
-      (* The case [n=0] is basically just one of the above characterizations of lex-ness. *)
+      (** The case [n=0] is basically just one of the above characterizations of lex-ness. *)
       destruct (modal_over_connected_isconst_lex O (acc_gen O i) P)
         as [Q [QinO f]].
       exists (fun _ => (Q ; QinO)).

--- a/theories/Modalities/Modality.v
+++ b/theories/Modalities/Modality.v
@@ -991,6 +991,15 @@ Section ConnectedMaps.
       + refine (to_O_natural _ _ _).
   Defined.
 
+  (** As a consequence, connected maps between modal types are equivalences. *)
+  Definition isequiv_conn_map_ino {A B : Type} (f : A -> B)
+         `{In O A} `{In O B} `{IsConnMap O _ _ f}
+    : IsEquiv f.
+  Proof.
+    refine (isequiv_commsq' f (O_functor O f) (to O A) (to O B)
+                            (to_O_natural O f)).
+  Defined.
+
 End ConnectedMaps.
 
 (** ** The modal factorization system *)

--- a/theories/Modalities/Modality.v
+++ b/theories/Modalities/Modality.v
@@ -994,11 +994,8 @@ Section ConnectedMaps.
   (** As a consequence, connected maps between modal types are equivalences. *)
   Definition isequiv_conn_map_ino {A B : Type} (f : A -> B)
          `{In O A} `{In O B} `{IsConnMap O _ _ f}
-    : IsEquiv f.
-  Proof.
-    refine (isequiv_commsq' f (O_functor O f) (to O A) (to O B)
-                            (to_O_natural O f)).
-  Defined.
+    : IsEquiv f
+    := isequiv_commsq' f (O_functor O f) (to O A) (to O B) (to_O_natural O f).
 
 End ConnectedMaps.
 


### PR DESCRIPTION
It turns out that the main part of the characterization of accessible lex modalities in terms of modal-ness of the universe doesn't depend on accessibility and is an equivalent characterization of lex-ness for arbitrary modalities, namely that families of modal types indexed by a connected type are constant.