### PR TITLE
Delete erroneously committed SearchAbout command

### DIFF
--- a/theories/BoundedSearch.v
+++ b/theories/BoundedSearch.v
@@ -98,7 +98,6 @@ Section bounded_search.
 
   Local Definition prop_n_to_min_n : min_n_Type.
   Proof.
-    SearchAbout (merely).
     refine (Trunc_rec _ P_inhab).
     - exact ishpropmin_n.
     - induction 1 as [n Pn]. exact (n_to_min_n n Pn).


### PR DESCRIPTION
Added by mistake in 949cdcc. Spotted by @co-dan.