### PR TITLE
Deduplicate notation for defining dependent pairs

### DIFF
--- a/theories/Classes/interfaces/canonical_names.v
+++ b/theories/Classes/interfaces/canonical_names.v
@@ -51,8 +51,6 @@ Class TrivialApart A {Aap : Apart A} :=
   { trivial_apart_prop :> is_mere_relation A apart
   ; trivial_apart : forall x y, x ≶ y <-> x <> y }.
 
-Notation "x ↾ p" := (exist _ x p) (at level 20) : mc_scope.
-
 Definition sig_apart `{Apart A} (P: A -> Type) : Apart (sig P) := fun x y => x.1 ≶ y.1.
 Hint Extern 10 (Apart (sig _)) => apply @sig_apart : typeclass_instances.
 

--- a/theories/Classes/interfaces/integers.v
+++ b/theories/Classes/interfaces/integers.v
@@ -25,13 +25,13 @@ Section specializable.
 
   Definition int_abs `{ia : IntAbs} (x : Z) : N :=
     match int_abs_sig x with
-    | inl (n↾_) => n
-    | inr (n↾_) => n
+    | inl (n;_) => n
+    | inr (n;_) => n
     end.
 
   Definition int_to_nat `{Zero N} `{ia : IntAbs} (x : Z) : N :=
     match int_abs_sig x with
-    | inl (n↾_) => n
-    | inr (n↾_) => 0
+    | inl (n;_) => n
+    | inr (n;_) => 0
     end.
 End specializable.

--- a/theories/Classes/interfaces/naturals.v
+++ b/theories/Classes/interfaces/naturals.v
@@ -22,6 +22,6 @@ Class NatDistance N `{Plus N}
                                    { z : N | (y + z = x)%mc }.
 Definition nat_distance `{nd : NatDistance N} (x y : N) :=
   match nat_distance_sig x y with
-  | inl (n↾_) => n
-  | inr (n↾_) => n
+  | inl (n;_) => n
+  | inr (n;_) => n
   end.

--- a/theories/Classes/theory/dec_fields.v
+++ b/theories/Classes/theory/dec_fields.v
@@ -196,7 +196,7 @@ Section is_field.
     apply trivial_apart. trivial.
   Qed.
 
-  Lemma dec_recip_correct (x : F) Px : / x = // x↾Px.
+  Lemma dec_recip_correct (x : F) Px : / x = // (x;Px).
   Proof.
   apply (left_cancellation_ne_0 (.*.) x).
   - apply trivial_apart. trivial.
@@ -275,7 +275,7 @@ Section morphisms.
   Qed.
 
   Lemma dec_recip_to_recip `{Field F2} `{!SemiRingStrongPreserving (f : F -> F2)}
-    x Pfx : f (/ x) = // (f x)↾Pfx.
+    x Pfx : f (/ x) = // (f x;Pfx).
   Proof.
   assert (x <> 0).
   - intros Ex.

--- a/theories/Classes/theory/fields.v
+++ b/theories/Classes/theory/fields.v
@@ -10,19 +10,19 @@ Context `{Field F}.
 
 (* Add Ring F : (stdlib_ring_theory F). *)
 
-Lemma reciperse_alt (x : F) Px : x // x↾Px = 1.
+Lemma reciperse_alt (x : F) Px : x // (x;Px) = 1.
 Proof.
-rewrite <-(recip_inverse (x↾Px)). trivial.
+rewrite <-(recip_inverse (x;Px)). trivial.
 Qed.
 
-Lemma recip_proper_alt x y Px Py : x = y -> // x↾Px = // y↾Py.
+Lemma recip_proper_alt x y Px Py : x = y -> // (x;Px) = // (y;Py).
 Proof.
 intro E. apply ap.
 apply Sigma.path_sigma with E.
 apply path_ishprop.
 Qed.
 
-Lemma recip_irrelevant x Px1 Px2 : // x↾Px1 = // x↾Px2.
+Lemma recip_irrelevant x Px1 Px2 : // (x;Px1) = // (x;Px2).
 Proof.
 apply recip_proper_alt. reflexivity.
 Qed.
@@ -79,7 +79,7 @@ Global Instance: forall z, PropHolds (z ≶ 0) -> StrongLeftCancellation (.*.) z
 Proof.
 intros z Ez x y E. red in Ez.
 rewrite !(commutativity z).
-apply (strong_extensionality (.* // z↾(Ez : (≶0) z))).
+apply (strong_extensionality (.* // (z;(Ez : (≶0) z)))).
 rewrite <-!simple_associativity, !reciperse_alt.
 rewrite !mult_1_r;trivial.
 Qed.
@@ -105,7 +105,7 @@ Instance mult_apart_zero x y :
   PropHolds (x ≶ 0) -> PropHolds (y ≶ 0) -> PropHolds (x * y ≶ 0).
 Proof.
 intros Ex Ey.
-apply (strong_extensionality (.* // y↾(Ey : (≶0) y))).
+apply (strong_extensionality (.* // (y;(Ey : (≶0) y)))).
 rewrite <-simple_associativity, reciperse_alt, mult_1_r, mult_0_l.
 trivial.
 Qed.
@@ -177,11 +177,11 @@ split; intro E.
 Qed.
 
 Lemma recip_distr_alt (x y : F) Px Py Pxy :
-  // (x * y)↾Pxy = // x↾Px * // y↾Py.
+  // (x * y ; Pxy) = // (x;Px) * // (y;Py).
 Proof.
 apply (left_cancellation_ne_0 (.*.) (x * y)).
 - apply apart_ne;trivial.
-- transitivity ((x // x↾Px) *  (y // y↾Py)).
+- transitivity ((x // (x;Px)) *  (y // (y;Py))).
   + rewrite 3!reciperse_alt,mult_1_r. reflexivity.
   + rewrite <-simple_associativity,<-simple_associativity.
     apply ap.
@@ -227,7 +227,7 @@ Section morphisms.
   solve_propholds.
   Qed.
 
-  Lemma preserves_recip x Px Pfx : f (// x↾Px) = // (f x)↾Pfx.
+  Lemma preserves_recip x Px Pfx : f (// (x;Px)) = // (f x;Pfx).
   Proof.
   apply (left_cancellation_ne_0 (.*.) (f x)).
   - apply apart_ne;trivial.


### PR DESCRIPTION
The Classes libray declares the notation (in `theories/Classes/interfaces/canonical_names.v`):
```coq
Notation "x ↾ p" := (exist _ x p) (at level 20) : mc_scope.
```
However, the HoTT library itself already has (in `theories/Basics/Overture.v`):
```coq
Notation "( x ; y )" := (existT _ x y) : fibration_scope.
```
(Note that we have `Notation existT := exist (only parsing).` in `coq/theories/Init/Specif.v`.)
This PR removes the declaration from Classes and replaces its usages with the one from the overture.