### PR TITLE
Added definition of homotopy group

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -411,6 +411,8 @@ theories/Classes/interfaces/orders.v
 theories/Classes/interfaces/integers.v
 theories/Classes/tests/ring_tac.v
 
+theories/Homotopy/HomotopyGroup.v
+
 contrib/HoTTBook.v
 contrib/HoTTBookExercises.v
 contrib/Freudenthal.v

--- a/theories/Homotopy/HomotopyGroup.v
+++ b/theories/Homotopy/HomotopyGroup.v
@@ -46,7 +46,6 @@ Section HomotopyGroups.
   Proof.
     refine (tr _).
     destruct n, gt.
-    rewrite iterated_loops_unfold.
     exact idpath.
   Defined.
 

--- a/theories/Homotopy/HomotopyGroup.v
+++ b/theories/Homotopy/HomotopyGroup.v
@@ -11,7 +11,7 @@ Section HomotopyGroups.
 
   Context
    `{Univalence}
-    {n : nat}
+    (n : nat)
     (X : pType).
 
   Definition Pi := Tr 0 (iterated_loops n X).

--- a/theories/Homotopy/HomotopyGroup.v
+++ b/theories/Homotopy/HomotopyGroup.v
@@ -10,7 +10,6 @@ Require Import DProp.
 Section HomotopyGroups.
 
   Context
-   `{Univalence}
     (n : nat)
     (X : Type)
    `{IsPointed X}.
@@ -34,11 +33,8 @@ Section HomotopyGroups.
   Proof.
     intros x y z.
     strip_truncations.
-    unfold PiOp.
-    simpl.
-    serapply equiv_path_Tr.
-    refine (tr _).
-    simpl.
+    unfold PiOp; cbn.
+    apply ap.
     destruct n, gt.
     refine ((concat_pp_p _ _ _)^).
   Defined.
@@ -54,10 +50,8 @@ Section HomotopyGroups.
   Proof.
     intro x.
     strip_truncations.
-    unfold PiOp.
-    simpl.
-    serapply equiv_path_Tr.
-    refine (tr _).
+    unfold PiOp; cbn.
+    apply ap.
     destruct n, gt.
     apply concat_1p.
   Defined.
@@ -66,10 +60,8 @@ Section HomotopyGroups.
   Proof.
     intro x.
     strip_truncations.
-    unfold PiOp.
-    simpl.
-    serapply equiv_path_Tr.
-    refine (tr _).
+    unfold PiOp; cbn.
+    apply ap.
     destruct n, gt.
     apply concat_p1.
   Defined.
@@ -87,11 +79,8 @@ Section HomotopyGroups.
   Proof.
     intro x.
     strip_truncations.
-    unfold PiOp.
-    simpl.
-    serapply equiv_path_Tr.
-    simpl.
-    refine (tr _).
+    unfold PiOp; cbn.
+    apply ap.
     destruct n, gt.
     apply concat_Vp.
   Defined.
@@ -100,11 +89,8 @@ Section HomotopyGroups.
   Proof.
     intro x.
     strip_truncations.
-    unfold PiOp.
-    simpl.
-    serapply equiv_path_Tr.
-    simpl.
-    refine (tr _).
+    unfold PiOp; cbn.
+    apply ap.
     destruct n, gt.
     apply concat_pV.
   Defined.

--- a/theories/Homotopy/HomotopyGroup.v
+++ b/theories/Homotopy/HomotopyGroup.v
@@ -108,7 +108,7 @@ Section HomotopyGroups.
     apply concat_pV.
   Defined.
 
- Global Instance pi_is_Group : @Group Pi PiOp PiUnit PiInverse.
+  Global Instance pi_is_Group : @Group Pi PiOp PiUnit PiInverse.
   Proof.
     repeat split.
     - exact _.

--- a/theories/Homotopy/HomotopyGroup.v
+++ b/theories/Homotopy/HomotopyGroup.v
@@ -104,6 +104,6 @@ Section HomotopyGroups.
     - exact PiOp_rightId.
     - exact PiOp_leftInv.
     - exact PiOp_rightInv.
-  Qed.
+  Defined.
 
 End  HomotopyGroups.

--- a/theories/Homotopy/HomotopyGroup.v
+++ b/theories/Homotopy/HomotopyGroup.v
@@ -108,22 +108,15 @@ Section HomotopyGroups.
     apply concat_pV.
   Defined.
 
-  (* Why is this so slow? *)
-  Global Instance pi_is_Group : @Group Pi PiOp PiUnit PiInverse.
+ Global Instance pi_is_Group : @Group Pi PiOp PiUnit PiInverse.
   Proof.
-    serapply Build_Group.
-    + serapply Build_Monoid.
-      * serapply Build_SemiGroup.
-        unfold Associative, HeteroAssociative.
-        apply PiOp_assoc.
-      * unfold LeftIdentity.
-        apply PiOp_leftId.
-      * unfold RightIdentity.
-        apply PiOp_rightId.
-    + unfold LeftInverse.
-      apply PiOp_leftInv.
-    + unfold RightInverse.
-      apply PiOp_rightInv.
-  Defined.
+    repeat split.
+    - exact _.
+    - exact PiOp_assoc.
+    - exact PiOp_leftId.
+    - exact PiOp_rightId.
+    - exact PiOp_leftInv.
+    - exact PiOp_rightInv.
+  Qed.
 
 End  HomotopyGroups.

--- a/theories/Homotopy/HomotopyGroup.v
+++ b/theories/Homotopy/HomotopyGroup.v
@@ -1,0 +1,130 @@
+Require Import Basics.
+Require Import Types.
+Require Import HIT.Truncations.
+Require Import Pointed.
+Require Import abstract_algebra.
+Require Import Spaces.Nat.
+Require Import DProp.
+(* In this file we define homotopy groups *)
+
+Section HomotopyGroups.
+
+  Context
+   `{Univalence}
+    {n : nat}
+    (X : pType).
+
+  Definition Pi := Tr 0 (iterated_loops n X).
+
+  (* We only have a group structure when 0 < n *)
+  Context `{gt : 0 < n}.
+
+  (* We explicitly give the operation here *)
+  Definition PiOp : Pi -> Pi -> Pi.
+  Proof.
+    intros a b.
+    strip_truncations.
+    refine (tr _).
+    destruct n, gt.
+    exact (concat a b).
+  Defined.
+
+  Definition PiOp_assoc : forall x y z, PiOp x (PiOp y z) = PiOp (PiOp x y) z.
+  Proof.
+    intros x y z.
+    strip_truncations.
+    unfold PiOp.
+    simpl.
+    serapply equiv_path_Tr.
+    refine (tr _).
+    simpl.
+    destruct n, gt.
+    refine ((concat_pp_p _ _ _)^).
+  Defined.
+
+  Definition PiUnit : Pi.
+  Proof.
+    refine (tr _).
+    destruct n, gt.
+    rewrite iterated_loops_unfold.
+    exact idpath.
+  Defined.
+
+  Definition PiOp_leftId : forall x, PiOp PiUnit x = x.
+  Proof.
+    intro x.
+    strip_truncations.
+    unfold PiOp.
+    simpl.
+    serapply equiv_path_Tr.
+    refine (tr _).
+    destruct n, gt.
+    apply concat_1p.
+  Defined.
+
+  Definition PiOp_rightId : forall x, PiOp x PiUnit = x.
+  Proof.
+    intro x.
+    strip_truncations.
+    unfold PiOp.
+    simpl.
+    serapply equiv_path_Tr.
+    refine (tr _).
+    destruct n, gt.
+    apply concat_p1.
+  Defined.
+
+  Definition PiInverse : Pi -> Pi.
+  Proof.
+    intro a.
+    strip_truncations.
+    refine (tr _).
+    destruct n, gt.
+    exact a^.
+  Defined.
+
+  Definition PiOp_leftInv : forall x, PiOp (PiInverse x) x = PiUnit.
+  Proof.
+    intro x.
+    strip_truncations.
+    unfold PiOp.
+    simpl.
+    serapply equiv_path_Tr.
+    simpl.
+    refine (tr _).
+    destruct n, gt.
+    apply concat_Vp.
+  Defined.
+
+  Definition PiOp_rightInv : forall x, PiOp x (PiInverse x) = PiUnit.
+  Proof.
+    intro x.
+    strip_truncations.
+    unfold PiOp.
+    simpl.
+    serapply equiv_path_Tr.
+    simpl.
+    refine (tr _).
+    destruct n, gt.
+    apply concat_pV.
+  Defined.
+
+  (* Why is this so slow? *)
+  Global Instance pi_is_Group : @Group Pi PiOp PiUnit PiInverse.
+  Proof.
+    serapply Build_Group.
+    + serapply Build_Monoid.
+      * serapply Build_SemiGroup.
+        unfold Associative, HeteroAssociative.
+        apply PiOp_assoc.
+      * unfold LeftIdentity.
+        apply PiOp_leftId.
+      * unfold RightIdentity.
+        apply PiOp_rightId.
+    + unfold LeftInverse.
+      apply PiOp_leftInv.
+    + unfold RightInverse.
+      apply PiOp_rightInv.
+  Defined.
+
+End  HomotopyGroups.

--- a/theories/Homotopy/HomotopyGroup.v
+++ b/theories/Homotopy/HomotopyGroup.v
@@ -20,7 +20,7 @@ Section HomotopyGroups.
   Context `{gt : 0 < n}.
 
   (* We explicitly give the operation here *)
-  Definition PiOp : Pi -> Pi -> Pi.
+  Global Instance PiOp : SgOp Pi.
   Proof.
     intros a b.
     strip_truncations.
@@ -29,14 +29,14 @@ Section HomotopyGroups.
     exact (concat a b).
   Defined.
 
-  Definition PiOp_assoc : forall x y z, PiOp x (PiOp y z) = PiOp (PiOp x y) z.
+  Global Instance PiOp_assoc : Associative PiOp.
   Proof.
     intros x y z.
     strip_truncations.
     unfold PiOp; cbn.
     apply ap.
     destruct n, gt.
-    refine ((concat_pp_p _ _ _)^).
+    refine (concat_pp_p _ _ _)^.
   Defined.
 
   Definition PiUnit : Pi.
@@ -46,7 +46,7 @@ Section HomotopyGroups.
     exact idpath.
   Defined.
 
-  Definition PiOp_leftId : forall x, PiOp PiUnit x = x.
+  Global Instance PiOp_leftId : LeftIdentity PiOp PiUnit.
   Proof.
     intro x.
     strip_truncations.
@@ -56,7 +56,7 @@ Section HomotopyGroups.
     apply concat_1p.
   Defined.
 
-  Definition PiOp_rightId : forall x, PiOp x PiUnit = x.
+  Global Instance PiOp_rightId : RightIdentity PiOp PiUnit.
   Proof.
     intro x.
     strip_truncations.
@@ -75,7 +75,7 @@ Section HomotopyGroups.
     exact a^.
   Defined.
 
-  Definition PiOp_leftInv : forall x, PiOp (PiInverse x) x = PiUnit.
+  Global Instance PiOp_leftInv : LeftInverse PiOp PiInverse PiUnit.
   Proof.
     intro x.
     strip_truncations.
@@ -85,7 +85,7 @@ Section HomotopyGroups.
     apply concat_Vp.
   Defined.
 
-  Definition PiOp_rightInv : forall x, PiOp x (PiInverse x) = PiUnit.
+  Global Instance PiOp_rightInv : RightInverse PiOp PiInverse PiUnit.
   Proof.
     intro x.
     strip_truncations.
@@ -97,13 +97,7 @@ Section HomotopyGroups.
 
   Global Instance pi_is_Group : @Group Pi PiOp PiUnit PiInverse.
   Proof.
-    repeat split.
-    - exact _.
-    - exact PiOp_assoc.
-    - exact PiOp_leftId.
-    - exact PiOp_rightId.
-    - exact PiOp_leftInv.
-    - exact PiOp_rightInv.
+    repeat split; exact _.
   Defined.
 
 End  HomotopyGroups.

--- a/theories/Homotopy/HomotopyGroup.v
+++ b/theories/Homotopy/HomotopyGroup.v
@@ -12,7 +12,8 @@ Section HomotopyGroups.
   Context
    `{Univalence}
     (n : nat)
-    (X : pType).
+    (X : Type)
+   `{IsPointed X}.
 
   Definition Pi := Tr 0 (iterated_loops n X).
 

--- a/theories/Pointed.v
+++ b/theories/Pointed.v
@@ -46,7 +46,7 @@ Fixpoint iterated_loops (n : nat) (A : Type) `{H : IsPointed A}
          {struct n} : pType
   := match n with
        | O => Build_pType A (@point A H)
-       | S p => iterated_loops p (point A = point A)
+       | S p => loops (iterated_loops p A)
      end.
 
 (** The loop space decreases the truncation level by one.  We don't bother making this an instance because it is automatically found by typeclass search, but we record it here in case anyone is looking for it. *)


### PR DESCRIPTION
Defined the homotopy group of a pointed type. It uses the Groups structures found in mathclasses. I also modified `iterated_loops` in `Pointed.v` so that I can have loops on the outside, allowing path lemmas to be used.

The constructors for mathclasses are very slow, I am not really sure why? Perhaps it is my use of `serapply`?

I have also started a `Homotopy` foldeer in `theories`, later on we can move more synthetic homotopy theory relevent things here. At least it is a start.