### PR TITLE
Cantor's theorem, k-small categories and power objects

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -414,3 +414,6 @@ theories/Classes/tests/ring_tac.v
 contrib/HoTTBook.v
 contrib/HoTTBookExercises.v
 contrib/Freudenthal.v
+
+contrib/Powers.v
+contrib/SmallCategory.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -416,4 +416,3 @@ contrib/HoTTBookExercises.v
 contrib/Freudenthal.v
 
 contrib/Powers.v
-contrib/SmallCategory.v

--- a/contrib/FixPoint.v
+++ b/contrib/FixPoint.v
@@ -1,0 +1,62 @@
+Require Import Basics.Overture.
+Require Import Types.Bool.
+Require Import HProp.
+
+Require Import Basics.Trunc. (* IsEmbedding *)
+Require Import HIT.Truncations. (* IsSurjection *)
+
+Import TrM.
+
+Lemma isSur2 {A B} {f : A -> B} {sur : IsSurjection f} :
+  forall y, exists x, f x = y.
+Proof.
+  intro.
+  destruct (sur y) as [c d].
+  set (c' := c).
+  apply (untrunc_istrunc) in c'.
+  + apply c'.
+Admitted.
+
+Section Lawvere.
+
+  Context {A B : Type}.
+
+
+(** 
+    Lawveres theorem
+    If there is an onto map e : A -> B^A then every f : B -> B has 
+    a fixed point.
+**)
+
+  Theorem Lawvere (e : A -> (A -> B)) {sur : IsSurjection e} 
+    : forall (f : B -> B), exists x, f x = x.
+  Proof.
+    intro f.
+    set (sur2 := isSur2 e).
+    destruct (isSur2 (fun x => f (e x x))) as [y p].
+    refine (e y y; _).
+    set (foo := f (e y y)).
+    rewrite p. unfold foo. reflexivity.
+  Admitted.
+
+End Lawvere.
+
+Section Cantor.
+  Context {A : Type}.
+
+  Lemma negb_not_fixed : not (exists x, negb x = x).
+  Proof.
+    intro.
+    destruct X as [x p].
+    revert p. 
+    apply (not_fixed_negb x).
+  Qed.
+
+  Corollary cantor (f : A -> (A -> Bool)) :  not (IsSurjection f).
+  Proof.
+    intro X.
+    pose ((@Lawvere _ _ f X negb)) as bar.
+    apply (negb_not_fixed bar).
+  Qed.
+
+End Cantor.

--- a/contrib/Powers.v
+++ b/contrib/Powers.v
@@ -1,0 +1,45 @@
+Require Import Basics.
+Require Import Category.Core.
+Require Import Functor.Core.
+Require Import Functor.Composition.Core.
+Require Import Limits.Core.
+Require Import Limits.Functors.
+Require Import FunctorCategory.Core.
+Require Import Adjoint.Core.
+Require Import InitialTerminalCategory.Core NatCategory.
+Require Import Comma.Core.
+Require Import DiscreteCategory.
+
+Set Universe Polymorphism.
+Set Implicit Arguments.
+Generalizable All Variables.
+Set Asymmetric Patterns.
+
+
+(**
+  Power limit and copower colimit in a category
+**)
+
+Section powers.
+
+Local Open Scope category_scope.
+Local Open Scope functor_scope.
+
+Context {C : PreCategory}.
+
+Context `{Funext}.
+
+Variables I : hSet.
+
+Definition I_cat := discrete_category I.
+
+Context `(has_limits
+              : forall (F : Functor I_cat C),
+                  @IsLimit _ C I_cat F (limits F)).
+
+Definition PowerFunctor : Functor C C :=
+   ExponentialLaws.Law1.Functors.functor _ 
+   o limit_functor has_limits 
+   o diagonal_functor' C I_cat.
+
+End powers.

--- a/contrib/Powers.v
+++ b/contrib/Powers.v
@@ -20,36 +20,34 @@ Set Asymmetric Patterns.
   Power limit and copower colimit in a category
 **)
 
-Section powers.
+Section Powers.
+  Context `{Funext}.
 
-Local Open Scope category_scope.
-Local Open Scope functor_scope.
+  Local Open Scope category_scope.
+  Local Open Scope functor_scope.
 
-Context {C : PreCategory}.
+  Context {C : PreCategory}.
+  Context (I : hSet).
 
-Context `{Funext}.
+  Notation I_cat := (discrete_category I).
 
-Variables I : hSet.
+  Context `(has_limits : forall (F : Functor I_cat C),
+              @IsLimit _ C I_cat F (limits F)).
 
-Definition I_cat := discrete_category I.
+  Definition PowerFunctor : Functor C C :=
+     ExponentialLaws.Law1.Functors.functor _
+     o limit_functor has_limits 
+     o diagonal_functor' C I_cat.
 
-Context `(has_limits
-              : forall (F : Functor I_cat C),
-                  @IsLimit _ C I_cat F (limits F)).
+  Local Open Scope functor_scope.
 
-Definition PowerFunctor : Functor C C :=
-   ExponentialLaws.Law1.Functors.functor _ 
-   o limit_functor has_limits 
-   o diagonal_functor' C I_cat.
 
-Local Open Scope functor_scope.
-
-Theorem foo (x y : C) 
-  : (morphism _ x (PowerFunctor y)) <~> forall (i : I), (morphism _ x y).
-Proof.
-  serapply (equiv_adjointify).
-  + intro h. simpl in h.
-Admitted.
+  Theorem foo (x y : C) 
+    : (morphism _ x (PowerFunctor y)) <~> forall (i : I), (morphism _ x y).
+  Proof.
+    serapply (equiv_adjointify).
+    + intro h. simpl in h.
+  Admitted.
 
 
 End powers.

--- a/contrib/Powers.v
+++ b/contrib/Powers.v
@@ -50,7 +50,7 @@ Section Powers.
   Admitted.
 
 
-End powers.
+End Powers.
 
 
 

--- a/contrib/Powers.v
+++ b/contrib/Powers.v
@@ -42,4 +42,19 @@ Definition PowerFunctor : Functor C C :=
    o limit_functor has_limits 
    o diagonal_functor' C I_cat.
 
+Local Open Scope functor_scope.
+
+Theorem foo (x y : C) 
+  : (morphism _ x (PowerFunctor y)) <~> forall (i : I), (morphism _ x y).
+Proof.
+  serapply (equiv_adjointify).
+  + intro h. simpl in h.
+Admitted.
+
+
 End powers.
+
+
+
+
+

--- a/contrib/SmallCategory.v
+++ b/contrib/SmallCategory.v
@@ -77,18 +77,6 @@ Record ThinCat := {
   thin : IsThinCat thin_cat;
 }.
 
-Lemma exp_card_leq `{Univalence} {a b : Card} (e : leq_card a b) (c : Card) 
-  : leq_card (exp_card c a) (exp_card c b).
-  Proof.
-    revert e; strip_truncations.
-    intro; strip_truncations; apply tr.
-    induction e as [e_i e_isinj].
-    srefine (fun f => e_i o f; _).
-    intros f g h; apply path_forall.
-    intro x; apply e_isinj.
-    apply (ap10 h).
-  Defined.
-
 Section Freyd.
   Context `{Univalence}.
   Context `{ExcludedMiddle}.

--- a/contrib/SmallCategory.v
+++ b/contrib/SmallCategory.v
@@ -4,7 +4,7 @@ Require Import Functor.
 Require Import Limits.Core.
 Require Import Spaces.Card.
 Require Import HIT.Truncations.
-
+Require Import ExcludedMiddle.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.
@@ -65,6 +65,7 @@ Record ThinCat := {
 Section freyd.
 
 Context `{Univalence}.
+Context `{ExcludedMiddle}.
 
 (**
   Prop 3.7.3 Category theory in context, Riehl
@@ -83,9 +84,9 @@ Context `{Univalence}.
  
  **)
 
-Proposition Freyd_preorder_limit (k : Card) (C : kSmallCategory k) 
-  {h : HaskLimits k C} 
-  : IsThin C.
+Proposition Freyd_preorder_limit 
+  (k : Card) (C : kSmallCategory k) {h : HaskLimits k C} : 
+    IsThin C.
 Proof.
   remember (CatCard C) as l eqn:p.
   intros X Y f g; srapply (BuildContr).

--- a/contrib/SmallCategory.v
+++ b/contrib/SmallCategory.v
@@ -1,0 +1,95 @@
+Require Import HoTT.Basics HoTT.Types.
+Require Import Category.Core Category.Strict.
+Require Import Functor.
+Require Import Limits.Core.
+Require Import Spaces.Card.
+Require Import HIT.Truncations.
+
+
+Set Universe Polymorphism.
+Set Implicit Arguments.
+Generalizable All Variables.
+Set Asymmetric Patterns.
+
+Section Small_Category.
+
+Context `{Univalence}.
+
+(* A small category is a strict category *)
+
+(* Cardinality of a small category *)
+Definition CatCard (C : StrictCategory) : Card := 
+  tr (BuildhSet (exists (X Y : C), C.(morphism) X Y)).
+
+(* A k-small category is a small category with object set 
+   cardinality less than k *)
+Definition IsSmall (k : Card) (C : StrictCategory): hProp :=
+  leq_card (CatCard C) k.
+
+Record kSmallCategory (k : Card) := {
+  C :> StrictCategory;
+  k_small : IsSmall k C
+}.
+
+Context {C : PreCategory}.
+Context {strc : IsStrictCategory C}.
+
+Definition DiagramIskSmall {D : PreCategory} (k : Card) (F : Functor C D) : hProp
+ := IsSmall k (Build_StrictCategory C strc).
+
+Record kSmallDiagram (k : Card) (D : PreCategory) := {
+  F :> Functor C D;
+  isks : DiagramIskSmall k F
+}.
+
+(** k-Completeness **)
+Definition HaskLimits (k : Card) (D : PreCategory) := 
+  forall (F : kSmallDiagram k D), exists L, @IsLimit _ D C F L.
+
+(** k-Cocompleteness **)
+Definition HaskColimits (k : Card) (D : PreCategory) :=
+  forall (F : kSmallDiagram k D), exists L, @IsColimit _ D C F L.
+
+End Small_Category.
+
+Definition IsThin (C : PreCategory) :=
+  forall (x y : C), IsHProp(C.(morphism) x y).
+
+Record ThinCat := {
+  thin_cat :> StrictCategory;
+  thin : IsThin thin_cat;
+}.
+
+
+
+Section freyd.
+
+Context `{Univalence}.
+
+(**
+  Prop 3.7.3 Category theory in context, Riehl
+
+  Any k-small category C that admits all k-small limits or all k-small 
+  colimits is a preorder.
+
+  Preorder means is a thin category.
+
+  Assume there are two parallel non-equal morphisms f,g : X -> Y in C,
+  then |C(X,Y)| >= 2. Let l be the cardinality of C, then we have
+  |C(X,Y)|^l = |C(X,Y^l)| >= 2^l where Y^l is the power object indexed
+  by l. However this is absurd since by Cantor's theorem 2^l > l = |Mor C|.
+  And C(X,Y^l) is a subset of Mor C. Considering copowers gives a dual 
+  construction for the second part.
+ 
+ **)
+
+Proposition Freyd_preorder_limit (k : Card) (C : kSmallCategory k) 
+  {h : HaskLimits k C} 
+  : IsThin C.
+Proof.
+  remember (CatCard C) as l eqn:p.
+  intros X Y f g; srapply (BuildContr).
+  + pose (ab := (f <> g)).
+Admitted.
+
+End freyd.

--- a/contrib/SmallCategory.v
+++ b/contrib/SmallCategory.v
@@ -24,7 +24,7 @@ Definition CatCard (C : StrictCategory) : Card :=
 (* A k-small category is a small category with object set 
    cardinality less than k *)
 Definition IsSmall (k : Card) (C : StrictCategory): hProp :=
-  leq_card (CatCard C) k.
+  lt_card (CatCard C) k.
 
 Record kSmallCategory (k : Card) := {
   C :> StrictCategory;

--- a/contrib/SmallCategory.v
+++ b/contrib/SmallCategory.v
@@ -126,7 +126,7 @@ Section Freyd.
     intros x y f g.
     srapply (BuildContr).
     + destruct (LEM (f = g)).
-      * admit.
+      * compute; apply ((C.(trunc_morphism) x y) f g). 
       * apply p.
       * set (s := exp_card_leq (@bool_leq_at_least_two _ _ f g n) l).
         admit.

--- a/contrib/SmallCategory.v
+++ b/contrib/SmallCategory.v
@@ -25,15 +25,20 @@ Set Asymmetric Patterns.
 
 
 Section Small_Category.
-
   Context `{Univalence}.
 
   (* A small category is a strict category *)
   Context (C : PreCategory).
   Context `{IsStrictCategory C}.
 
+  (* Type of morphisms of a category *)
+  Definition Morphisms := { X : C & { Y : C & morphism _ X Y } }.
+
+  (* Set of morphisms of a strict category *)
+  Definition MorphismSet := BuildhSet Morphisms.
+
   (* Cardinality of a small category *)
-  Definition CatCard : Card := tr (BuildhSet {X:C & {Y:C & morphism _ X Y }}).
+  Definition CatCard : Card := tr MorphismSet.
 
   Context (k : Card).
 
@@ -77,10 +82,6 @@ Record ThinCat := {
   thin : IsThinCat thin_cat;
 }.
 
-Section Freyd.
-  Context `{Univalence}.
-  Context `{ExcludedMiddle}.
-
 (**
   Prop 3.7.3 Category theory in context, Riehl
 
@@ -95,18 +96,19 @@ Section Freyd.
   by l. However this is absurd since by Cantor's theorem 2^l > l = |Mor C|.
   And C(X,Y^l) is a subset of Mor C. Considering copowers gives a dual 
   construction for the second part.
- 
+
  **)
 
+Section FreydTheorem.
+  Context `{Univalence}.
+  Context `{ExcludedMiddle}.
 
   Context (C : PreCategory).
   Context `{IsStrictCategory C}.
-
   Context (k : Card).
   Context `{IskSmall C k}.
-  Context {h : kComplete _ k C}.
 
-  Theorem Freyd : IsThinCat C.
+  Theorem Freyd {h : kComplete _ k C} : IsThinCat C.
   Proof.
     set (l := CatCard C).
     intros x y f g.
@@ -114,8 +116,23 @@ Section Freyd.
     + destruct (LEM (f = g)).
       * compute; apply ((C.(trunc_morphism) x y) f g). 
       * apply p.
-      * set (s := exp_card_leq (@bool_leq_at_least_two _ _ f g n) l).
-        admit.
+      * admit.
+    + intro. destruct y0. compute.
   Admitted.
 
-End Freyd.
+  Theorem CoFreyd {h : kCoComplete _ k C} : IsThinCat C.
+  Proof.
+    set (l := CatCard C).
+    intros x y f g.
+    srapply (BuildContr).
+    + destruct (LEM (f = g)).
+      * compute; apply ((C.(trunc_morphism) x y) f g). 
+      * apply p.
+      * admit.
+    + intro. destruct y0. compute.
+  Admitted.
+
+End FreydTheorem.
+
+(* set (s := exp_card_leq (@bool_leq_at_least_two _ _ f g n) l). *)
+

--- a/contrib/SmallCategory.v
+++ b/contrib/SmallCategory.v
@@ -1,16 +1,22 @@
 Require Import Basics.Overture.
 Require Import Basics.Trunc.
+Require Import Basics.PathGroupoids.
 
 Require Import Types.Universe.
+Require Import Types.Paths.
+Require Import Types.Sigma.
+
 Require Import ExcludedMiddle.
+Require Import Spaces.Card.
+Require Import HIT.Truncations.
+Require Import HSet.
 
 Require Import Category.Core.
 Require Import Category.Strict.
 Require Import Functor.Core.
 Require Import Limits.Core.
 
-Require Import Spaces.Card.
-Require Import HIT.Truncations.
+Import TrM.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.
@@ -71,6 +77,20 @@ Record ThinCat := {
   thin : IsThinCat thin_cat;
 }.
 
+Lemma exp_card_leq `{Univalence} {a b : Card} (e : leq_card a b) (c : Card) :
+    leq_card (exp_card c a) (exp_card c b).
+  Proof.
+    revert e; strip_truncations.
+    intro; strip_truncations.
+    apply tr; simpl in *.
+    induction e as [e_i e_isinj].
+    srefine (_; _); simpl.
+    + refine (fun f => e_i o f).
+    + unfold isinj in e_isinj.
+      intros f g. intro.
+      simpl. unfold isinj.
+    Admitted.
+    
 Section Freyd.
   Context `{Univalence}.
   Context `{ExcludedMiddle}.
@@ -99,11 +119,6 @@ Section Freyd.
   Context (k : Card).
   Context `{IskSmall C k}.
   Context {h : kComplete _ k C}.
-
-  Lemma exp_card_leq {a b : Card} (e : leq_card a b) (c : Card) :
-    leq_card (exp_card a c) (exp_card b c).
-  Proof. Admitted.
-
 
   Theorem Freyd : IsThinCat C.
   Proof.

--- a/contrib/SmallCategory.v
+++ b/contrib/SmallCategory.v
@@ -77,20 +77,18 @@ Record ThinCat := {
   thin : IsThinCat thin_cat;
 }.
 
-Lemma exp_card_leq `{Univalence} {a b : Card} (e : leq_card a b) (c : Card) :
-    leq_card (exp_card c a) (exp_card c b).
+Lemma exp_card_leq `{Univalence} {a b : Card} (e : leq_card a b) (c : Card) 
+  : leq_card (exp_card c a) (exp_card c b).
   Proof.
     revert e; strip_truncations.
-    intro; strip_truncations.
-    apply tr; simpl in *.
+    intro; strip_truncations; apply tr.
     induction e as [e_i e_isinj].
-    srefine (_; _); simpl.
-    + refine (fun f => e_i o f).
-    + unfold isinj in e_isinj.
-      intros f g. intro.
-      simpl. unfold isinj.
-    Admitted.
-    
+    srefine (fun f => e_i o f; _).
+    intros f g h; apply path_forall.
+    intro x; apply e_isinj.
+    apply (ap10 h).
+  Defined.
+
 Section Freyd.
   Context `{Univalence}.
   Context `{ExcludedMiddle}.

--- a/theories/HSet.v
+++ b/theories/HSet.v
@@ -3,7 +3,7 @@
 
 Require Import HoTT.Basics.
 Require Import Types.Paths Types.Sigma Types.Empty Types.Record Types.Unit Types.Arrow HProp.
-
+Require Import Types.Bool.
 
 Local Open Scope path_scope.
 
@@ -161,3 +161,39 @@ Proof.
     * apply ap. apply H'.
     * by rewrite eissect.
 Qed.
+
+Section Lawvere.
+
+(* I should probably use ISSurjective from HIT/Truncations.v *)
+Definition issur {X Y} (f : X -> Y)
+  := forall y : Y, exists x : X,
+        f x = y.
+
+(* fixed points of a function *)
+Definition fixed {X} (f : X -> X) := exists x, f x = x.
+
+Context {A B : Type}.
+
+(** 
+    Lawveres theorem 
+
+    If there is an onto map e : A -> B^A then every f : B -> B has 
+    a fixed point.
+**)
+(*TODO: RENAME
+
+  Do rewriting at end properly.
+*)
+Theorem Lawvere (e : A -> (A -> B)) {sur : issur e} 
+  : forall (f : B -> B), fixed f.
+Proof.
+  intro.
+  set (s := fun x => f (e x x)).
+  unfold issur in sur.
+  destruct (sur s) as [y p].
+  refine (e y y; _).
+  set (foo := f (e y y)).
+  rewrite p; reflexivity.
+Qed.
+
+End Lawvere.

--- a/theories/HSet.v
+++ b/theories/HSet.v
@@ -197,3 +197,23 @@ Proof.
 Qed.
 
 End Lawvere.
+
+Section Cantor.
+  Context {A B : hSet}.
+
+  Lemma negb_not_fixed : not (fixed negb).
+  Proof.
+    intro.
+    destruct X as [x p].
+    revert p. 
+    apply (not_fixed_negb x).
+  Qed.
+
+  Corollary cantor (f : A -> (A -> Bool)) :  not (issur f).
+  Proof.
+    intro X.
+    pose ((@Lawvere _ _ f X negb)) as bar.
+    apply (negb_not_fixed bar).
+  Qed.
+
+End Cantor.

--- a/theories/HSet.v
+++ b/theories/HSet.v
@@ -112,10 +112,6 @@ Definition isinj {X Y} (f : X -> Y)
   := forall x0 x1 : X,
        f x0 = f x1 -> x0 = x1.
 
-Definition issur {X Y} (f : X -> Y)
-  := forall y : Y, exists x : X,
-        f x = y.
-
 Lemma isinj_embedding {A B : Type} (m : A -> B) : IsEmbedding m -> isinj m.
 Proof.
   intros ise x y p.

--- a/theories/HSet.v
+++ b/theories/HSet.v
@@ -2,8 +2,9 @@
 (** * H-Sets *)
 
 Require Import HoTT.Basics.
-Require Import Types.Paths Types.Sigma Types.Empty Types.Record Types.Unit Types.Arrow HProp.
-Require Import Types.Bool.
+Require Import Types.Paths Types.Sigma Types.Unit Types.Arrow.
+Require Import Types.Empty Types.Record Types.Bool.
+Require Import HProp.
 
 Local Open Scope path_scope.
 
@@ -111,6 +112,10 @@ Definition isinj {X Y} (f : X -> Y)
   := forall x0 x1 : X,
        f x0 = f x1 -> x0 = x1.
 
+Definition issur {X Y} (f : X -> Y)
+  := forall y : Y, exists x : X,
+        f x = y.
+
 Lemma isinj_embedding {A B : Type} (m : A -> B) : IsEmbedding m -> isinj m.
 Proof.
   intros ise x y p.
@@ -161,59 +166,3 @@ Proof.
     * apply ap. apply H'.
     * by rewrite eissect.
 Qed.
-
-Section Lawvere.
-
-(* I should probably use ISSurjective from HIT/Truncations.v *)
-Definition issur {X Y} (f : X -> Y)
-  := forall y : Y, exists x : X,
-        f x = y.
-
-(* fixed points of a function *)
-Definition fixed {X} (f : X -> X) := exists x, f x = x.
-
-Context {A B : Type}.
-
-(** 
-    Lawveres theorem 
-
-    If there is an onto map e : A -> B^A then every f : B -> B has 
-    a fixed point.
-**)
-(*TODO: RENAME
-
-  Do rewriting at end properly.
-*)
-Theorem Lawvere (e : A -> (A -> B)) {sur : issur e} 
-  : forall (f : B -> B), fixed f.
-Proof.
-  intro.
-  set (s := fun x => f (e x x)).
-  unfold issur in sur.
-  destruct (sur s) as [y p].
-  refine (e y y; _).
-  set (foo := f (e y y)).
-  rewrite p; reflexivity.
-Qed.
-
-End Lawvere.
-
-Section Cantor.
-  Context {A B : hSet}.
-
-  Lemma negb_not_fixed : not (fixed negb).
-  Proof.
-    intro.
-    destruct X as [x p].
-    revert p. 
-    apply (not_fixed_negb x).
-  Qed.
-
-  Corollary cantor (f : A -> (A -> Bool)) :  not (issur f).
-  Proof.
-    intro X.
-    pose ((@Lawvere _ _ f X negb)) as bar.
-    apply (negb_not_fixed bar).
-  Qed.
-
-End Cantor.

--- a/theories/Spaces/Card.v
+++ b/theories/Spaces/Card.v
@@ -145,13 +145,13 @@ Section contents.
     lt_card a (exp_card a two_card).
   Proof.
     strip_truncations; split; simpl.
-    + srapply (@tr -1); srefine (_ ; _).
-      - intros x y. destruct a as [a is_a].
-        remember (LEM (x = y) _) as cases eqn:p.
-        refine (match cases with
-                  | inl _ => true
-                  | inr _ => false end).
-      - simpl. intros x y.
+    + serapply (tr ( _ ; _ )).
+      - intros x y.
+        set (cases:= LEM (x = y) _).
+        destruct cases as [p|q].
+        * refine true.
+        * refine false.
+      - intros x y.
         intros e; apply ap10 in e; specialize (e x); cbn in e.
         set (cases1 := LEM (x = x) _) in *.
         set (cases2 := LEM (y = x) _) in *.
@@ -160,7 +160,7 @@ Section contents.
         * elim (true_ne_false e).
         * elim (false_ne_true e).
         * elim (q1 idpath).
-    + apply cand_ne_exp_two_card.
+    + apply card_ne_exp_two_card.
   Defined.
 
   (** *** Properties of ≤ *)

--- a/theories/Spaces/Card.v
+++ b/theories/Spaces/Card.v
@@ -149,6 +149,18 @@ Section contents.
     exp_card c (a * b) = (exp_card c a) * (exp_card c b).
   Proof. reduce. symmetry. apply equiv_prod_coind. Defined.
 
+  Lemma exp_card_leq `{Univalence} {a b : Card} (e : leq_card a b) (c : Card) 
+    : leq_card (exp_card c a) (exp_card c b).
+  Proof.
+    revert e; strip_truncations.
+    intro; strip_truncations; apply tr.
+    induction e as [e_i e_isinj].
+    srefine (fun f => e_i o f; _).
+    intros f g h; apply path_forall.
+    intro x; apply e_isinj.
+    apply (ap10 h).
+  Defined.
+
   (* Cantor's theorem *)
   Lemma card_ne_exp_two_card (a : Card) :
     a <> (exp_card a two).

--- a/theories/Spaces/Card.v
+++ b/theories/Spaces/Card.v
@@ -1,12 +1,13 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 (** Representation of cardinals, see Chapter 10 of the HoTT book. *)
-Require Import HoTT.Basics HoTT.HSet HoTT.TruncType.
-Require Import HoTT.Types.
-Require Import HoTT.Classes.interfaces.abstract_algebra.
-Require Import HoTT.HIT.Truncations.
+Require Import Basics.
+Require Import HSet.
+Require Import TruncType.
+Require Import Types.
+Require Import Classes.interfaces.abstract_algebra.
+Require Import HIT.Truncations.
 Require Import Spaces.Finite.
 Require Import Types.Sigma.
-
 Require Import ExcludedMiddle.
 
 (** ** Definitions and operations *)
@@ -44,8 +45,6 @@ Definition lt_card `{Univalence} (a : Card) (b : Card) : hProp :=
 (** Cardinals **)
 
 Section Cardinals.
-  Context `{Univalence}.
-
   Definition zero : Card := tr (BuildhSet Empty).
   Definition one  : Card := tr (BuildhSet Unit).
   Definition two  : Card := tr (BuildhSet Bool).
@@ -208,6 +207,25 @@ Section contents.
   Global Instance preorder_card : PreOrder le_card.
   Proof. split; apply _. Defined.
 
+  (* If we can give two elements of a set we can assure it has a 
+     cardinality less than or equal to the cardinaity of Bool.
+
+     Another way of phrasing this is if there exists an injection
+     i : Bool -> X, this can be generalised to any finite set. *)
+  Lemma bool_leq_at_least_two {X : hSet} (x y : X) `{x <> y} 
+    : leq_card two (tr X).
+  Proof.
+    simpl; apply tr; srefine (_;_).
+    refine (fun b => if b then x else y).
+    simpl; unfold isinj; intros a b p.
+      destruct a, b.
+      reflexivity.
+      apply H0 in p; elim p.
+      apply symmetry in p; apply H0 in p; elim p.
+      reflexivity.
+  Defined.
+
+
   Section Regular.
 
     (** Definition of regular cardinals (from nlab)
@@ -253,11 +271,13 @@ Section contents.
 
 **)
 
-  Notation "| X | < k" := (lt_card (tr X) k) (at level 20).
-  Notation "| X | < k" := (lt_card (tr (BuildhSet X)) k) (at level 20).
+  Notation "| X | < k" := (lt_card (tr X) k) (at level 20) : card_scope.
+  Notation "| X | < k" := (lt_card (tr (BuildhSet X)) k) (at level 20) : card_scope.
 
   Context {X : hSet}.
   Context {P : X -> hSet}.
+
+  Local Open Scope card_scope.
 
   Definition regular (k : Card) `{|X| <  k} `{forall x, |P x| < k} :=
         |exists (x:X), P x| < k.

--- a/theories/Spaces/Card.v
+++ b/theories/Spaces/Card.v
@@ -132,7 +132,7 @@ Section contents.
     apply ((equiv_path_Tr (A := hSet) a (BuildhSet (a -> Bool)))^-1) in e.
     strip_truncations.
     apply ((equiv_path_trunctype a (BuildhSet (a -> Bool)))^-1) in e.
-    destruct a as [A Aset]; cbn in *.
+    destruct a as [A ?]. cbn in e.
     pose (f := (fun a:A => negb (e a a))).
     pose (a0 := e^-1 f).
     pose (b := f a0).
@@ -147,15 +147,12 @@ Section contents.
     strip_truncations; split; simpl.
     + serapply (tr ( _ ; _ )).
       - intros x y.
-        set (cases:= LEM (x = y) _).
-        destruct cases as [p|q].
+        destruct (LEM (x = y) _).
         * refine true.
         * refine false.
-      - intros x y.
-        intros e; apply ap10 in e; specialize (e x); cbn in e.
-        set (cases1 := LEM (x = x) _) in *.
-        set (cases2 := LEM (y = x) _) in *.
-        destruct cases1 as [p1|q1], cases2 as [p2|q2].
+      - intros x y e.
+        apply ap10 in e; specialize (e x); cbn in e.
+        destruct (LEM (x = x) _) as [?|q1], (LEM (y = x) _).
         * symmetry; assumption.
         * elim (true_ne_false e).
         * elim (false_ne_true e).

--- a/theories/Spaces/Card.v
+++ b/theories/Spaces/Card.v
@@ -4,6 +4,8 @@ Require Import HoTT.Basics HoTT.Types HoTT.HSet HoTT.TruncType.
 Require Import HoTT.Classes.interfaces.abstract_algebra.
 Require Import HoTT.HIT.Truncations.
 
+Require Import ExcludedMiddle.
+
 (** ** Definitions and operations *)
 
 Definition Card := Trunc 0 hSet.
@@ -33,6 +35,9 @@ Proof.
   refine (hexists (fun (i : a -> b) => isinj i)).
 Defined.
 
+Definition lt_card `{Univalence} (a : Card) (b : Card) : Type :=
+  BuildhProp (leq_card a b * BuildhProp (a <> b)).
+
 (** ** Properties *)
 Section contents.
   Context `{Univalence}.
@@ -42,6 +47,8 @@ Section contents.
   Global Instance zero_card : Zero Card := tr (BuildhSet Empty).
   Global Instance one_card : One Card := tr (BuildhSet Unit).
   Global Instance le_card : Le Card := leq_card.
+
+  Definition two_card : Card := tr (BuildhSet Bool).
 
   (* Reduce an algebraic equation to an equivalence *)
   Local Ltac reduce :=
@@ -115,6 +122,22 @@ Section contents.
   Lemma exp_card_mult_mult (a b c : Card) :
     exp_card c (a * b) = (exp_card c a) * (exp_card c b).
   Proof. reduce. symmetry. apply equiv_prod_coind. Defined.
+
+(* Cantor's theorem *)
+  Lemma card_lt_exp_two_card `{ExcludedMiddle} (a : Card) :
+    lt_card a (exp_card a two_card).
+  Proof.
+    strip_truncations; split; simpl.
+    + srapply (@tr -1); srefine (_ ; _).
+      - intros x y. destruct a as [a is_a].
+        remember (LEM (x = y) _) as cases eqn:p.
+        refine (match cases with
+                  | inl _ => true
+                  | inr _ => false end).
+      - simpl. intros x y. intro.
+        admit.
+    + intro.
+  Admitted.
 
   (** *** Properties of ≤ *)
   Instance reflexive_card : Reflexive leq_card.

--- a/theories/Spaces/Card.v
+++ b/theories/Spaces/Card.v
@@ -1,8 +1,11 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 (** Representation of cardinals, see Chapter 10 of the HoTT book. *)
-Require Import HoTT.Basics HoTT.Types HoTT.HSet HoTT.TruncType.
+Require Import HoTT.Basics HoTT.HSet HoTT.TruncType.
+Require Import HoTT.Types.
 Require Import HoTT.Classes.interfaces.abstract_algebra.
 Require Import HoTT.HIT.Truncations.
+Require Import Spaces.Finite.
+Require Import Types.Sigma.
 
 Require Import ExcludedMiddle.
 
@@ -38,17 +41,41 @@ Defined.
 Definition lt_card `{Univalence} (a : Card) (b : Card) : hProp :=
   BuildhProp ((leq_card a b) * (a <> b)).
 
+(** Cardinals **)
+
+Section Cardinals.
+  Context `{Univalence}.
+
+  Definition zero : Card := tr (BuildhSet Empty).
+  Definition one  : Card := tr (BuildhSet Unit).
+  Definition two  : Card := tr (BuildhSet Bool).
+
+  Definition nat_card (n : nat) : Card := tr (BuildhSet (Fin n)).
+
+  Definition aleph_0 : Card := tr (BuildhSet nat).
+
+  (** TODO: 
+    Perhaps include "sucessor" cardinals aleph_n upto some assumptions.
+
+    This would allow us to define aleph_w as the infinite union over N
+
+    This is a nice cardinal to have because it's an example of one that isn't
+    regular.
+  **)
+
+
+End Cardinals.
+
+
 (** ** Properties *)
 Section contents.
   Context `{Univalence}.
 
   Global Instance plus_card : Plus Card := sum_card.
   Global Instance mult_card : Mult Card := prod_card.
-  Global Instance zero_card : Zero Card := tr (BuildhSet Empty).
-  Global Instance one_card : One Card := tr (BuildhSet Unit).
-  Global Instance le_card : Le Card := leq_card.
-
-  Definition two_card : Card := tr (BuildhSet Bool).
+  Global Instance zero_card : Zero Card := zero.
+  Global Instance one_card  : One Card  := one.
+  Global Instance le_card   : Le Card   := leq_card.
 
   (* Reduce an algebraic equation to an equivalence *)
   Local Ltac reduce :=
@@ -125,7 +152,7 @@ Section contents.
 
   (* Cantor's theorem *)
   Lemma card_ne_exp_two_card (a : Card) :
-    a <> (exp_card a two_card).
+    a <> (exp_card a two).
   Proof.
     unfold Card in *; strip_truncations; cbn.
     intros e.
@@ -142,7 +169,7 @@ Section contents.
   Defined.
 
   Lemma card_lt_exp_two_card `{ExcludedMiddle} (a : Card) :
-    lt_card a (exp_card a two_card).
+    lt_card a (exp_card a two).
   Proof.
     strip_truncations; split; simpl.
     + serapply (tr ( _ ; _ )).
@@ -181,4 +208,59 @@ Section contents.
   Global Instance preorder_card : PreOrder le_card.
   Proof. split; apply _. Defined.
 
+  Section Regular.
+
+    (** Definition of regular cardinals (from nlab)
+
+    An infinite cardinal κ\kappa is a regular cardinal if it 
+    satisfies the following equivalent properties:
+
+     1. no set (in a material set theory) of cardinality κ\kappa 
+      is the union of fewer than κ\kappa sets of cardinality 
+      less than κ\kappa.
+
+     2. no set (in a structural set theory) of cardinality κ\kappa 
+      is the disjoint union of fewer than κ\kappa sets of 
+      cardinality less than κ\kappa.
+
+     3. given a function P→XP \to X (regarded as a family 
+      of sets {P x} x∈X\{P_x\}_{x\in X}) such that 
+      |X|<κ{|X|} \lt \kappa and |P x|<κ{|P_x|} \lt \kappa for 
+      all x∈Xx \in X, then |P|<κ{|P|} \lt \kappa.
+
+     4. the category Set <κ\Set_{\lt\kappa} of sets of 
+      cardinality <κ\lt\kappa has all colimits 
+      (or just all coproducts) of size <κ\lt\kappa.
+
+     5. the cofinality of κ\kappa is equal to κ\kappa.
+
+    A cardinal that is not regular is called singular.
+
+
+    We are not working in a material set theory so we can't choose 1.
+    Definitions 2, 3, 4 seem the most likely. I (Ali) am not familar
+    with 5 and 4 relies on categorical machinary which I see no reason
+    to have to use.
+
+    Definition 3 essentially says for every X, for every family 
+    of sets P : X -> Set_U such that X and the fibers of P have 
+    cardinality less than k, then the total space (set) has cardinality
+    less then k. I don't know if this is an easy thing to prove in practice
+    but seems like the kind of thing HoTT is good at.
+
+    Definition 2 would require defining disjoint unions. And I am sure
+    it is basically the same thing as 3.
+
+**)
+
+  Notation "| X | < k" := (lt_card (tr X) k) (at level 20).
+  Notation "| X | < k" := (lt_card (tr (BuildhSet X)) k) (at level 20).
+
+  Context {X : hSet}.
+  Context {P : X -> hSet}.
+
+  Definition regular (k : Card) `{|X| <  k} `{forall x, |P x| < k} :=
+        |exists (x:X), P x| < k.
+
+  End Regular.
 End contents.


### PR DESCRIPTION
Attempted to prove Cantor's theorem in theories/Spaces/Card.v but couldn't finish.

I have tried to define strict inequality but it seems there are two choices. I have gone for the more constructive looking one but I am not sure if this matters much given Cantor's theorem has a nonconstructive proof.

Added definitions for what it means for a precategory to be k-small and started a proof of Freyd's preorder proposition. Which a full proof is detailed in the file contrib/SmallCategory.v but I think I will need some more cardinal arithmetic lemmas before I can finish it. Also defined thin categories, having k-small (co)limits, and k-small diagrams etc.

Defined the indexed power functor in contrib/Powers.v. It just takes the limit functor over the discrete category of a set.

---

I am submitting the pull request in case anybody want's to help. Also I might be inclined to make Cantor's theorem a theorem in HSet.v with a corollary in Card.v however this is up to you. I have no idea if there are any constructive variants of cantors theorem.

The notion of thin category / preorder category might be better suited on its own.

There aren't many examples of limits in the Category theory library (unlike the UniMath one). I have started Powers.v in order to reason about it's universal property C(A,B^l) = C(A, B)^l. There is still more to add.

The proof of Freyd's preorder proposition may have a constructive counter part but I have not been able to come up with one.