### PR TITLE
Remove some unnecessary funext and univalence, esp. in Pointed

### DIFF
--- a/theories/HIT/Truncations.v
+++ b/theories/HIT/Truncations.v
@@ -265,6 +265,16 @@ Ltac strip_truncations :=
 
 (** ** Path-spaces of truncations *)
 
+(** This direction doesn't require univalence. *)
+Definition path_Tr {n A} (x y : A)
+: Tr n (x = y) -> (tr x = tr y :> Tr n.+1 A).
+Proof.
+  intros e.
+  strip_truncations.
+  exact (ap tr e).
+Defined.
+
+(** But the full characterization does. *)
 Definition equiv_path_Tr `{Univalence} {n A} (x y : A)
 : Tr n (x = y) <~> (tr x = tr y :> Tr n.+1 A).
 Proof.

--- a/theories/Homotopy/HomotopyGroup.v
+++ b/theories/Homotopy/HomotopyGroup.v
@@ -4,7 +4,6 @@ Require Import HIT.Truncations.
 Require Import Pointed.
 Require Import abstract_algebra.
 Require Import Spaces.Nat.
-Require Import UnivalenceAxiom.
 
 Import TrM.
 
@@ -105,8 +104,8 @@ Section PiFunctor.
     apply Build_MonoidPreserving.
     + intros x y.
       strip_truncations.
-      apply equiv_path_Tr, tr, loops_functor_pp.
-    + apply equiv_path_Tr, tr; cbn.
+      apply path_Tr, tr, loops_functor_pp.
+    + apply path_Tr, tr; cbn.
       destruct n; hott_simpl.
   Defined.
 

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -726,7 +726,7 @@ Section Reflective_Subuniverse.
       apply isequiv_precompose; exact _.
     Defined.
 
-    Definition equiv_O_prod_cmp {fs : Funext} (A B : Type)
+    Definition equiv_O_prod_cmp (A B : Type)
     : O (A * B) <~> (O A * O B)
     := BuildEquiv _ _ (O_prod_cmp A B) _.
 

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -93,7 +93,7 @@ Coercion pfam_pr1 : pFam >-> Funclass.
 
 (* IsTrunc for a pointed type family *)
 Class IsTrunc_pFam n {A} (X : pFam A)
-  := Trunc_pFam_is_trunc : forall x, IsTrunc n (X.1 x).
+  := trunc_pfam_is_trunc : forall x, IsTrunc n (X.1 x).
 
 (* Pointed sigma *)
 Definition psigma {A : pType} (P : pFam A) : pType.

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -88,24 +88,23 @@ Coercion pointed_equiv_equiv {A B} (f : A <~>* B)
 
 (* Pointed type family *)
 Definition pFam (A : pType) := {P : A -> Type & P (point A)}.
+Definition pfam_pr1 {A : pType} (P : pFam A) : A -> Type := pr1 P.
+Coercion pfam_pr1 : pFam >-> Funclass.
 
 (* IsTrunc for a pointed type family *)
-Definition IsTrunc_pFam n {A} (X : pFam A) := forall x, IsTrunc n (X.1 x).
+Class IsTrunc_pFam n {A} (X : pFam A)
+  := Trunc_pFam_is_trunc : forall x, IsTrunc n (X.1 x).
 
 (* Pointed sigma *)
-Definition psigma : {A : pType & pFam A} -> pType.
+Definition psigma {A : pType} (P : pFam A) : pType.
 Proof.
-  intros [[A a] [P p]].
   exists {x : A & P x}.
-  exact (a; p).
+  exact (point A; P.2).
 Defined.
 
 (* Pointed pi types, note that the domain is not pointed *)
-Definition pforall : {A : Type & A -> pType} -> pType.
-Proof.
-  intros [A F].
-  exact (Build_pType (forall (a : A), pointed_type (F a)) (ispointed_type o F)).
-Defined.
+Definition pforall {A : Type} (F : A -> pType) : pType
+  := Build_pType (forall (a : A), pointed_type (F a)) (ispointed_type o F).
 
 (** The following tactic often allows us to "pretend" that pointed maps and homotopies preserve basepoints strictly.  We have carefully defined [pMap] and [pHomotopy] so that when destructed, their second components are paths with right endpoints free, to which we can apply Paulin-Morhing path-induction. *)
 Ltac pointed_reduce :=

--- a/theories/Pointed/Loops.v
+++ b/theories/Pointed/Loops.v
@@ -208,7 +208,7 @@ Proof.
   reflexivity.
 Defined.
 
-(* Iterated loops products preserve products *)
+(* Iterated loops of products are products of iterated loops *)
 Lemma iterated_loops_prod (X Y : pType) {n}
   : iterated_loops n (X * Y) <~>* (iterated_loops n X) * (iterated_loops n Y).
 Proof.
@@ -278,8 +278,7 @@ Defined.
 (* We declare this local notation to make it easier to write pointed types *)
 Local Notation "( X , x )" := (Build_pType X x).
 
-(* We can convert between families of loops in a type and
-   loops in Type at that type *)
+(* We can convert between families of loops in a type and loops in Type at that type. *)
 Definition loops_type `{Univalence} (A : Type)
   : loops (Type,A) <~>* (A <~> A, equiv_idmap).
 Proof.

--- a/theories/Pointed/Loops.v
+++ b/theories/Pointed/Loops.v
@@ -40,6 +40,10 @@ Proof.
   by refine (ap loops IHn @ _).
 Defined.
 
+Definition unfold_iterated_loops' (n : nat) (X : pType)
+  : iterated_loops n.+1 X <~>* iterated_loops n (loops X)
+  := pequiv_path (unfold_iterated_loops n X).
+
 (** The loop space decreases the truncation level by one.  We don't bother making this an instance because it is automatically found by typeclass search, but we record it here in case anyone is looking for it. *)
 Definition istrunc_loops {n} (A : pType) `{IsTrunc n.+1 A}
   : IsTrunc n (loops A) := _.
@@ -80,17 +84,6 @@ Proof.
   by pointed_reduce.
 Defined.
 
-(* Iterated loops functor respects composition *)
-Lemma iterated_loops_functor_compose `{Univalence} n A B C (f : B ->* C)
-  (g : A ->* B) : iterated_loops_functor n (f o* g)
-  ==* (iterated_loops_functor n f) o* (iterated_loops_functor n g).
-Proof.
-  induction n; cbn.
-  1: reflexivity.
-  destruct (path_pmap IHn)^.
-  apply loops_functor_compose.
-Defined.
-
 (* Loops functor respects identity *)
 Definition loops_functor_idmap (A : pType)
   : loops_functor (@pmap_idmap A) ==* pmap_idmap.
@@ -109,6 +102,7 @@ Proof.
   apply ap_pp.
 Defined.
 
+(* Loops functor preserves pointed homotopies *)
 Definition loops_2functor {A B : pType} {f g : A ->* B} (p : f ==* g)
   : (loops_functor f) ==* (loops_functor g).
 Proof.
@@ -118,6 +112,17 @@ Proof.
     refine (_ @ (concat_p1 _)^ @ (concat_1p _)^).
     apply moveR_Vp, concat_Ap. }
   hott_simpl.
+Defined.
+
+(* Iterated loops functor respects composition *)
+Lemma iterated_loops_functor_compose n A B C (f : B ->* C)
+  (g : A ->* B) : iterated_loops_functor n (f o* g)
+  ==* (iterated_loops_functor n f) o* (iterated_loops_functor n g).
+Proof.
+  induction n; cbn.
+  1: reflexivity.
+  refine (_ @* (loops_functor_compose _ _)).
+  apply loops_2functor, IHn.
 Defined.
 
 (** The loop space functor decreases the truncation level by one.  *)
@@ -173,7 +178,7 @@ Proof.
 Defined.
 
 (* Loops functor preserves equivalences *)
-Definition pequiv_loops_functor `{Funext} {A B : pType}
+Definition pequiv_loops_functor {A B : pType}
   : A <~>* B -> loops A <~>* loops B.
 Proof.
   intro f.
@@ -181,12 +186,12 @@ Proof.
   1: apply loops_functor, f.
   1: apply loops_functor, (pequiv_inverse f).
   1,2: refine ((loops_functor_compose _ _)^* @* _ @* loops_functor_idmap _).
-  1,2: apply phomotopy_ap.
+  1,2: apply loops_2functor.
   1: apply peisretr.
   apply peissect.
 Defined.
 
-Lemma pequiv_iterated_loops_functor `{Funext} {A B n} : A <~>* B
+Lemma pequiv_iterated_loops_functor {A B n} : A <~>* B
   -> iterated_loops n A <~>* iterated_loops n B.
 Proof.
   intros f.
@@ -204,7 +209,7 @@ Proof.
 Defined.
 
 (* Iterated loops products preserve products *)
-Lemma iterated_loops_prod `{Univalence} (X Y : pType) {n}
+Lemma iterated_loops_prod (X Y : pType) {n}
   : iterated_loops n (X * Y) <~>* (iterated_loops n X) * (iterated_loops n Y).
 Proof.
   induction n.
@@ -214,107 +219,86 @@ Proof.
 Defined.
 
 (* A dependent form of loops *)
-Definition loopsD A : pFam A -> pFam (loops A)
+Definition loopsD {A} : pFam A -> pFam (loops A)
   := fun Pp => (fun q => transport Pp.1 q Pp.2 = Pp.2; 1).
 
-(* Loops for pointed type families *)
-Definition pfam_loops : {A : pType & pFam A} -> {A : pType & pFam A}
-  := functor_sigma loops loopsD.
+Global Instance istrunc_pfam_loopsD {n} {A} (P : pFam A)
+       {H :IsTrunc_pFam n.+1 P}
+  : IsTrunc_pFam n (loopsD P).
+Proof.
+  intros a. pose (H (point A)). exact _.
+Defined.
 
 (* psigma and loops 'commute' *)
-Lemma loops_psigma_commute `{Univalence}
-  : loops o psigma == psigma o pfam_loops.
+Lemma loops_psigma_commute (A : pType) (P : pFam A)
+  : loops (psigma P) <~>* psigma (loopsD P).
 Proof.
-  intros x.
-  apply path_ptype.
   srefine (Build_pEquiv _ _ (Build_pMap _ _ (_ : Equiv _ _) _) _).
   1: exact (equiv_path_sigma _ _ _)^-1%equiv.
   reflexivity.
 Defined.
 
 (* pforall and loops 'commute' *)
-Lemma loops_pforall_commute `{Univalence} (A : Type) (F : A -> pType)
-  : loops (pforall (A; F)) = pforall (A; loops o F).
+Lemma loops_pforall_commute `{Funext} (A : Type) (F : A -> pType)
+  : loops (pforall F) <~>* pforall (loops o F).
 Proof.
-  apply path_ptype.
   srefine (Build_pEquiv _ _ (Build_pMap _ _ (_ : Equiv _ _) _) _).
   1: apply equiv_apD10.
   reflexivity.
 Defined.
 
 (* pforall and iterated loops commute *)
-Lemma iterated_loops_pforall_commute `{Univalence} (A : Type) (F : A -> pType) (n : nat)
-  : iterated_loops n (pforall (A; F)) = pforall (A; iterated_loops n o F).
+Lemma iterated_loops_pforall_commute `{Funext} (A : Type) (F : A -> pType) (n : nat)
+  : iterated_loops n (pforall F) <~>* pforall (iterated_loops n o F).
 Proof.
-  induction n; cbn.
+  induction n.
   1: reflexivity.
-  refine (ap loops IHn @ _).
-  apply loops_pforall_commute.
+  refine (loops_pforall_commute _ _ o*E _).
+  apply pequiv_loops_functor, IHn.
 Defined.
 
 (* Loops neutralise sigmas when truncated *)
-Lemma loops_psigma_trunc `{Univalence} (n : nat) : forall (Aa : pType)
+Lemma loops_psigma_trunc (n : nat) : forall (Aa : pType)
   (Pp : pFam Aa) (istrunc_Pp : IsTrunc_pFam (nat_to_trunc_index_2 n) Pp),
-  iterated_loops n (psigma (Aa; Pp))
-  = iterated_loops n Aa.
+  iterated_loops n (psigma Pp)
+  <~>* iterated_loops n Aa.
 Proof.
   induction n.
   { intros A P p.
-    serapply path_ptype.
     srefine (Build_pEquiv _ _ (Build_pMap _ _ (_ : Equiv _ _) _) _).
     1: refine (@equiv_sigma_contr _ _ p).
     reflexivity. }
   intros A P p.
-  refine (unfold_iterated_loops _ _ @ _).
-  refine (ap _ (loops_psigma_commute _) @ _).
-  refine (IHn _ _ _ @ (unfold_iterated_loops _ _)^).
-  intro; refine (@istrunc_paths _ _ (p (point A)) _ _).
+  refine (pequiv_inverse (unfold_iterated_loops' _ _) o*E _ o*E unfold_iterated_loops' _ _).
+  refine (IHn _ _ _ o*E _).
+  apply pequiv_iterated_loops_functor.
+  apply loops_psigma_commute.
 Defined.
 
 (* We declare this local notation to make it easier to write pointed types *)
 Local Notation "( X , x )" := (Build_pType X x).
 
-(* Here are some path lemmas we will need *)
-Local Lemma path_ptype_path_equiv `{Univalence} (A : Type)
-  : (A = A, 1) = (A <~> A, 1%equiv).
-Proof.
-  apply path_ptype.
-  refine (Build_pEquiv _ _ (Build_pMap (A = A, 1)
-    (A <~> A, 1%equiv) (equiv_path A A) 1) _).
-  exact (isequiv_equiv_path A A).
-Defined.
-
-Local Lemma path_ptype_issig_equiv `{Univalence} (A : Type)
-  : (A <~> A, 1%equiv) = Build_pType
-    {f : A -> A & IsEquiv f} (idmap; isequiv_idmap A).
-Proof.
-  symmetry.
-  apply path_ptype.
-  refine (Build_pEquiv _ _ (Build_pMap
-    ({f : A -> A & IsEquiv f}, (idmap; isequiv_idmap A))
-    (A <~> A, 1%equiv) (issig_equiv _ _) 1) _).
-Defined.
-
 (* We can convert between families of loops in a type and
    loops in Type at that type *)
+Definition loops_type `{Univalence} (A : Type)
+  : loops (Type,A) <~>* (A <~> A, equiv_idmap).
+Proof.
+  apply issig_pequiv.
+  exists (equiv_equiv_path A A).
+  reflexivity.
+Defined.
+  
 Lemma local_global_looping `{Univalence} (A : Type) (n : nat)
   : iterated_loops n.+2 (Type, A)
-  = pforall (A; fun a => iterated_loops n.+1 (A, a)).
+  <~>* pforall (fun a => iterated_loops n.+1 (A, a)).
 Proof.
-  refine (unfold_iterated_loops _ _ @ _).
-  change (loops (Type, A)) with (A = A, 1).
-  refine (ap _ (path_ptype_path_equiv A) @ _).
-  refine (ap _ (path_ptype_issig_equiv A) @ _).
-  change ({f : A -> A & IsEquiv f}, (idmap; isequiv_idmap A)) with
-    (psigma ((A -> A, idmap); (IsEquiv; isequiv_idmap A))).
-  refine (loops_psigma_trunc n.+1 (A -> A, idmap)
-    (IsEquiv; isequiv_idmap A) _ @ _).
-  { intros x.
-    induction n.
-    1: apply hprop_isequiv.
-    apply trunc_succ. }
-  change (A -> A, idmap) with (pforall (A; fun a => (A, a))).
-  apply (iterated_loops_pforall_commute _ _ n.+1).
+  induction n.
+  { refine (_ o*E pequiv_loops_functor (loops_type A)).
+    apply issig_pequiv.
+    exists (equiv_inverse (equiv_path_arrow 1%equiv 1%equiv)
+            oE equiv_inverse (equiv_path_equiv 1%equiv 1%equiv)).
+    reflexivity. }
+  exact (loops_pforall_commute _ _ o*E pequiv_loops_functor IHn).
 Defined.
 
 (* 7.2.7 *)

--- a/theories/Pointed/pEquiv.v
+++ b/theories/Pointed/pEquiv.v
@@ -75,6 +75,11 @@ Defined.
 Definition path_ptype `{Univalence} {A B : pType} : (A <~>* B) -> A = B
   := equiv_path_ptype A B.
 
+Definition pequiv_path {A B : pType} : (A = B) -> (A <~>* B).
+Proof.
+  intros p; destruct p; exact pequiv_pmap_idmap.
+Defined.
+
 (* A pointed version of Sect (sometimes useful for proofs
    of some equivalences) *)
 Definition pSect {A B : pType} (s : A ->* B) (r : B ->* A)

--- a/theories/Pointed/pEquiv.v
+++ b/theories/Pointed/pEquiv.v
@@ -60,6 +60,11 @@ Proof.
   intro; cbn; apply equiv_sigma_symm0.
 Defined.
 
+(* Sometimes we wish to construct a pEquiv from an equiv and a proof that it is pointed *)
+Definition Build_pEquiv' {A B : pType} (f : A <~> B)
+  (p : f (point A) = point B)
+  : A <~>* B := Build_pEquiv _ _ (Build_pMap _ _ f p) _.
+
 (* Under univalence, pointed equivalences are equivalent to paths *)
 Definition equiv_path_ptype `{Univalence} (A B : pType) : A <~>* B <~> A = B.
 Proof.
@@ -77,11 +82,11 @@ Definition path_ptype `{Univalence} {A B : pType} : (A <~>* B) -> A = B
 
 Definition pequiv_path {A B : pType} : (A = B) -> (A <~>* B).
 Proof.
-  intros p; destruct p; exact pequiv_pmap_idmap.
+  intros p; apply (ap issig_ptype^-1) in p.
+  srefine (Build_pEquiv' (equiv_path A B p..1) p..2).
 Defined.
 
-(* A pointed version of Sect (sometimes useful for proofs
-   of some equivalences) *)
+(* A pointed version of Sect (sometimes useful for proofs of some equivalences) *)
 Definition pSect {A B : pType} (s : A ->* B) (r : B ->* A)
   := r o* s ==* pmap_idmap.
 
@@ -108,12 +113,6 @@ Proof.
   hott_simpl.
   apply eisadj.
 Qed.
-
-(* Sometimes we wish to construct a pEquiv from an equiv and a proof
-  that it is pointed *)
-Definition Build_pEquiv' {A B : pType} (f : A <~> B)
-  (p : f (point A) = point B)
-  : A <~>* B := Build_pEquiv _ _ (Build_pMap _ _ f p) _.
 
 (* A version of equiv_adjointify for pointed equivalences
   where all data is pointed. There is a lot of unecessery data here

--- a/theories/Pointed/pMap.v
+++ b/theories/Pointed/pMap.v
@@ -54,7 +54,7 @@ Proof.
   - reflexivity.
 Qed.
 
-(* A kind of ap for pHomotopies *)
+(* A kind of ap for pHomotopies, obtained by going through funext.  Usually unnecessary. *)
 Definition phomotopy_ap `{Funext} {A B C D : pType} {f g : A ->* B}
   (h : (A ->* B) -> C ->* D) : f ==* g -> h f ==* h g.
 Proof.

--- a/theories/Pointed/pMap.v
+++ b/theories/Pointed/pMap.v
@@ -53,13 +53,3 @@ Proof.
   - intros ?; reflexivity.
   - reflexivity.
 Qed.
-
-(* A kind of ap for pHomotopies, obtained by going through funext.  Usually unnecessary. *)
-Definition phomotopy_ap `{Funext} {A B C D : pType} {f g : A ->* B}
-  (h : (A ->* B) -> C ->* D) : f ==* g -> h f ==* h g.
-Proof.
-  intro p.
-  destruct (path_pmap p).
-  reflexivity.
-Defined.
-


### PR DESCRIPTION
While reviewing #1086 I noticed that a fair number of funext and univalence assumptions in the Pointed library could be eliminated -- some completely, others by rephrasing theorems in terms of pointed equivalences rather than equalities of pointed types (which are generally more useful to have defined directly anyway -- it produces fewer univalence redexes).

Whichever of this or #1086 is merged second will probably require rebasing onto the other.