### PR TITLE
Declare argument scopes explicitly for `AdjunctionUnitCounit`

### DIFF
--- a/theories/Categories/Adjoint/UnitCounit.v
+++ b/theories/Categories/Adjoint/UnitCounit.v
@@ -285,5 +285,6 @@ Bind Scope adjunction_scope with AdjunctionUnitCounit.
 
 Arguments unit [C D]%category [F G]%functor _%adjunction / .
 Arguments counit [C D]%category [F G]%functor _%adjunction / .
+Arguments AdjunctionUnitCounit [C D]%category (F G)%functor.
 Arguments unit_counit_equation_1 [C D]%category [F G]%functor _%adjunction _%object.
 Arguments unit_counit_equation_2 [C D]%category [F G]%functor _%adjunction _%object.


### PR DESCRIPTION
HoTT was relying on a Coq bug which made some bound scopes visible even
if they were not imported in some scenarios. We avoid this by declaring explicitly some argument scopes.

This is in preparation for https://github.com/coq/coq/pull/10181, but
should be backward compatible (remains to be tested).