### PR TITLE
Fix implicit arguments to be compatible with coq/coq#9314

### DIFF
--- a/theories/Categories/NaturalTransformation/Isomorphisms.v
+++ b/theories/Categories/NaturalTransformation/Isomorphisms.v
@@ -113,6 +113,9 @@ Section composition.
     path_natural_transformation; path_induction; simpl; auto with functor.
   Defined.
 End composition.
+Arguments isisomorphism_compose {H C D F' F''} T' {F} T {H0 H1}.
+Arguments iso_whisker_l {H} C D E F G G' T {H0}.
+Arguments iso_whisker_r {H} C D E F F' T G {H0}.
 
 (** ** Equalities induced by isomorphisms of objects *)
 Section object_isomorphisms.


### PR DESCRIPTION
The default choice of implicit arguments for Instances combined with the `Implicit Arguments` option is currently inconsistent with other commands like `Definition`. coq/coq#9314 changes this behavior, but https://github.com/HoTT/HoTT/blob/31c31c5c7673141979e274bc0afcc21417af9698/theories/Categories/Pseudofunctor/RewriteLaws.v#L44 is incompatible with the new default choice of implicit arguments for `iso_whisker_l`
Here we explicitly specify the implicit arguments for nearby instances as well to maintain compatibility.