### PR TITLE
Remove compilation warnings

### DIFF
--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -325,7 +325,7 @@ Eval compute in (Book_2_4_npath 2 A). (* and so on... *)
 Definition Book_2_4_nboundary
   : forall {n : nat} {A : Type}, Book_2_4_npath (S n) A ->
                           (Book_2_4_npath n A * Book_2_4_npath n A)
-  := fun n A p => (pr1 p, pr1 (pr2 p)).
+  := fun {n} {A} p => (pr1 p, pr1 (pr2 p)).
 
 (* ================================================== ex:ap-to-apd-equiv-apd-to-ap *)
 (** Exercise 2.5 *)

--- a/coq/theories/Init/Datatypes.v
+++ b/coq/theories/Init/Datatypes.v
@@ -28,7 +28,8 @@ Inductive option (A : Type) : Type :=
 
 Scheme option_rect := Induction for option Sort Type.
 
-Arguments None [A].
+Arguments Some {A} a.
+Arguments None {A}.
 
 Register option as core.option.type.
 
@@ -144,7 +145,7 @@ Inductive list (A : Type) : Type :=
 
 Scheme list_rect := Induction for list Sort Type.
 
-Arguments nil [A].
+Arguments nil {A}.
 Declare Scope list_scope.
 Infix "::" := cons (at level 60, right associativity) : list_scope.
 Delimit Scope list_scope with list.

--- a/coq/theories/Init/Notations.v
+++ b/coq/theories/Init/Notations.v
@@ -76,12 +76,16 @@ Reserved Notation "{ x : A  |  P  & Q }" (at level 0, x at level 99).
 Reserved Notation "{ x : A  & P }" (at level 0, x at level 99).
 Reserved Notation "{ x : A  & P  & Q }" (at level 0, x at level 99).
 
-Delimit Scope type_scope with type.
-Delimit Scope function_scope with function.
+Declare Scope core_scope.
 Delimit Scope core_scope with core.
 
-Bind Scope type_scope with Sortclass.
+Declare Scope function_scope.
+Delimit Scope function_scope with function.
 Bind Scope function_scope with Funclass.
+
+Declare Scope type_scope.
+Delimit Scope type_scope with type.
+Bind Scope type_scope with Sortclass.
 
 Open Scope core_scope.
 Open Scope function_scope.

--- a/coq/theories/Init/Specif.v
+++ b/coq/theories/Init/Specif.v
@@ -160,10 +160,11 @@ End Dependent_choice_lemmas.
      It is implemented using the option type. *)
 
 Definition Exc := option.
-Definition value := Some.
+Definition value := @Some.
 Definition error := @None.
 
-Arguments error [A].
+Arguments value {A} a.
+Arguments error {A}.
 
 Definition except := False_rec. (* for compatibility with previous versions *)
 

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -15,9 +15,6 @@ Local Unset Elimination Schemes.
 (** This command changes Coq's subterm selection to always use full conversion after finding a subterm whose head/key matches the key of the term we're looking for.  This applies to [rewrite] and higher-order unification in [apply]/[elim]/[destruct].  Again, if you don't know what that means, ignore it. *)
 Global Set Keyed Unification.
 
-(** This command makes it so that when defining an [Instance], if you give a term explicitly with [:=], then Coq must be able to fill in all the holes in that term.  This is the same as the behavior of [Definition].  (Without this command, if Coq is unable to fill in all the holes in a term given to an [Instance], it silently drops into interactive proof mode.  This is a source of hard-to-find bugs, and you can always obtain equivalent behavior by beginning an interactive proof with [refine].) *)
-Global Unset Refine Instance Mode.
-
 (** This command makes it so that you don't have to declare universes explicitly when mentioning them in the type.  (Without this command, if you want to say [Definition foo := Type@{i}.], you must instead say [Definition foo@{i} := Type@{i}.]. *)
 Global Unset Strict Universe Declaration.
 
@@ -31,7 +28,7 @@ Global Set Default Goal Selector "!".
 Global Set Printing Primitive Projection Parameters.
 
 (** Apply using the same opacity information as typeclass proof search. *)
-Ltac class_apply c := autoapply c using typeclass_instances.
+Ltac class_apply c := autoapply c with typeclass_instances.
 
 Definition relation (A : Type) := A -> A -> Type.
 

--- a/theories/Categories/Adjoint/HomCoercions.v
+++ b/theories/Categories/Adjoint/HomCoercions.v
@@ -219,8 +219,6 @@ Section AdjunctionEquivalences'.
   Defined.
 End AdjunctionEquivalences'.
 
-Coercion adjunction_unit__of__adjunction_hom : AdjunctionHom >-> AdjunctionUnit.
-
 Definition AdjunctionUnitWithFunext `{Funext} C D F G := @AdjunctionUnit C D F G.
 Definition AdjunctionCounitWithFunext `{Funext} C D F G := @AdjunctionCounit C D F G.
 Definition AdjunctionUnitCounitWithFunext `{Funext} C D F G := @AdjunctionUnitCounit C D F G.
@@ -235,15 +233,8 @@ Definition adjunction_hom__of__adjunction_unit_Funext `{Funext} C D F G
 Definition AdjunctionHomOfAdjunctionCounit_Funext `{Funext} C D F G
            (A : AdjunctionCounitWithFunext _ _)
 : AdjunctionHom _ _
-  := @adjunction_hom__of__adjunction_unit _ C D F G A.
+  := @adjunction_hom__of__adjunction_unit _ C D F G (adjunction_unit_counit__of__adjunction_counit A).
 Definition adjunction_hom__of__adjunction_unitCounit_Funext `{Funext} C D F G
            (A : AdjunctionUnitCounitWithFunext _ _)
 : AdjunctionHom _ _
   := @adjunction_hom__of__adjunction_unit _ C D F G A.
-
-Coercion adjunction_hom__of__adjunction_unit_Funext
-: AdjunctionUnitWithFunext >-> AdjunctionHom.
-Coercion AdjunctionHomOfAdjunctionCounit_Funext
-: AdjunctionCounitWithFunext >-> AdjunctionHom.
-Coercion adjunction_hom__of__adjunction_unitCounit_Funext
-: AdjunctionUnitCounitWithFunext >-> AdjunctionHom.

--- a/theories/Categories/Adjoint/UnitCounitCoercions.v
+++ b/theories/Categories/Adjoint/UnitCounitCoercions.v
@@ -180,8 +180,3 @@ Coercion adjunction_unit__of__adjunction_unit_counit
 : AdjunctionUnitCounit >-> AdjunctionUnit.
 Coercion adjunction_counit__of__adjunction_unit_counit
 : AdjunctionUnitCounit >-> AdjunctionCounit.
-
-Coercion adjunction_unit_counit__of__adjunction_unit
-: AdjunctionUnit >-> AdjunctionUnitCounit.
-Coercion adjunction_unit_counit__of__adjunction_counit
-: AdjunctionCounit >-> AdjunctionUnitCounit.

--- a/theories/Categories/Adjoint/UniversalMorphisms/Core.v
+++ b/theories/Categories/Adjoint/UniversalMorphisms/Core.v
@@ -120,7 +120,7 @@ Section adjunction_from_universal.
     Definition adjunction__of__initial_morphism
     : functor__of__initial_morphism -| G.
     Proof.
-      refine (_ : AdjunctionUnit functor__of__initial_morphism G).
+      refine (adjunction_unit_counit__of__adjunction_unit _).
       eexists (Build_NaturalTransformation
                 1
                 (G o functor__of__initial_morphism)

--- a/theories/Categories/Category/Morphisms.v
+++ b/theories/Categories/Category/Morphisms.v
@@ -28,7 +28,7 @@ Hint Rewrite @left_inverse @right_inverse : morphism.
 
 Class Isomorphic {C : PreCategory} s d :=
   {
-    morphism_isomorphic :> morphism C s d;
+    morphism_isomorphic : morphism C s d;
     isisomorphism_isomorphic :> IsIsomorphism morphism_isomorphic
   }.
 

--- a/theories/Categories/Grothendieck/ToCat.v
+++ b/theories/Categories/Grothendieck/ToCat.v
@@ -25,9 +25,9 @@ Section Grothendieck.
 
   (** ** Category of elements *)
   Definition category : PreCategory
-    := category (F : FunctorToCat).
+    := category (pseudofunctor_of_functor_to_cat F).
 
   (** ** First projection functor *)
   Definition pr1 : Functor category C
-    := pr1 (F : FunctorToCat).
+    := pr1 (pseudofunctor_of_functor_to_cat F).
 End Grothendieck.

--- a/theories/Categories/NatCategory.v
+++ b/theories/Categories/NatCategory.v
@@ -40,10 +40,17 @@ Module Export Core.
       | S (S n') => discrete_category (S (S n'))
     end.
 
-  Coercion nat_category : nat >-> PreCategory.
-
   Module Export NatCategoryCoreNotations.
+    Notation "0" := (nat_category 0) : category_scope.
     Notation "1" := (nat_category 1) : category_scope.
+    Notation "2" := (nat_category 2) : category_scope.
+    Notation "3" := (nat_category 3) : category_scope.
+    Notation "4" := (nat_category 4) : category_scope.
+    Notation "5" := (nat_category 5) : category_scope.
+    Notation "6" := (nat_category 6) : category_scope.
+    Notation "7" := (nat_category 7) : category_scope.
+    Notation "8" := (nat_category 8) : category_scope.
+    Notation "9" := (nat_category 9) : category_scope.
   End NatCategoryCoreNotations.
 
   Typeclasses Transparent nat_category.

--- a/theories/Categories/Pseudofunctor/FromFunctor.v
+++ b/theories/Categories/Pseudofunctor/FromFunctor.v
@@ -161,5 +161,3 @@ Definition FunctorToCat `{Funext} {C} `{HP : forall C D, P C -> P D -> IsHSet (F
 Identity Coercion functor_to_cat_id : FunctorToCat >-> Functor.
 Definition pseudofunctor_of_functor_to_cat `(F : @FunctorToCat H C P HP)
   := @pseudofunctor_of_functor _ C P HP F.
-
-Coercion pseudofunctor_of_functor_to_cat : FunctorToCat >-> Pseudofunctor.

--- a/theories/Categories/SetCategory/Functors/SetProp.v
+++ b/theories/Categories/SetCategory/Functors/SetProp.v
@@ -53,6 +53,3 @@ Section set_coercions.
                                                         m')
                      (fun x => identity_of F (BuildhSet x)).
 End set_coercions.
-
-Coercion to_prop2set : to_prop >-> to_set.
-Coercion from_set2prop : from_set >-> from_prop.

--- a/theories/Classes/tactics/ring_quote.v
+++ b/theories/Classes/tactics/ring_quote.v
@@ -31,12 +31,12 @@ Inductive Expr (V:Type0) :=
   | Neg (a : Expr V)
 .
 
-Arguments Var [V] v.
-Arguments Zero [V].
-Arguments One [V].
-Arguments Plus [V] a b.
-Arguments Mult [V] a b.
-Arguments Neg [V] a.
+Arguments Var {V} v.
+Arguments Zero {V}.
+Arguments One {V}.
+Arguments Plus {V} a b.
+Arguments Mult {V} a b.
+Arguments Neg {V} a.
 
 Section contents.
 Universe U.


### PR DESCRIPTION
This patch fixes all the compilation warnings.

**EDIT:** except from the warnings from coqdep `declared ML module ... has not been found!`