### PR TITLE
simpler proof of Exercise 6.9 not using univalence

### DIFF
--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -1145,10 +1145,6 @@ Section Book_6_9.
 
   Definition AllExistsOther(X : Type) := forall x:X, { y:X | y <> x }.
 
-  Lemma isHPropAllExOth `{Funext} (X: Type) : IsHProp(Contr (AllExistsOther X)).
-  Proof. apply (hprop_trunc -2).
-  Defined.
-
   Definition centerAllExOthBool : AllExistsOther Bool := 
     fun (b:Bool) => (negb b ; not_fixed_negb b).
 
@@ -1165,7 +1161,7 @@ Section Book_6_9.
   Definition solution_6_9 `{Funext} : forall X, X -> X.
   Proof.
     intro X.
-    elim (@LEM (Contr (AllExistsOther X)) (isHPropAllExOth X)); intro.
+    elim (@LEM (Contr (AllExistsOther X)) _); intro.
     - exact (fun x:X => (center (AllExistsOther X) x).1).
     - exact (fun x:X => x).
   Defined.
@@ -1175,7 +1171,7 @@ Section Book_6_9.
     intro Bad. pose proof ((happly Bad) true) as Ugly.
     assert ((solution_6_9 Bool true) = false) as Good.
     unfold solution_6_9.
-    destruct (LEM (Contr (AllExistsOther Bool))(isHPropAllExOth Bool)) as [[f C]|C];simpl.
+    destruct (LEM (Contr (AllExistsOther Bool)) _) as [[f C]|C];simpl.
     - elim (centralAllExOthBool f). reflexivity.
     - elim (C contrAllExOthBool).
     - apply false_ne_true. rewrite (inverse Good). assumption.

--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -1140,6 +1140,47 @@ Section Book_6_9.
         | [ H : false = true |- _ ] => exact (match false_ne_true H with end)
       end.
   Qed.
+
+(** Simpler solution not using univalence **)
+
+  Definition AllExistsOther(X : Type) := forall x:X, { y:X | y <> x }.
+
+  Lemma isHPropAllExOth `{Funext} (X: Type) : IsHProp(Contr (AllExistsOther X)).
+  Proof. apply (hprop_trunc -2).
+  Defined.
+
+  Definition centerAllExOthBool : AllExistsOther Bool := 
+    fun (b:Bool) => (negb b ; not_fixed_negb b).
+
+  Lemma centralAllExOthBool `{Funext} (f: AllExistsOther Bool) : centerAllExOthBool = f.
+  Proof. apply path_forall. intro b. pose proof (inverse (negb_ne (f b).2)) as fst.
+  unfold centerAllExOthBool.
+  apply (@path_sigma _ _ (negb b; not_fixed_negb b) (f b) fst); simpl.
+  apply equiv_hprop_allpath. apply trunc_forall.
+  Defined.
+
+  Definition contrAllExOthBool `{Funext} : Contr (AllExistsOther Bool) :=
+  (BuildContr _ centerAllExOthBool centralAllExOthBool).
+
+  Definition solution_6_9 `{Funext} : forall X, X -> X.
+  Proof.
+    intro X.
+    elim (@LEM (Contr (AllExistsOther X)) (isHPropAllExOth X)); intro.
+    - exact (fun x:X => (center (AllExistsOther X) x).1).
+    - exact (fun x:X => x).
+  Defined.
+
+  Lemma not_id_on_Bool `{Funext} : solution_6_9 Bool <> idmap.
+  Proof.
+    intro Bad. pose proof ((happly Bad) true) as Ugly.
+    assert ((solution_6_9 Bool true) = false) as Good.
+    unfold solution_6_9.
+    destruct (LEM (Contr (AllExistsOther Bool))(isHPropAllExOth Bool)) as [[f C]|C];simpl.
+    - elim (centralAllExOthBool f). reflexivity.
+    - elim (C contrAllExOthBool).
+    - apply false_ne_true. rewrite (inverse Good). assumption.
+  Defined.
+
 End Book_6_9.
 
 (* ================================================== ex:funext-from-interval *)

--- a/etc/Book.py
+++ b/etc/Book.py
@@ -190,7 +190,7 @@ for label in sorted(entries.keys(),
         content = content[content.index('\n')+1:]
         # Update Book_X_Y_Z
         book = "_".join(map(str,entry['number']))
-        content = re.sub('Book_[0-9_]*[0-9]', 'Book_{0}'.format(book), content)
+        content = re.sub('Definition Book_[0-9_]*[0-9]', 'Definition Book_{0}'.format(book), content)
         # It is a common error to write things like Lemma_X_Y_Z instead of Book_X_Y_Z,
         # so we warn about those.
         suspect_names = "|".join(['Axiom',


### PR DESCRIPTION
HoTTBookExercises.v has been validated with `make contrib', and this went well. However, there is issue #921. The warnings about Book_5_2 in HoTTBookExercises.v appear to stem from pedagogical considerations:

````
Query commands should not be inserted in scripts
prod_rect
     : forall (A B : Type) (P : A * B -> Type), (forall (fst : A) (snd : B), P (fst, snd)) -> forall p : A * B, P p
The command has indeed failed with message:
In environment
ez := true : Bool
es := fun _ : nat => idmap : nat -> Bool -> Bool
The term "1" has type "Book_5_2_i = Book_5_2_i" while it is expected to have type "Book_5_2_i = Book_5_2_ii"
(cannot unify "Book_5_2_i" and "Book_5_2_ii").
The command has indeed failed with message:
In environment
ez := 1 : nat
es := fun _ : nat => S : nat -> nat -> nat
The term "1" has type "Book_5_2'_i = Book_5_2'_i" while it is expected to have type "Book_5_2'_i = Book_5_2'_ii"
(cannot unify "Book_5_2'_i" and "Book_5_2'_ii").
````