### PR TITLE
Drop support for Coq 8.8 in preparation for 8.9

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,11 @@
 [submodule "coq-HoTT"]
 	path = coq-HoTT
 	url = https://github.com/coq/coq.git
-	branch = master
+	branch = v8.8
 [submodule "etc/coq-scripts"]
 	path = etc/coq-scripts
 	url = https://github.com/JasonGross/coq-scripts.git
 [submodule "etc/coq-dpdgraph"]
 	path = etc/coq-dpdgraph
 	url = https://github.com/Karmaki/coq-dpdgraph.git
-	branch = coq-trunk
+	branch = coq-v8.8

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,11 @@
 [submodule "coq-HoTT"]
 	path = coq-HoTT
 	url = https://github.com/coq/coq.git
-	branch = v8.8
+	branch = master
 [submodule "etc/coq-scripts"]
 	path = etc/coq-scripts
 	url = https://github.com/JasonGross/coq-scripts.git
 [submodule "etc/coq-dpdgraph"]
 	path = etc/coq-dpdgraph
 	url = https://github.com/Karmaki/coq-dpdgraph.git
-	branch = coq-v8.8
+	branch = coq-master

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,6 @@ env:
    - UPDATE_HTML="yes"       WITH_AUTORECONF="yes"
    - VALIDATE="yes"
    - FORCE_COQ_VERSION=""       BUILD_COQ="yes" WITH_AUTORECONF="yes"
-   - FORCE_COQ_VERSION="v8.8"   BUILD_COQ="yes" WITH_AUTORECONF="yes"
    - FORCE_COQ_VERSION="master" BUILD_COQ="yes" WITH_AUTORECONF="yes"
 
  global:
@@ -60,7 +59,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: VALIDATE="yes"
-    - FORCE_COQ_VERSION="master" BUILD_COQ="yes" WITH_AUTORECONF="yes"
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: VALIDATE="yes"
+    - FORCE_COQ_VERSION="master" BUILD_COQ="yes" WITH_AUTORECONF="yes"
 
 
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@
 
 After installing Coq via opam [1]. One can install our version of Coq by:
 ```
-   opam install coq-hott
+   opam install coq.8.8.0
 ```
 
 However, one still needs to install the library via git to contribute.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,7 +9,7 @@ However, one still needs to install the library via git to contribute.
 Opam support on windows is experimental.
 [1]: https://coq.inria.fr/opam/www/using.html
 
-We are compatible with [Coq 8.8](https://github.com/coq/coq/releases/tag/V8.8.0), so binary packages can be used. Paths still need to be set manually.
+We will be compatible with [Coq 8.9](https://github.com/coq/coq/releases/tag/V8.9.0), so binary packages can be used once it is released.  Until then, the development version of Coq must be installed. Either way, paths still need to be set manually.
 
 
 # QUICK INSTALLATION INSTRUCTIONS

--- a/etc/ci/before_script.sh
+++ b/etc/ci/before_script.sh
@@ -9,7 +9,7 @@ pushd "$DIR" 1>/dev/null
 
 if [ -z "$BUILD_COQ" ]
 then
-    sudo add-apt-repository -y ppa:jgross-h/coq-8.8-daily
+    sudo add-apt-repository -y ppa:jgross-h/coq-master-daily
     sudo apt-get update
 fi
 # (un)install autoreconf

--- a/etc/ci/before_script.sh
+++ b/etc/ci/before_script.sh
@@ -9,7 +9,7 @@ pushd "$DIR" 1>/dev/null
 
 if [ -z "$BUILD_COQ" ]
 then
-    sudo add-apt-repository -y ppa:jgross-h/coq-master-daily
+    sudo add-apt-repository -y ppa:jgross-h/coq-8.8-daily
     sudo apt-get update
 fi
 # (un)install autoreconf


### PR DESCRIPTION
We bump the versions of the dpdgraph and coq submodules, and tell travis
to stop checking 8.8 in preparation for numeral notations landing in
Coq.  This will allow us to merge #945
quickly once numeral notations lands.

On top of #952.  It'd be nice to get #952 and this PR merged quickly, so I can tag V8.8, and then get the necessary approving reviews on #945 so that it can be merged in sync with https://github.com/coq/coq/pull/8064 (which is basically ready to be merged).