### PR TITLE
Changed definition of suspension to be in terms of pushout

### DIFF
--- a/theories/HIT/Coeq.v
+++ b/theories/HIT/Coeq.v
@@ -10,7 +10,7 @@ Local Open Scope path_scope.
 
 Module Export Coeq.
 
-  Private Inductive Coeq {B A : Type} (f g : B -> A) : Type :=
+  Private Inductive Coeq {B A : Type@{i}} (f g : B -> A) : Type@{i} :=
   | coeq : A -> Coeq f g.
 
   Arguments coeq {B A f g} a.

--- a/theories/HIT/Spheres.v
+++ b/theories/HIT/Spheres.v
@@ -167,10 +167,9 @@ Proof.
   intro x.
   refine ((Susp_rec_eta_homot (S2_to_Sph2 o Sph2_to_S2) x) @ _). symmetry.
   generalize dependent x.
-  
   refine (Susp_ind _ 1 (merid North)^ _).
   intro x.
-  refine ((transport_paths_FlFr _ _) @ _).
+  refine ((transport_paths_FlFr (f := fun y => y) _ _) @ _).
   rewrite_moveR_Vp_p. refine ((concat_1p _) @ _).
   refine (_ @ (ap (fun w => w @ _) (ap_idmap _)^)).
   refine ((Susp_rec_beta_merid _) @ _).

--- a/theories/HIT/Suspension.v
+++ b/theories/HIT/Suspension.v
@@ -2,16 +2,16 @@
 
 (** * The suspension of a type *)
 
-Require Import HoTT.Basics HoTT.Types.
+Require Import Basics Types.
+Require Import HIT.Pushout.
 Require Import Pointed NullHomotopy.
-
 Local Open Scope path_scope.
 Local Open Scope pointed_scope.
 
 Generalizable Variables X A B f g n.
 
 (* ** Definition of suspension. *)
-
+(* 
 Module Export Suspension.
 
 (** We ensure that [Susp X] does not live in a lower universe than [X] *)
@@ -38,7 +38,38 @@ Axiom Susp_ind_beta_merid : forall {X : Type} (P : Susp X -> Type)
   (x:X),
 apD (Susp_ind P H_N H_S H_merid) (merid x) = H_merid x.
 
-End Suspension.
+End Suspension. *)
+
+Definition Susp (X : Type) := pushout (@const X _ tt) (const tt).
+Definition North {X} : Susp X := pushl tt.
+Definition South {X} : Susp X := pushr tt.
+Definition merid {X} (x : X) : North = South := pp x.
+
+Definition Susp_ind {X : Type} (P : Susp X -> Type)
+  (H_N : P North) (H_S : P South)
+  (H_merid : forall x:X, (merid x) # H_N = H_S)
+  : forall (y : Susp X), P y.
+Proof.
+  serapply pushout_ind.
+  exact (Unit_ind H_N).
+  exact (Unit_ind H_S).
+  exact (H_merid).
+Defined.
+
+Definition Susp_ind_beta_merid {X : Type}
+  (P : Susp X -> Type) (H_N : P North) (H_S : P South)
+  (H_merid : forall x:X, (merid x) # H_N = H_S) (x : X)
+  : apD (Susp_ind P H_N H_S H_merid) (merid x) = H_merid x.
+Proof.
+  serapply pushout_ind_beta_pp.
+Defined.
+
+(** But we want to allow the user to forget that we've defined the circle in that way. *)
+Arguments Susp : simpl never.
+Arguments North : simpl never.
+Arguments South : simpl never.
+Arguments merid : simpl never.
+Arguments Susp_ind_beta_merid : simpl never.
 
 (* ** Non-dependent eliminator. *)
 

--- a/theories/HIT/Suspension.v
+++ b/theories/HIT/Suspension.v
@@ -64,7 +64,7 @@ Proof.
   serapply pushout_ind_beta_pp.
 Defined.
 
-(** But we want to allow the user to forget that we've defined the circle in that way. *)
+(** We want to allow the user to forget that we've defined suspension in this way. *)
 Arguments Susp : simpl never.
 Arguments North : simpl never.
 Arguments South : simpl never.


### PR DESCRIPTION
Changed the definition of suspension to be defined in terms a pushout. It should lose none of it's functionality. This will also make it possible to use flattening lemma on pushouts.

I have also added universe parameters to coequalizers as they were omitted before.