### PR TITLE
A class for bounded lattices with some examples

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -396,6 +396,7 @@ theories/Classes/implementations/peano_naturals.v
 theories/Classes/implementations/natpair_integers.v
 theories/Classes/implementations/field_of_fractions.v
 theories/Classes/implementations/list.v
+theories/Classes/implementations/bool.v
 theories/Classes/interfaces/monad.v
 theories/Classes/interfaces/abstract_algebra.v
 theories/Classes/interfaces/naturals.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -397,6 +397,8 @@ theories/Classes/implementations/natpair_integers.v
 theories/Classes/implementations/field_of_fractions.v
 theories/Classes/implementations/list.v
 theories/Classes/implementations/bool.v
+theories/Classes/implementations/hprop_lattice.v
+theories/Classes/implementations/pointwise.v
 theories/Classes/interfaces/monad.v
 theories/Classes/interfaces/abstract_algebra.v
 theories/Classes/interfaces/naturals.v

--- a/theories/Classes/implementations/bool.v
+++ b/theories/Classes/implementations/bool.v
@@ -1,0 +1,25 @@
+Require Import
+  HoTT.Classes.interfaces.abstract_algebra
+  HoTT.Types.Bool.
+
+Instance join_bool : Join Bool := orb.
+Instance meet_bool : Meet Bool := andb.
+Instance bottom_bool : Bottom Bool := false.
+Instance top_bool : Top Bool := true.
+
+Section contents.
+  Local Ltac solve_bool :=
+    repeat (intros [|]); compute; (contradiction || auto).
+
+  Global Instance boundedjoinsemilattice_bool :
+    BoundedJoinSemiLattice Bool.
+  Proof. repeat split; (apply _ || solve_bool). Defined.
+
+  Global Instance boundedmeetsemilattice_bool :
+    @BoundedSemiLattice Bool (⊓) true.
+  Proof. repeat split; (apply _ || solve_bool). Defined.
+
+  Global Instance lattice_bool : Lattice Bool.
+  Proof. repeat split; (apply _ || solve_bool). Defined.
+
+End contents.

--- a/theories/Classes/implementations/bool.v
+++ b/theories/Classes/implementations/bool.v
@@ -11,15 +11,7 @@ Section contents.
   Local Ltac solve_bool :=
     repeat (intros [|]); compute; (contradiction || auto).
 
-  Global Instance boundedjoinsemilattice_bool :
-    BoundedJoinSemiLattice Bool.
-  Proof. repeat split; (apply _ || solve_bool). Defined.
-
-  Global Instance boundedmeetsemilattice_bool :
-    @BoundedSemiLattice Bool (⊓) true.
-  Proof. repeat split; (apply _ || solve_bool). Defined.
-
-  Global Instance lattice_bool : Lattice Bool.
+  Global Instance lattice_bool : BoundedLattice Bool.
   Proof. repeat split; (apply _ || solve_bool). Defined.
 
 End contents.

--- a/theories/Classes/implementations/hprop_lattice.v
+++ b/theories/Classes/implementations/hprop_lattice.v
@@ -1,0 +1,116 @@
+Require Import
+  HoTT.Classes.interfaces.abstract_algebra
+  HoTT.HProp HoTT.TruncType
+  HoTT.Types.Universe HoTT.Types.Prod.
+
+(** Demonstrate the [hProp] is a (bounded) lattice w.r.t. the logical
+operations. This requires Univalence. *)
+(* We use this notation because [hor] can accept arguments of type [Type], which leads to minor confusion in the instances below *)
+Notation lor := (hor : hProp -> hProp -> hProp).
+Instance join_hor : Join hProp := hor.
+Definition hand (X Y : hProp) : hProp := BuildhProp (X * Y).
+Instance meet_hprop : Meet hProp := hand.
+Instance bottom_hprop : Bottom hProp := False_hp.
+Instance top_hprop : Top hProp := Unit_hp.
+
+Section contents.
+  Context `{Univalence}.
+
+  (* This tactic attempts to destruct a truncated sum (disjunction) *)
+  Local Ltac hor_intros :=
+    let x := fresh in
+    intro x; repeat (strip_truncations; destruct x as [x | x]).
+
+  Instance commutative_hor : Commutative lor.
+  Proof.
+    intros ??.
+    apply path_iff_hprop; hor_intros; apply tr; auto.
+  Defined.
+
+  Instance commutative_hand : Commutative hand.
+  Proof.
+    intros ??.
+    apply path_hprop.
+    apply equiv_prod_symm.
+  Defined.
+
+  Instance associative_hor : Associative lor.
+  Proof.
+    intros ???.
+    apply path_iff_hprop;
+    hor_intros; apply tr;
+    ((by auto) || (left; apply tr) || (right; apply tr));
+    auto.
+  Defined.
+
+  Instance associative_hand : Associative hand.
+  Proof.
+    intros ???.
+    apply path_hprop.
+    apply equiv_prod_assoc.
+  Defined.
+
+  Instance idempotent_hor : BinaryIdempotent lor.
+  Proof.
+    intros ?. compute.
+    apply path_iff_hprop; hor_intros; auto.
+    by apply tr, inl.
+  Defined.
+
+  Instance idempotent_hand : BinaryIdempotent hand.
+  Proof.
+    intros ?.
+    apply path_iff_hprop.
+    - intros [a _] ; apply a.
+    - intros a; apply (pair a a).
+  Defined.
+
+  Instance leftidentity_hor : LeftIdentity lor False_hp.
+  Proof.
+    intros ?.
+    apply path_iff_hprop; hor_intros; try contradiction || assumption.
+    by apply tr, inr.
+  Defined.
+
+  Instance rightidentity_hor : RightIdentity lor False_hp.
+  Proof.
+    intros ?.
+    apply path_iff_hprop; hor_intros; try contradiction || assumption.
+    by apply tr, inl.
+  Defined.
+
+  Instance leftidentity_hand : LeftIdentity hand Unit_hp.
+  Proof.
+    intros ?.
+    apply path_trunctype, prod_unit_l.
+  Defined.
+
+  Instance rightidentity_hand : RightIdentity hand Unit_hp.
+  Proof.
+    intros ?.
+    apply path_trunctype, prod_unit_r.
+  Defined.
+
+  Instance absorption_hor_hand : Absorption lor hand.
+  Proof.
+    intros ??.
+    apply path_iff_hprop.
+    - intros X; strip_truncations.
+      destruct X as [? | [? _]]; assumption.
+    - intros ?. by apply tr, inl.
+  Defined.
+
+  Instance absorption_hand_hor : Absorption hand lor.
+  Proof.
+    intros ??.
+    apply path_iff_hprop.
+    - intros [? _]; assumption.
+    - intros ?.
+      split.
+      * assumption.
+      * by apply tr, inl.
+  Defined.
+
+  Global Instance boundedlattice_hprop : BoundedLattice hProp.
+  Proof. repeat split; apply _. Defined.
+End contents.

--- a/theories/Classes/implementations/hprop_lattice.v
+++ b/theories/Classes/implementations/hprop_lattice.v
@@ -5,8 +5,6 @@ Require Import
 
 (** Demonstrate the [hProp] is a (bounded) lattice w.r.t. the logical
 operations. This requires Univalence. *)
-(* We use this notation because [hor] can accept arguments of type [Type], which leads to minor confusion in the instances below *)
-Notation lor := (hor : hProp -> hProp -> hProp).
 Instance join_hor : Join hProp := hor.
 Definition hand (X Y : hProp) : hProp := BuildhProp (X * Y).
 Instance meet_hprop : Meet hProp := hand.
@@ -15,6 +13,9 @@ Instance top_hprop : Top hProp := Unit_hp.
 
 Section contents.
   Context `{Univalence}.
+
+  (* We use this notation because [hor] can accept arguments of type [Type], which leads to minor confusion in the instances below *)
+  Notation lor := (hor : hProp -> hProp -> hProp).
 
   (* This tactic attempts to destruct a truncated sum (disjunction) *)
   Local Ltac hor_intros :=

--- a/theories/Classes/implementations/pointwise.v
+++ b/theories/Classes/implementations/pointwise.v
@@ -4,12 +4,13 @@ Require Import
 (** If [B] is a (bounded) lattice, then so is [A -> B], pointwise.
     This relies on functional extensionality. *)
 Section contents.
+  Context `{Funext}.
+
   Context {A B : Type}.
   Context `{BJoin : Join B}.
   Context `{BMeet : Meet B}.
   Context `{BBottom : Bottom B}.
   Context `{BTop : Top B}.
-  Context `{Funext}.
 
   Global Instance bot_fun : Bottom (A -> B)
     := fun _ => ⊥.
@@ -34,7 +35,7 @@ Section contents.
     reduce_fun;
     eauto 10 with lattice_hints typeclass_instances.
 
-  Global Instance lattice_fun `{@Lattice B BJoin BMeet} : Lattice (A -> B).
+  Global Instance lattice_fun `{!Lattice B} : Lattice (A -> B).
   Proof.
     repeat split; try apply _; try_solve_fun.
     * apply binary_idempotent.
@@ -42,7 +43,7 @@ Section contents.
   Defined.
 
   Instance boundedjoinsemilattice_fun
-   `{@BoundedJoinSemiLattice B BJoin BBottom} :
+   `{!BoundedJoinSemiLattice B} :
     BoundedJoinSemiLattice (A -> B).
   Proof.
     repeat split; try apply _; try_solve_fun.
@@ -53,7 +54,7 @@ Section contents.
   Defined.
 
   Instance boundedmeetsemilattice_fun
-   `{@BoundedMeetSemiLattice B BMeet BTop} :
+   `{!BoundedMeetSemiLattice B} :
     BoundedMeetSemiLattice (A -> B).
   Proof.
     repeat split; try apply _; reduce_fun.
@@ -65,7 +66,7 @@ Section contents.
   Defined.
 
   Global Instance boundedlattice_fun
-   `{@BoundedLattice B BJoin BMeet BBottom BTop} : BoundedLattice (A -> B).
+   `{!BoundedLattice B} : BoundedLattice (A -> B).
   Proof.
     repeat split; try apply _; reduce_fun; apply absorption.
   Defined.

--- a/theories/Classes/implementations/pointwise.v
+++ b/theories/Classes/implementations/pointwise.v
@@ -1,0 +1,72 @@
+Require Import
+  HoTT.Classes.interfaces.abstract_algebra.
+
+(** If [B] is a (bounded) lattice, then so is [A -> B], pointwise.
+    This relies on functional extensionality. *)
+Section contents.
+  Context {A B : Type}.
+  Context `{BJoin : Join B}.
+  Context `{BMeet : Meet B}.
+  Context `{BBottom : Bottom B}.
+  Context `{BTop : Top B}.
+  Context `{Funext}.
+
+  Global Instance bot_fun : Bottom (A -> B)
+    := fun _ => ⊥.
+
+  Global Instance top_fun : Top (A -> B)
+    := fun _ => ⊤.
+
+  Global Instance join_fun : Join (A -> B) :=
+    fun (f g : A -> B) (a : A) => (f a) ⊔ (g a).
+
+  Global Instance meet_fun : Meet (A -> B) :=
+    fun (f g : A -> B) (a : A) => (f a) ⊓ (g a).
+
+  (** Try to solve some of the lattice obligations automatically *)
+  Create HintDb lattice_hints.
+  Hint Resolve
+       associativity
+       absorption
+       commutativity | 1 : lattice_hints.
+  Local Ltac reduce_fun := compute; intros; apply path_forall; intro.
+  Local Ltac try_solve_fun :=
+    reduce_fun;
+    eauto 10 with lattice_hints typeclass_instances.
+
+  Global Instance lattice_fun `{@Lattice B BJoin BMeet} : Lattice (A -> B).
+  Proof.
+    repeat split; try apply _; try_solve_fun.
+    * apply binary_idempotent.
+    * apply binary_idempotent.
+  Defined.
+
+  Instance boundedjoinsemilattice_fun
+   `{@BoundedJoinSemiLattice B BJoin BBottom} :
+    BoundedJoinSemiLattice (A -> B).
+  Proof.
+    repeat split; try apply _; try_solve_fun.
+    * apply left_identity.
+    * apply right_identity.
+    * apply commutativity.
+    * apply binary_idempotent.
+  Defined.
+
+  Instance boundedmeetsemilattice_fun
+   `{@BoundedMeetSemiLattice B BMeet BTop} :
+    BoundedMeetSemiLattice (A -> B).
+  Proof.
+    repeat split; try apply _; reduce_fun.
+    * apply associativity.
+    * apply left_identity.
+    * apply right_identity.
+    * apply commutativity.
+    * apply binary_idempotent.
+  Defined.
+
+  Global Instance boundedlattice_fun
+   `{@BoundedLattice B BJoin BMeet BBottom BTop} : BoundedLattice (A -> B).
+  Proof.
+    repeat split; try apply _; reduce_fun; apply absorption.
+  Defined.
+End contents.

--- a/theories/Classes/interfaces/abstract_algebra.v
+++ b/theories/Classes/interfaces/abstract_algebra.v
@@ -170,7 +170,7 @@ Arguments dec_recip_inverse
 Arguments dec_recip_0 {A Aplus Amult Azero Aone Anegate Adec_recip DecField}.
 
 Section lattice.
-  Context A {Ajoin: Join A} {Ameet: Meet A} {Abottom : Bottom A}.
+  Context A {Ajoin: Join A} {Ameet: Meet A} {Abottom : Bottom A} {Atop : Top A}.
 
   Class JoinSemiLattice := 
     join_semilattice :> @SemiLattice A join_is_sg_op.
@@ -179,12 +179,21 @@ Section lattice.
       join_is_sg_op bottom_is_mon_unit.
   Class MeetSemiLattice := 
     meet_semilattice :> @SemiLattice A meet_is_sg_op.
+  Class BoundedMeetSemiLattice :=
+    bounded_meet_semilattice :> @BoundedSemiLattice A
+      meet_is_sg_op top_is_mon_unit.
 
   Class Lattice := 
     { lattice_join :> JoinSemiLattice
     ; lattice_meet :> MeetSemiLattice
     ; join_meet_absorption :> Absorption (⊔) (⊓) 
     ; meet_join_absorption :> Absorption (⊓) (⊔)}.
+
+  Class BoundedLattice :=
+    { boundedlattice_join :> BoundedJoinSemiLattice
+    ; boundedlattice_meet :> BoundedMeetSemiLattice
+    ; boundedjoin_meet_absorption :> Absorption (⊔) (⊓)
+    ; boundedmeet_join_absorption :> Absorption (⊓) (⊔)}.
 
   Class DistributiveLattice := 
     { distr_lattice_lattice :> Lattice

--- a/theories/Classes/theory/lattices.v
+++ b/theories/Classes/theory/lattices.v
@@ -12,6 +12,11 @@ Proof.
 repeat (split; try apply _).
 Qed.
 
+Instance bounded_meet_sl_is_meet_sl `{BoundedMeetSemiLattice L} : MeetSemiLattice L.
+Proof.
+repeat (split; try apply _).
+Qed.
+
 Instance bounded_lattice_is_lattice `{BoundedLattice L} : Lattice L.
 Proof.
 repeat split; apply _.

--- a/theories/Classes/theory/lattices.v
+++ b/theories/Classes/theory/lattices.v
@@ -12,6 +12,11 @@ Proof.
 repeat (split; try apply _).
 Qed.
 
+Instance bounded_lattice_is_lattice `{BoundedLattice L} : Lattice L.
+Proof.
+repeat split; apply _.
+Qed.
+
 Instance bounded_sl_mor_is_sl_mor `{H : BoundedJoinPreserving A B f}
   : JoinPreserving f.
 Proof.


### PR DESCRIPTION
These commits introduce classes `BoundedLattice` and `BoundedMeetSemiLattice`, and show that
- booleans
- `hProp`
- functions `A -> B` for a (bounded) lattice `B`

form bounded lattices.

Some context for this: we have been working on a [formalisation of Kuratowski-finite sets](https://github.com/nmvdw/HITs-Examples/tree/master/FiniteSets) in HoTT pre hottclasses. For those purposes we had some in-house typeclasses for unified notation and generalized lemmas. In particular, for many proofs about finite subobjects we relied on the fact that `hProp` and `A -> hProp` are bounded lattices.

We would like to port our code to the "new" HoTT enhanced with hottclasses. I think at least the `hProp` instances can be quite useful in general.

Pinging @nmvdw, @spitters.