### PR TITLE
Generalized surreal numbers parametrized by option sorts

### DIFF
--- a/contrib/HoTTBook.v
+++ b/contrib/HoTTBook.v
@@ -2293,9 +2293,9 @@ Definition Book_11_6_1 := @HoTT.Spaces.No.Core.No.
 (* ================================================== thm:NO-refl-opt *)
 (** Theorem 11.6.4 *)
 
-Definition Book_11_6_4_i := @HoTT.Spaces.No.Core.Conway_theorem0_i.
-Definition Book_11_6_4_ii_l := @HoTT.Spaces.No.Core.Conway_theorem0_ii_l.
-Definition Book_11_6_4_ii_r := @HoTT.Spaces.No.Core.Conway_theorem0_ii_r.
+Definition Book_11_6_4_i := @HoTT.Spaces.No.Core.le_reflexive.
+Definition Book_11_6_4_ii_l := @HoTT.Spaces.No.Core.lt_lopt.
+Definition Book_11_6_4_ii_r := @HoTT.Spaces.No.Core.lt_ropt.
 
 (* ================================================== thm:NO-set *)
 (** Corollary 11.6.5 *)

--- a/contrib/HoTTBook.v
+++ b/contrib/HoTTBook.v
@@ -2284,6 +2284,7 @@ Definition Book_10_5_8_item_ix := @HoTT.HIT.V.separation.
 (** Definition 11.6.1 *)
 
 Definition Book_11_6_1 := @HoTT.Spaces.No.Core.Surreals.No.
+Definition Book_11_6_1 := @HoTT.Spaces.No.Core.MaxNo.
 
 (* ================================================== thm:NO-simplicity *)
 (** Theorem 11.6.2 *)

--- a/contrib/HoTTBook.v
+++ b/contrib/HoTTBook.v
@@ -2283,8 +2283,7 @@ Definition Book_10_5_8_item_ix := @HoTT.HIT.V.separation.
 (* ================================================== defn:surreals *)
 (** Definition 11.6.1 *)
 
-Definition Book_11_6_1 := @HoTT.Spaces.No.Core.Surreals.No.
-Definition Book_11_6_1 := @HoTT.Spaces.No.Core.MaxNo.
+Definition Book_11_6_1 := @HoTT.Spaces.No.Core.No.
 
 (* ================================================== thm:NO-simplicity *)
 (** Theorem 11.6.2 *)

--- a/theories/Spaces/No/Addition.v
+++ b/theories/Spaces/No/Addition.v
@@ -7,12 +7,24 @@ Local Open Scope surreal_scope.
 
 (** * Addition of surreal numbers *)
 
+(** Addition requires the option sorts to be closed under finite sums. *)
+Class HasAddition (S : OptionSort) := 
+  { empty_options : InSort S Empty Empty
+    ; sum_options : forall L R L' R',
+        InSort S L R -> InSort S L' R' -> InSort S (L + L') (R + R')
+  }.
+Existing Instance empty_options.
+Existing Instance sum_options.
+
 Section Addition.
   Context `{Univalence}.
+  Context {S : OptionSort@{i}} `{HasAddition S}.
+  Let No := GenNo S.
 
   Section Inner.
 
-    Context {L R : Type@{i} } (xL : L -> No@{i}) (xR : R -> No@{i})
+    Context {L R : Type@{i} } {Sx : InSort@{i} S L R}
+            (xL : L -> No@{i}) (xR : R -> No@{i})
             (xcut : forall (l : L) (r : R), xL l < xR r).
 
     Let A := {g : No@{i} -> No@{i} &
@@ -38,7 +50,7 @@ Section Addition.
                 (fun _ _ _ z w => z.1 <= w.1)
                 (fun _ _ _ z w => z.1 < w.1)
                 _ _ _ _ _).
-      - intros L' R' yL yR ycut x_plus_yL x_plus_yR x_plus_yL_lt_yR.
+      - intros L' R' ? yL yR ycut x_plus_yL x_plus_yR x_plus_yL_lt_yR.
         pose (L'' := L + L').  pose (R'' := R + R').
         pose (zL := sum_ind (fun _ => No)
                             (fun l => (xL_plus l).1 {{ yL | yR // ycut }})
@@ -53,55 +65,57 @@ Section Addition.
           intros [l|l] [r|r]; cbn;
           [ apply xL_lt_xR_plus
           | transitivity ((xL_plus l).1 (yR r));
-            [ apply (snd (xL_plus l).2), Conway_theorem0_ii_r
+            [ apply (snd (xL_plus l).2), Conway_theorem0_ii_r; exact _
             | exact (fst (x_plus_yR r).2 l) ]
           | transitivity ((xR_plus r).1 (yL l));
             [ exact (snd (x_plus_yL l).2 r)
-            | apply (snd (xR_plus r).2), Conway_theorem0_ii_l ]
+            | apply (snd (xR_plus r).2), Conway_theorem0_ii_l; exact _ ]
           | apply x_plus_yL_lt_yR ]). }
+        assert (InSort S L'' R'') by (apply sum_options; exact _).
         exists ({{ zL | zR // zcut }}); split.
         + intros l.
-          refine (Conway_theorem0_ii_l _ _ zL zR zcut (inl l)).
+          refine (Conway_theorem0_ii_l zL zR zcut (inl l)).
         + intros r.
-          refine (Conway_theorem0_ii_r _ _ zL zR zcut (inl r)).
+          refine (Conway_theorem0_ii_r zL zR zcut (inl r)).
       - abstract (
         intros x y [a ?] [b ?] p q r s;
         rewrite transport_sigma; cbn in *;
         apply path_sigma_hprop, path_No; cbn;
         rewrite transport_const; assumption).
       - abstract (
-        intros L' R' yL yR ycut x_plus_yL x_plus_yR x_plus_yL_lt_yR
-               L'' R'' zL zR zcut x_plus_zL x_plus_zR x_plus_zL_lt_zR
+        intros L' R' ? yL yR ycut x_plus_yL x_plus_yR x_plus_yL_lt_yR
+               L'' R'' ? zL zR zcut x_plus_zL x_plus_zR x_plus_zL_lt_zR
                yL_lt_z x_plus_yL_lt_z y_lt_zR x_plus_y_lt_zR;
         cbn in *;
         apply le_lr; [ intros [l|l] | intros [r|r] ]; cbn;
-        [ refine (le_lt_trans
+        [ refine (le_lt_trans _
                     (fst (xL_plus l).2 _ {{ zL | zR // zcut}} _) _);
           [ by (apply le_lr; assumption)
-          | refine (Conway_theorem0_ii_l _ _ _ _ _ (inl l)) ]
+          | refine (Conway_theorem0_ii_l _ _ _ (inl l)) ]
         | exact (x_plus_yL_lt_z l)
-        | refine (lt_le_trans _
+        | refine (lt_le_trans _ _
                     (fst (xR_plus r).2 {{ yL | yR // ycut}} _ _));
-          [ refine (Conway_theorem0_ii_r _ _ _ _ _ (inl r))
+          [ refine (Conway_theorem0_ii_r _ _ _ (inl r))
           | by (apply le_lr; assumption) ]
         | exact (x_plus_y_lt_zR r) ] ).
       - abstract (
-        intros L' R' yL yR ycut x_plus_yL x_plus_yR x_plus_yL_lt_yR
-               L'' R'' zL zR zcut x_plus_zL x_plus_zR x_plus_zL_lt_zR
+        intros L' R' ? yL yR ycut x_plus_yL x_plus_yR x_plus_yL_lt_yR
+               L'' R'' ? zL zR zcut x_plus_zL x_plus_zR x_plus_zL_lt_zR
                l y_le_zL x_plus_y_le_zL; cbn;
         apply lt_l with (inr l);
         apply x_plus_y_le_zL ).
       - abstract (
-        intros L' R' yL yR ycut x_plus_yL x_plus_yR x_plus_yL_lt_yR
-               L'' R'' zL zR zcut x_plus_zL x_plus_zR x_plus_zL_lt_zR
+        intros L' R' ? yL yR ycut x_plus_yL x_plus_yR x_plus_yL_lt_yR
+               L'' R'' ? zL zR zcut x_plus_zL x_plus_zR x_plus_zL_lt_zR
                r yR_le_z x_plus_yR_le_z; cbn;
         apply lt_r with (inr r);
         apply x_plus_yR_le_z).
     Defined.
 
-    (** We now prove a computation law for [inner_cut].  It holds definitionally, so we would like to prove it with just [:= 1] and then rewrite along it later, as we did above.  However, there is a subtlety in that the output should be a surreal defined by a cut, which in particular includes a proof of cut-ness, and that proof is rather long, so we would not like to see it in the type of this lemma.  Thus, instead we assert only that there *exists* some proof of cut-ness and an equality. *)
+    (** We now prove a computation law for [plus_inner].  It holds definitionally, so we would like to prove it with just [:= 1] and then rewrite along it later, as we did above.  However, there is a subtlety in that the output should be a surreal defined by a cut, which in particular includes a proof of cut-ness, and that proof is rather long, so we would not like to see it in the type of this lemma.  Thus, instead we assert only that there *exists* some proof of cut-ness and an equality. *)
     Definition plus_inner_cut
-               {L' R' : Type@{i} } (yL : L' -> No@{i}) (yR : R' -> No@{i})
+               {L' R' : Type@{i} } {Sy : InSort@{i} S L' R'}
+               (yL : L' -> No@{i}) (yR : R' -> No@{i})
                (ycut : forall (l : L') (r : R'), yL l < yR r)
     : let L'' := L + L' in
       let R'' := R + R' in
@@ -113,8 +127,9 @@ Section Addition.
                         (fun r => (xR_plus r).1 {{ yL | yR // ycut }})
                         (fun r => (plus_inner.1 (yR r)).1)
                 : R'' -> No in
+      let Sz := sum_options L R L' R' _ _ in 
       { zcut : forall (l:L'') (r:R''), zL l < zR r &
-        (plus_inner.1 {{ yL | yR // ycut }}).1 = {{ zL | zR // zcut }} }.
+        (plus_inner.1 {{ yL | yR // ycut }}).1 = (@No_cut _ _ _ Sz zL zR zcut) }.
     Proof.
       (** Now we tell Coq that we want the equality to be definitional, and let it figure out what the proof of cut-ness has to be. *)
       eexists.
@@ -137,7 +152,7 @@ Section Addition.
                 (forall x y, x <  y -> g x <  g y) }
               (fun g h => forall x, g.1 x <= h.1 x)
               (fun g h => forall x, g.1 x <  h.1 x)
-              (fun L R xL xR xcut xL_plus xR_plus xL_lt_xR_plus =>
+              (fun L R Sx xL xR xcut xL_plus xR_plus xL_lt_xR_plus =>
                  let g := plus_inner xL_plus xR_plus xL_lt_xR_plus in
                  ((fun y => (g.1 y).1) ; (g.2)))
                _ _ _ _).
@@ -147,12 +162,12 @@ Section Addition.
       apply path_arrow; intros x;
       apply path_No; [ apply p | apply q ] ).
     - abstract (
-      intros L R xL xR xcut xL_plus xR_plus xL_lt_xR_plus
-           L' R' yL yR ycut yL_plus yR_plus yL_lt_yR_plus;
+      intros L R ? xL xR xcut xL_plus xR_plus xL_lt_xR_plus
+           L' R' ? yL yR ycut yL_plus yR_plus yL_lt_yR_plus;
       intros xL_lt_y xL_lt_y_plus x_lt_yR x_lt_yR_plus z;
       lazy beta zeta in *; cbn [pr1] in *;
       pattern z; refine (No_ind_hprop _ _ z);
-      intros L'' R'' zL zR zcut x_le_y_plus_zL x_le_y_plus_zR;
+      intros L'' R'' ? zL zR zcut x_le_y_plus_zL x_le_y_plus_zR;
       destruct (plus_inner_cut xL_plus xR_plus xL_lt_xR_plus
                                zL zR zcut) as [xzcut p]; rewrite p;
       destruct (plus_inner_cut yL_plus yR_plus yL_lt_yR_plus
@@ -163,41 +178,41 @@ Section Addition.
         rewrite q in xL_lt_y_plus;
         exact xL_lt_y_plus
       | (** x + z^L < y + z *)
-        refine (le_lt_trans (x_le_y_plus_zL l) _);
-        refine (Conway_theorem0_ii_l _ _ _ _ _ (inr l))
+        refine (le_lt_trans _ (x_le_y_plus_zL l) _);
+        refine (Conway_theorem0_ii_l _ _ _ (inr l))
       | (** x + z < y^R + z *)
         specialize (x_lt_yR_plus r {{ zL | zR // zcut }});
         rewrite p in x_lt_yR_plus;
         exact x_lt_yR_plus
       | (** x + z < y + z^R *)
-        refine (lt_le_trans _ (x_le_y_plus_zR r));
-        refine (Conway_theorem0_ii_r _ _ _ _ _ (inr r)) ]).
+        refine (lt_le_trans _ _ (x_le_y_plus_zR r));
+        refine (Conway_theorem0_ii_r _ _ _ (inr r)) ]).
     - abstract (
-      intros L R xL xR xcut xL_plus xR_plus xL_lt_xR_plus
-             L' R' yL yR ycut yL_plus yR_plus yL_lt_yR_plus;
+      intros L R ? xL xR xcut xL_plus xR_plus xL_lt_xR_plus
+             L' R' ? yL yR ycut yL_plus yR_plus yL_lt_yR_plus;
       intros l x_le_yL x_le_yL_plus z;
       lazy beta zeta in *; cbn [pr1] in *;
       pattern z; refine (No_ind_hprop _ _ z);
-      intros L'' R'' zL zR zcut x_le_y_plus_zL x_le_y_plus_zR;
+      intros L'' R'' ? zL zR zcut x_le_y_plus_zL x_le_y_plus_zR;
       destruct (plus_inner_cut xL_plus xR_plus xL_lt_xR_plus
                                zL zR zcut) as [xzcut p]; rewrite p;
       destruct (plus_inner_cut yL_plus yR_plus yL_lt_yR_plus
                                zL zR zcut) as [yzcut q];rewrite q;
-      refine (le_lt_trans (x_le_yL_plus {{ zL | zR // zcut }}) _);
-      refine (Conway_theorem0_ii_l _ _ _ _ _ (inl l)) ).
+      refine (le_lt_trans _ (x_le_yL_plus {{ zL | zR // zcut }}) _);
+      refine (Conway_theorem0_ii_l _ _ _ (inl l)) ).
     - abstract (
-      intros L R xL xR xcut xL_plus xR_plus xL_lt_xR_plus
-             L' R' yL yR ycut yL_plus yR_plus yL_lt_yR_plus;
+      intros L R ? xL xR xcut xL_plus xR_plus xL_lt_xR_plus
+             L' R' ? yL yR ycut yL_plus yR_plus yL_lt_yR_plus;
       intros r xR_le_y xR_le_y_plus z;
       lazy beta zeta in *; cbn [pr1] in *;
       pattern z; refine (No_ind_hprop _ _ z);
-      intros L'' R'' zL zR zcut x_le_y_plus_zL x_le_y_plus_zR;
+      intros L'' R'' ? zL zR zcut x_le_y_plus_zL x_le_y_plus_zR;
       destruct (plus_inner_cut xL_plus xR_plus xL_lt_xR_plus
                                zL zR zcut) as [xzcut p]; rewrite p;
       destruct (plus_inner_cut yL_plus yR_plus yL_lt_yR_plus
                                zL zR zcut) as [yzcut q];rewrite q;
-      refine (lt_le_trans _ (xR_le_y_plus {{ zL | zR // zcut }}));
-      refine (Conway_theorem0_ii_r _ _ _ _ _ (inl r)) ).
+      refine (lt_le_trans _ _ (xR_le_y_plus {{ zL | zR // zcut }}));
+      refine (Conway_theorem0_ii_r _ _ _ (inl r)) ).
   Defined.
 
   Definition plus (x y : No) : No
@@ -223,9 +238,11 @@ Section Addition.
 
   (** See the remarks above [plus_inner_cut] to explain the type of this lemma. *)
   Definition plus_cut
-             {L R : Type@{i} } (xL : L -> No@{i}) (xR : R -> No@{i})
+             {L R : Type@{i} } {Sx : InSort@{i} S L R}
+             (xL : L -> No@{i}) (xR : R -> No@{i})
              (xcut : forall (l : L) (r : R), xL l < xR r)
-             {L' R' : Type@{i} } (yL : L' -> No@{i}) (yR : R' -> No@{i})
+             {L' R' : Type@{i} } {Sy : InSort@{i} S L' R'}
+             (yL : L' -> No@{i}) (yR : R' -> No@{i})
              (ycut : forall (l : L') (r : R'), yL l < yR r)
   : let L'' := (L + L')%type in
     let R'' := (R + R')%type in
@@ -237,8 +254,9 @@ Section Addition.
     let zR := sum_ind (fun _ => No)
                       (fun r => (xR r) + y) (fun r => x + (yR r))
               : R'' -> No in
+    let Sz := sum_options L R L' R' _ _ in 
     { zcut : forall (l:L'') (r:R''), zL l < zR r &
-      x + y = {{ zL | zR // zcut }} }
+      x + y = @No_cut _ _ _ Sz zL zR zcut }
     := plus_inner_cut
          (fun l => plus_outer.1 (xL l))
          (fun r => plus_outer.1 (xR r))

--- a/theories/Spaces/No/Addition.v
+++ b/theories/Spaces/No/Addition.v
@@ -88,12 +88,11 @@ Section Addition.
                yL_lt_z x_plus_yL_lt_z y_lt_zR x_plus_y_lt_zR;
         cbn in *;
         apply le_lr; [ intros [l|l] | intros [r|r] ]; cbn;
-        [ refine (le_lt_trans _
-                    (fst (xL_plus l).2 _ {{ zL | zR // zcut}} _) _);
+        [ refine (le_lt_trans (fst (xL_plus l).2 _ {{ zL | zR // zcut}} _) _);
           [ by (apply le_lr; assumption)
           | refine (Conway_theorem0_ii_l _ _ _ (inl l)) ]
         | exact (x_plus_yL_lt_z l)
-        | refine (lt_le_trans _ _
+        | refine (lt_le_trans _
                     (fst (xR_plus r).2 {{ yL | yR // ycut}} _ _));
           [ refine (Conway_theorem0_ii_r _ _ _ (inl r))
           | by (apply le_lr; assumption) ]
@@ -178,14 +177,14 @@ Section Addition.
         rewrite q in xL_lt_y_plus;
         exact xL_lt_y_plus
       | (** x + z^L < y + z *)
-        refine (le_lt_trans _ (x_le_y_plus_zL l) _);
+        refine (le_lt_trans (x_le_y_plus_zL l) _);
         refine (Conway_theorem0_ii_l _ _ _ (inr l))
       | (** x + z < y^R + z *)
         specialize (x_lt_yR_plus r {{ zL | zR // zcut }});
         rewrite p in x_lt_yR_plus;
         exact x_lt_yR_plus
       | (** x + z < y + z^R *)
-        refine (lt_le_trans _ _ (x_le_y_plus_zR r));
+        refine (lt_le_trans _ (x_le_y_plus_zR r));
         refine (Conway_theorem0_ii_r _ _ _ (inr r)) ]).
     - abstract (
       intros L R ? xL xR xcut xL_plus xR_plus xL_lt_xR_plus
@@ -198,7 +197,7 @@ Section Addition.
                                zL zR zcut) as [xzcut p]; rewrite p;
       destruct (plus_inner_cut yL_plus yR_plus yL_lt_yR_plus
                                zL zR zcut) as [yzcut q];rewrite q;
-      refine (le_lt_trans _ (x_le_yL_plus {{ zL | zR // zcut }}) _);
+      refine (le_lt_trans (x_le_yL_plus {{ zL | zR // zcut }}) _);
       refine (Conway_theorem0_ii_l _ _ _ (inl l)) ).
     - abstract (
       intros L R ? xL xR xcut xL_plus xR_plus xL_lt_xR_plus
@@ -211,7 +210,7 @@ Section Addition.
                                zL zR zcut) as [xzcut p]; rewrite p;
       destruct (plus_inner_cut yL_plus yR_plus yL_lt_yR_plus
                                zL zR zcut) as [yzcut q];rewrite q;
-      refine (lt_le_trans _ _ (xR_le_y_plus {{ zL | zR // zcut }}));
+      refine (lt_le_trans _ (xR_le_y_plus {{ zL | zR // zcut }}));
       refine (Conway_theorem0_ii_r _ _ _ (inl r)) ).
   Defined.
 

--- a/theories/Spaces/No/Addition.v
+++ b/theories/Spaces/No/Addition.v
@@ -271,7 +271,7 @@ Section Addition.
     let Sz := sum_options L R L' R' _ _ in 
     { zcut : forall (l:L'') (r:R''), zL l < zR r &
       x + y = @No_cut _ _ _ Sz zL zR zcut }
-    := plus_inner_cut
+    := plus_inner_cut (Sx := Sx)
          (fun l => plus_outer.1 (xL l))
          (fun r => plus_outer.1 (xR r))
          (fun l r => snd plus_outer.2 (xL l) (xR r) (xcut l r))

--- a/theories/Spaces/No/Addition.v
+++ b/theories/Spaces/No/Addition.v
@@ -65,18 +65,18 @@ Section Addition.
           intros [l|l] [r|r]; cbn;
           [ apply xL_lt_xR_plus
           | transitivity ((xL_plus l).1 (yR r));
-            [ apply (snd (xL_plus l).2), Conway_theorem0_ii_r; exact _
+            [ apply (snd (xL_plus l).2), lt_ropt; exact _
             | exact (fst (x_plus_yR r).2 l) ]
           | transitivity ((xR_plus r).1 (yL l));
             [ exact (snd (x_plus_yL l).2 r)
-            | apply (snd (xR_plus r).2), Conway_theorem0_ii_l; exact _ ]
+            | apply (snd (xR_plus r).2), lt_lopt; exact _ ]
           | apply x_plus_yL_lt_yR ]). }
         assert (InSort S L'' R'') by (apply sum_options; exact _).
         exists ({{ zL | zR // zcut }}); split.
         + intros l.
-          refine (Conway_theorem0_ii_l zL zR zcut (inl l)).
+          refine (lt_lopt zL zR zcut (inl l)).
         + intros r.
-          refine (Conway_theorem0_ii_r zL zR zcut (inl r)).
+          refine (lt_ropt zL zR zcut (inl r)).
       - abstract (
         intros x y [a ?] [b ?] p q r s;
         rewrite transport_sigma; cbn in *;
@@ -90,11 +90,11 @@ Section Addition.
         apply le_lr; [ intros [l|l] | intros [r|r] ]; cbn;
         [ refine (le_lt_trans (fst (xL_plus l).2 _ {{ zL | zR // zcut}} _) _);
           [ by (apply le_lr; assumption)
-          | refine (Conway_theorem0_ii_l _ _ _ (inl l)) ]
+          | refine (lt_lopt _ _ _ (inl l)) ]
         | exact (x_plus_yL_lt_z l)
         | refine (lt_le_trans _
                     (fst (xR_plus r).2 {{ yL | yR // ycut}} _ _));
-          [ refine (Conway_theorem0_ii_r _ _ _ (inl r))
+          [ refine (lt_ropt _ _ _ (inl r))
           | by (apply le_lr; assumption) ]
         | exact (x_plus_y_lt_zR r) ] ).
       - abstract (
@@ -178,14 +178,14 @@ Section Addition.
         exact xL_lt_y_plus
       | (** x + z^L < y + z *)
         refine (le_lt_trans (x_le_y_plus_zL l) _);
-        refine (Conway_theorem0_ii_l _ _ _ (inr l))
+        refine (lt_lopt _ _ _ (inr l))
       | (** x + z < y^R + z *)
         specialize (x_lt_yR_plus r {{ zL | zR // zcut }});
         rewrite p in x_lt_yR_plus;
         exact x_lt_yR_plus
       | (** x + z < y + z^R *)
         refine (lt_le_trans _ (x_le_y_plus_zR r));
-        refine (Conway_theorem0_ii_r _ _ _ (inr r)) ]).
+        refine (lt_ropt _ _ _ (inr r)) ]).
     - abstract (
       intros L R ? xL xR xcut xL_plus xR_plus xL_lt_xR_plus
              L' R' ? yL yR ycut yL_plus yR_plus yL_lt_yR_plus;
@@ -198,7 +198,7 @@ Section Addition.
       destruct (plus_inner_cut yL_plus yR_plus yL_lt_yR_plus
                                zL zR zcut) as [yzcut q];rewrite q;
       refine (le_lt_trans (x_le_yL_plus {{ zL | zR // zcut }}) _);
-      refine (Conway_theorem0_ii_l _ _ _ (inl l)) ).
+      refine (lt_lopt _ _ _ (inl l)) ).
     - abstract (
       intros L R ? xL xR xcut xL_plus xR_plus xL_lt_xR_plus
              L' R' ? yL yR ycut yL_plus yR_plus yL_lt_yR_plus;
@@ -211,7 +211,7 @@ Section Addition.
       destruct (plus_inner_cut yL_plus yR_plus yL_lt_yR_plus
                                zL zR zcut) as [yzcut q];rewrite q;
       refine (lt_le_trans _ (xR_le_y_plus {{ zL | zR // zcut }}));
-      refine (Conway_theorem0_ii_r _ _ _ (inl r)) ).
+      refine (lt_ropt _ _ _ (inl r)) ).
   Defined.
 
   Definition plus (x y : No) : No

--- a/theories/Spaces/No/Addition.v
+++ b/theories/Spaces/No/Addition.v
@@ -16,6 +16,21 @@ Class HasAddition (S : OptionSort) :=
 Existing Instance empty_options.
 Existing Instance sum_options.
 
+Global Instance hasaddition_maxsort : HasAddition MaxSort
+  := { empty_options := tt ;
+       sum_options := fun _ _ _ _ _ _ => tt }.
+  
+Global Instance hasaddition_ordsort : HasAddition OrdSort
+  := { empty_options := idmap ;
+       sum_options := fun _ _ _ _ f g => sum_ind _ f g }.
+
+Global Instance hasaddition_decsort : HasAddition DecSort.
+Proof.
+  constructor.
+  - apply insort_decsort.
+  - intros L R L' R' [? ?] [? ?]; split; exact _.
+Qed.
+
 Section Addition.
   Context `{Univalence}.
   Context {S : OptionSort@{i}} `{HasAddition S}.

--- a/theories/Spaces/No/Core.v
+++ b/theories/Spaces/No/Core.v
@@ -1053,6 +1053,13 @@ Section RaiseSort.
 
 End RaiseSort.
 
+(** ** Ordinals *)
+
+(** The type of "plump ordinals" can be identified with surreal numbers that hereditarily have no right options. *)
+Definition OrdSort : OptionSort := fun L R => ~R.
+Definition POrd := GenNo OrdSort.
+Instance insort_ordsort {L : Type} : InSort OrdSort L Empty := idmap.
+
 (** ** Decidable options *)
 
 (** A particularly interesting option sort restricts [L] and [R] to be decidable, i.e. either inhabited or empty. *)

--- a/theories/Spaces/No/Core.v
+++ b/theories/Spaces/No/Core.v
@@ -461,6 +461,7 @@ End NoRec.
 
 (** ** Conway's Theorem 0 *)
 
+(** First we prove that *if* a left option of [y] is [<=] itself, then it is [< y]. *)
 Lemma Conway_theorem0_lemma1 `{Funext} (x : No@{i}) (xle : x <= x)
       {L' R' : Type@{i}} {s' : InSort@{i} S L' R'}
       (yL : L' -> No@{i}) (yR : R' -> No@{i})
@@ -473,6 +474,7 @@ Proof.
   exact (transport (fun z => {{ xL | xR // xcut}} <= z) p xle).
 Defined.
 
+(** And dually *)
 Lemma Conway_theorem0_lemma2 `{Funext} (x : No@{i}) (xle : x <= x)
       {L' R' : Type@{i}} {s' : InSort@{i} S L' R'}
       (yL : L' -> No@{i}) (yR : R' -> No@{i})
@@ -485,7 +487,8 @@ Proof.
   exact (transport (fun z => z <= {{ xL | xR // xcut}}) p xle).
 Defined.
 
-Theorem Conway_theorem0_i `{Funext} (x : No)
+(** Theorem 0 Part (i) *)
+Theorem le_reflexive `{Funext} (x : No)
 : x <= x.
 Proof.
   revert x; refine (No_ind_hprop _ _); intros.
@@ -495,9 +498,10 @@ Proof.
 Defined.
 
 Instance reflexive_le `{Funext} : Reflexive le
-  := Conway_theorem0_i.
+  := le_reflexive.
 
-Theorem Conway_theorem0_ii_l `{Funext}
+(** Theorem 0 Part (ii), left half *)
+Theorem lt_lopt `{Funext}
         {L R : Type@{i}} {s : InSort@{i} S L R}
         (xL : L -> No@{i}) (xR : R -> No@{i})
         (xcut : forall (l:L) (r:R), (xL l) < (xR r))
@@ -505,10 +509,11 @@ Theorem Conway_theorem0_ii_l `{Funext}
 : xL l < {{ xL | xR // xcut }}.
 Proof.
   refine (Conway_theorem0_lemma1 (xL l) _ _ _ _ _ 1).
-  apply Conway_theorem0_i.
+  apply le_reflexive.
 Defined.
 
-Theorem Conway_theorem0_ii_r `{Funext}
+(** Theorem 0 Part (ii), right half *)
+Theorem lt_ropt `{Funext}
         {L R : Type@{i}} {s : InSort@{i} S L R}
         (xL : L -> No@{i}) (xR : R -> No@{i})
         (xcut : forall (l:L) (r:R), (xL l) < (xR r))
@@ -516,13 +521,13 @@ Theorem Conway_theorem0_ii_r `{Funext}
 : {{ xL | xR // xcut }} < xR r.
 Proof.
   refine (Conway_theorem0_lemma2 (xR r) _ _ _ _ _ 1).
-  apply Conway_theorem0_i.
+  apply le_reflexive.
 Defined.
 
 Global Instance isset_No `{Funext} : IsHSet No.
 Proof.
   refine (@isset_hrel_subpaths No (fun (x y:No) => (x <= y) * (y <= x)) _ _ _).
-  - intros x; split; apply Conway_theorem0_i.
+  - intros x; split; apply le_reflexive.
   - intros x y [xley ylex]; apply path_No; assumption.
 Defined.
 
@@ -539,8 +544,8 @@ Definition path_No_easy `{Funext}
 Proof.
   apply path_No; apply le_lr; intros;
   [ rewrite xLeq | rewrite <- xReq | rewrite <- xLeq | rewrite xReq ];
-  try apply Conway_theorem0_ii_l;
-  try apply Conway_theorem0_ii_r.
+  try apply lt_lopt;
+  try apply lt_ropt.
 Qed.
 
 Definition path_No_easy' `{Funext}
@@ -624,13 +629,13 @@ Section NoCodes.
               [ refine (snd (fst (xL_let l).2.2) (yL l') y _ _);
                 [ refine (fst (fst (fst (xL_let l).2.2)) (yL l') _);
                   exact (snd (fst (x_let_yL l').2) l h)
-                | by (apply Conway_theorem0_ii_l; exact _) ]
+                | by (apply lt_lopt; exact _) ]
               | exact (y_lt_le l' r' h)
               | exact (x_lt_le l r y h)
               | refine (snd (x_let_yR r').2 r _);
                 refine (fst (fst (fst (xR_let r).2.2)) _ _);
                 refine (snd (fst (xR_let r).2.2) y (yR r') h _);
-                apply Conway_theorem0_ii_r; exact _ ]
+                apply lt_ropt; exact _ ]
             | intros l [h k]; apply h
             | intros r h; apply tr, inr; exact (r;h) ] ).
       - abstract (
@@ -1085,17 +1090,17 @@ Proof.
   assert (wcut : forall l r, wL l < wR r).
   { intros [[]|l] [[]|r]; cbn.
     - transitivity y.
-      { refine (Conway_theorem0_ii_r _ _ _ tt). }
+      { refine (lt_ropt _ _ _ tt). }
       transitivity z.
       { apply lt_l with (inl tt); cbn.
         apply le_lr; intros []. }
-      { refine (Conway_theorem0_ii_l _ _ _ tt). }
+      { refine (lt_lopt _ _ _ tt). }
     - transitivity y.
-      { refine (Conway_theorem0_ii_r _ _ _ tt). }
-      { refine (Conway_theorem0_ii_r _ _ _ (inr (inr r))). }
+      { refine (lt_ropt _ _ _ tt). }
+      { refine (lt_ropt _ _ _ (inr (inr r))). }
     - transitivity z.
-      { refine (Conway_theorem0_ii_l _ _ _ (inr (inl l))). }
-      { refine (Conway_theorem0_ii_l _ _ _ tt). }
+      { refine (lt_lopt _ _ _ (inr (inl l))). }
+      { refine (lt_lopt _ _ _ tt). }
     - apply No_raise_reflects_lt.
       rewrite (IHL l).2, (IHR r).2.
       apply xcut. }
@@ -1106,27 +1111,27 @@ Proof.
   - intros [[]|l].
     + apply (lt_le_trans (y := No_raise y)).
       * apply No_raise_lt.
-        refine (Conway_theorem0_ii_r _ _ _ tt).
+        refine (lt_ropt _ _ _ tt).
       * apply le_lr; [ intros [] | intros r ].
         rewrite <- (IHR r).2.
-        refine (Conway_theorem0_ii_r _ _ _ (inr (inr r))).
+        refine (lt_ropt _ _ _ (inr (inr r))).
     + rewrite (IHL l).2.
-      refine (Conway_theorem0_ii_l _ _ _ l).
+      refine (lt_lopt _ _ _ l).
   - intros r.
     rewrite <- (IHR r).2.
-    refine (Conway_theorem0_ii_r _ _ _ (inr r)).
+    refine (lt_ropt _ _ _ (inr r)).
   - intros l.
     rewrite <- (IHL l).2.
-    refine (Conway_theorem0_ii_l _ _ _ (inr l)).
+    refine (lt_lopt _ _ _ (inr l)).
   - intros [[]|r].
     + apply (le_lt_trans (y := No_raise z)).
       * apply le_lr; [ intros l | intros [] ].
         rewrite <- (IHL l).2.
-        refine (Conway_theorem0_ii_l _ _ _ (inr (inl l))).
+        refine (lt_lopt _ _ _ (inr (inl l))).
       * apply No_raise_lt.
-        refine (Conway_theorem0_ii_l _ _ _ tt).
+        refine (lt_lopt _ _ _ tt).
     + rewrite (IHR r).2.
-      refine (Conway_theorem0_ii_r _ _ _ r).
+      refine (lt_ropt _ _ _ r).
 Defined.
 
 Definition equiv_DecNo_raise `{Univalence}

--- a/theories/Spaces/No/Core.v
+++ b/theories/Spaces/No/Core.v
@@ -961,7 +961,7 @@ End NoCodes.
 (** There is of course a "maximal" option sort, which defines "the" surreal numbers as in the book. *)
 
 Definition MaxSort : OptionSort := fun _ _ => Unit.
-Definition MaxNo : Type := GenNo MaxSort.
+Definition No : Type := GenNo MaxSort.
 Instance insort_maxsort {L R : Type} : InSort MaxSort L R := tt.
 
 (** Furthermore, every other kind of surreal number *embeds* into the maximal ones.  So the other kinds of surreal numbers are really just subsets of the usual set of surreal numbers; but I don't know of a good way to define them except as their own HIITs. *)
@@ -969,9 +969,9 @@ Instance insort_maxsort {L R : Type} : InSort MaxSort L R := tt.
 Section RaiseSort.
   Context `{Univalence} `{S : OptionSort}.
 
-  Definition No_raise : GenNo S -> MaxNo.
+  Definition No_raise : GenNo S -> No.
   Proof.
-    simple refine (No_rec MaxNo le lt _ _ _ _ _).
+    simple refine (No_rec No le lt _ _ _ _ _).
     - intros L R ? xL xR xcut fxL fxR fxcut.
       exact {{ fxL | fxR // fxcut }}.
     - apply path_No.
@@ -1130,5 +1130,5 @@ Proof.
 Defined.
 
 Definition equiv_DecNo_raise `{Univalence}
-  : DecNo <~> MaxNo
+  : DecNo <~> No
   := BuildEquiv _ _ No_raise _.

--- a/theories/Spaces/No/Core.v
+++ b/theories/Spaces/No/Core.v
@@ -1037,7 +1037,7 @@ Section RaiseSort.
       strip_truncations.
       destruct sh as [[l sh]|[r sh]].
       + apply lt_l with l.
-        apply IHL0, No_decode_le.
+        apply IHL0, (@No_decode_le _).
         rewrite p; exact sh.
       + apply lt_r with r.
         apply IHR, No_decode_le.

--- a/theories/Spaces/No/Negation.v
+++ b/theories/Spaces/No/Negation.v
@@ -7,26 +7,38 @@ Local Open Scope surreal_scope.
 
 (** * Negation of surreal numbers *)
 
-Definition negate : No -> No.
-Proof.
-  simple refine (No_rec No (fun x y => y <= x) (fun x y => y < x)
-                 _ _ _ _ _); intros.
-  - exact {{ fxR | fxL // fun r l => fxcut l r }}.
-  - apply path_No; assumption.
-  - cbn in *. apply le_lr; intros; [ apply dq | apply dp ].
-  - cbn in *. apply lt_r with l; intros; assumption.
-  - cbn in *. apply lt_l with r; intros; assumption.
-Defined.
+(** Negation requires the option sorts to be symmetric. *)
+Class SymmetricOptions (S : OptionSort) 
+  := symmetric_options : forall L R, InSort S L R -> InSort S R L.
+Existing Instance symmetric_options.
 
-(** The following proof verifies that [No_rec] applied to a cut reduces definitionally to a cut with the expected options (although it does produce quite a large term). *)
-Goal negate one = minusone.
-Proof.
-  apply path_No; apply le_lr; intros.
-  (** Since [le_lr] only proves inequality of cuts, this would not work if [negate] didn't compute to a cut when applied to a cut. *)
-  - elim l.
-  - apply lt_r with r.
-    apply le_lr; apply Empty_ind.
-  - elim l.
-  - apply lt_r with r.
-    apply le_lr; apply Empty_ind.
-Qed.
+Section SymmetricOptions.
+  Context {S : OptionSort} `{SymmetricOptions S}.
+  Let No := GenNo S.
+
+  Definition negate : No -> No.
+  Proof.
+    simple refine (No_rec No (fun x y => y <= x) (fun x y => y < x)
+                          _ _ _ _ _); intros.
+    - exact {{ fxR | fxL // fun r l => fxcut l r }}.
+    - apply path_No; assumption.
+    - cbn in *. apply le_lr; intros; [ apply dq | apply dp ].
+    - cbn in *. apply lt_r with l; intros; assumption.
+    - cbn in *. apply lt_l with r; intros; assumption.
+  Defined.
+
+  (** The following proof verifies that [No_rec] applied to a cut reduces definitionally to a cut with the expected options (although it does produce quite a large term). *)
+  Context `{InSort S Empty Empty} `{InSort S Unit Empty}.
+  Goal negate one = minusone.
+  Proof.
+    apply path_No; apply le_lr; intros.
+    (** Since [le_lr] only proves inequality of cuts, this would not work if [negate] didn't compute to a cut when applied to a cut. *)
+    - elim l.
+    - apply lt_r with r.
+      apply le_lr; apply Empty_ind.
+    - elim l.
+    - apply lt_r with r.
+      apply le_lr; apply Empty_ind.
+  Qed.
+
+End SymmetricOptions.

--- a/theories/Spaces/No/Negation.v
+++ b/theories/Spaces/No/Negation.v
@@ -8,12 +8,12 @@ Local Open Scope surreal_scope.
 (** * Negation of surreal numbers *)
 
 (** Negation requires the option sorts to be symmetric. *)
-Class SymmetricOptions (S : OptionSort) 
+Class HasNegation (S : OptionSort) 
   := symmetric_options : forall L R, InSort S L R -> InSort S R L.
 Existing Instance symmetric_options.
 
-Section SymmetricOptions.
-  Context {S : OptionSort} `{SymmetricOptions S}.
+Section HasNegation.
+  Context {S : OptionSort} `{HasNegation S}.
   Let No := GenNo S.
 
   Definition negate : No -> No.
@@ -41,4 +41,4 @@ Section SymmetricOptions.
       apply le_lr; apply Empty_ind.
   Qed.
 
-End SymmetricOptions.
+End HasNegation.

--- a/theories/Spaces/No/Negation.v
+++ b/theories/Spaces/No/Negation.v
@@ -12,6 +12,14 @@ Class HasNegation (S : OptionSort)
   := symmetric_options : forall L R, InSort S L R -> InSort S R L.
 Existing Instance symmetric_options.
 
+Global Instance hasnegation_maxsort : HasNegation MaxSort
+  := fun _ _ _ => tt.
+
+Global Instance hasnegation_decsort : HasNegation DecSort.
+Proof.
+  intros L R [? ?]; split; assumption.
+Qed.
+
 Section HasNegation.
   Context {S : OptionSort} `{HasNegation S}.
   Let No := GenNo S.


### PR DESCRIPTION
Basically, you can get a "notion of surreal numbers" by restricting the types parametrizing the left and right options in any way you like, and the basic theorems about order are completely unaffected, while addition and so on do just fine as long as the option sorts are closed under the appropriate operations.  In particular, this includes the plump ordinals from Exercise 11.17 in the book.  All kinds of generalized surreal numbers embed into the "maximal" surreal numbers, though I don't know of a good way to define their images intrinsically.  Finally, and interestingly, *every* surreal number is equal to one whose option sorts are decidable (i.e. either it has no left options or it has a left option, and either it has no right options or it has a right option).