### PR TITLE
Adapt to coq/coq#8820

### DIFF
--- a/theories/Categories/InitialTerminalCategory/Functors.v
+++ b/theories/Categories/InitialTerminalCategory/Functors.v
@@ -98,7 +98,7 @@ Section unique.
     := fun P x => initial_category_ind P (F x).
 
   Global Instance trunc_terminal_category
-         `{@IsTerminalCategory one H0 H1}
+         `{@IsTerminalCategory one H1 H2}
   : Contr (Functor C one).
   Proof.
     refine (BuildContr _ (to_terminal C) _).

--- a/theories/Categories/InitialTerminalCategory/NaturalTransformations.v
+++ b/theories/Categories/InitialTerminalCategory/NaturalTransformations.v
@@ -43,7 +43,7 @@ Section NaturalTransformations.
     := trunc_from_initial F G.
 
   Definition to_terminal
-             `{@IsTerminalCategory one H0 H1} (F G : Functor C one)
+             `{@IsTerminalCategory one H1 H2} (F G : Functor C one)
   : NaturalTransformation F G
     := Build_NaturalTransformation
          F G
@@ -52,7 +52,7 @@ Section NaturalTransformations.
 
   Global Instance trunc_to_terminal
          `{Funext}
-         `{@IsTerminalCategory one H0 H1} (F G : Functor C one)
+         `{@IsTerminalCategory one H1 H2} (F G : Functor C one)
   : Contr (NaturalTransformation F G).
   Proof.
     refine (BuildContr _ (to_terminal F G) _).

--- a/theories/Tactics/EquivalenceInduction.v
+++ b/theories/Tactics/EquivalenceInduction.v
@@ -258,7 +258,7 @@ End equiv_transfer.
 Section equiv.
   Global Instance equiv_respects_equivalenceL `{Funext} {A} {P Q : forall B, (A <~> B) -> Type}
          `{HP : RespectsEquivalenceL A P}
-         `{HP : RespectsEquivalenceL A Q}
+         `{HQ : RespectsEquivalenceL A Q}
   : RespectsEquivalenceL A (fun B e => P B e <~> Q B e).
   Proof.
     simple refine (fun B e => _; fun _ => _).
@@ -269,7 +269,7 @@ Section equiv.
 
   Global Instance equiv_respects_equivalenceR `{Funext} {A} {P Q : forall B, (B <~> A) -> Type}
          `{HP : RespectsEquivalenceR A P}
-         `{HP : RespectsEquivalenceR A Q}
+         `{HQ : RespectsEquivalenceR A Q}
   : RespectsEquivalenceR A (fun B e => P B e <~> Q B e).
   Proof.
     simple refine (fun B e => _; fun _ => _).


### PR DESCRIPTION
Adds compatibility with coq/coq#8820.
`EquivalenceInduction.v` had two premises named `HP`.
The changes in `InitialTerminalCategory/` are to avoid coq/coq#8819.