### PR TITLE
Non-dependent funext implies dependent funext

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -11,7 +11,6 @@ theories/Basics/Contractible.v
 theories/Basics/Equivalences.v
 theories/Basics/Trunc.v
 theories/Basics/Decidable.v
-theories/Basics/FunextVarieties.v
 theories/Basics.v
 theories/Types/Paths.v
 theories/Types/Unit.v
@@ -32,6 +31,7 @@ theories/Fibrations.v
 theories/Conjugation.v
 theories/HProp.v
 theories/EquivalenceVarieties.v
+theories/FunextVarieties.v
 theories/UnivalenceVarieties.v
 theories/Extensions.v
 theories/HSet.v

--- a/contrib/HoTTBook.v
+++ b/contrib/HoTTBook.v
@@ -701,7 +701,7 @@ Definition Book_4_8_4 := @HoTT.ObjectClassifier.objclasspb_is_fibrantreplacement
 (* ================================================== weakfunext *)
 (** Definition 4.9.1 *)
 
-Definition Book_4_9_1 := @HoTT.Basics.FunextVarieties.WeakFunext.
+Definition Book_4_9_1 := @HoTT.FunextVarieties.WeakFunext.
 
 (* ================================================== UA-eqv-hom-eqv *)
 (** Lemma 4.9.2 *)
@@ -721,7 +721,7 @@ Definition Book_4_9_4 := @HoTT.UnivalenceImpliesFunext.Univalence_implies_WeakFu
 (* ================================================== wfetofe *)
 (** Theorem 4.9.5 *)
 
-Definition Book_4_9_5 := @HoTT.Basics.FunextVarieties.WeakFunext_implies_Funext.
+Definition Book_4_9_5 := @HoTT.FunextVarieties.WeakFunext_implies_Funext.
 
 (* ================================================== thm:nat-uniq *)
 (** Theorem 5.1.1 *)

--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -874,7 +874,7 @@ End Book_4_5.
 (** Exercise 4.6 *)
 
 Section Book_4_6_i.
-  Section OneUniverse.
+
   Definition is_qinv {A B : Type} (f : A -> B) 
     := { g : B -> A & (Sect g f * Sect f g)%type }.
   Definition qinv (A B : Type)
@@ -968,36 +968,8 @@ Section Book_4_6_i.
     reflexivity.
   Defined.
 
-  End OneUniverse.
-  Section TwoUniverses.
-
-  Context `{qua1 : QInv_Univalence_type, qua2 : QInv_Univalence_type}.
-  (** Now we use this to prove weak funext, which as we know implies (with dependent eta) also the strong dependent funext. *)
-
-  Theorem QInv_Univalence_implies_WeakFunext : WeakFunext.
-  Proof.
-    intros A P allcontr.
-    (** We are going to replace [P] with something simpler. *)
-    pose (U := (fun (_ : A) => Unit)).
-    assert (p : P = U).
-    - apply (@QInv_Univalence_implies_FunextNondep qua2).
-      intro x.
-      apply (@equiv_inv _ _ _ (isequiv_qinv (qua1 _ _))).
-      exact (qinv_isequiv (@equiv_contr_unit (P x) _)).
-    - rewrite p.
-      unfold U; simpl.
-      exists (fun _ => tt).
-      intro f.
-      apply (@QInv_Univalence_implies_FunextNondep qua2).
-      intro x.
-      destruct (@contr Unit _ (f x)).
-      reflexivity.
-  Qed.
-  End TwoUniverses.
-
-  Definition QInv_Univalence_type_implies_Funext_type
-             `{qua1 : QInv_Univalence_type, qua2 : QInv_Univalence_type} : Funext_type
-  := WeakFunext_implies_Funext (@QInv_Univalence_implies_WeakFunext qua1 qua2).
+  Definition QInv_Univalence_implies_Funext_type : Funext_type
+    := NaiveNondepFunext_implies_Funext QInv_Univalence_implies_FunextNondep.
 
 End Book_4_6_i.
 
@@ -1056,10 +1028,10 @@ End EquivFunctorFunextType.
 
 (** Using the Kraus-Sattler space of loops rather than the version in the book, since it is simpler and avoids use of propositional truncation. *)
 Definition Book_4_6_ii
-           (qua1 qua2 qua3 : QInv_Univalence_type)
+           (qua1 qua2 : QInv_Univalence_type)
   : ~ IsHProp (forall A : { X : Type & X = X }, A = A).
 Proof.
-  pose (fa := @QInv_Univalence_type_implies_Funext_type qua2 qua3).
+  pose (fa := @QInv_Univalence_implies_Funext_type qua2).
   intros H.
   pose (K := forall (X:Type) (p:X=X), { q : X=X & p @ q = q @ p }).
   assert (e : K <~> forall A : { X : Type & X = X }, A = A).
@@ -1096,9 +1068,9 @@ Proof.
   destruct p; cbn; reflexivity.
 Defined.
 
-Definition Book_4_6_iii (qua1 qua2 qua3 : QInv_Univalence_type) : Empty.
+Definition Book_4_6_iii (qua1 qua2 : QInv_Univalence_type) : Empty.
 Proof.
-  apply (Book_4_6_ii qua1 qua2 qua3).
+  apply (Book_4_6_ii qua1 qua2).
   refine (trunc_succ).
   exists (fun A => 1); intros u.
   set (B := {X : Type & X = X}) in *.

--- a/theories/Basics.v
+++ b/theories/Basics.v
@@ -6,4 +6,3 @@ Require Export Basics.Contractible.
 Require Export Basics.Equivalences.
 Require Export Basics.Trunc.
 Require Export Basics.Decidable.
-Require Export Basics.FunextVarieties.

--- a/theories/Basics/Contractible.v
+++ b/theories/Basics/Contractible.v
@@ -92,3 +92,9 @@ Defined.
 (** If the domain is contractible, the function is propositionally constant. *)
 Definition contr_dom_equiv {A B} (f : A -> B) `{Contr A} : forall x y : A, f x = f y
   := fun x y => ap f ((contr x)^ @ contr y).
+
+(** Any retract of a contractible type is contractible *)
+Definition contr_retract {X Y : Type} `{Contr X} 
+           (r : X -> Y) (s : Y -> X) (h : forall y, r (s y) = y)
+  : Contr Y
+  := BuildContr _ (r (center X)) (fun y => (ap r (contr _)) @ h _).

--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -307,6 +307,27 @@ Proof.
   intros ?; apply contr.
 Defined.
 
+(** The projection from the sum of a family of contractible types is an equivalence. *)
+Global Instance isequiv_pr1 {A : Type} (P : A -> Type) `{forall x, Contr (P x)}
+  : IsEquiv (@pr1 A P).
+Proof.
+  apply (BuildIsEquiv
+           _ _ (@pr1 A P)
+           (fun x => (x ; center (P x)))
+           (fun x => 1)
+           (fun xy => match xy with
+                      | existT x y => ap (exist _ x) (contr _)
+                      end)).
+  intros [x y].
+  rewrite <- ap_compose.
+  symmetry; apply ap_const.
+Defined.
+
+Definition equiv_pr1 {A : Type} (P : A -> Type) `{forall x, Contr (P x)}
+  : { x : A & P x } <~> A
+  := BuildEquiv _ _ (@pr1 A P) _.
+
+
 (** Assuming function extensionality, composing with an equivalence is itself an equivalence *)
 
 Global Instance isequiv_precompose `{Funext} {A B C : Type}

--- a/theories/HIT/IntervalImpliesFunext.v
+++ b/theories/HIT/IntervalImpliesFunext.v
@@ -2,7 +2,7 @@
 
 (** * Theorems about the homotopical interval. *)
 
-Require Import HoTT.Basics.
+Require Import HoTT.Basics FunextVarieties.
 Require Import HIT.Interval.
 
 (** ** From an interval type, we can prove function extensionality. *)

--- a/theories/HIT/TruncImpliesFunext.v
+++ b/theories/HIT/TruncImpliesFunext.v
@@ -2,7 +2,7 @@
 
 (** * Theorems about trunctions *)
 
-Require Import HoTT.Basics.
+Require Import HoTT.Basics FunextVarieties.
 Require Import HIT.Truncations HoTT.Types.Bool.
 
 (** ** We can construct an interval type as [Trunc -1 Bool] *)

--- a/theories/HoTT.v
+++ b/theories/HoTT.v
@@ -13,6 +13,7 @@ Require Export HProp.
 Require Export HSet.
 Require Export EquivGroupoids.
 Require Export EquivalenceVarieties.
+Require Export FunextVarieties.
 Require Export UnivalenceVarieties.
 Require Export Extensions.
 Require Export Misc.

--- a/theories/Idempotents.v
+++ b/theories/Idempotents.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 Require Import HoTT.Basics HoTT.Types.
-Require Import Fibrations UnivalenceImpliesFunext EquivalenceVarieties Constant.
+Require Import Fibrations FunextVarieties UnivalenceImpliesFunext EquivalenceVarieties Constant.
 Require Import HIT.Truncations.
 
 Local Open Scope nat_scope.
@@ -81,18 +81,8 @@ Proof.
 Defined.
 
 (** Retraction preserves contractibility **)
-Definition contr_retracttype {X : Type} (R : RetractOf X ) (contra : Contr X) : Contr (retract_type R ).
-Proof.
- simple refine (BuildContr _ _ _).
- - refine (retract_retr _ _).
-   exact (center X).
- - intro y.
-   simple refine (concat _ _).
-   + exact (retract_retr R (retract_sect R y)).
-   + refine (ap (retract_retr R) _).
-     * exact (contr _).
-   + exact (retract_issect R _).
-Defined.
+Definition contr_retracttype {X : Type} (R : RetractOf X ) (contra : Contr X) : Contr (retract_type R )
+  := contr_retract (retract_retr R) (retract_sect R) (retract_issect R).
 
 (** Like any record type, [RetractOf X] is equivalent to a nested sigma-type.  We use a product at one place in the middle, rather than a sigma, to simplify the next proof. *)
 Definition issig_retractof (X : Type)

--- a/theories/UnivalenceImpliesFunext.v
+++ b/theories/UnivalenceImpliesFunext.v
@@ -5,9 +5,12 @@ Generalizable All Variables.
 (** * Univalence Implies Functional Extensionality *)
 
 (** Here we prove that univalence implies function extensionality. *)
-
+Set Printing Universes.
 (** We define an axiom-free variant of [Univalence] *)
-Definition Univalence_type := forall (A B : Type), IsEquiv (equiv_path A B).
+Definition Univalence_type := forall (A B : Type@{i}), IsEquiv (equiv_path A B).
+
+(** Univalence is a property of a single universe; its statement lives in a higher universe *)
+Check Univalence_type@{i iplusone} : Type@{iplusone}.
 
 Section UnivalenceImpliesFunext.
   Context `{ua : Univalence_type}.
@@ -72,10 +75,9 @@ Section UnivalenceImpliesFunext.
         reflexivity.
   Defined.
 
-  Theorem Univalence_implies_FunextNondep (A B : Type)
-  : forall f g : A -> B, f == g -> f = g.
+  Theorem Univalence_implies_FunextNondep : NaiveNondepFunext.
   Proof.
-    intros f g p.
+    intros A B f g p.
     (** Consider the following maps. *)
     pose (d := fun x : A => existT (fun xy => fst xy = snd xy) (f x, f x) (idpath (f x))).
     pose (e := fun x : A => existT (fun xy => fst xy = snd xy) (f x, g x) (p x)).
@@ -88,36 +90,23 @@ Section UnivalenceImpliesFunext.
     apply H'.
     reflexivity.
   Defined.
+
 End UnivalenceImpliesFunext.
 
-Section UnivalenceImpliesWeakFunext.
-  Context `{ua1 : Univalence_type, ua2 : Univalence_type}.
-  (** Now we use this to prove weak funext, which as we know implies (with dependent eta) also the strong dependent funext. *)
+(** Note that only the codomain universe of [NaiveNondepFunext] is required to be univalent. *)
+Check @Univalence_implies_FunextNondep@{j jplusone i max j max}
+  : Univalence_type@{j jplusone} -> NaiveNondepFunext@{i j max}.
 
-  Theorem Univalence_implies_WeakFunext : WeakFunext.
-  Proof.
-    intros A P allcontr.
-    (** We are going to replace [P] with something simpler. *)
-    pose (U := (fun (_ : A) => Unit)).
-    assert (p : P = U).
-    - apply (@Univalence_implies_FunextNondep ua2).
-      intro x.
-      apply (@equiv_inv _ _ _ (ua1 _ _)).
-      apply equiv_contr_unit.
-    - (** Now this is much easier. *)
-      rewrite p.
-      unfold U; simpl.
-      exists (fun _ => tt).
-      intro f.
-      apply (@Univalence_implies_FunextNondep ua2).
-      intro x.
-      destruct (@contr Unit _ (f x)).
-      reflexivity.
-  Qed.
-End UnivalenceImpliesWeakFunext.
+(** Now we use this to prove strong dependent funext.  Again only the codomain universe must be univalent, but the domain universe must be no larger than it is.  Thus practically speaking this means that a univalent universe satisfies funext only for functions between two types in that same universe. *)
 
-Definition Univalence_type_implies_Funext_type `{ua1 : Univalence_type, ua2 : Univalence_type} : Funext_type
-  := WeakFunext_implies_Funext (@Univalence_implies_WeakFunext ua1 ua2).
+Definition Univalence_implies_WeakFunext : Univalence_type -> WeakFunext
+  := NaiveNondepFunext_implies_WeakFunext o @Univalence_implies_FunextNondep.
+
+Definition Univalence_type_implies_Funext_type
+           `{ua : Univalence_type@{j jplusone} }
+  : Funext_type@{i j j}
+  := NaiveNondepFunext_implies_Funext
+       (@Univalence_implies_FunextNondep ua).
 
 (** As justified by the above proof, we may assume [Univalence -> Funext]. *)
 Global Instance Univalence_implies_Funext `{Univalence} : Funext.

--- a/theories/UnivalenceImpliesFunext.v
+++ b/theories/UnivalenceImpliesFunext.v
@@ -1,4 +1,4 @@
-Require Import HoTT.Basics Types.Universe Types.Paths Types.Unit.
+Require Import HoTT.Basics Types.Universe Types.Paths Types.Unit FunextVarieties.
 
 Generalizable All Variables.
 


### PR DESCRIPTION
Martin Escardo pointed out that this fact is in Foundations.  But somehow it never made it into this library, and I wasn't even aware that it was known.

I had to move `FunextVarieties` out of `Basics` so that it can import `EquivalenceVarieties`, but this had no ill effects, just requires importing it explicitly in a few places.