### PR TITLE
Remove Bracketing Last Introduction Pattern, close #993

### DIFF
--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -4,9 +4,6 @@
 (** Import the file of reserved notations so we maintain consistent level notations throughout the library *)
 Require Export Basics.Notations.
 
-(** Change in introduction patterns not adding an implicit [] *)
-Global Unset Bracketing Last Introduction Pattern.
-
 (** ** Type classes *)
 
 (** This command prevents Coq from trying to guess the values of existential variables while doing typeclass resolution.  If you don't know what that means, ignore it. *)

--- a/theories/Categories/Category/Sigma/OnObjects.v
+++ b/theories/Categories/Category/Sigma/OnObjects.v
@@ -66,7 +66,9 @@ Section sigT_obj.
     /\ sigT_functor_obj_inv o sigT_functor_obj = 1.
   Proof.
     split; path_functor; trivial.
-    repeat (intros [] || intro || apply path_forall).
+    apply path_forall; intros [].
+    apply path_forall; intros [].
+    apply path_forall; intros [? []].
     reflexivity.
   Qed.
 

--- a/theories/Fibrations.v
+++ b/theories/Fibrations.v
@@ -114,7 +114,7 @@ Proof.
                _
                (fun c => idpath)
                _)).
-  - repeat (intros [] || intro); reflexivity.
+  - intros [? [? []]]; reflexivity.
   - reflexivity.
 Defined.
 
@@ -128,7 +128,7 @@ Proof.
                _
                (fun Px => idpath)
                _)).
-  - repeat (intros [] || intro); reflexivity.
+  - intros [[] []]; reflexivity.
   - reflexivity.
 Defined.
 

--- a/theories/HIT/Colimits/Flattening.v
+++ b/theories/HIT/Colimits/Flattening.v
@@ -238,20 +238,19 @@ Section POCase.
   Definition POCase_E : dep_diagram (span f g).
   Proof.
     simple refine (Build_diagram _ _ _); cbn.
-    - intros [[] x]; revert x.
+    - intros [[] x]; revert x. 
       + exact A0.
       + destruct b; assumption.
-    - intros [[] x] [[] y] []; cbn; intros [].
-      destruct b; intro p.
+    - intros [[[]|[]] x] [[[]|[]] y]; cbn; intros [[] p].
       + exact (fun y => p # (f0 x y)).
       + exact (fun y => p # (g0 x y)).
   Defined.
 
   Definition POCase_HE : equifibered _ POCase_E.
   Proof.
-    intros [] [] [] x; cbn. destruct b; cbn in *.
-    - apply (f0 x).
-    - apply (g0 x).
+    intros [[]|[]] [[]|[]] [] x; compute.
+    - exact (equiv_isequiv (f0 x)).
+    - exact (equiv_isequiv (g0 x)).
   Defined.
 
   Definition PO_flattening
@@ -262,7 +261,7 @@ Section POCase.
       unfold PO; apply ap.
       serapply path_diagram; cbn.
       - intros [|[]]; cbn. all: reflexivity.
-      - intros [] [] [] x; destruct b; cbn in *.
+      - intros [[]|[]] [[]|[]] [] x; cbn in *.
         all: reflexivity. }
     rewrite X; clear X.
     transitivity (exists x, E' (span f g) POCase_E POCase_HE x).
@@ -273,13 +272,14 @@ Section POCase.
         unfold E', POCase_P, PO_rec.
         f_ap. serapply path_cocone.
         - intros [[]|[]] y; cbn.
-          1:{ apply path_universe_uncurried. apply g0. }
+          1: apply path_universe_uncurried; apply g0.
           all: reflexivity.
-        - intros [] [] []; cbn.
-          destruct b, u; intro y; simpl; hott_simpl.
-          unfold path_universe.
-          rewrite <- path_universe_V_uncurried.
-          refine (path_universe_compose (f0 y)^-1 (g0 y))^. }
+        - intros [[]|[]] [[]|[]] []; cbn.
+          + intro y; simpl; hott_simpl.
+            unfold path_universe.
+            rewrite <- path_universe_V_uncurried.
+            refine (path_universe_compose (f0 y)^-1 (g0 y))^. 
+          + intros; apply concat_Vp. }
       rewrite X. reflexivity.
   Defined.
 

--- a/theories/HIT/Colimits/Pushout.v
+++ b/theories/HIT/Colimits/Pushout.v
@@ -43,11 +43,7 @@ Section PO.
     : cocone (span f g) Z.
   Proof.
     unshelve econstructor.
-    - intros []; cbn.
-      + intros _. exact (inr' o g).
-      + intros [].
-        * exact inl'.
-        * exact inr'.
+    - intros [|[]]; [ exact (inr' o g) | exact inl' | exact inr' ].
     - intros [] [] []; cbn. destruct b.
       + exact pp'.
       + reflexivity.
@@ -85,10 +81,10 @@ Section PO.
     : forall w, P w.
   Proof.
     simple refine (colimit_ind P _ _).
-    - intros []; cbn.
-      + intros [] x.
-        exact (@colimp _ (span f g) (inl tt) (inr true) tt x # l' (f x)).
-      + intros []; cbn;[exact l' | exact r'].
+    - intros [[]|[]] x; cbn.
+      + exact (@colimp _ (span f g) (inl tt) (inr true) tt x # l' (f x)).
+      + exact (l' x).
+      + exact (r' x).
     - intros [] [] []; cbn.
       destruct u, b; cbn.
       + reflexivity.

--- a/theories/Modalities/Topological.v
+++ b/theories/Modalities/Topological.v
@@ -120,7 +120,7 @@ Module Topological_Lex.
                                | inr (a ; (b1, b2)) => (b1 = b2)
                                end : Type)).
     assert (Dtrunc : forall c:C, IsTrunc n.+1 (D c)).
-    { intros [a | [a b1 b2]]; [ cbn | exact _ ].
+    { intros [a | [a [b1 b2]]]; [ cbn | exact _ ].
       (* Because [trunc_hprop] can't be used as an idmap... *)
       destruct n; exact _. }
     assert (OeqD : OeqO O (Nul D)).

--- a/theories/Types/Sum.v
+++ b/theories/Types/Sum.v
@@ -969,8 +969,9 @@ Definition sum_of_sigT A B (x : { b : Bool & if b then A else B })
 Global Instance isequiv_sigT_of_sum A B : IsEquiv (@sigT_of_sum A B) | 0.
 Proof.
   apply (isequiv_adjointify (@sigT_of_sum A B)
-                            (@sum_of_sigT A B));
-  repeat (intros [] || intro); exact idpath.
+                            (@sum_of_sigT A B)).
+  - intros [[] ?]; exact idpath.
+  - intros []; exact idpath.
 Defined.
 
 Global Instance isequiv_sum_of_sigT A B : IsEquiv (sum_of_sigT A B)


### PR DESCRIPTION
I don't know if anyone is listening, but I think this is an argument against relying on fancy tactic stuff like this.  Not only does it make the code harder to step through and understand, but it renders it fragile to changes to the details of tactics, and when that happens it is hard to figure out how to fix it because it's hard to step through and understand.