### PR TITLE
Uncomment contrib in _CoqProject

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -174,9 +174,9 @@ theories/Tests.v
 #   Contrib  
 #
 
-#contrib/HoTTBook.v
-#contrib/HoTTBookExercises.v
-#contrib/Freudenthal.v
+contrib/HoTTBook.v
+contrib/HoTTBookExercises.v
+contrib/Freudenthal.v
 
 
 #


### PR DESCRIPTION
The contrib files were incorrectly commented out in #1062, preventing hoqc from functioning from an installed HoTT.

See also https://github.com/HoTT/HoTT/pull/1062#issuecomment-520593918