### PR TITLE
Cumulative paths

### DIFF
--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -214,7 +214,7 @@ Notation "g 'oD' f" := (composeD g f) : function_scope.
 (** The results in this file are used everywhere else, so we need to be extra careful about how we define and prove things.  We prefer hand-written terms, or at least tactics that allow us to retain clear control over the proof-term produced. *)
 
 (** We define our own identity type, rather than using the one in the Coq standard library, so as to have more control over transitivity, symmetry and inverse.  It seems impossible to change these for the standard eq/identity type (or its Type-valued version) because it breaks various other standard things.  Merely changing notations also doesn't seem to quite work. *)
-Inductive paths {A : Type} (a : A) : A -> Type :=
+Cumulative Inductive paths {A : Type} (a : A) : A -> Type :=
   idpath : paths a a.
 
 Arguments idpath {A a} , [A] a.

--- a/theories/Classes/implementations/natpair_integers.v
+++ b/theories/Classes/implementations/natpair_integers.v
@@ -492,7 +492,7 @@ Qed.
 
 Definition Zle_hProp@{} : Z -> Z -> TruncType@{UN} -1.
 Proof.
-apply (@Z_rec2@{Ularge Ularge} _ (@istrunc_trunctype@{Ularge Uhuge UN} _ _)
+apply (@Z_rec2@{Ularge Ularge} _ (@istrunc_trunctype@{UN Ularge Uhuge} _ _)
   (fun q r => BuildhProp (PairT.Tle q r))).
 intros. apply path_hprop@{UN Ularge Uhuge}. simpl.
 apply (PairT.le_respects _);trivial.
@@ -601,7 +601,7 @@ Qed.
 
 Definition Zlt_hProp@{} : Z -> Z -> TruncType@{UN} -1.
 Proof.
-apply (@Z_rec2@{Ularge Ularge} _ (@istrunc_trunctype@{Ularge Uhuge UN} _ _)
+apply (@Z_rec2@{Ularge Ularge} _ (@istrunc_trunctype@{UN Ularge Uhuge} _ _)
   (fun q r => BuildhProp (PairT.Tlt q r))).
 intros. apply path_hprop@{UN Ularge Uhuge}. simpl.
 apply (PairT.lt_respects _);trivial.
@@ -697,7 +697,7 @@ Local Existing Instance pseudo_order_apart.
 
 Definition Zapart_hProp@{} : Z -> Z -> TruncType@{UN} -1.
 Proof.
-apply (@Z_rec2@{Ularge Ularge} _ (@istrunc_trunctype@{Ularge Uhuge UN} _ _)
+apply (@Z_rec2@{Ularge Ularge} _ (@istrunc_trunctype@{UN Ularge Uhuge} _ _)
   (fun q r => BuildhProp (PairT.Tapart q r))).
 intros. apply path_hprop@{UN Ularge Uhuge}. simpl.
 apply (PairT.apart_respects _);trivial.

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -496,7 +496,7 @@ Section Reflective_Subuniverse.
     Defined.
 
     (** Thus, [T] is in a subuniverse as soon as [to O T] admits a retraction. *)
-    Definition inO_to_O_retract (T:Type) (mu : O T -> T)
+    Definition inO_to_O_retract@{i | Oa <= i} (T:Type@{i}) (mu : O T -> T)
     : Sect (to O T) mu -> In O T.
     Proof.
       unfold Sect; intros H.
@@ -1256,8 +1256,8 @@ Section ConnectedTypes.
       simple_induction n n IHn; intros C ?;
       [ exact tt | split ].
     - intros f.
-      exists (fun _ : Unit => (isconnected_elim@{i j j k i} C f).1); intros a.
-      symmetry; apply ((isconnected_elim@{i j j k i} C f).2).
+      exists (fun _ : Unit => (isconnected_elim@{i j k j j i} C f).1); intros a.
+      symmetry; apply ((isconnected_elim@{i j k j j i} C f).2).
     - intros h k.
       refine (extendable_postcompose'@{i i j j j j l l l l} n _ _ _ _ (IHn (h tt = k tt) (inO_paths@{Ou Oa j m} _ _ _ _))).
       intros []; apply equiv_idmap.

--- a/theories/PropResizing/Nat.v
+++ b/theories/PropResizing/Nat.v
@@ -159,7 +159,7 @@ Section AssumeStuff.
                               f Ha Hb.
 
     Definition graph_unsucc_equiv_edge@{} (x y : vert A)
-      : edge A x y <-> edge B (graph_unsucc_equiv_vert x) (graph_unsucc_equiv_vert y).
+      : iff@{s s s} (edge A x y) (edge B (graph_unsucc_equiv_vert x) (graph_unsucc_equiv_vert y)).
     Proof.
       pose (h := e (inl x) (inl y)).
       rewrite <- (unfunctor_sum_l_beta f Ha x) in h.

--- a/theories/TruncType.v
+++ b/theories/TruncType.v
@@ -94,11 +94,11 @@ Qed.
 Definition path_hset {A B} := @path_trunctype 0 A B.
 Definition path_hprop {A B} := @path_trunctype -1 A B.
 
-Global Instance istrunc_trunctype {n : trunc_index}
-  : IsTrunc n.+1 (TruncType n) | 0.
+Global Instance istrunc_trunctype@{i j k | i < j, j < k} {n : trunc_index}
+  : IsTrunc@{j} n.+1 (TruncType@{i} n) | 0.
 Proof.
   intros A B.
-  refine (trunc_equiv _ (equiv_path_trunctype A B)).
+  refine (trunc_equiv _ (equiv_path_trunctype@{i j k} A B)).
   case n as [ | n'].
   - apply contr_equiv_contr_contr. (* The reason is different in this case. *)
   - apply istrunc_equiv.


### PR DESCRIPTION
Make the paths type cumulative, so that it can be used with Equations

Making paths cumulative means that the universe parameter is now treated as irrelevant:`@paths@{i} A x y <= @paths@{j} A x y` for any i and j (which must by typing be greater or equal to A's universe). See the [section on cumulative inductives](https://coq.inria.fr/refman/addendum/universe-polymorphism.html?highlight=irrelevant#cumulative-noncumulative) for more information.

This allows, e.g. to inject `@paths@{Set} nat x y` equalities in higher universes, and deconstruct equalities in the homogeneous cumulative sigma type used by Equations (where both components live in the same universe, and the sigma as well) into equalities for the components, e.g: `@paths{i} (Sigma@{i} x : nat, P x) p q` can be turned into `Sigma@{i} e : @paths@{i} nat p.1 q.1, @paths@{i} (transport P e p.2) q.2` without trouble. 

Trying out the same sigma-types for HoTT would be a good exercise: instead of "preemptively" making sigma types allow cumulativity by using different universes `i` and `j` for the components and putting the sigma in `max(i,j)`, it rather says that every universe is closed under sigmas, and cumulativity is orthogonal (the universe annotation of the sigma is irrelevant as well). This can result in less useless universes representing `max(i,j)` and still allow using cumulativity when necessary.

This requires two restrictiction of the more flexible constraints due to cumulativity of paths in Modalities and PropResizing, otherwise nothing changes.
