### PR TITLE
Coq now prunes phantom universes.

### DIFF
--- a/theories/Classes/implementations/natpair_integers.v
+++ b/theories/Classes/implementations/natpair_integers.v
@@ -531,7 +531,8 @@ Qed.
 
 (* Where are these universes even coming from? *)
 Instance Z_partial_order@{} : PartialOrder Zle
-  := Z_partial_order'@{Ularge Ularge Ularge Ularge Ularge}.
+  := ltac:(first [exact Z_partial_order'@{Ularge Ularge Ularge Ularge Ularge}|
+                  exact Z_partial_order']).
 
 Lemma Zle_cast_embedding' : OrderEmbedding (cast N Z).
 Proof.
@@ -543,7 +544,8 @@ split;red.
 Qed.
 
 Global Instance Zle_cast_embedding@{} : OrderEmbedding (cast N Z)
-  := Zle_cast_embedding'@{Ularge Ularge}.
+  := ltac:(first [exact Zle_cast_embedding'@{Ularge Ularge}|
+                  exact Zle_cast_embedding']).
 
 Lemma Zle_plus_preserving_l' : forall z : Z, OrderPreserving ((+) z).
 Proof.
@@ -559,7 +561,8 @@ apply (order_preserving _),E.
 Qed.
 
 Instance Zle_plus_preserving_l@{} : forall z : Z, OrderPreserving ((+) z)
-  := Zle_plus_preserving_l'@{Ularge Ularge}.
+  := ltac:(first [exact Zle_plus_preserving_l'@{Ularge Ularge}|
+                  exact Zle_plus_preserving_l']).
 
 Lemma Zmult_nonneg' : forall x y : Z, PropHolds (0 ≤ x) -> PropHolds (0 ≤ y) ->
   PropHolds (0 ≤ x * y).
@@ -578,7 +581,8 @@ Qed.
 
 Instance Zmult_nonneg@{} : forall x y : Z, PropHolds (0 ≤ x) -> PropHolds (0 ≤ y) ->
   PropHolds (0 ≤ x * y)
-  := Zmult_nonneg'@{Ularge Ularge Ularge}.
+  := ltac:(first [exact Zmult_nonneg'@{Ularge Ularge Ularge}|
+                  exact Zmult_nonneg']).
 
 Global Instance Z_order@{} : SemiRingOrder Zle.
 Proof. pose proof Z_ring; apply rings.from_ring_order; apply _. Qed.
@@ -608,7 +612,7 @@ Proof. unfold Zlt;exact _. Qed.
 Lemma Zlt_def' : forall a b, ' a < ' b = PairT.Tlt a b.
 Proof. reflexivity. Qed.
 
-Definition Zlt_def@{i} := Zlt_def'@{Uhuge i}.
+Definition Zlt_def@{i} := ltac:(first [exact Zlt_def'@{Uhuge i}|exact Zlt_def'@{i}]).
 
 Lemma Zlt_strict' : StrictOrder Zlt.
 Proof.
@@ -697,10 +701,11 @@ Global Instance Zapart@{} : Apart Z := fun x y => Zapart_hProp x y.
 Lemma Zapart_def' : forall a b, apart (' a) (' b) = PairT.Tapart a b.
 Proof. reflexivity. Qed.
 
+Definition Zapart_def@{i} := ltac:(first [exact Zapart_def'@{Uhuge i}|
+                                          exact Zapart_def'@{i}]).
+
 Global Instance ishprop_Zapart : is_mere_relation _ Zapart.
 Proof. unfold Zapart;exact _. Qed.
-
-Definition Zapart_def@{i} := Zapart_def'@{Uhuge i}.
 
 Lemma Z_trivial_apart' `{!TrivialApart N}
   : TrivialApart Z.
@@ -794,9 +799,10 @@ split;[apply _|split;try apply _|].
 Qed.
 
 Instance Z_full_psorder@{} : FullPseudoOrder Zle Zlt
-  := Z_full_psorder'@{
-    Ularge Ularge Ularge Ularge Ularge
-    Ularge Ularge Ularge Ularge Ularge}.
+  := ltac:(first [exact Z_full_psorder'@{Ularge Ularge Ularge Ularge Ularge
+                                                Ularge Ularge Ularge Ularge}|
+                  exact Z_full_psorder'@{Ularge Ularge Ularge Ularge Ularge
+                                         Ularge Ularge Ularge Ularge Ularge}]).
 
 Lemma Zmult_strong_ext_l' : forall z : Z, StrongExtensionality (z *.).
 Proof.

--- a/theories/Classes/implementations/peano_naturals.v
+++ b/theories/Classes/implementations/peano_naturals.v
@@ -531,7 +531,8 @@ split;[apply _|split|].
     destruct E;auto.
 Qed.
 
-Definition nat_full@{} := nat_full'@{Ularge Ularge N}.
+Definition nat_full@{} := ltac:(first[exact nat_full'@{Ularge Ularge}|
+                                      exact nat_full'@{Ularge Ularge N}]).
 Local Existing Instance nat_full.
 
 Instance S_embedding : OrderEmbedding S.

--- a/theories/Classes/isomorphisms/rings.v
+++ b/theories/Classes/isomorphisms/rings.v
@@ -63,7 +63,7 @@ Qed.
 Lemma iso_leibnitz : forall P : Operations -> Type, P A -> P B.
 Proof.
 intros P;apply transport.
-exact iso_same_semirings@{V V}.
+first [exact iso_same_semirings|exact iso_same_semirings@{V V}].
 Qed.
 
 End contents.
@@ -131,7 +131,7 @@ Qed.
 Lemma iso_leibnitz : forall P : Operations -> Type, P A -> P B.
 Proof.
 intros P;apply transport.
-exact iso_same_rings@{V V}.
+first [exact iso_same_rings|exact iso_same_rings@{V V}].
 Qed.
 
 End contents.

--- a/theories/Idempotents.v
+++ b/theories/Idempotents.v
@@ -752,7 +752,7 @@ Section RetractOfRetracts.
   Defined.
 
   (** We have a similar result for splittings of a fixed map [f].  *)
-  Definition splitting_retractof_isqidem (f : X -> X)
+  Definition splitting_retractof_isqidem0 (f : X -> X)
   : RetractOf { I : IsPreIdempotent f & IsQuasiIdempotent f }.
   Proof.
     simple refine (@equiv_retractof'
@@ -776,6 +776,13 @@ Section RetractOfRetracts.
         intros R; simpl.
       apply equiv_ap10.
   Defined.
+
+  (* A phantom universe is introduced at some point, and causes
+  incompatibilities since it is pruned by Coq >= 8.8. *)
+  Definition splitting_retractof_isqidem@{a b}
+    := Eval unfold splitting_retractof_isqidem0 in
+        ltac:(first [exact splitting_retractof_isqidem0@{a b}|
+                     exact splitting_retractof_isqidem0@{a a b}]).
 
   (** And also for splittings of a fixed map that also induce a given witness of pre-idempotency. *)
   Definition Splitting_PreIdempotent (f : PreIdempotent X)
@@ -875,10 +882,10 @@ Section CoherentIdempotents.
 
   (** For instance, here is the standard coherent idempotent structure on the identity map. *)
   Global Instance isidem_idmap (X : Type@{i})
-  : @IsIdempotent@{i i j j} X idmap
+  : @IsIdempotent@{i i j} X idmap
     := Build_IsIdempotent idmap (splitting_idmap X).
 
-  Definition idem_idmap (X : Type@{i}) : Idempotent@{i i j j} X
+  Definition idem_idmap (X : Type@{i}) : Idempotent@{i i j} X
   := (idmap ; isidem_idmap X).
 
   (** Note that [Idempotent X], unlike [RetractOf X], lives in the same universe as [X], even if we demand that it contain the identity. *)

--- a/theories/Modalities/Localization.v
+++ b/theories/Modalities/Localization.v
@@ -379,7 +379,9 @@ Module Localization_ReflectiveSubuniverses <: ReflectiveSubuniverses.
   : IsHProp (In@{u a i} O T).
   Proof.
     apply (@trunc_forall@{a i i} _); intros i.
-    apply ishprop_ooextendable@{a a i i i i i i i i i i}.
+    (* compat Coq before/after 8.8 *)
+    first [apply ishprop_ooextendable@{a a i i i i i i i i}|
+           apply ishprop_ooextendable@{a a i i i i i i i i i i}].
   Defined.
 
   Definition extendable_to_O

--- a/theories/Modalities/Open.v
+++ b/theories/Modalities/Open.v
@@ -126,7 +126,9 @@ Module Accessible_OpenModalities <: Accessible_Modalities OpenModalities.
   Proof.
     pose (funext_Op O); split.
     - intros X_inO u.
-      apply (equiv_inverse (equiv_ooextendable_isequiv@{a a i i i i i i i i i i i} _ _)).
+      (* Phantom universes are pruned by Coq >=8.8 (see Coq/Coq#1033). *)
+      first [apply (equiv_inverse (equiv_ooextendable_isequiv@{a a i i i i i i i i i} _ _))|
+             apply (equiv_inverse (equiv_ooextendable_isequiv@{a a i i i i i i i i i i i} _ _))].
       refine (cancelR_isequiv (fun x (u:Unit) => x)).
       apply X_inO.
     - intros ext; specialize (ext tt).
@@ -138,8 +140,11 @@ Module Accessible_OpenModalities <: Accessible_Modalities OpenModalities.
   (* Phantom universes (ie not appearing in the term) are produced by some un-annotated functions and foralls.
      For instance if we explicitate [(B:=(Unit -> _))] in the [isequiv_compose] use above only one extra is produced.
      I can't figure out where the last extra is coming from so we have to manually identify it with [i].
-     Since we have to do this manual identification step we might as well use it for the universe from [B] too. *)
-  Definition inO_iff_isnull@{u a i} := inO_iff_isnull'@{u a i i i}.
+     Since we have to do this manual identification step we might as well use it for the universe from [B] too.
+
+   Phantom universes are pruned by Coq >=8.8 (see Coq/Coq#1033). *)
+  Definition inO_iff_isnull@{u a i}
+    := Eval unfold inO_iff_isnull' in ltac:(first [exact inO_iff_isnull'@{u a i i i}|exact inO_iff_isnull'@{u a i}]).
 
 End Accessible_OpenModalities.
 

--- a/theories/PropResizing/Nat.v
+++ b/theories/PropResizing/Nat.v
@@ -422,7 +422,7 @@ Section AssumeStuff.
   Proof.
     exists (vert A + vert B).
     exists (fun ab ab' =>
-              match ab, ab' with
+              match ab, ab' return Type@{s} with
               | inl a, inl a' => edge A a a'
               | inl a, inr b => Unit
               | inr b, inl a => Empty
@@ -430,8 +430,10 @@ Section AssumeStuff.
               end).
     intros [a|b] [a'|b']; exact _.
   Defined.
-  (** These are just on the return Type@{foo} clauses of the above match and destructs. *)
-  Definition graph_add@{} := Eval unfold graph_add0 in graph_add0@{s s s}.
+
+  (* Coq pre 8.8 produces phantom universes, see GitHub Coq/Coq#1033. *)
+  Definition graph_add@{} : Graph -> Graph -> Graph
+    := Eval unfold graph_add0 in ltac:(first [exact graph_add0|exact graph_add0@{s s}]).
 
   Definition graph_add_zero_r@{} (A : Graph) : graph_add A graph_zero = A.
   Proof.


### PR DESCRIPTION
(after coq/coq#1033)
This should be backwards compatible, which is why there are all these ugly `ltac:(first [exact foo@{bla}|exact foo@{bli}])` things.