### PR TITLE
Backward compatible fix w.r.t. changes in primitives projections

### DIFF
--- a/theories/Categories/ChainCategory.v
+++ b/theories/Categories/ChainCategory.v
@@ -81,7 +81,7 @@ Module Export Univalent.
   Proof.
     intros s d.
     refine (isequiv_iff_hprop _ _).
-    { refine (trunc_equiv' _ (issig_isomorphic _ _ _)). }
+    { refine (trunc_equiv' _ (issig_isomorphic _ _ _)); simpl; refine _. }
     { intro m; apply leq_antisym; apply m. }
   Defined.
 


### PR DESCRIPTION
This patch makes HoTT compile after the changes in primitive projections introduced in PR coq/coq#984. It should be backward compatible with Coq 8.7.0.