### PR TITLE
Show that `path_sigma_hprop` and `path_trunctype` are functorial.

### DIFF
--- a/theories/TruncType.v
+++ b/theories/TruncType.v
@@ -56,6 +56,41 @@ Proof.
   exact _.
 Defined.
 
+(** [path_trunctype] is functorial *)
+Definition path_trunctype_1 {n : trunc_index} {A : TruncType n}
+: path_trunctype (equiv_idmap A) = idpath.
+Proof.
+  unfold path_trunctype; simpl.
+  rewrite (eta_path_universe_uncurried 1).
+  rewrite path_sigma_hprop_1.
+  reflexivity.
+Defined.
+
+Definition path_trunctype_V {n : trunc_index} {A B : TruncType n}
+           (f : A <~> B)
+  : path_trunctype f^-1 = (path_trunctype f)^.
+Proof.
+  unfold path_trunctype; simpl.
+  rewrite path_universe_V_uncurried.
+  rewrite (path_sigma_hprop_V (path_universe_uncurried f)).
+  refine (concat_p1 _ @ concat_1p _ @ _).
+  refine (_ @ (ap inverse (concat_1p _))^ @ (ap inverse (concat_p1 _))^).
+  refine (ap_V _ _).
+Defined.
+
+Definition path_trunctype_pp {n : trunc_index} {A B C : TruncType n}
+           (f : A <~> B) (g : B <~> C)
+  : path_trunctype (g oE f) = path_trunctype f @ path_trunctype g.
+Proof.
+  unfold path_trunctype; simpl.
+  rewrite path_universe_compose_uncurried.
+  rewrite (path_sigma_hprop_pp _ _ _ (istrunc_trunctype_type B)).
+  refine (concat_p1 _ @ concat_1p _ @ _).
+  refine (_ @ (ap _ (concat_1p _))^ @ (ap _ (concat_p1 _))^).
+  refine (_ @ (ap (fun z => z @ _) (concat_1p _))^ @ (ap (fun z => z @ _) (concat_p1 _))^).
+  refine (ap_pp _ _ _).
+Defined.
+
 Definition path_hset {A B} := @path_trunctype 0 A B.
 Definition path_hprop {A B} := @path_trunctype -1 A B.
 

--- a/theories/TruncType.v
+++ b/theories/TruncType.v
@@ -64,7 +64,7 @@ Proof.
   rewrite (eta_path_universe_uncurried 1).
   rewrite path_sigma_hprop_1.
   reflexivity.
-Defined.
+Qed.
 
 Definition path_trunctype_V {n : trunc_index} {A B : TruncType n}
            (f : A <~> B)
@@ -76,7 +76,7 @@ Proof.
   refine (concat_p1 _ @ concat_1p _ @ _).
   refine (_ @ (ap inverse (concat_1p _))^ @ (ap inverse (concat_p1 _))^).
   refine (ap_V _ _).
-Defined.
+Qed.
 
 Definition path_trunctype_pp {n : trunc_index} {A B C : TruncType n}
            (f : A <~> B) (g : B <~> C)
@@ -89,7 +89,7 @@ Proof.
   refine (_ @ (ap _ (concat_1p _))^ @ (ap _ (concat_p1 _))^).
   refine (_ @ (ap (fun z => z @ _) (concat_1p _))^ @ (ap (fun z => z @ _) (concat_p1 _))^).
   refine (ap_pp _ _ _).
-Defined.
+Qed.
 
 Definition path_hset {A B} := @path_trunctype 0 A B.
 Definition path_hprop {A B} := @path_trunctype -1 A B.

--- a/theories/Types/Sigma.v
+++ b/theories/Types/Sigma.v
@@ -649,6 +649,8 @@ Definition isequiv_ap_pr1_hprop {A} {P : A -> Type}
 : IsEquiv (@ap _ _ (@pr1 A P) x y)
   := _.
 
+
+(** [path_sigma_hprop] is functorial *)
 Definition path_sigma_hprop_1 {A : Type} {P : A -> Type}
            `{forall x, IsHProp (P x)} (u : sigT P)
 : path_sigma_hprop u u 1 = 1.
@@ -658,6 +660,34 @@ Proof.
   (** Ugh *)
   refine (ap (fun p => match p in (_ = v2) return (u = (u.1; v2)) with 1 => 1 end)
              (contr (idpath u.2))).
+Defined.
+
+Definition path_sigma_hprop_V {A : Type} {P : A -> Type}
+           `{forall x, IsHProp (P x)} {a b : A} (p : a = b)
+           (x : P a) (y : P b)
+: path_sigma_hprop (b;y) (a;x) p^ = (path_sigma_hprop (a;x) (b;y) p)^.
+Proof.
+  destruct p; simpl.
+  rewrite (path_ishprop x y).
+  refine (path_sigma_hprop_1 _ @ (ap inverse (path_sigma_hprop_1 _))^).
+Defined.
+
+Definition path_sigma_hprop_pp
+           {A : Type}
+           {P : A -> Type}
+           `{forall x, IsHProp (P x)}
+           {a b c : A}
+           (p : a = b) (q : b = c)
+           (x : P a) (y : P b) (z : P c)
+: path_sigma_hprop (a;x) (c;z) (p @ q)
+    =
+  path_sigma_hprop (a;x) (b;y) p @ path_sigma_hprop (b;y) (c;z) q.
+Proof.
+  destruct p, q.
+  rewrite (path_ishprop y x).
+  rewrite (path_ishprop z x).
+  refine (_ @ (ap (fun z => z @ _) (path_sigma_hprop_1 _))^).
+  apply (concat_1p _)^.
 Defined.
 
 (** The inverse of [path_sigma_hprop] has its own name, so we give special names to the section and retraction homotopies to help [rewrite] out. *)

--- a/theories/Types/Sigma.v
+++ b/theories/Types/Sigma.v
@@ -670,7 +670,7 @@ Proof.
   destruct p; simpl.
   rewrite (path_ishprop x y).
   refine (path_sigma_hprop_1 _ @ (ap inverse (path_sigma_hprop_1 _))^).
-Defined.
+Qed.
 
 Definition path_sigma_hprop_pp
            {A : Type}
@@ -688,7 +688,7 @@ Proof.
   rewrite (path_ishprop z x).
   refine (_ @ (ap (fun z => z @ _) (path_sigma_hprop_1 _))^).
   apply (concat_1p _)^.
-Defined.
+Qed.
 
 (** The inverse of [path_sigma_hprop] has its own name, so we give special names to the section and retraction homotopies to help [rewrite] out. *)
 Definition path_sigma_hprop_ap_pr1 {A : Type} {P : A -> Type}

--- a/theories/Types/Universe.v
+++ b/theories/Types/Universe.v
@@ -103,6 +103,18 @@ Proof.
   intros x; reflexivity.
 Defined.
 
+Definition path_universe_compose_uncurried `{Funext} {A B C : Type}
+           (f : A <~> B) (g : B <~> C)
+: path_universe_uncurried (equiv_compose g f)
+= path_universe_uncurried f @ path_universe_uncurried g.
+Proof.
+  revert f. equiv_intro (equiv_path A B) f.
+  revert g. equiv_intro (equiv_path B C) g.
+  refine ((ap path_universe_uncurried (equiv_path_pp f g))^ @ _).
+  refine (eta_path_universe (f @ g) @ _).
+  apply concat2; symmetry; apply eta_path_universe.
+Defined.
+
 Definition path_universe_compose `{Funext} {A B C : Type}
            (f : A <~> B) (g : B <~> C)
 : path_universe (g o f) = path_universe f @ path_universe g.


### PR DESCRIPTION
We've used these properties in another development, but they seemed general enough to me.
I don't think those are mentioned in the HoTT book necessarily, though.
I tried to implement it without rewrites, but failed to do so in a number of cases, don't know if that's important.