### PR TITLE
Fix handling of --datadir in autoconf and configure

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,7 +11,7 @@ if make_hoqchk
   bin_SCRIPTS += hoqchk
 endif
 
-hottdir=$(datarootdir)/hott
+hottdir=$(datadir)/hott
 EXTRA_DIST = coq theories etc LICENSE.txt CREDITS.txt INSTALL.txt README.markdown
 
 # The path to the Coq library in $(srcdir)

--- a/configure.ac
+++ b/configure.ac
@@ -172,7 +172,7 @@ AS_IF([test "x$COQMAKEFILE" = "xno"],
       [AC_MSG_ERROR([Could not find coq_makefile])])
 
 
-hottdir="$datarootdir/hott"
+hottdir="$datadir/hott"
 AC_SUBST([hottdir])
 
 AC_CHECK_PROGS(ETAGS,etags,[: skipping etags])

--- a/hoq-config.in
+++ b/hoq-config.in
@@ -4,6 +4,7 @@
 # options.  One day we might figure out how to create an honest Coq
 # toplevel instead.
 prefix="@prefix@"
+datarootdir="@datarootdir@"
 export COQC="@COQC@"
 export COQCHK="@COQCHK@"
 export COQDEP="@COQDEP@"


### PR DESCRIPTION
in Install.md the option --datadir to configure is described. But it does not work. The variable datadir is set but not used. This PR fixes this.