### PR TITLE
No substitution of "Book_X_Y" at all

### DIFF
--- a/etc/Book.py
+++ b/etc/Book.py
@@ -190,7 +190,9 @@ for label in sorted(entries.keys(),
         content = content[content.index('\n')+1:]
         # Update Book_X_Y_Z
         book = "_".join(map(str,entry['number']))
-        content = re.sub('Definition Book_[0-9_]*[0-9]', 'Definition Book_{0}'.format(book), content)
+        # content = re.sub('Book_[0-9_]*[0-9]', 'Book_{0}'.format(book), content) 
+        # content = re.sub('Definition Book_[0-9_]*[0-9]', 'Definition Book_{0}'.format(book), content)
+        # previous two removed since they break Exercise 2.2 and 2.3
         # It is a common error to write things like Lemma_X_Y_Z instead of Book_X_Y_Z,
         # so we warn about those.
         suspect_names = "|".join(['Axiom',


### PR DESCRIPTION
Line 193 in Book.py broke HoTTBookExercises.v, for example, in Book_2_2 where references to Book_2_1 occur. I experimented with limiting substitution to contexts of the form `Definition Book_X_Y`. But then Exercise 2.3 was still broken, while it made sense to call the definition there Book_2_1_concatenation4. We probably don't need the substitution anymore, as the numbering in book is not likely to change. If this assumption proves to be false, the substitution could be reintroduced on an ad-hoc basis. 

If this patch is accepted, I will change the guidelines in the files HoTTBook{Exercises}.v accordingly.