### PR TITLE
Make trivial instances explicit

### DIFF
--- a/theories/Categories/ExponentialLaws/Law0.v
+++ b/theories/Categories/ExponentialLaws/Law0.v
@@ -28,7 +28,7 @@ Section law0.
   Variable C : PreCategory.
 
   Global Instance IsTerminalCategory_functors_from_initial
-  : IsTerminalCategory (0 -> C).
+  : IsTerminalCategory (0 -> C) := {}.
 
   (** There is only one functor to the terminal category [1]. *)
   Definition functor : Functor (0 -> C) 1

--- a/theories/Categories/ExponentialLaws/Law1/Functors.v
+++ b/theories/Categories/ExponentialLaws/Law1/Functors.v
@@ -68,7 +68,7 @@ Section law1'.
 
   Variable C : PreCategory.
 
-  Global Instance: IsTerminalCategory (C -> 1).
+  Global Instance: IsTerminalCategory (C -> 1) := {}.
 
   (** ** [1ˣ → 1] *)
   Definition functor' : Functor (C -> 1) 1

--- a/theories/Categories/InitialTerminalCategory/Core.v
+++ b/theories/Categories/InitialTerminalCategory/Core.v
@@ -31,10 +31,10 @@ Global Instance trunc_initial_category_mor `{IsInitialCategory C} x y
 
 (** ** Default intitial ([0]) and terminal ([1]) precategories. *)
 Global Instance is_initial_category_0 : IsInitialCategory 0 := (fun T => @Empty_ind (fun _ => T)).
-Global Instance: IsTerminalCategory 1 | 0.
+Global Instance: IsTerminalCategory 1 | 0 := {}.
 Global Instance: Contr (object 1) | 0 := _.
 Global Instance: Contr (morphism 1 x y) | 0 := fun x y => _.
-Global Instance default_terminal C {H H1} : @IsTerminalCategory C H H1 | 10.
+Global Instance default_terminal C {H H1} : @IsTerminalCategory C H H1 | 10 := {}.
 
 Arguments initial_category_ind / .
 Arguments is_initial_category_0 / .


### PR DESCRIPTION
This is in preparation for coq/coq#9274.

Should be backward compatible but that remains to be tested.