### PR TITLE
Local Unset Elimination Schemes

### DIFF
--- a/theories/Classes/implementations/binary_naturals.v
+++ b/theories/Classes/implementations/binary_naturals.v
@@ -15,6 +15,11 @@ Require Import
         HoTT.Classes.orders.semirings
         HoTT.Classes.theory.apartness.
 
+(* Disable automatic generation of elimination schemes to avoid
+   generation of induction/recursion principles to [Prop]/[Set]. *)
+
+Local Unset Elimination Schemes.
+
 Section basics.
 
   (* This definition of binary naturals is due to Martín Escardó and
@@ -24,6 +29,10 @@ Section basics.
   | bzero   :           binnat  (* zero *)
   | double1 : binnat -> binnat  (* 2n+1 *)
   | double2 : binnat -> binnat. (* 2n+2 *)
+
+  Scheme binnat_ind := Induction for binnat Sort Type.
+  Scheme binnat_rec := Minimality for binnat Sort Type.
+  Definition binnat_rect := binnat_ind.
 
   Fixpoint Succ (n : binnat) : binnat :=
     match n with

--- a/theories/Classes/implementations/ne_list.v
+++ b/theories/Classes/implementations/ne_list.v
@@ -4,6 +4,11 @@ Require Import
   HoTT.Basics.Overture
   HoTT.Spaces.Nat.
 
+(* Disable automatic generation of elimination schemes to avoid
+   generation of induction/recursion principles to [Prop]/[Set]. *)
+
+Local Unset Elimination Schemes.
+
 Declare Scope ne_list_scope.
 
 Delimit Scope ne_list_scope with ne_list.
@@ -14,52 +19,64 @@ Open Scope ne_list_scope.
 
 Module ne_list.
 
-Section with_type.
-  Context {T: Type}.
-
 (** A nonempty list. Below there is an implicit coercion
     [ne_list >-> list]. *)
 
-  Inductive ne_list : Type
-    := one: T → ne_list | cons: T → ne_list → ne_list.
+Inductive ne_list (T:Type) : Type
+  := one: T → ne_list T | cons: T → ne_list T → ne_list T.
 
-  Fixpoint app (a b: ne_list): ne_list :=
+Arguments one {T}.
+Arguments cons {T}.
+
+Scheme ne_list_ind := Induction for ne_list Sort Type.
+Arguments ne_list_ind [T].
+
+Scheme ne_list_rec := Minimality for ne_list Sort Type.
+Arguments ne_list_rec [T].
+
+Definition ne_list_rect := ne_list_ind.
+Arguments ne_list_rect [T].
+
+Section with_type.
+  Context {T: Type}.
+
+  Fixpoint app (a b: ne_list T): ne_list T :=
     match a with
     | one x => cons x b
     | cons x y => cons x (app y b)
     end.
 
-  Fixpoint foldr {R} (u: T → R) (f: T → R → R) (a: ne_list): R :=
+  Fixpoint foldr {R} (u: T → R) (f: T → R → R) (a: ne_list T): R :=
     match a with
     | one x => u x
     | cons x y => f x (foldr u f y)
     end.
 
-  Fixpoint foldr1 (f: T → T → T) (a: ne_list): T :=
+  Fixpoint foldr1 (f: T → T → T) (a: ne_list T): T :=
     match a with
     | one x => x
     | cons x y => f x (foldr1 f y)
     end.
 
-  Definition head (l: ne_list): T
+  Definition head (l: ne_list T): T
     := match l with one x => x | cons x _ => x end.
 
-  Fixpoint to_list (l: ne_list): list T :=
+  Fixpoint to_list (l: ne_list T): list T :=
     match l with
     | one x => x :: nil
     | cons x xs => x :: to_list xs
     end.
 
-  Fixpoint from_list (x: T) (xs: list T): ne_list :=
+  Fixpoint from_list (x: T) (xs: list T): ne_list T :=
     match xs with
     | nil => one x
     | Datatypes.cons h t => cons x (from_list h t)
     end.
 
-  Definition tail (l: ne_list): list T
+  Definition tail (l: ne_list T): list T
     := match l with one _ => nil | cons _ x => to_list x end.
 
-  Lemma decomp_eq (l: ne_list): l = from_list (head l) (tail l).
+  Lemma decomp_eq (l: ne_list T): l = from_list (head l) (tail l).
   Proof with auto.
     induction l...
     destruct l...
@@ -67,27 +84,27 @@ Section with_type.
     rewrite IHl...
   Qed. 
 
-  Definition last: ne_list → T := foldr1 (fun x y => y).
+  Definition last: ne_list T → T := foldr1 (fun x y => y).
 
-  Fixpoint replicate_Sn (x: T) (n: nat): ne_list :=
+  Fixpoint replicate_Sn (x: T) (n: nat): ne_list T :=
     match n with
     | 0 => one x
     | S n' => cons x (replicate_Sn x n')
     end.
 
-  Fixpoint take (n: nat) (l: ne_list): ne_list :=
+  Fixpoint take (n: nat) (l: ne_list T): ne_list T :=
     match l, n with
     | cons x xs, S n' => take n' xs
     | _, _ => one (head l)
     end.
 
-  Fixpoint front (l: ne_list) : list T :=
+  Fixpoint front (l: ne_list T) : list T :=
     match l with
     | one _ => nil
     | cons x xs => x :: front xs
     end.
 
-  Lemma two_level_rect (P: ne_list → Type)
+  Lemma two_level_rect (P: ne_list T → Type)
     (Pone: ∀ x, P (one x))
     (Ptwo: ∀ x y, P (cons x (one y)))
     (Pmore: ∀ x y z, P z → (∀ y', P (cons y' z)) → P (cons x (cons y z)))
@@ -104,12 +121,10 @@ Section with_type.
      + intro. apply Pmore; intros; apply IHl.
   Qed.
 
-  Lemma tl_length (l: ne_list)
+  Lemma tl_length (l: ne_list T)
     : S (length (tl (to_list l))) = length (to_list l).
   Proof. destruct l; reflexivity. Qed.
 End with_type.
-
-Arguments ne_list : clear implicits.
 
 Fixpoint tails {T} (l: ne_list T): ne_list (ne_list T) :=
   match l with
@@ -121,7 +136,7 @@ Lemma tails_are_shorter {T} (y x: ne_list T):
   InList x (to_list (tails y)) →
   le (length (to_list x)) (length (to_list y)).
 Proof with auto.
- induction y; cbn.
+ induction y using ne_list_ind; cbn.
  - intros [[] | C].
    + constructor.
    + elim C.

--- a/theories/Classes/interfaces/canonical_names.v
+++ b/theories/Classes/interfaces/canonical_names.v
@@ -2,6 +2,11 @@ Require Export HoTT.Basics.Overture HoTT.Types.Bool HoTT.Basics.Decidable HoTT.B
 
 Require Import HoTT.Types.Sigma HoTT.Types.Forall HoTT.Types.Record.
 
+(* Disable automatic generation of elimination schemes to avoid
+   generation of induction/recursion principles to [Prop]/[Set]. *)
+
+Local Unset Elimination Schemes.
+
 Declare Scope mc_scope.
 Delimit Scope mc_scope with mc.
 Global Open Scope mc_scope.
@@ -353,7 +358,11 @@ Notation "(∸)" := cut_minus (only parsing) : mc_scope.
 Notation "( x ∸)" := (cut_minus x) (only parsing) : mc_scope.
 Notation "(∸ y )" := (fun x => x ∸ y) (only parsing) : mc_scope.
 
-Inductive comparison : Set := LT | EQ | GT.
+Inductive comparison : Type0 := LT | EQ | GT.
+
+Scheme comparison_ind := Induction for comparison Sort Type.
+Scheme comparison_rec := Minimality for comparison Sort Type.
+Definition comparison_rect := comparison_ind.
 
 Class Compare A := compare : A -> A -> comparison.
 Infix "?=" := compare (at level 70, no associativity) : mc_scope.

--- a/theories/Classes/tactics/ring_pol.v
+++ b/theories/Classes/tactics/ring_pol.v
@@ -5,6 +5,11 @@ Require Import
   HoTT.Classes.tactics.ring_quote
   HoTT.Classes.theory.rings.
 
+(* Disable automatic generation of elimination schemes to avoid
+   generation of induction/recursion principles to [Prop]/[Set]. *)
+
+Local Unset Elimination Schemes.
+
 Import Quoting.
 Local Set Universe Minimization ToSet.
 
@@ -18,6 +23,10 @@ Context {C : Type@{UC} } {V : Type0 }.
 Inductive Pol : Type@{UC} :=
   | Pconst (c : C)
   | PX (P : Pol) (v : V) (Q : Pol).
+
+Scheme Pol_ind := Induction for Pol Sort Type.
+Scheme Pol_rec := Minimality for Pol Sort Type.
+Definition Pol_rect := Pol_ind.
 
 (* [C] is the scalar semiring: Z when working on rings,
    N on semirings, other sometimes. *)

--- a/theories/Classes/tactics/ring_quote.v
+++ b/theories/Classes/tactics/ring_quote.v
@@ -3,6 +3,11 @@ Require Import HoTT.Classes.theory.rings
   HoTT.Classes.interfaces.abstract_algebra
   HoTT.Classes.implementations.list.
 
+(* Disable automatic generation of elimination schemes to avoid
+   generation of induction/recursion principles to [Prop]/[Set]. *)
+
+Local Unset Elimination Schemes.
+
 Class AlmostNegate A := almost_negate : A -> A.
 
 Class AlmostRing A {Aplus : Plus A} {Amult : Mult A}
@@ -37,6 +42,15 @@ Arguments One [V].
 Arguments Plus [V] a b.
 Arguments Mult [V] a b.
 Arguments Neg [V] a.
+
+Scheme Expr_ind := Induction for Expr Sort Type.
+Arguments Expr_ind [V].
+
+Scheme Expr_rec := Minimality for Expr Sort Type.
+Arguments Expr_rec [V].
+
+Definition Expr_rect := Expr_ind.
+Arguments Expr_rect [V].
 
 Section contents.
 Universe U.

--- a/theories/Modalities/Identity.v
+++ b/theories/Modalities/Identity.v
@@ -2,8 +2,12 @@
 Require Import HoTT.Basics HoTT.Types.
 Require Import Modality Accessible Nullification.
 
-Local Open Scope path_scope.
+Local Unset Elimination Schemes.
 
+(* Disable automatic generation of elimination schemes to avoid
+   generation of induction/recursion principles to [Prop]/[Set]. *)
+
+Local Open Scope path_scope.
 
 (** * The identity modality *)
 
@@ -11,6 +15,10 @@ Local Open Scope path_scope.
 
 Inductive Identity_Modality : Type1
   := purely : Identity_Modality.
+
+Scheme Identity_Modality_ind := Induction for Identity_Modality Sort Type.
+Scheme Identity_Modality_rec := Minimality for Identity_Modality Sort Type.
+Definition Identity_Modality_rect := Identity_Modality_ind.
 
 Module Identity_Modalities <: Modalities.
 

--- a/theories/Spaces/Int.v
+++ b/theories/Spaces/Int.v
@@ -5,6 +5,11 @@
 Require Import HoTT.Basics HoTT.Types.Universe.
 Require Import HSet.
 
+(* Disable automatic generation of elimination schemes to avoid
+   generation of induction/recursion principles to [Prop]/[Set]. *)
+
+Local Unset Elimination Schemes.
+
 Local Open Scope path_scope.
 
 (* ** Positive Numbers *)
@@ -12,6 +17,10 @@ Local Open Scope path_scope.
 Inductive Pos : Type0 :=
 | one : Pos
 | succ_pos : Pos -> Pos.
+
+Scheme Pos_ind := Induction for Pos Sort Type.
+Scheme Pos_rec := Minimality for Pos Sort Type.
+Definition Pos_rect := Pos_ind.
 
 Definition one_neq_succ_pos (z : Pos) : ~ (one = succ_pos z)
   := fun p => transport (fun s => match s with one => Unit | succ_pos t => Empty end) p tt.
@@ -25,6 +34,10 @@ Inductive Int : Type0 :=
 | neg : Pos -> Int
 | zero : Int
 | pos : Pos -> Int.
+
+Scheme Int_ind := Induction for Int Sort Type.
+Scheme Int_rec := Minimality for Int Sort Type.
+Definition Int_rect := Int_ind.
 
 Definition neg_injective {z w : Pos} (p : neg z = neg w) : z = w
   := transport (fun s => z = (match s with neg a => a | zero => w | pos a => w end)) p (idpath z).

--- a/theories/Tactics/EvalIn.v
+++ b/theories/Tactics/EvalIn.v
@@ -3,6 +3,11 @@
 (** * Evaluating tactics on terms *)
 Require Import Basics.Overture Basics.PathGroupoids.
 
+(* Disable automatic generation of elimination schemes to avoid
+   generation of induction/recursion principles to [Prop]/[Set]. *)
+
+Local Unset Elimination Schemes.
+
 (** It sometimes happens, in the course of writing a tactic, that we have some term in an Ltac variable (more precisely, we have what Ltac calls a "constr") and we would like to act on it with some tactic such as [cbv] or [rewrite].  Ordinarily, such tactics only act on the current *goal*, and generally they have a version such as [rewrite ... in ...] which acts on something in the current *context*, but neither of these is the same as acting on a term held in an Ltac variable.
 
 For some tactics, such as [cbv] and [pattern], we can write [eval TAC in H], where [H] is the term in question; this form *returns* the modified term so we can place it in another Ltac variable.  However, other tactics such as [rewrite] do not support this syntax.  (There is a feature request for it at https://coq.inria.fr/bugs/show_bug.cgi?id=3677.)
@@ -34,7 +39,7 @@ Ltac eval_in_using tac_in using_tac H :=
 
 Ltac eval_in tac_in H := eval_in_using tac_in idtac H.
 
-Example eval_in_example : forall A B : Set, A = B -> A -> B.
+Example eval_in_example : forall A B : Type0, A = B -> A -> B.
 Proof.
   intros A B H a.
   let x := (eval_in ltac:(fun H' => rewrite H in H') a) in

--- a/theories/Tests.v
+++ b/theories/Tests.v
@@ -1,5 +1,10 @@
 Require Import HoTT.
 
+(* Disable automatic generation of elimination schemes to avoid
+   generation of induction/recursion principles to [Prop]/[Set]. *)
+
+Local Unset Elimination Schemes.
+
 Fail Check Type0 : Type0.
 Check Susp nat : Type0.
 Fail Check Susp Type0 : Type0.

--- a/theories/Types/Wtype.v
+++ b/theories/Types/Wtype.v
@@ -5,6 +5,11 @@ Require Import HoTT.Basics.
 Require Import Types.Forall Types.Sigma Types.Paths Types.Unit.
 Local Open Scope path_scope.
 
+(* Disable automatic generation of elimination schemes to avoid
+   generation of induction/recursion principles to [Prop]/[Set]. *)
+
+Local Unset Elimination Schemes.
+
 Generalizable Variables X A B C f g n.
 
 (** Primitive projections do not work for recursive records; see bug #4648 - https://coq.inria.fr/bugs/show_bug.cgi?id=4648. *)
@@ -15,6 +20,15 @@ Local Set Primitive Projections.
 
 Arguments w_label {A B} _.
 Arguments w_arg {A B} _ _.
+
+Scheme W_ind := Induction for W Sort Type.
+Arguments W_ind [A B].
+
+Scheme W_rec := Minimality for W Sort Type.
+Arguments W_rec [A B].
+
+Definition W_rect := W_ind.
+Arguments W_rect [A B].
 
 (** ** Paths *)
 


### PR DESCRIPTION
I have spotted some places where inductive types are defined with the default elimination schemes to `Prop` and `Set`. We are not using `Prop` and `Set` in HoTT, so I have changed this, according to the style guideline https://github.com/HoTT/HoTT/blob/master/STYLE.md#induction-and-recursion-principles.