### PR TITLE
Fix unfoldings of private recursors.

### DIFF
--- a/theories/Classes/implementations/natpair_integers.v
+++ b/theories/Classes/implementations/natpair_integers.v
@@ -846,7 +846,7 @@ Proof.
 pose proof Z_ring.
 first [apply from_full_pseudo_ring_order@{UN UN UN UN UN UN UN Ularge}|
        apply from_full_pseudo_ring_order]; try apply _.
-apply apartness.strong_binary_setoid_morphism_commutative.
+srapply apartness.strong_binary_setoid_morphism_commutative.
 Qed.
 
 Goal FullPseudoSemiRingOrder Zle Zlt.

--- a/theories/Spaces/Card.v
+++ b/theories/Spaces/Card.v
@@ -93,10 +93,20 @@ Section contents.
 
   (** *** Properties of exponentiation *)
   Lemma exp_zero_card (a : Card) : exp_card 0 a = 1.
-  Proof. simpl_ops. reduce. symmetry. apply equiv_empty_rec. Defined.
+  Proof.
+    revert a. apply Trunc_ind;[exact _|].
+    intros a. simpl. unfold one_card,one.
+    f_ap. apply path_hset.
+    symmetry; apply equiv_empty_rec.
+  Defined.
 
   Lemma exp_card_one (a : Card) : exp_card a 1 = 1.
-  Proof. simpl_ops. reduce. symmetry. apply equiv_unit_coind. Defined.
+  Proof.
+    revert a. refine (Trunc_ind _ _).
+    intros a;simpl. unfold one,one_card.
+    f_ap. apply path_hset.
+    symmetry. apply equiv_unit_coind.
+  Defined.
 
   Lemma exp_one_card (a : Card) : exp_card 1 a = a.
   Proof. reduce. symmetry. apply equiv_unit_rec. Defined.

--- a/theories/Spaces/No/Core.v
+++ b/theories/Spaces/No/Core.v
@@ -1016,7 +1016,8 @@ Section RaiseSort.
         {{ (fun l => No_raise (xL l)) | (fun r => No_raise (xR r)) // rxcut }} }.
   Proof.
     eexists.
-    reflexivity.
+    rel_hnf. (* required to avoid exposing the private inductive *)
+    exact idpath.
   Qed.
 
   Definition No_raise_le (x y : GenNo S)
@@ -1142,7 +1143,7 @@ Proof.
     + apply (lt_le_trans (y := No_raise y)).
       * apply No_raise_lt.
         refine (lt_ropt _ _ _ tt).
-      * apply le_lr; [ intros [] | intros r ].
+      * rel_hnf. apply le_lr; [ intros [] | intros r ].
         rewrite <- (IHR r).2.
         refine (lt_ropt _ _ _ (inr (inr r))).
     + rewrite (IHL l).2.
@@ -1155,7 +1156,7 @@ Proof.
     refine (lt_lopt _ _ _ (inr l)).
   - intros [[]|r].
     + apply (le_lt_trans (y := No_raise z)).
-      * apply le_lr; [ intros l | intros [] ].
+      * rel_hnf. apply le_lr; [ intros l | intros [] ].
         rewrite <- (IHL l).2.
         refine (lt_lopt _ _ _ (inr (inl l))).
       * apply No_raise_lt.

--- a/theories/Spaces/No/Negation.v
+++ b/theories/Spaces/No/Negation.v
@@ -39,13 +39,13 @@ Section HasNegation.
   Context `{InSort S Empty Empty} `{InSort S Unit Empty}.
   Goal negate one = minusone.
   Proof.
-    apply path_No; apply le_lr; intros.
+    apply path_No; rel_hnf; apply le_lr; intros.
     (** Since [le_lr] only proves inequality of cuts, this would not work if [negate] didn't compute to a cut when applied to a cut. *)
     - elim l.
     - apply lt_r with r.
-      apply le_lr; apply Empty_ind.
+      rel_hnf; apply le_lr; apply Empty_ind.
     - elim l.
-    - apply lt_r with r.
+    - rel_hnf; apply lt_r with r.
       apply le_lr; apply Empty_ind.
   Qed.
 
@@ -58,7 +58,7 @@ Section HasNegation.
         negate {{ xL | xR // xcut }} =
         {{ (fun r => negate (xR r)) | (fun l => negate (xL l)) // nxcut }} }.
   Proof.
-    eexists.
+    eexists. rel_hnf.
     reflexivity.
   Defined.
 


### PR DESCRIPTION
After coq/coq#9609 the kernel will reject matches on private
inductives outside their home module. This breaks proofs that generate
such terms by over-reducing.

Since HoTT is the primary user of Private (AFAIK) please speak up if
that's not a desired change.

Should be backwards compatible.