### PR TITLE
Rigid types and automorphisms of the universe

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -524,6 +524,18 @@ globally but depending on elements of those dummy types.  This is not
 something you generally need to worry about; see the comments in
 `Basics/Overture` for more information.
 
+However, one situation in which this matters is when proving an
+implication between axioms.  Because `Univalence` and `Funext' are
+dummy types, we cannot actually prove that `Univalence -> Funext`.
+Instead we define placeholders with names like `Funext_type` and
+`Univalence_type` that have the actual type that the axiom would have
+except for the polymorphism trick, and prove that `Univalence_type ->
+Funext_type`.  Then we feel justified in asserting as a further
+`Axiom` that `Univalence -> Funext`.
+
+When introducing further axioms, please use this same naming
+convention.  For another example, see `ExcludedMiddle.v`.
+
 
 ## Higher Inductive Types ##
 

--- a/_CoqProject
+++ b/_CoqProject
@@ -53,6 +53,7 @@ theories/Idempotents.v
 theories/Pullback.v
 theories/Factorization.v
 theories/Constant.v
+theories/ExcludedMiddle.v
 theories/PropResizing/PropResizing.v
 theories/PropResizing/Truncations.v
 theories/PropResizing/Nat.v
@@ -95,7 +96,9 @@ theories/Spaces/BAut/Cantor.v
 theories/Spaces/Finite.v
 theories/Spaces/BAut/Bool.v
 theories/Spaces/BAut/Bool/IncoherentIdempotent.v
+theories/Spaces/BAut/Rigid.v
 theories/Spaces/No.v
+theories/Spaces/Universe.v
 theories/Algebra/ooGroup.v
 theories/Algebra/Aut.v
 theories/Algebra/ooAction.v

--- a/theories/ExcludedMiddle.v
+++ b/theories/ExcludedMiddle.v
@@ -7,6 +7,8 @@ Existing Class ExcludedMiddle.
 
 Axiom LEM : forall `{ExcludedMiddle} (P : Type), IsHProp P -> P + ~P.
 
+Definition LEM_type := forall (P : Type), IsHProp P -> P + ~P.
+
 (** ** LEM means that all propositions are decidable *)
 
 Global Instance decidable_lem `{ExcludedMiddle} (P : Type) `{IsHProp P} : Decidable P
@@ -26,7 +28,7 @@ Defined.
 
 (** This direction requires Funext. *)
 Definition DNE_to_LEM `{Funext} : 
-  DNE -> forall (P : Type), IsHProp P -> P + ~P.
+  DNE -> LEM_type.
 Proof.
   intros dn P hp.
   refine (dn (P + ~P) _ _).
@@ -41,4 +43,25 @@ Proof.
     apply nlem.
     apply inl.
     apply p.
+Defined.
+
+(** DNE is equivalent to "every proposition is a negation". *)
+Definition allneg_from_DNE (H : DNE) (P : Type) `{IsHProp P}
+  : {Q : Type & P <-> ~Q}.
+Proof.
+  exists (~P); split.
+  - intros p np; exact (np p).
+  - apply H; exact _.
+Defined.
+
+Definition DNE_from_allneg (H : forall P, IsHProp P -> {Q : Type & P <-> ~Q})
+  : DNE.
+Proof.
+  intros P ? nnp.
+  destruct (H P _) as [Q e].
+  apply e.
+  intros q.
+  apply nnp.
+  intros p.
+  exact (fst e p q).
 Defined.

--- a/theories/ExcludedMiddle.v
+++ b/theories/ExcludedMiddle.v
@@ -7,7 +7,7 @@ Existing Class ExcludedMiddle.
 
 Axiom LEM : forall `{ExcludedMiddle} (P : Type), IsHProp P -> P + ~P.
 
-Definition LEM_type := forall (P : Type), IsHProp P -> P + ~P.
+Definition ExcludedMiddle_type := forall (P : Type), IsHProp P -> P + ~P.
 
 (** ** LEM means that all propositions are decidable *)
 
@@ -16,9 +16,9 @@ Global Instance decidable_lem `{ExcludedMiddle} (P : Type) `{IsHProp P} : Decida
 
 (** ** Double-negation elimination *)
 
-Definition DNE := forall P, IsHProp P -> ~~P -> P.
+Definition DNE_type := forall P, IsHProp P -> ~~P -> P.
 
-Definition LEM_to_DNE : ExcludedMiddle -> DNE.
+Definition LEM_to_DNE : ExcludedMiddle -> DNE_type.
 Proof.
   intros lem P hp nnp.
   case (LEM P _).
@@ -28,7 +28,7 @@ Defined.
 
 (** This direction requires Funext. *)
 Definition DNE_to_LEM `{Funext} : 
-  DNE -> LEM_type.
+  DNE_type -> ExcludedMiddle_type.
 Proof.
   intros dn P hp.
   refine (dn (P + ~P) _ _).
@@ -46,7 +46,7 @@ Proof.
 Defined.
 
 (** DNE is equivalent to "every proposition is a negation". *)
-Definition allneg_from_DNE (H : DNE) (P : Type) `{IsHProp P}
+Definition allneg_from_DNE (H : DNE_type) (P : Type) `{IsHProp P}
   : {Q : Type & P <-> ~Q}.
 Proof.
   exists (~P); split.
@@ -55,7 +55,7 @@ Proof.
 Defined.
 
 Definition DNE_from_allneg (H : forall P, IsHProp P -> {Q : Type & P <-> ~Q})
-  : DNE.
+  : DNE_type.
 Proof.
   intros P ? nnp.
   destruct (H P _) as [Q e].

--- a/theories/ExcludedMiddle.v
+++ b/theories/ExcludedMiddle.v
@@ -1,0 +1,44 @@
+Require Import HoTT.Basics HoTT.Types.
+
+(** * The law of excluded middle *)
+
+Monomorphic Axiom ExcludedMiddle : Type0.
+Existing Class ExcludedMiddle.
+
+Axiom LEM : forall `{ExcludedMiddle} (P : Type), IsHProp P -> P + ~P.
+
+(** ** LEM means that all propositions are decidable *)
+
+Global Instance decidable_lem `{ExcludedMiddle} (P : Type) `{IsHProp P} : Decidable P
+  := LEM P _.
+
+(** ** Double-negation elimination *)
+
+Definition DNE := forall P, IsHProp P -> ~~P -> P.
+
+Definition LEM_to_DNE : ExcludedMiddle -> DNE.
+Proof.
+  intros lem P hp nnp.
+  case (LEM P _).
+  - auto.
+  - intros np; elim (nnp np).
+Defined.
+
+(** This direction requires Funext. *)
+Definition DNE_to_LEM `{Funext} : 
+  DNE -> forall (P : Type), IsHProp P -> P + ~P.
+Proof.
+  intros dn P hp.
+  refine (dn (P + ~P) _ _).
+  apply ishprop_sum.
+  - exact _.
+  - exact _.
+  - intros p np; exact (np p).
+  - intros nlem.
+    apply nlem.
+    apply inr.
+    intros p.
+    apply nlem.
+    apply inl.
+    apply p.
+Defined.

--- a/theories/HIT/Connectedness.v
+++ b/theories/HIT/Connectedness.v
@@ -94,6 +94,15 @@ Proof.
   refine (isconnected_elim n.+1 C f).
 Defined.
 
+(** By induction, an [n.+1]-connected type is also [-1]-connected. *)
+Definition merely_isconnected n A `{IsConnected n.+1 A}
+  : merely A.
+Proof.
+  induction n as [|n IHn].
+  - apply center; assumption.
+  - apply IHn, isconnected_pred; assumption.
+Defined.
+
 (** ** Connectedness of path spaces *)
 
 Global Instance isconnected_paths `{Univalence} {n A}

--- a/theories/HoTT.v
+++ b/theories/HoTT.v
@@ -25,6 +25,7 @@ Require Export DProp.
 Require Export NullHomotopy.
 Require Export Idempotents.
 Require Export Pullback.
+Require Export ExcludedMiddle.
 
 Require Export PropResizing.PropResizing.
 (* Don't export the rest of [PropResizing] *)
@@ -69,7 +70,9 @@ Require Export Spaces.BAut.Cantor.
 Require Export Spaces.Finite.
 Require Export Spaces.BAut.Bool.
 Require Export Spaces.BAut.Bool.IncoherentIdempotent.
+Require Export Spaces.BAut.Rigid.
 Require Export Spaces.No.
+Require Export Spaces.Universe.
 
 Require Export Algebra.ooGroup.
 Require Export Algebra.Aut.

--- a/theories/Spaces/BAut.v
+++ b/theories/Spaces/BAut.v
@@ -78,6 +78,30 @@ Proof.
   destruct p; exact _.
 Defined.
 
+(** ** Operations on [BAut] *)
+
+(** Multiplying by a fixed type *)
+
+Definition baut_prod_r (X A : Type)
+  : BAut X -> BAut (X * A)
+  := fun Z:BAut X =>
+       (Z * A ; Trunc_functor -1 (ap (fun W => W * A)) (pr2 Z))
+       : BAut (X * A).
+
+Definition ap_baut_prod_r `{Univalence} (X A : Type)
+           {Z W : BAut X} (e : Z <~> W)
+  : ap (baut_prod_r X A) (path_baut Z W e)
+    = path_baut (baut_prod_r X A Z) (baut_prod_r X A W) (equiv_functor_prod_r e).
+Proof.
+  cbn.
+  apply moveL_equiv_M; cbn; unfold pr1_path.
+  rewrite <- (ap_compose (baut_prod_r X A) pr1 (path_sigma_hprop Z W _)).
+  rewrite <- ((ap_compose pr1 (fun Z => Z * A) (path_sigma_hprop Z W _))^).
+  rewrite ap_pr1_path_sigma_hprop.
+  apply moveL_equiv_M; cbn.
+  apply ap_prod_r_path_universe.
+Qed.
+
 (** ** Centers *)
 
 (** The following lemma says that to define a section of a family [P] of hsets over [BAut X], it is equivalent to define an element of [P X] which is fixed by all automorphisms of [X]. *)

--- a/theories/Spaces/BAut/Rigid.v
+++ b/theories/Spaces/BAut/Rigid.v
@@ -11,17 +11,69 @@ Local Open Scope path_scope.
 (** * Rigid types *)
 
 Class IsRigid (A : Type) := 
-  contr_baut_rigid : Contr (BAut A).
-Existing Instance contr_baut_rigid.
+  path_aut_rigid : forall f g : A <~> A, f == g.
 
-Definition aut_idmap_rigid `{Univalence} {A : Type} `{IsRigid A}
-           (f : A <~> A)
-  : f == equiv_idmap.
+(** Assuming funext, rigidity is equivalent to contractibility of [A <~> A]. *)
+
+Global Instance contr_aut_rigid `{Funext} (A : Type) `{IsRigid A}
+  : Contr (A <~> A).
 Proof.
-  apply ap10, (ap equiv_fun).
-  refine ((eissect (path_baut (point _) (point _)) f)^ @ _).
-  apply moveR_equiv_V.
-  apply path_contr.
+  exists equiv_idmap.
+  intros f; apply path_equiv, path_arrow, path_aut_rigid.
+Defined.
+
+(** Assuming univalence, rigidity is equivalent to contractibility of [BAut A]. *)
+
+Global Instance contr_baut_rigid `{Univalence} {A : Type} `{IsRigid A}
+  : Contr (BAut A).
+Proof.
+  refine (contr_trunc_conn (Tr 0)).
+  intros Z W; baut_reduce.
+  refine (trunc_equiv (A <~> A)
+                      (path_baut (point (BAut A)) (point (BAut A)))).
+Defined.
+
+Definition rigid_contr_Baut `{Univalence} {A : Type} `{Contr (BAut A)}
+  : IsRigid A.
+Proof.
+  unfold IsRigid.
+  equiv_intro ((path_baut (point (BAut A)) (point (BAut A)))^-1) f.
+  equiv_intro ((path_baut (point (BAut A)) (point (BAut A)))^-1) g.
+  apply ap10, ap, ap, path_contr.
+Defined.
+
+(** ** HProps are rigid *)
+
+Global Instance rigid_ishprop
+       (A : Type) `{IsHProp A} : IsRigid A.
+Proof.
+  intros f g x; apply path_ishprop.
+Defined.
+
+(** ** Equivalences of BAut *)
+
+(** Under a truncatedness/connectedness assumption, multiplying by a rigid type doesn't change the automorphism oo-group. *)
+
+(** A lemma: a "monoid homomorphism up to homotopy" between endomorphism monoids restricts to automorphism groups. *)
+Definition aut_homomorphism_end `{Funext} {X Y : Type}
+           (M : (X -> X) -> (Y -> Y))
+           (Mid : M idmap == idmap)
+           (MC : forall f g, M (g o f) == M g o M f)
+  : (X <~> X) -> (Y <~> Y).
+Proof.
+  assert (MS : forall f g, Sect f g -> Sect (M f) (M g)).
+  { intros g f s x.
+    transitivity (M (f o g) x).
+    + symmetry. refine (MC g f x).
+    + transitivity (M idmap x).
+      * apply ap10, ap, path_arrow.
+        intros y; apply s.
+      * apply Mid. }
+  assert (ME : (forall f, IsEquiv f -> IsEquiv (M f))).
+  { intros f ?.
+    refine (isequiv_adjointify (M f) (M f^-1) _ _);
+      apply MS; [ apply eisretr | apply eissect ]. }
+  exact (fun f => (BuildEquiv _ _ (M f) (ME f _))).
 Defined.
 
 Definition baut_prod_rigid_equiv `{Univalence}
@@ -29,45 +81,25 @@ Definition baut_prod_rigid_equiv `{Univalence}
            `{IsTrunc n.+1 X} `{IsRigid A} `{IsConnected n.+1 A}
   : BAut X <~> BAut (X * A).
 Proof.
-  pose (f := fun Z:BAut X =>
-               (Z * A ; Trunc_functor -1 (ap (fun W => W * A)) (pr2 Z))
-               : BAut (X * A)).
-  assert (p : f (point (BAut X)) = (point (BAut (X * A))))
-    by (apply path_sigma_hprop; reflexivity).
-  refine (BuildEquiv _ _ f _).
+  refine (BuildEquiv _ _ (baut_prod_r X A) _).
   apply isequiv_surj_emb.
   { apply BuildIsSurjection; intros Z.
     baut_reduce.
-    exact (tr (point _ ; p)). }
+    refine (tr (point _ ; _)).
+    apply path_sigma_hprop; reflexivity. }
   { apply isembedding_isequiv_ap.
-    intros Z W; baut_reduce.
-    pose (L := fun e : X <~> X => equiv_functor_prod_r (B := A) e).
+    intros Z W.
+    pose (L := fun e : Z <~> W => equiv_functor_prod_r (B := A) e).
     refine (isequiv_commsq
-             L _
-             (path_baut (point (BAut X)) (point (BAut X)))
-             (path_baut (point (BAut (X*A))) (point (BAut (X*A))))
-             _).
-    { intros e; revert e; equiv_intro (equiv_path X X) e; cbn.
-      rewrite path_universe_uncurried_equiv_path.
-      apply moveR_equiv_M; cbn; unfold pr1_path.
-      refine (_ @ ap_compose f pr1
-                (path_sigma_hprop (X; tr 1) (X; tr 1) e)).
-      unfold f.
-      refine (_ @ (ap_compose pr1 (fun Z => Z * A)
-                (path_sigma_hprop (X; tr 1) (X; tr 1) e))^).
-      rewrite ap_pr1_path_sigma_hprop. unfold L.
-      assert (G : forall Y W (e:Y=W),
-                 path_universe_uncurried (equiv_functor_prod_r (equiv_path Y W e))
-                 = ap (fun Z => Z * A) e).
-      { intros ? ? []; cbn.
-        apply moveR_equiv_M; cbn.
-        apply path_equiv, path_arrow; intros x; reflexivity. }
-      apply G. }
-    clear f p.
+             L (ap (baut_prod_r X A))
+             (path_baut Z W)
+             (path_baut (baut_prod_r X A Z) (baut_prod_r X A W))
+             (fun e => (ap_baut_prod_r X A e)^)).
     refine ((isconnected_elim (Tr -1) (A := A) _ _).1).
     { apply contr_inhabited_hprop;
         [ exact _ | refine (merely_isconnected n A) ]. }
     intros a0.
+    baut_reduce.
     pose (M := fun f:X*A -> X*A => fun x => fst (f (x,a0))).
     assert (MH : forall (a:A) (f:X*A -> X*A) (x:X),
                fst (f (x,a)) = fst (f (x,a0))).
@@ -79,26 +111,8 @@ Proof.
       transitivity (fst (g (fst (f (x,a0)), snd (f (x,a0))))).
       - reflexivity.
       - apply MH. }
-    transparent assert (ME : (forall (f:X*A -> X*A), IsEquiv f -> IsEquiv (M f))).
-    { intros f ?.
-      refine (isequiv_adjointify (M f) (M f^-1) _ _).
-      - intros x. transitivity (M (f o f^-1) x).
-        + symmetry. refine (MC f^-1 f x).
-        + transitivity (M idmap x).
-          * apply ap10, ap, path_arrow. 
-            intros y; apply eisretr.
-          * reflexivity.
-      - intros x. transitivity (M (f^-1 o f) x).
-        + symmetry. refine (MC f f^-1 x).
-        + transitivity (M idmap x).
-          * apply ap10, ap, path_arrow. 
-            intros y; apply eissect.
-          * reflexivity. }
-    pose (M' := fun f:X*A<~>X*A => (BuildEquiv _ _ (M f) (ME f _))).
-    assert (Misretr : forall e, M' (L e) = e)
-      by (intros e; apply path_equiv, path_arrow;
-          intros x; reflexivity).
-    assert (Mker : forall f, M' f == equiv_idmap -> f == equiv_idmap).
+    pose (M' := aut_homomorphism_end M (fun x => 1) MC).
+    assert (Mker : forall f, M' f == 1%equiv -> f == 1%equiv).
     { unfold M', M; cbn. intros f p.
       pose (fh := fun x a => (MH a f x) @ p x).
       pose (g := fun x a => snd (f (x,a))).
@@ -109,7 +123,7 @@ Proof.
         intros [x a]; cbn.
         apply path_prod; [ apply fh | reflexivity ]. }
       intros [x a].
-      pose (gisid := aut_idmap_rigid (BuildEquiv _ _ (g x) (ge x))).
+      pose (gisid := path_aut_rigid (BuildEquiv _ _ (g x) (ge x)) 1).
       apply path_prod.
       - apply fh.
       - apply gisid. }
@@ -120,10 +134,11 @@ Proof.
       refine (Mker (g^-1 oE f) _).
       intros x.
       refine (MC f g^-1 x @ _).
-      change ((M g)^-1 (M f x) = x).
+      change ((M' g)^-1 (M f x) = x).
       apply moveR_equiv_V, p. }
-    refine (isequiv_adjointify L M' _ Misretr).
-    intros f.
-    apply path_equiv, path_arrow, Minj. 
-    intros x; reflexivity. }
+    refine (isequiv_adjointify L M' _ _);
+      intros e;
+      apply path_equiv, path_arrow;
+      try apply Minj;
+      intros x; reflexivity. }
 Defined.

--- a/theories/Spaces/BAut/Rigid.v
+++ b/theories/Spaces/BAut/Rigid.v
@@ -1,0 +1,129 @@
+(* -*- mode: coq; mode: visual-line -*-  *)
+Require Import HoTT.Basics HoTT.Types.
+Require Import HProp UnivalenceImpliesFunext Fibrations.
+Require Import Modalities.Modality HIT.Truncations HIT.Connectedness.
+Import TrM.
+Require Import Spaces.BAut.
+
+Local Open Scope trunc_scope.
+Local Open Scope path_scope.
+
+(** * Rigid types *)
+
+Class IsRigid (A : Type) := 
+  contr_baut_rigid : Contr (BAut A).
+Existing Instance contr_baut_rigid.
+
+Definition aut_idmap_rigid `{Univalence} {A : Type} `{IsRigid A}
+           (f : A <~> A)
+  : f == equiv_idmap.
+Proof.
+  apply ap10, (ap equiv_fun).
+  refine ((eissect (path_baut (point _) (point _)) f)^ @ _).
+  apply moveR_equiv_V.
+  apply path_contr.
+Defined.
+
+Definition baut_prod_rigid_equiv `{Univalence}
+           (X A : Type) (n : trunc_index)
+           `{IsTrunc n.+1 X} `{IsRigid A} `{IsConnected n.+1 A}
+  : BAut X <~> BAut (X * A).
+Proof.
+  pose (f := fun Z:BAut X =>
+               (Z * A ; Trunc_functor -1 (ap (fun W => W * A)) (pr2 Z))
+               : BAut (X * A)).
+  assert (p : f (point (BAut X)) = (point (BAut (X * A))))
+    by (apply path_sigma_hprop; reflexivity).
+  refine (BuildEquiv _ _ f _).
+  apply isequiv_surj_emb.
+  { apply BuildIsSurjection; intros Z.
+    baut_reduce.
+    exact (tr (point _ ; p)). }
+  { apply isembedding_isequiv_ap.
+    intros Z W; baut_reduce.
+    pose (L := fun e : X <~> X => equiv_functor_prod_r (B := A) e).
+    refine (isequiv_commsq
+             L _
+             (path_baut (point (BAut X)) (point (BAut X)))
+             (path_baut (point (BAut (X*A))) (point (BAut (X*A))))
+             _).
+    { intros e; revert e; equiv_intro (equiv_path X X) e; cbn.
+      rewrite path_universe_uncurried_equiv_path.
+      apply moveR_equiv_M; cbn; unfold pr1_path.
+      refine (_ @ ap_compose f pr1
+                (path_sigma_hprop (X; tr 1) (X; tr 1) e)).
+      unfold f.
+      refine (_ @ (ap_compose pr1 (fun Z => Z * A)
+                (path_sigma_hprop (X; tr 1) (X; tr 1) e))^).
+      rewrite ap_pr1_path_sigma_hprop. unfold L.
+      assert (G : forall Y W (e:Y=W),
+                 path_universe_uncurried (equiv_functor_prod_r (equiv_path Y W e))
+                 = ap (fun Z => Z * A) e).
+      { intros ? ? []; cbn.
+        apply moveR_equiv_M; cbn.
+        apply path_equiv, path_arrow; intros x; reflexivity. }
+      apply G. }
+    clear f p.
+    refine ((isconnected_elim (Tr -1) (A := A) _ _).1).
+    { apply contr_inhabited_hprop;
+        [ exact _ | refine (merely_isconnected n A) ]. }
+    intros a0.
+    pose (M := fun f:X*A -> X*A => fun x => fst (f (x,a0))).
+    assert (MH : forall (a:A) (f:X*A -> X*A) (x:X),
+               fst (f (x,a)) = fst (f (x,a0))).
+    { refine (conn_map_elim (Tr n) (unit_name a0) _ _).
+      - apply conn_point_incl; assumption.
+      - intros; reflexivity. }
+    assert (MC : forall (f g :X*A -> X*A), M (g o f) == M g o M f).
+    { intros f g x; unfold M.
+      transitivity (fst (g (fst (f (x,a0)), snd (f (x,a0))))).
+      - reflexivity.
+      - apply MH. }
+    transparent assert (ME : (forall (f:X*A -> X*A), IsEquiv f -> IsEquiv (M f))).
+    { intros f ?.
+      refine (isequiv_adjointify (M f) (M f^-1) _ _).
+      - intros x. transitivity (M (f o f^-1) x).
+        + symmetry. refine (MC f^-1 f x).
+        + transitivity (M idmap x).
+          * apply ap10, ap, path_arrow. 
+            intros y; apply eisretr.
+          * reflexivity.
+      - intros x. transitivity (M (f^-1 o f) x).
+        + symmetry. refine (MC f f^-1 x).
+        + transitivity (M idmap x).
+          * apply ap10, ap, path_arrow. 
+            intros y; apply eissect.
+          * reflexivity. }
+    pose (M' := fun f:X*A<~>X*A => (BuildEquiv _ _ (M f) (ME f _))).
+    assert (Misretr : forall e, M' (L e) = e)
+      by (intros e; apply path_equiv, path_arrow;
+          intros x; reflexivity).
+    assert (Mker : forall f, M' f == equiv_idmap -> f == equiv_idmap).
+    { unfold M', M; cbn. intros f p.
+      pose (fh := fun x a => (MH a f x) @ p x).
+      pose (g := fun x a => snd (f (x,a))).
+      assert (ge : forall x, IsEquiv (g x)).
+      { apply isequiv_from_functor_sigma.
+        refine (isequiv_commsq' _ f
+                  (equiv_sigma_prod0 X A) (equiv_sigma_prod0 X A) _).
+        intros [x a]; cbn.
+        apply path_prod; [ apply fh | reflexivity ]. }
+      intros [x a].
+      pose (gisid := aut_idmap_rigid (BuildEquiv _ _ (g x) (ge x))).
+      apply path_prod.
+      - apply fh.
+      - apply gisid. }
+    assert (Minj : forall f g, M' f == M' g -> f == g).
+    { intros f g p z.
+      apply moveL_equiv_M.
+      revert z.
+      refine (Mker (g^-1 oE f) _).
+      intros x.
+      refine (MC f g^-1 x @ _).
+      change ((M g)^-1 (M f x) = x).
+      apply moveR_equiv_V, p. }
+    refine (isequiv_adjointify L M' _ Misretr).
+    intros f.
+    apply path_equiv, path_arrow, Minj. 
+    intros x; reflexivity. }
+Defined.

--- a/theories/Spaces/Universe.v
+++ b/theories/Spaces/Universe.v
@@ -98,6 +98,25 @@ Definition equiv_swap_empty_unit `{Univalence} `{ExcludedMiddle}
   : Type <~> Type
   := equiv_swap_rigid Empty Unit (fun e => e^-1 tt).
 
+(** In this case we get an untruncated witness of the swapping. *)
+
+Definition equiv_swap_rigid_swaps `{Univalence} `{ExcludedMiddle}
+           (A B : Type) `{IsRigid A} `{IsRigid B} (ne : ~(A <~> B))
+  : equiv_swap_rigid A B ne A = B.
+Proof.
+  unfold equiv_swap_rigid, equiv_swap_types.
+  apply moveR_equiv_V.
+  rewrite (equiv_decidable_sum_l
+             (fun X => merely (X=A)) A (tr 1)).
+  assert (ne' : ~ merely (B=A))
+    by (intros p; strip_truncations; exact (ne (equiv_path A B p^))).
+  rewrite (equiv_decidable_sum_r
+             (fun X => merely (X=A)) B ne').
+  cbn.
+  apply ap, path_sigma_hprop; cbn.
+  exact ((path_contr (center (BAut B)) (point (BAut B)))..1).
+Defined.
+
 (** We can also swap the products of two rigid types with another type [X], under a connectedness/truncatedness assumption. *)
 
 Definition equiv_swap_prod_rigid  `{Univalence} `{ExcludedMiddle}

--- a/theories/Spaces/Universe.v
+++ b/theories/Spaces/Universe.v
@@ -1,0 +1,112 @@
+(* -*- mode: coq; mode: visual-line -*-  *)
+Require Import HoTT.Basics HoTT.Types.
+Require Import HProp UnivalenceImpliesFunext Fibrations.
+Require Import Modalities.Modality HIT.Truncations HIT.Connectedness.
+Import TrM.
+Require Import Spaces.BAut Spaces.BAut.Rigid.
+Require Import ExcludedMiddle.
+
+Local Open Scope trunc_scope.
+Local Open Scope path_scope.
+
+(** * The universe *)
+
+(** ** Automorphisms of the universe *)
+
+(** If two inequivalent types have equivalent automorphism oo-groups, then assuming LEM we can swap them and leave the rest of the universe untouched. *)
+Section SwapTypes.
+  (** Amusingly, this does not actually require univalence!  But of course, to verify [BAut A <~> BAut B] in any particular example does require univalence. *)
+  Context `{Funext} `{ExcludedMiddle}.
+  Context (A B : Type) (ne : ~(A <~> B)) (e : BAut A <~> BAut B).
+
+  Definition equiv_swap_types : Type <~> Type.
+  Proof.
+    refine (((equiv_decidable_sum (fun X:Type => merely (X=A)))^-1)
+              oE _ oE
+              (equiv_decidable_sum (fun X:Type => merely (X=A)))).
+    refine ((equiv_functor_sum_l
+               (equiv_decidable_sum (fun X => merely (X.1=B)))^-1)
+              oE _ oE
+              (equiv_functor_sum_l
+                 (equiv_decidable_sum (fun X => merely (X.1=B))))).
+    refine ((equiv_sum_assoc _ _ _)
+              oE _ oE
+              (equiv_sum_assoc _ _ _)^-1).
+    apply equiv_functor_sum_r.
+    assert (q : BAut B <~> {x : {x : Type & ~ merely (x = A)} &
+                                merely (x.1 = B)}).
+    { refine (equiv_sigma_assoc _ _ oE _).
+      apply equiv_functor_sigma_id; intros X.
+      apply equiv_iff_hprop.
+      - intros p.
+        refine (fun q => _ ; p).
+        strip_truncations.
+        destruct q.
+        exact (ne (equiv_path X B p)).
+      - exact pr2. }
+    refine (_ oE equiv_sum_symm _ _).
+    apply equiv_functor_sum'.
+    - exact (e^-1 oE q^-1).
+    - exact (q oE e).
+  Defined.
+
+  Definition equiv_swap_types_swaps : merely (equiv_swap_types A = B).
+  Proof.
+    assert (ea := (e (point _)).2). cbn in ea.
+    strip_truncations; apply tr.
+    unfold equiv_swap_types.
+    apply moveR_equiv_V.
+    rewrite (equiv_decidable_sum_l
+               (fun X => merely (X=A)) A (tr 1)).
+    assert (ne' : ~ merely (B=A))
+      by (intros p; strip_truncations; exact (ne (equiv_path A B p^))).
+    rewrite (equiv_decidable_sum_r
+               (fun X => merely (X=A)) B ne').
+    cbn.
+    apply ap, path_sigma_hprop; cbn.
+    exact ea.
+  Defined.
+
+  Definition equiv_swap_types_not_id
+    : equiv_swap_types <> equiv_idmap.
+  Proof.
+    intros p.
+    assert (q := equiv_swap_types_swaps).
+    strip_truncations.
+    apply ne.
+    apply equiv_path.
+    rewrite p in q; exact q.
+  Qed.
+
+End SwapTypes.
+
+(** In particular, we can swap any two distinct rigid types. *)
+
+Definition equiv_swap_rigid `{Univalence} `{ExcludedMiddle}
+           (A B : Type) `{IsRigid A} `{IsRigid B} (ne : ~(A <~> B))
+  : Type <~> Type.
+Proof.
+  refine (equiv_swap_types A B ne _).
+  apply equiv_contr_contr.
+Defined.
+
+(** Such as [Empty] and [Unit]. *)
+
+Definition equiv_swap_empty_unit `{Univalence} `{ExcludedMiddle}
+  : Type <~> Type
+  := equiv_swap_rigid Empty Unit (fun e => e^-1 tt).
+
+(** We can also swap the products of two rigid types with another type [X], under a connectedness/truncatedness assumption. *)
+
+Definition equiv_swap_prod_rigid  `{Univalence} `{ExcludedMiddle}
+           (X A B : Type) (n : trunc_index) (ne : ~(X*A <~> X*B))
+           `{IsRigid A} `{IsConnected n.+1 A}
+           `{IsRigid B} `{IsConnected n.+1 B}
+           `{IsTrunc n.+1 X}
+  : Type <~> Type.
+Proof.
+  refine (equiv_swap_types (X*A) (X*B) ne _).
+  transitivity (BAut X).
+  - symmetry; exact (baut_prod_rigid_equiv X A n).
+  - exact (baut_prod_rigid_equiv X B n).
+Defined.

--- a/theories/Spaces/Universe.v
+++ b/theories/Spaces/Universe.v
@@ -191,7 +191,7 @@ Proof.
     exact (snd (equiv_hprop_idprod A P a) q).
 Defined.
 
-(** If you can derive a constructive taboo from an automorphism of the universe such that [g X <> X], then you get [X]-many beers. *)
+(** If you can derive a constructive taboo from an automorphism of the universe such that [g X <> X], then you get [X]-many beers; see <https://groups.google.com/d/msg/homotopytypetheory/8CV0S2DuOI8/blCo7x-B7aoJ>. *)
 
 Definition zero_beers `{Univalence}
            (g : Type <~> Type) (ge : g Empty <> Empty)

--- a/theories/Spaces/Universe.v
+++ b/theories/Spaces/Universe.v
@@ -136,7 +136,7 @@ Defined.
 
 Definition lem_from_aut_type_unit_empty `{Univalence}
            (f : Type <~> Type) (eu : f Unit = Empty)
-  : LEM_type.
+  : ExcludedMiddle_type.
 Proof.
   apply DNE_to_LEM, DNE_from_allneg; intros P ?.
   exists (f P); split.
@@ -174,7 +174,7 @@ Defined.
 Definition lem_from_aut_type_inhabited_empty `{Univalence}
            (f : Type <~> Type)
            (A : Type) (a : merely A) (eu : f A = Empty)
-  : LEM_type.
+  : ExcludedMiddle_type.
 Proof.
   apply DNE_to_LEM, DNE_from_allneg; intros P ?.
   exists (f (P * A)); split.
@@ -195,7 +195,7 @@ Defined.
 
 Definition zero_beers `{Univalence}
            (g : Type <~> Type) (ge : g Empty <> Empty)
-  : ~~LEM_type.
+  : ~~ExcludedMiddle_type.
 Proof.
   pose (f := equiv_inverse g).
   intros nlem.
@@ -207,8 +207,8 @@ Proof.
 Defined.
 
 Definition lem_beers `{Univalence}
-           (g : Type <~> Type) (ge : g LEM_type <> LEM_type)
-  : ~~LEM_type.
+           (g : Type <~> Type) (ge : g ExcludedMiddle_type <> ExcludedMiddle_type)
+  : ~~ExcludedMiddle_type.
 Proof.
   intros nlem.
   pose (nlem' := equiv_to_empty nlem).

--- a/theories/Types/Empty.v
+++ b/theories/Types/Empty.v
@@ -38,6 +38,9 @@ Proof.
   exact (Empty_rec (f t)).
 Defined.
 
+Definition equiv_to_empty {T : Type} (f : T -> Empty) : T <~> Empty
+  := BuildEquiv T Empty f _.
+
 (** ** Paths *)
 
 (** We could probably prove some theorems about non-existing paths in

--- a/theories/Types/Sum.v
+++ b/theories/Types/Sum.v
@@ -158,6 +158,58 @@ Proof.
                  (fun x => equiv_path_sum (inr x) (inr b))) _).
 Defined.
 
+(** ** Decomposition *)
+
+(** Conversely, a decidable predicate decomposes a type as a sum. *)
+
+Section DecidableSum.
+  Context `{Funext} {A : Type} (P : A -> Type)
+          `{forall a, IsHProp (P a)} `{forall a, Decidable (P a)}.
+
+  Definition equiv_decidable_sum
+    : A <~> {x:A & P x} + {x:A & ~(P x)}.
+  Proof.
+    transparent assert (f : (A -> {x:A & P x} + {x:A & ~(P x)})).
+    { intros x.
+      destruct (dec (P x)) as [p|np].
+      - exact (inl (x;p)).
+      - exact (inr (x;np)). }
+    refine (BuildEquiv _ _ f _).
+    refine (isequiv_adjointify
+              _ (fun z => match z with
+                          | inl (x;p) => x
+                          | inr (x;np) => x
+                          end) _ _).
+    - intros [[x p]|[x np]]; unfold f;
+        destruct (dec (P x)) as [p'|np'].
+      + apply ap, ap, path_ishprop.
+      + elim (np' p).
+      + elim (np p').
+      + apply ap, ap, path_ishprop.
+    - intros x; unfold f.
+      destruct (dec (P x)); cbn; reflexivity.
+  Defined.
+
+  Definition equiv_decidable_sum_l (a : A) (p : P a)
+    : equiv_decidable_sum a = inl (a;p).
+  Proof.
+    unfold equiv_decidable_sum; cbn.
+    destruct (dec (P a)) as [p'|np'].
+    - apply ap, path_sigma_hprop; reflexivity.
+    - elim (np' p).
+  Defined.
+
+  Definition equiv_decidable_sum_r (a : A) (np : ~ (P a))
+    : equiv_decidable_sum a = inr (a;np).
+  Proof.
+    unfold equiv_decidable_sum; cbn.
+    destruct (dec (P a)) as [p'|np'].
+    - elim (np p').
+    - apply ap, path_sigma_hprop; reflexivity.
+  Defined.
+
+End DecidableSum.
+
 (** ** Transport *)
 
 Definition transport_sum {A : Type} {P Q : A -> Type} {a a' : A} (p : a = a')

--- a/theories/Types/Universe.v
+++ b/theories/Types/Universe.v
@@ -2,7 +2,7 @@
 (** * Theorems about the universe, including the Univalence Axiom. *)
 
 Require Import HoTT.Basics.
-Require Import Types.Sigma Types.Forall Types.Arrow Types.Paths Types.Equiv Types.Bool.
+Require Import Types.Sigma Types.Forall Types.Arrow Types.Paths Types.Equiv Types.Bool Types.Prod.
 
 Local Open Scope path_scope.
 
@@ -132,6 +132,8 @@ Definition path_universe_V `{Funext} `(f : A -> B) `{IsEquiv A B f}
   : path_universe (f^-1) = (path_universe f)^
   := path_universe_V_uncurried (BuildEquiv A B f _).
 
+(** ** Path operations vs Type operations *)
+
 (** [ap (Equiv A)] behaves like postcomposition. *)
 Definition ap_equiv_path_universe `{Funext} A {B C} (f : B <~> C)
 : equiv_path (A <~> B) (A <~> C) (ap (Equiv A) (path_universe f))
@@ -143,6 +145,28 @@ Proof.
   apply path_equiv, path_forall; intros g.
   apply path_equiv, path_forall; intros a.
   reflexivity.
+Defined.
+
+(** [ap (prod A)] behaves like [equiv_functor_prod_l]. *)
+Definition ap_prod_l_path_universe `{Funext} A {B C} (f : B <~> C)
+  : equiv_path (A * B) (A * C) (ap (prod A) (path_universe f))
+    = equiv_functor_prod_l f.
+Proof.
+  revert f. equiv_intro (equiv_path B C) f.
+  rewrite (eissect (equiv_path B C) f : path_universe (equiv_path B C f) = f).
+  destruct f.
+  apply path_equiv, path_arrow; intros x; reflexivity.
+Defined.
+
+(** [ap (fun Z => Z * A)] behaves like [equiv_functor_prod_l]. *)
+Definition ap_prod_r_path_universe `{Funext} A {B C} (f : B <~> C)
+  : equiv_path (B * A) (C * A) (ap (fun Z => Z * A) (path_universe f))
+    = equiv_functor_prod_r f.
+Proof.
+  revert f. equiv_intro (equiv_path B C) f.
+  rewrite (eissect (equiv_path B C) f : path_universe (equiv_path B C f) = f).
+  destruct f.
+  apply path_equiv, path_arrow; intros x; reflexivity.
 Defined.
 
 (** ** Transport *)

--- a/theories/Types/Universe.v
+++ b/theories/Types/Universe.v
@@ -158,7 +158,7 @@ Proof.
   apply path_equiv, path_arrow; intros x; reflexivity.
 Defined.
 
-(** [ap (fun Z => Z * A)] behaves like [equiv_functor_prod_l]. *)
+(** [ap (fun Z => Z * A)] behaves like [equiv_functor_prod_r]. *)
 Definition ap_prod_r_path_universe `{Funext} A {B C} (f : B <~> C)
   : equiv_path (B * A) (C * A) (ap (fun Z => Z * A) (path_universe f))
     = equiv_functor_prod_r f.


### PR DESCRIPTION
The part of https://homotopytypetheory.org/2017/01/26/parametricity-automorphisms-of-the-universe-and-excluded-middle/ having to do with automorphisms of the universe, plus a clever argument due to @peterlefanulumsdaine showing that we can swap `X*A` with `X*B` when `A` and `B` are rigid and connected while `X` is truncated.