### PR TITLE
Fix validate target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -192,7 +192,7 @@ checkproofs:
 
 validate: $(ALL_VOFILES)
 	$(VECHO) HOQCHK
-	$(Q) $(TIMER) $(HOQCHK) $(HOQCHKFLAGS) $(notdir $(^:.vo=))
+	$(Q) $(TIMER) $(HOQCHK) $(HOQCHKFLAGS) $^
 
 $(STD_VOFILES) : %.vo : %.v coq-HoTT
 	$(VECHO) COQTOP $*


### PR DESCRIPTION
In Coq master, coqchk supports being pasesd .vo files and no longer
supports unqualified library names.