### PR TITLE
A bunch of lemmas about pushouts

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -124,6 +124,7 @@ theories/HIT/surjective_factor.v
 theories/HIT/quotient.v
 theories/HIT/iso.v
 theories/HIT/Pushout.v
+theories/HIT/SetCone.v
 theories/HIT/Join.v
 theories/HIT/V.v
 theories/HIT/Colimits/CommutativeSquares.v

--- a/theories/HIT/Pushout.v
+++ b/theories/HIT/Pushout.v
@@ -91,6 +91,52 @@ Proof.
   refine (pushout_ind_beta_pp (fun _ => P) _ _ _ _).
 Defined.
 
+(** ** Universal property *)
+
+Definition pushout_unrec {A B C P} (f : A -> B) (g : A -> C)
+           (h : pushout f g -> P)
+  : {psh : (B -> P) * (C -> P) &
+           forall a, fst psh (f a) = snd psh (g a)}.
+Proof.
+  exists (h o pushl , h o pushr).
+  intros a; cbn.
+  exact (ap h (pp a)).
+Defined.
+
+Definition isequiv_pushout_rec `{Funext} {A B C} (f : A -> B) (g : A -> C) P
+  : IsEquiv (fun p : {psh : (B -> P) * (C -> P) &
+                            forall a, fst psh (f a) = snd psh (g a) }
+             => pushout_rec P (fst p.1) (snd p.1) p.2).
+Proof.
+  srefine (isequiv_adjointify _ (pushout_unrec f g) _ _).
+  - intros h.
+    apply path_arrow; intros x.
+    srefine (pushout_ind (fun x => pushout_rec P (fst (pushout_unrec f g h).1) (snd (pushout_unrec f g h).1) (pushout_unrec f g h).2 x = h x) _ _ _ x).
+    + intros b; reflexivity.
+    + intros c; reflexivity.
+    + intros a; cbn.
+      abstract (rewrite transport_paths_FlFr, pushout_rec_beta_pp;
+                rewrite concat_p1; apply concat_Vp).
+  - intros [[pushb pushc] pusha]; unfold pushout_unrec; cbn.
+    srefine (path_sigma' _ _ _).
+    + srefine (path_prod' _ _); reflexivity.
+    + apply path_forall; intros a.
+      abstract (rewrite transport_forall_constant, pushout_rec_beta_pp;
+                reflexivity).
+Defined.
+
+Definition equiv_pushout_rec `{Funext} {A B C} (f : A -> B) (g : A -> C) P
+  : {psh : (B -> P) * (C -> P) &
+           forall a, fst psh (f a) = snd psh (g a) }
+      <~> (pushout f g -> P)
+  := BuildEquiv _ _ _ (isequiv_pushout_rec f g P).
+
+Definition equiv_pushout_unrec `{Funext} {A B C} (f : A -> B) (g : A -> C) P
+  : (pushout f g -> P)
+      <~> {psh : (B -> P) * (C -> P) &
+                 forall a, fst psh (f a) = snd psh (g a) }
+  := equiv_inverse (equiv_pushout_rec f g P).
+
 (** ** Symmetry *)
 
 Definition pushout_sym_map {A B C} {f : A -> B} {g : A -> C}

--- a/theories/HIT/Pushout.v
+++ b/theories/HIT/Pushout.v
@@ -425,8 +425,8 @@ End PushoutAssoc.
 
 (** ** Pushouts of equvialences are equivalences *)
 
-Definition isequiv_pushout_isequiv {A B C} (f : A -> B) (g : A -> C)
-           `{IsEquiv _ _ f} : IsEquiv (pushr' f g).
+Global Instance isequiv_pushout_isequiv {A B C} (f : A -> B) (g : A -> C)
+       `{IsEquiv _ _ f} : IsEquiv (pushr' f g).
 Proof.
   srefine (isequiv_adjointify _ _ _ _).
   - srefine (pushout_rec C (g o f^-1) idmap _).
@@ -444,5 +444,28 @@ Proof.
       rewrite pushout_rec_beta_pp, eisadj, ap_idmap, concat_p1;
       rewrite <- ap_compose, <- (ap_compose g (pushr' f g));
       exact (concat_Ap (pp' f g) (eissect f a)) ).
+  - intros c; reflexivity.
+Defined.
+
+Global Instance isequiv_pushout_isequiv' {A B C} (f : A -> B) (g : A -> C)
+       `{IsEquiv _ _ g} : IsEquiv (pushl' f g).
+Proof.
+  srefine (isequiv_adjointify _ _ _ _).
+  - srefine (pushout_rec B idmap (f o g^-1) _).
+    intros a; cbn. symmetry; apply ap, eissect.
+  - srefine (pushout_ind _ _ _ _); cbn.
+    + intros b; reflexivity.
+    + intros c; change (pushl' f g (f (g^-1 c)) = pushr c).
+      transitivity (pushr' f g (g (g^-1 c))).
+      * apply pp.
+      * apply ap, eisretr.
+    + intros a.
+      abstract (
+      rewrite transport_paths_FlFr, ap_compose, !concat_pp_p;
+      apply moveR_Vp;
+      rewrite pushout_rec_beta_pp, eisadj, ap_idmap, concat_1p, ap_V;
+      apply moveL_Vp;
+      rewrite <- !ap_compose;
+      exact (concat_Ap (pp' f g) (eissect g a)) ).
   - intros c; reflexivity.
 Defined.

--- a/theories/HIT/Pushout.v
+++ b/theories/HIT/Pushout.v
@@ -3,7 +3,6 @@ Require Import HoTT.Basics.
 Require Import HoTT.Types.
 Require Import HSet TruncType.
 Require Export HIT.Coeq.
-Require Import HIT.Truncations.
 Local Open Scope path_scope.
 
 
@@ -447,15 +446,3 @@ Proof.
       exact (concat_Ap (pp' f g) (eissect f a)) ).
   - intros c; reflexivity.
 Defined.
-
-(** ** Cones of hsets *)
-
-Section SetCone.
-  Context {A B : hSet} (f : A -> B).
-
-  Definition setcone := Trunc 0 (pushout f (const tt)).
-
-  Global Instance istrunc_setcone : IsHSet setcone := _.
-
-  Definition setcone_point : setcone := tr (push (inr tt)).
-End SetCone.

--- a/theories/HIT/Pushout.v
+++ b/theories/HIT/Pushout.v
@@ -261,6 +261,169 @@ Section EquivSigmaPushout.
 
 End EquivSigmaPushout.
 
+(** ** Pushouts are associative *)
+
+Section PushoutAssoc.
+
+  Context {A1 A2 B C D : Type}
+          (f1 : A1 -> B) (g1 : A1 -> C) (f2 : A2 -> C) (g2 : A2 -> D).
+
+  Definition pushout_assoc_left := pushout (pushr' f1 g1 o f2) g2.
+  Let pushll : B -> pushout_assoc_left
+    := pushl' (pushr' f1 g1 o f2) g2 o pushl' f1 g1.
+  Let pushlm : C -> pushout_assoc_left
+    := pushl' (pushr' f1 g1 o f2) g2 o pushr' f1 g1.
+  Let pushlr : D -> pushout_assoc_left
+    := pushr' (pushr' f1 g1 o f2) g2.
+  Let ppll : forall a1, pushll (f1 a1) = pushlm (g1 a1)
+    := fun a1 => ap (pushl' (pushr' f1 g1 o f2) g2) (pp' f1 g1 a1).
+  Let pplr : forall a2, pushlm (f2 a2) = pushlr (g2 a2)
+    := fun a2 => pp' (pushr' f1 g1 o f2) g2 a2.
+
+  Definition pushout_assoc_left_ind
+             (P : pushout_assoc_left -> Type)
+             (pushb : forall b, P (pushll b))
+             (pushc : forall c, P (pushlm c))
+             (pushd : forall d, P (pushlr d))
+             (pusha1 : forall a1, (ppll a1) # pushb (f1 a1) = pushc (g1 a1))
+             (pusha2 : forall a2, (pplr a2) # pushc (f2 a2) = pushd (g2 a2))
+    : forall x, P x.
+  Proof.
+    srefine (pushout_ind _ _ pushd _).
+    - srefine (pushout_ind _ pushb pushc _).
+      intros a1.
+      exact (transport_compose P pushl _ _ @ pusha1 a1).
+    - exact pusha2.
+  Defined.
+
+  Section Pushout_Assoc_Left_Rec.
+
+    Context (P : Type)
+            (pushb : B -> P)
+            (pushc : C -> P)
+            (pushd : D -> P)
+            (pusha1 : forall a1, pushb (f1 a1) = pushc (g1 a1))
+            (pusha2 : forall a2, pushc (f2 a2) = pushd (g2 a2)).
+
+    Definition pushout_assoc_left_rec
+      : pushout_assoc_left -> P.
+    Proof.
+      srefine (pushout_rec _ _ pushd _).
+      - srefine (pushout_rec _ pushb pushc pusha1).
+      - exact pusha2.
+    Defined.
+
+    Definition pushout_assoc_left_rec_beta_ppll a1
+      : ap pushout_assoc_left_rec (ppll a1) = pusha1 a1.
+    Proof.
+      unfold ppll.
+      rewrite <- (ap_compose (pushl' (pushr' f1 g1 o f2) g2)
+                             pushout_assoc_left_rec).
+      change (ap (pushout_rec P pushb pushc pusha1) (pp' f1 g1 a1) = pusha1 a1).
+      apply pushout_rec_beta_pp.
+    Defined.
+
+    Definition pushout_assoc_left_rec_beta_pplr a2
+      : ap pushout_assoc_left_rec (pplr a2) = pusha2 a2.
+    Proof.
+      unfold pushout_assoc_left_rec, pplr.
+      apply (pushout_rec_beta_pp (f := pushr' f1 g1 o f2) (g := g2)).
+    Defined.
+
+  End Pushout_Assoc_Left_Rec.
+
+  Definition pushout_assoc_right := pushout f1 (pushl' f2 g2 o g1).
+  Let pushrl : B -> pushout_assoc_right
+    := pushl' f1 (pushl' f2 g2 o g1).
+  Let pushrm : C -> pushout_assoc_right
+    := pushr' f1 (pushl' f2 g2 o g1) o pushl' f2 g2.
+  Let pushrr : D -> pushout_assoc_right
+    := pushr' f1 (pushl' f2 g2 o g1) o pushr' f2 g2.
+  Let pprl : forall a1, pushrl (f1 a1) = pushrm (g1 a1)
+    := fun a1 => pp' f1 (pushl' f2 g2 o g1) a1.
+  Let pprr : forall a2, pushrm (f2 a2) = pushrr (g2 a2)
+    := fun a2 => ap (pushr' f1 (pushl' f2 g2 o g1)) (pp' f2 g2 a2).
+
+  Definition pushout_assoc_right_ind
+             (P : pushout_assoc_right -> Type)
+             (pushb : forall b, P (pushrl b))
+             (pushc : forall c, P (pushrm c))
+             (pushd : forall d, P (pushrr d))
+             (pusha1 : forall a1, (pprl a1) # pushb (f1 a1) = pushc (g1 a1))
+             (pusha2 : forall a2, (pprr a2) # pushc (f2 a2) = pushd (g2 a2))
+    : forall x, P x.
+  Proof.
+    srefine (pushout_ind _ pushb _ _).
+    - srefine (pushout_ind _ pushc pushd _).
+      intros a2.
+      exact (transport_compose P pushr _ _ @ pusha2 a2).
+    - exact pusha1.
+  Defined.
+
+  Section Pushout_Assoc_Right_Rec.
+
+    Context (P : Type)
+            (pushb : B -> P)
+            (pushc : C -> P)
+            (pushd : D -> P)
+            (pusha1 : forall a1, pushb (f1 a1) = pushc (g1 a1))
+            (pusha2 : forall a2, pushc (f2 a2) = pushd (g2 a2)).
+
+    Definition pushout_assoc_right_rec
+      : pushout_assoc_right -> P.
+    Proof.
+      srefine (pushout_rec _ pushb _ _).
+      - srefine (pushout_rec _ pushc pushd pusha2).
+      - exact pusha1.
+    Defined.
+
+    Definition pushout_assoc_right_rec_beta_pprl a1
+      : ap pushout_assoc_right_rec (pprl a1) = pusha1 a1.
+    Proof.
+      unfold pushout_assoc_right_rec, pprl.
+      apply (pushout_rec_beta_pp (f := f1) (g := pushl' f2 g2 o g1)).
+    Defined.
+
+    Definition pushout_assoc_right_rec_beta_pprr a2
+      : ap pushout_assoc_right_rec (pprr a2) = pusha2 a2.
+    Proof.
+      unfold pprr.
+      rewrite <- (ap_compose (pushr' f1 (pushl' f2 g2 o g1))
+                             pushout_assoc_right_rec).
+      change (ap (pushout_rec P pushc pushd pusha2) (pp' f2 g2 a2) = pusha2 a2).
+      apply pushout_rec_beta_pp.
+    Defined.
+
+  End Pushout_Assoc_Right_Rec.
+
+  Definition equiv_pushout_assoc
+    : pushout (pushr' f1 g1 o f2) g2 <~> pushout f1 (pushl' f2 g2 o g1).
+  Proof.
+    srefine (equiv_adjointify _ _ _ _).
+    - exact (pushout_assoc_left_rec _ pushrl pushrm pushrr pprl pprr).
+    - exact (pushout_assoc_right_rec _ pushll pushlm pushlr ppll pplr).
+    - abstract (
+      srefine (pushout_assoc_right_ind
+                 _ (fun _ => 1) (fun _ => 1) (fun _ => 1) _ _);
+        intros; rewrite transport_paths_FlFr, ap_compose;
+      [ rewrite pushout_assoc_right_rec_beta_pprl,
+        pushout_assoc_left_rec_beta_ppll
+      | rewrite pushout_assoc_right_rec_beta_pprr,
+        pushout_assoc_left_rec_beta_pplr ];
+      rewrite concat_p1, ap_idmap; apply concat_Vp ).
+    - abstract (
+      srefine (pushout_assoc_left_ind
+                 _ (fun _ => 1) (fun _ => 1) (fun _ => 1) _ _);
+        intros; rewrite transport_paths_FlFr, ap_compose;
+      [ rewrite pushout_assoc_left_rec_beta_ppll,
+        pushout_assoc_right_rec_beta_pprl
+      | rewrite pushout_assoc_left_rec_beta_pplr,
+        pushout_assoc_right_rec_beta_pprr ];
+      rewrite concat_p1, ap_idmap; apply concat_Vp ).
+  Defined.
+
+End PushoutAssoc.
+
 (** ** Cones of hsets *)
 
 Section SetCone.

--- a/theories/HIT/Pushout.v
+++ b/theories/HIT/Pushout.v
@@ -424,6 +424,30 @@ Section PushoutAssoc.
 
 End PushoutAssoc.
 
+(** ** Pushouts of equvialences are equivalences *)
+
+Definition isequiv_pushout_isequiv {A B C} (f : A -> B) (g : A -> C)
+           `{IsEquiv _ _ f} : IsEquiv (pushr' f g).
+Proof.
+  srefine (isequiv_adjointify _ _ _ _).
+  - srefine (pushout_rec C (g o f^-1) idmap _).
+    intros a; cbn; apply ap, eissect.
+  - srefine (pushout_ind _ _ _ _); cbn.
+    + intros b; change (pushr' f g (g (f^-1 b)) = pushl b).
+      transitivity (pushl' f g (f (f^-1 b))).
+      * symmetry; apply pp.
+      * apply ap, eisretr.
+    + intros c; reflexivity.
+    + intros a.
+      abstract (
+      rewrite transport_paths_FlFr, ap_compose, !concat_pp_p;
+      apply moveR_Vp; apply moveR_Vp;
+      rewrite pushout_rec_beta_pp, eisadj, ap_idmap, concat_p1;
+      rewrite <- ap_compose, <- (ap_compose g (pushr' f g));
+      exact (concat_Ap (pp' f g) (eissect f a)) ).
+  - intros c; reflexivity.
+Defined.
+
 (** ** Cones of hsets *)
 
 Section SetCone.

--- a/theories/HIT/SetCone.v
+++ b/theories/HIT/SetCone.v
@@ -1,0 +1,18 @@
+(* -*- mode: coq; mode: visual-line -*- *)
+Require Import HoTT.Basics.
+Require Import HoTT.Types.
+Require Import HSet TruncType.
+Require Import HIT.Pushout.
+Require Import HIT.Truncations.
+
+(** ** Cones of hsets *)
+
+Section SetCone.
+  Context {A B : hSet} (f : A -> B).
+
+  Definition setcone := Trunc 0 (pushout f (const tt)).
+
+  Global Instance istrunc_setcone : IsHSet setcone := _.
+
+  Definition setcone_point : setcone := tr (push (inr tt)).
+End SetCone.

--- a/theories/HIT/SetCone.v
+++ b/theories/HIT/SetCone.v
@@ -5,7 +5,7 @@ Require Import HSet TruncType.
 Require Import HIT.Pushout.
 Require Import HIT.Truncations.
 
-(** ** Cones of hsets *)
+(** * Cones of hsets *)
 
 Section SetCone.
   Context {A B : hSet} (f : A -> B).

--- a/theories/HIT/epi.v
+++ b/theories/HIT/epi.v
@@ -1,7 +1,7 @@
 Require Import HoTT.Basics.
 Require Import Types.Universe Types.Unit Types.Forall Types.Arrow Types.Sigma Types.Paths.
 Require Import HProp HSet TruncType UnivalenceImpliesFunext.
-Require Import HIT.Pushout HIT.Truncations HIT.Connectedness.
+Require Import HIT.Pushout HIT.Truncations HIT.SetCone HIT.Connectedness.
 
 Local Open Scope path_scope.
 

--- a/theories/HoTT.v
+++ b/theories/HoTT.v
@@ -45,6 +45,7 @@ Require Export HIT.FreeIntQuotient.
 Require Export HIT.Suspension.
 Require Export HIT.Spheres.
 Require Export HIT.Pushout.
+Require Export HIT.SetCone.
 Require Export HIT.epi.
 Require Export HIT.unique_choice.
 Require Export HIT.iso.

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -2,7 +2,7 @@
 Require Import HoTT.Basics HoTT.Types.
 Require Import UnivalenceImpliesFunext EquivalenceVarieties Extensions HProp Fibrations NullHomotopy Pullback.
 Require Import HoTT.Tactics.
-Require Import HIT.Coeq.
+Require Import HIT.Coeq HIT.Pushout.
 Require Import Tactics.RewriteModuloAssociativity.
 
 Local Open Scope nat_scope.
@@ -1016,6 +1016,32 @@ Section Reflective_Subuniverse.
         := BuildEquiv _ _ O_coeq_cmp _.
 
     End OCoeq.
+
+    (* ** Pushouts *)
+
+    Section OPushout.
+      Context {A B C : Type} (f : A -> B) (g : A -> C).
+
+      Definition equiv_O_pushout
+        : O (pushout f g) <~> O (pushout (O_functor f) (O_functor g)).
+      Proof.
+        unfold pushout.
+        refine (_ oE equiv_O_coeq (inl o f) (inr o g)).
+        refine ((equiv_O_coeq _ _)^-1 oE _).
+        apply equiv_O_functor.
+        srefine (@equiv_functor_coeq'
+                   _ _ (O_functor (inl o f)) (O_functor (inr o g))
+                   _ _ (O_functor (inl o O_functor f))
+                   (O_functor (inr o O_functor g)) _ _ _ _).
+        - apply equiv_to_O; exact _.
+        - apply equiv_O_sum.
+        - srefine (O_indpaths _ _ _); intros a; cbn.
+          abstract (rewrite !to_O_natural, O_rec_beta; reflexivity).
+        - srefine (O_indpaths _ _ _); intros a; cbn.
+          abstract (rewrite !to_O_natural, O_rec_beta; reflexivity).
+      Defined.
+
+    End OPushout.
 
   End Types.
 

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -1017,7 +1017,7 @@ Section Reflective_Subuniverse.
 
     End OCoeq.
 
-    (* ** Pushouts *)
+    (** ** Pushouts *)
 
     Section OPushout.
       Context {A B C : Type} (f : A -> B) (g : A -> C).


### PR DESCRIPTION
Pushouts of equivalences are equivalence, pushouts are associative, pushouts have a universal property, and a reflective subuniverse reflects pushouts (into pushouts in the subuniverse, as with other colimits).  I had to break the bit about "set cones" out of Pushout.v to avoid cyclic dependencies with ReflectiveSubuniverse.