### PR TITLE
Cleaned up quotient

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -154,6 +154,7 @@ theories/Limits/Pullback.v
 
 theories/Colimits/Pushout.v
 theories/Colimits/SpanPushout.v
+theories/Colimits/Quotient.v
 
 theories/Colimits/Colimit.v
 theories/Colimits/Colimit_Sigma.v

--- a/contrib/HoTTBook.v
+++ b/contrib/HoTTBook.v
@@ -1007,7 +1007,7 @@ Definition Book7_1_11 := @HoTT.TruncType.istrunc_trunctype.
 (* ================================================== thm:h-set-refrel-in-paths-sets *)
 (** Theorem 7.2.2 *)
 
-Definition Book_7_2_2 := @HoTT.HSet.isset_hrel_subpaths.
+Definition Book_7_2_2 := @HoTT.HSet.ishset_hrel_subpaths.
 
 (* ================================================== notnotstable-equality-to-set *)
 (** Corollary 7.2.3 *)

--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -569,7 +569,7 @@ Proof.
   intros isHSet_A allBx_HSet.
   serapply hset_axiomK. intros x xx.
   pose (path_path_sigma B x x xx 1) as useful.
-  apply (useful (axiomK_hset _ _ _) (set_path2 _ _)).
+  apply (useful (axiomK_hset _ _ _) (hset_path2 _ _)).
 Defined.
 
 (* ================================================== ex:prop-endocontr *)
@@ -1483,7 +1483,7 @@ End Book_6_9.
 Section Book_7_1.
   Lemma Book_7_1_part_i (H : forall A, merely A -> A) A : IsHSet A.
   Proof.
-    apply (@HoTT.HSet.isset_hrel_subpaths
+    apply (@HoTT.HSet.ishset_hrel_subpaths
              A (fun x y => merely (x = y)));
     try typeclasses eauto.
     - intros ?.

--- a/theories/Algebra/Aut.v
+++ b/theories/Algebra/Aut.v
@@ -1,8 +1,8 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
-Require Import HoTT.Basics HoTT.Types.
-Require Import Pointed UnivalenceImpliesFunext Factorization.
-Require Import Modalities.Modality.
-Require Import HoTT.Truncations HIT.quotient.
+Require Import Basics.
+Require Import Types.
+Require Import Truncations.
+Require Import Factorization.
 Require Import Algebra.ooGroup.
 Import TrM.
 

--- a/theories/Algebra/ooGroup.v
+++ b/theories/Algebra/ooGroup.v
@@ -2,8 +2,8 @@
 Require Import Basics.
 Require Import Types.
 Require Import Pointed.
-Require Import HoTT.Truncations.
-Require Import HIT.quotient.
+Require Import Truncations.
+Require Import Colimits.Quotient.
 
 Import TrM.
 
@@ -281,6 +281,6 @@ Section Subgroups.
       apply moveR_Vp, moveL_pM. exact (p^).
   Defined.
 
-  Definition cosets := quotient in_coset.
+  Definition cosets := Quotient in_coset.
 
 End Subgroups.

--- a/theories/Basics/PathGroupoids.v
+++ b/theories/Basics/PathGroupoids.v
@@ -920,6 +920,20 @@ Proof.
   destruct p; reflexivity.
 Defined.
 
+Definition apD_compose {A A' : Type} {B : A' -> Type} (g : A -> A')
+  (f : forall a, B a) {x y : A} (p : x = y)
+  : apD (f o g) p  = (transport_compose _ _ _ _) @ apD f (ap g p).
+Proof.
+  by destruct p.
+Defined.
+
+Definition apD_compose' {A A' : Type} {B : A' -> Type} (g : A -> A')
+  (f : forall a, B a) {x y : A} (p : x = y)
+  : apD f (ap g p) = (transport_compose B _ _ _)^ @ apD (f o g) p.
+Proof.
+  by destruct p.
+Defined.
+
 (** ** The 2-dimensional groupoid structure *)
 
 (** Horizontal composition of 2-dimensional paths. *)

--- a/theories/Categories/Structure/Core.v
+++ b/theories/Categories/Structure/Core.v
@@ -148,7 +148,7 @@ Global Instance istrunc_homomorphism_standard_notion_of_structure
        X P `{@IsStandardNotionOfStructure X P} x
 : IsHSet (P x).
 Proof.
-  eapply (@isset_hrel_subpaths
+  eapply (@ishset_hrel_subpaths
             _ (fun a b => (a <= b) * (b <= a)));
   try typeclasses eauto.
   - repeat intro; split; apply reflexivity.

--- a/theories/Classes/interfaces/ua_algebra.v
+++ b/theories/Classes/interfaces/ua_algebra.v
@@ -241,7 +241,7 @@ Proof.
   unshelve eapply path_path_sigma.
   - transitivity (ap carriers p); [by destruct p |].
     transitivity (ap carriers q); [exact r | by destruct q].
-  - apply hprop_allpath. apply set_path2.
+  - apply hprop_allpath. apply hset_path2.
 Defined.
 
 Module algebra_notations.

--- a/theories/Classes/theory/premetric.v
+++ b/theories/Classes/theory/premetric.v
@@ -46,7 +46,7 @@ Class PreMetric@{i j} (A:Type@{i}) {Aclose : Closeness A} :=
 Global Instance premetric_hset@{i j} `{Funext}
   {A:Type@{i} } `{PreMetric@{i j} A} : IsHSet A.
 Proof.
-apply (@HSet.isset_hrel_subpaths@{j i j} _ (fun x y => forall e, close e x y)).
+apply (@HSet.ishset_hrel_subpaths@{j i j} _ (fun x y => forall e, close e x y)).
 - intros x;reflexivity.
 - apply _.
 - apply separated.

--- a/theories/Classes/theory/rationals.v
+++ b/theories/Classes/theory/rationals.v
@@ -62,7 +62,7 @@ Qed.
 
 Global Instance Qpos_isset : IsHSet Q+.
 Proof.
-apply (@HSet.isset_hrel_subpaths _ (fun e d => ' e = ' d)).
+apply (@HSet.ishset_hrel_subpaths _ (fun e d => ' e = ' d)).
 - intros e; reflexivity.
 - apply _.
 - exact pos_eq.

--- a/theories/Colimits/Pushout.v
+++ b/theories/Colimits/Pushout.v
@@ -5,25 +5,13 @@ Require Import HSet TruncType.
 Require Export HIT.Coeq.
 Local Open Scope path_scope.
 
-
 (** * Homotopy Pushouts *)
-
-(*
-Record Span :=
-  { A : Type; B : Type; C : Type;
-    f : C -> A;
-    g : C -> B }.
-
-Record Cocone (S : Span) (D : Type) :=
-  { i : A S -> D;
-    j : B S -> D;
-    h : forall c, i (f S c) = j (g S c) }.
-*)
 
 (** We define pushouts in terms of coproducts and coequalizers. *)
 
-Definition Pushout {A B C : Type} (f : A -> B) (g : A -> C) : Type
-  := Coeq (inl o f) (inr o g).
+Definition Pushout@{i j k l} {A : Type@{i}} {B : Type@{j}} {C : Type@{k}}
+  (f : A -> B) (g : A -> C) : Type@{l}
+  := Coeq@{l l} (inl o f) (inr o g).
 
 Definition push {A B C : Type} {f : A -> B} {g : A -> C}
  : B+C -> Pushout f g
@@ -46,14 +34,19 @@ Definition pglue' {A B C : Type} (f : A -> B) (g : A -> C) (a : A) : pushl (f a)
 
 Section PushoutInd.
 
-  Context {A B C : Type} {f : A -> B} {g : A -> C} (P : Pushout f g -> Type)
-          (pushb : forall b : B, P (pushl b))
-          (pushc : forall c : C, P (pushr c))
-          (pusha : forall a : A, (pglue a) # (pushb (f a)) = pushc (g a)).
+  Context {A B C : Type} {f : A -> B} {g : A -> C}
+    (P : Pushout f g -> Type)
+    (pushb : forall b : B, P (pushl b))
+    (pushc : forall c : C, P (pushr c))
+    (pusha : forall a : A, (pglue a) # (pushb (f a)) = pushc (g a)).
 
   Definition Pushout_ind
     : forall (w : Pushout f g), P w
-    := Coeq_ind P (fun bc => match bc with inl b => pushb b | inr c => pushc c end) pusha.
+    := Coeq_ind P (fun bc =>
+      match bc with
+        | inl b => pushb b
+        | inr c => pushc c 
+      end) pusha.
 
   Definition Pushout_ind_beta_pushl (b:B) : Pushout_ind (pushl b) = pushb b
     := 1.

--- a/theories/Colimits/Quotient.v
+++ b/theories/Colimits/Quotient.v
@@ -1,0 +1,405 @@
+Require Import Basics.
+Require Import Types.
+Require Import HSet.
+Require Import HProp.
+Require Import UnivalenceImpliesFunext.
+Require Import TruncType.
+Require Import HIT.epi.
+Require Import HIT.Coeq.
+Require Import Truncations.
+
+Local Open Scope path_scope.
+
+
+(** * Quotient of a Type by an hprop-valued relation
+
+We aim to model:
+<<
+Inductive quotient : Type :=
+   | class_of : A -> quotient
+   | related_classes_eq : forall x y, (R x y), class_of x = class_of y
+   | quotient_set : IsHSet quotient
+>>
+*)
+
+(** This development should be further connected with the sections in the book; see below.*)
+
+Definition Quotient@{i j k} {A : Type@{i}} (R : relation@{i j} A)
+  `{is_mere_relation _ R} : Type@{k}
+  := Trunc@{k} 0 (Coeq@{k k}
+    (fun x : sig@{k k} (fun a : A => sig (R a)) => x.1)
+    (fun x : sig@{k k} (fun a : A => sig (R a)) => x.2.1)).
+
+Definition class_of@{i j k} {A : Type@{i}} (R : relation@{i j} A)
+  `{is_mere_relation _ R} : A -> Quotient@{i j k} R := tr o coeq.
+
+Definition qglue@{i j k} {A : Type@{i}} {R : relation@{i j} A}
+  `{is_mere_relation _ R} {x y : A}
+  : R x y -> class_of@{i j k} R x = class_of R y
+  := fun p => ap tr (cglue (x; y; p)).
+
+Definition Quotient_ind@{i j k l}
+  {A : Type@{i}} (R : relation@{i j} A) `{is_mere_relation _ R}
+  (P : Quotient@{i j k} R -> Type@{l}) {sP : forall x, IsHSet (P x)}
+  (pclass : forall x, P (class_of R x))
+  (peq : forall x y (H : R x y), qglue H # pclass x = pclass y)
+  : forall q, P q.
+Proof.
+  eapply Trunc_ind, Coeq_ind.
+  1: assumption.
+  intros [a [b p]].
+  refine (transport_compose _ _ _ _ @ _).
+  apply peq.
+Defined.
+
+Definition Quotient_ind_beta_qglue@{i j k l}
+  {A : Type@{i}} (R : relation@{i j} A) `{is_mere_relation _ R}
+  (P : Quotient@{i j k} R -> Type@{l}) {sP : forall x, IsHSet (P x)}
+  (pclass : forall x, P (class_of R x))
+  (peq : forall x y (H : R x y), qglue H # pclass x = pclass y)
+  (x y : A) (p : R x y)
+  : apD (Quotient_ind@{i j k l} R P pclass peq) (qglue p) = peq x y p.
+Proof.
+  refine (apD_compose' tr _ _ @ _).
+  refine (ap _ (Coeq_ind_beta_cglue _ _ _ _) @ _).
+  apply concat_V_pp.
+Defined.
+
+Definition Quotient_rec@{i j k l}
+  {A : Type@{i}} (R : relation@{i j} A) `{is_mere_relation _ R}
+  (P : Type@{l}) `{IsHSet P} (pclass : A -> P)
+  (peq : forall x y, R x y -> pclass x = pclass y)
+  : Quotient@{i j k} R -> P.
+Proof.
+  eapply Trunc_rec, Coeq_rec.
+  intros [a [b p]].
+  by apply peq.
+Defined.
+
+Definition Quotient_rec_beta_qglue @{i j k l}
+  {A : Type@{i}} (R : relation@{i j} A) `{is_mere_relation _ R}
+  (P : Type@{l}) `{IsHSet P} (pclass : A -> P)
+  (peq : forall x y, R x y -> pclass x = pclass y)
+  (x y : A) (p : R x y)
+  : ap (Quotient_rec@{i j k l} R P pclass peq) (qglue p) = peq x y p.
+Proof.
+  refine ((ap_compose tr _ _)^ @ _).
+  serapply Coeq_rec_beta_cglue.
+Defined.
+
+Arguments Quotient : simpl never.
+Arguments class_of : simpl never.
+Arguments qglue : simpl never.
+Arguments Quotient_ind_beta_qglue : simpl never.
+Arguments Quotient_rec_beta_qglue : simpl never.
+
+(* TODO: add to Notations.v *)
+Notation "A / R" := (Quotient (A:=A) R).
+
+(*
+Module Export Quotient.
+
+  Section Domain.
+
+    Context {A : Type} (R:relation A) {sR: is_mere_relation _ R}.
+
+    (** We choose to let the definition of quotient depend on the proof that [R] is a set-relations.  Alternatively, we could have defined it for all relations and only develop the theory for set-relations.  The former seems more natural.
+
+We do not require [R] to be an equivalence relation, but implicitly consider its transitive-reflexive closure. *)
+
+
+    (** Note: If we wanted to be really accurate, we'd need to put [@quotient A R sr] in the max [U_{sup(i, j)}] of the universes of [A : U_i] and [R : A -> A -> U_j].  But this requires some hacky code, at the moment, and the only thing we gain is avoiding making use of an implicit hpropositional resizing "axiom". *)
+
+    (** This definition has a parameter [sR] that shadows the ambient one in the Context in order to ensure that it actually ends up depending on everything in the Context when the section is closed, since its definition doesn't actually refer to any of them.  *)
+    Private Inductive quotient {sR: is_mere_relation _ R} : Type :=
+    | class_of : A -> quotient.
+
+    (** The path constructors. *)
+    Axiom related_classes_eq
+    : forall {x y : A}, R x y ->
+                        class_of x = class_of y.
+
+    Axiom quotient_set : IsHSet (@quotient sR).
+    Global Existing Instance quotient_set.
+
+    Definition quotient_ind (P : (@quotient sR) -> Type) {sP : forall x, IsHSet (P x)}
+               (dclass : forall x, P (class_of x))
+               (dequiv : (forall x y (H : R x y), (related_classes_eq H) # (dclass x) = dclass y))
+    : forall q, P q
+      := fun q => match q with class_of a => fun _ _ => dclass a end sP dequiv.
+
+    Definition quotient_ind_compute {P sP} dclass dequiv x
+    : @quotient_ind P sP dclass dequiv (class_of x) = dclass x.
+    Proof.
+      reflexivity.
+    Defined.
+
+    (** Again equality of paths needs to be postulated *)
+    Axiom quotient_ind_compute_path
+    : forall P sP dclass dequiv,
+      forall x y (H : R x y),
+        apD (@quotient_ind P sP dclass dequiv) (related_classes_eq H)
+        = dequiv x y H.
+
+  End Domain.
+
+End Quotient. *)
+
+Section Equiv.
+
+  Context `{Univalence} {A : Type} (R : relation A) `{is_mere_relation _ R}
+    `{Transitive _ R} `{Symmetric _ R} `{Reflexive _ R}.
+
+  (* The proposition of being in a given class in a quotient. *)
+  Definition in_class : A / R -> A -> hProp.
+  Proof.
+    serapply Quotient_ind.
+    { intros a b.
+      exact (BuildhProp (R a b)). }
+    intros x y p.
+    refine (transport_const _ _ @ _).
+    funext z.
+    apply path_hprop.
+    serapply equiv_iff_hprop; cbn.
+    1: apply (transitivity (symmetry _ _ p)).
+    apply (transitivity p).
+  Defined.
+
+  (* TODO: remove this since this is true by definition? *)
+  (* If x is in the class of y then they are related. *)
+  Definition in_class_of : forall x y, (in_class (class_of R x) y : Type) = R x y
+    := ltac:(reflexivity).
+
+  (* Quotient induction into a hprop. *)
+  Definition Quotient_ind_hprop
+    (P : Quotient R -> Type) `{forall x, IsHProp (P x)}
+    (dclass : forall x, P (class_of R x)) : forall q, P q.
+  Proof.
+    serapply (Quotient_ind R P dclass).
+    1: intro; apply trunc_succ.
+    intros x y p.
+    apply path_ishprop.
+  Defined.
+
+  (* Being in a class is decidable if the relation is decidable. *)
+  Global Instance decidable_in_class `{forall x y, Decidable (R x y)}
+  : forall x a, Decidable (in_class x a).
+  Proof.
+    by serapply Quotient_ind_hprop.
+  Defined.
+
+  (* if x is in a class q, then the class of x is equal to q. *)
+  Lemma class_of_repr : forall q x, in_class q x -> q = class_of R x.
+  Proof.
+    serapply Quotient_ind.
+    { intros x y p.
+      apply (qglue p). }
+    intros x y p.
+    funext ? ?.
+    apply hset_path2.
+  Defined.
+
+  Lemma related_quotient_paths : forall x y,
+    class_of R x = class_of R y -> R x y.
+  Proof.
+    intros x y p.
+    change (in_class (class_of R x) y).
+    destruct p^.
+    cbv; reflexivity.
+  Defined.
+
+  (** Thm 10.1.8 *)
+  Theorem path_quotient : forall x y,
+    R x y <~> (class_of R x = class_of R y).
+  Proof.
+    intros ??.
+    apply equiv_iff_hprop.
+    - apply qglue.
+    - apply related_quotient_paths.
+  Defined.
+
+  Definition Quotient_rec2 `{Funext} {B : hSet} {dclass : A -> A -> B}
+    {dequiv : forall x x', R x x' -> forall y y',
+      R y y' -> dclass x y = dclass x' y'}
+    : A / R -> A / R -> B.
+  Proof.
+    serapply Quotient_rec.
+    { intro a.
+      serapply Quotient_rec.
+      { revert a.
+        assumption. }
+      by apply (dequiv a a). }
+    intros x y p.
+    apply path_forall.
+    serapply Quotient_ind.
+    { cbn; intro a.
+      by apply dequiv. }
+    intros a b q.
+    apply path_ishprop.
+  Defined.
+
+  Definition Quotient_ind_hprop' (P : A / R -> Type)
+    `{forall x, IsHProp (P (class_of _ x))}
+    (dclass : forall x, P (class_of _ x)) : forall y, P y.
+  Proof.
+    apply Quotient_ind with dclass.
+    { serapply Quotient_ind.
+      1: intro; apply trunc_succ.
+      intros ???; apply path_ishprop. }
+    intros; apply path_ishprop.
+  Defined.
+
+  (** The map class_of : A -> A/R is a surjection. *)
+  Global Instance issurj_class_of : IsSurjection (class_of R).
+  Proof.
+    apply BuildIsSurjection.
+    serapply Quotient_ind_hprop.
+    intro x.
+    apply tr.
+    by exists x.
+  Defined.
+
+  (* Universal property of quotient *)
+  (* Lemma 6.10.3 *)
+  Theorem equiv_quotient_ump (B : hSet)
+    : (Quotient R -> B) <~> {f : A -> B & forall x y, R x y -> f x = f y}.
+  Proof.
+    serapply equiv_adjointify.
+    + intro f.
+      exists (compose f (class_of R)).
+      intros; f_ap.
+      by apply qglue.
+    + intros [f H'].
+      apply (Quotient_rec _ _ _ H').
+    + intros [f Hf].
+      by apply equiv_path_sigma_hprop.
+    + intros f.
+      apply path_forall.
+      serapply Quotient_ind_hprop.
+      reflexivity.
+  Defined.
+
+  (** TODO:
+
+  The equivalence with VVquotient [A//R].
+
+  This should lead to the unnamed theorem:
+
+  10.1.10. Equivalence relations are effective and there is an equivalence [A/R<~>A//R].
+  
+  This will need propositional resizing if we don't want to raise the universe level. *)
+
+  (**
+  The theory of canonical quotients is developed by C.Cohen:
+  http://perso.crans.org/cohen/work/quotients/
+ *)
+
+End Equiv.
+
+Section Functoriality.
+
+  Definition Quotient_functor
+    {A : Type} (R : relation A) {sR : is_mere_relation _ R}
+    {B : Type} (S : relation B) {sS : is_mere_relation _ S}
+    (f : A -> B) (fresp : forall x y, R x y -> S (f x) (f y))
+    : Quotient R -> Quotient S.
+  Proof.
+    refine (Quotient_rec R _ (class_of S o f) _).
+    intros x y r.
+    apply qglue, fresp, r.
+  Defined.
+
+  Definition Quotient_functor_idmap
+    {A : Type} {R : relation A} {sR : is_mere_relation _ R}
+    : Quotient_functor R R idmap (fun x y => idmap) == idmap.
+  Proof.
+    by serapply Quotient_ind_hprop.
+  Defined.
+
+  Definition Quotient_functor_compose
+    {A : Type} {R : relation A} {sR : is_mere_relation _ R}
+    {B : Type} {S : relation B} {sS : is_mere_relation _ S}
+    {C : Type} {T : relation C} {sT : is_mere_relation _ T}
+    (f : A -> B) (fresp : forall x y, R x y -> S (f x) (f y))
+    (g : B -> C) (gresp : forall x y, S x y -> T (g x) (g y))
+    : Quotient_functor R T (g o f) (fun x y => (gresp _ _) o (fresp x y))
+    == Quotient_functor S T g gresp o Quotient_functor R S f fresp.
+  Proof.
+    by serapply Quotient_ind_hprop.
+  Defined.
+
+  Context {A : Type} (R : relation A) {sR : is_mere_relation _ R}
+          {B : Type} (S : relation B) {sS : is_mere_relation _ S}.
+
+  Global Instance isequiv_quotient_functor (f : A -> B)
+    (fresp : forall x y, R x y <-> S (f x) (f y)) `{IsEquiv _ _ f}
+    : IsEquiv (Quotient_functor R S f (fun x y => fst (fresp x y))).
+  Proof.
+    serapply (isequiv_adjointify _ (Quotient_functor S R f^-1 _)).
+    { intros u v s.
+      apply (snd (fresp _ _)).
+      abstract (do 2 rewrite eisretr; apply s). }
+    all: serapply Quotient_ind.
+    + intros b; simpl.
+      apply ap, eisretr.
+    + intros; apply path_ishprop.
+    + intros a; simpl.
+      apply ap, eissect.
+    + intros; apply path_ishprop.
+  Defined.
+
+  Definition equiv_quotient_functor (f : A -> B) `{IsEquiv _ _ f}
+    (fresp : forall x y, R x y <-> S (f x) (f y))
+    : Quotient R <~> Quotient S
+    := BuildEquiv _ _ (Quotient_functor R S f (fun x y => fst (fresp x y))) _.
+
+  Definition equiv_quotient_functor' (f : A <~> B)
+    (fresp : forall x y, R x y <-> S (f x) (f y))
+    : Quotient R <~> Quotient S
+    := equiv_quotient_functor f fresp.
+
+End Functoriality.
+
+Section Kernel.
+
+  (** ** Quotients of kernels of maps to sets give a surjection/mono factorization. *)
+
+  Context `{Funext}.
+  Universe i.
+
+  (** A function we want to factor. *)
+  Context {A : Type@{i}} {B : Type} `{IsHSet B} (f : A -> B).
+
+  (** A mere relation equivalent to its kernel. *)
+  Context (R : relation A) {sR : is_mere_relation _ R}
+          (is_ker : forall x y, f x = f y <~> R x y).
+
+  Theorem quotient_kernel_factor
+    : exists (C : Type@{i}) (e : A -> C) (m : C -> B),
+      IsHSet C * IsSurjection e * IsEmbedding m * (f = m o e).
+  Proof.
+    exists (Quotient R).
+    exists (class_of R).
+    srefine (_;_).
+    { apply Quotient_ind with f; try exact _.
+      intros x y p.
+      transitivity (f x).
+      - apply transport_const.
+      - exact ((is_ker x y)^-1 p). }
+    repeat split; try exact _.
+    intro u.
+    apply hprop_allpath.
+    intros [x q] [y p'].
+    apply path_sigma_hprop; simpl.
+    revert x y q p'.
+    serapply Quotient_ind.
+    2: intros; apply path_ishprop.
+    intro a.
+    serapply Quotient_ind.
+    2: intros; apply path_ishprop.
+    intros a' p p'.
+    apply qglue, is_ker.
+    exact (p @ p'^).
+  Defined.
+
+End Kernel.

--- a/theories/Colimits/Quotient.v
+++ b/theories/Colimits/Quotient.v
@@ -24,25 +24,24 @@ We do this by defining the quotient as a truncated coequalizer.
 
 *)
 
-Definition Quotient@{i j k} {A : Type@{i}} (R : relation@{i j} A)
-  `{is_mere_relation _ R} : Type@{k}
+Definition Quotient@{i j k} {A : Type@{i}} (R : relation@{i j} A) : Type@{k}
   := Trunc@{k} 0 (Coeq@{k k}
     (fun x : sig@{k k} (fun a : A => sig (R a)) => x.1)
     (fun x : sig@{k k} (fun a : A => sig (R a)) => x.2.1)).
 
 Definition class_of@{i j k} {A : Type@{i}} (R : relation@{i j} A)
-  `{is_mere_relation _ R} : A -> Quotient@{i j k} R := tr o coeq.
+  : A -> Quotient@{i j k} R := tr o coeq.
 
 Definition qglue@{i j k} {A : Type@{i}} {R : relation@{i j} A}
-  `{is_mere_relation _ R} {x y : A}
+  {x y : A}
   : R x y -> class_of@{i j k} R x = class_of R y
   := fun p => ap tr (cglue (x; y; p)).
 
 Global Instance ishset_quotient {A : Type} (R : relation A)
-  `{is_mere_relation _ R} : IsHSet (Quotient R) := _.
+  : IsHSet (Quotient R) := _.
 
 Definition Quotient_ind@{i j k l}
-  {A : Type@{i}} (R : relation@{i j} A) `{is_mere_relation _ R}
+  {A : Type@{i}} (R : relation@{i j} A)
   (P : Quotient@{i j k} R -> Type@{l}) {sP : forall x, IsHSet (P x)}
   (pclass : forall x, P (class_of R x))
   (peq : forall x y (H : R x y), qglue H # pclass x = pclass y)
@@ -56,7 +55,7 @@ Proof.
 Defined.
 
 Definition Quotient_ind_beta_qglue@{i j k l}
-  {A : Type@{i}} (R : relation@{i j} A) `{is_mere_relation _ R}
+  {A : Type@{i}} (R : relation@{i j} A)
   (P : Quotient@{i j k} R -> Type@{l}) {sP : forall x, IsHSet (P x)}
   (pclass : forall x, P (class_of R x))
   (peq : forall x y (H : R x y), qglue H # pclass x = pclass y)
@@ -69,7 +68,7 @@ Proof.
 Defined.
 
 Definition Quotient_rec@{i j k l}
-  {A : Type@{i}} (R : relation@{i j} A) `{is_mere_relation _ R}
+  {A : Type@{i}} (R : relation@{i j} A)
   (P : Type@{l}) `{IsHSet P} (pclass : A -> P)
   (peq : forall x y, R x y -> pclass x = pclass y)
   : Quotient@{i j k} R -> P.
@@ -80,7 +79,7 @@ Proof.
 Defined.
 
 Definition Quotient_rec_beta_qglue @{i j k l}
-  {A : Type@{i}} (R : relation@{i j} A) `{is_mere_relation _ R}
+  {A : Type@{i}} (R : relation@{i j} A)
   (P : Type@{l}) `{IsHSet P} (pclass : A -> P)
   (peq : forall x y, R x y -> pclass x = pclass y)
   (x y : A) (p : R x y)
@@ -244,8 +243,8 @@ Section Functoriality.
   (* TODO: Develop a notion of set with relation and use that instead of manually adding relation preserving conditions. *)
 
   Definition Quotient_functor
-    {A : Type} (R : relation A) {sR : is_mere_relation _ R}
-    {B : Type} (S : relation B) {sS : is_mere_relation _ S}
+    {A : Type} (R : relation A)
+    {B : Type} (S : relation B)
     (f : A -> B) (fresp : forall x y, R x y -> S (f x) (f y))
     : Quotient R -> Quotient S.
   Proof.
@@ -255,16 +254,16 @@ Section Functoriality.
   Defined.
 
   Definition Quotient_functor_idmap
-    {A : Type} {R : relation A} {sR : is_mere_relation _ R}
+    {A : Type} {R : relation A}
     : Quotient_functor R R idmap (fun x y => idmap) == idmap.
   Proof.
     by serapply Quotient_ind_hprop.
   Defined.
 
   Definition Quotient_functor_compose
-    {A : Type} {R : relation A} {sR : is_mere_relation _ R}
-    {B : Type} {S : relation B} {sS : is_mere_relation _ S}
-    {C : Type} {T : relation C} {sT : is_mere_relation _ T}
+    {A : Type} {R : relation A}
+    {B : Type} {S : relation B}
+    {C : Type} {T : relation C}
     (f : A -> B) (fresp : forall x y, R x y -> S (f x) (f y))
     (g : B -> C) (gresp : forall x y, S x y -> T (g x) (g y))
     : Quotient_functor R T (g o f) (fun x y => (gresp _ _) o (fresp x y))
@@ -273,8 +272,8 @@ Section Functoriality.
     by serapply Quotient_ind_hprop.
   Defined.
 
-  Context {A : Type} (R : relation A) {sR : is_mere_relation _ R}
-          {B : Type} (S : relation B) {sS : is_mere_relation _ S}.
+  Context {A : Type} (R : relation A)
+          {B : Type} (S : relation B).
 
   Global Instance isequiv_quotient_functor (f : A -> B)
     (fresp : forall x y, R x y <-> S (f x) (f y)) `{IsEquiv _ _ f}
@@ -318,7 +317,7 @@ Section Kernel.
   Context {A : Type@{i}} {B : Type} `{IsHSet B} (f : A -> B).
 
   (** A mere relation equivalent to its kernel. *)
-  Context (R : relation A) {sR : is_mere_relation _ R}
+  Context (R : relation A)
           (is_ker : forall x y, f x = f y <~> R x y).
 
   Theorem quotient_kernel_factor

--- a/theories/Colimits/Quotient.v
+++ b/theories/Colimits/Quotient.v
@@ -124,7 +124,6 @@ Section Equiv.
     (dclass : forall x, P (class_of R x)) : forall q, P q.
   Proof.
     serapply (Quotient_ind R P dclass).
-    1: intro; apply trunc_succ.
     intros x y p.
     apply path_ishprop.
   Defined.

--- a/theories/Colimits/Quotient.v
+++ b/theories/Colimits/Quotient.v
@@ -123,6 +123,7 @@ Section Equiv.
     (dclass : forall x, P (class_of R x)) : forall q, P q.
   Proof.
     serapply (Quotient_ind R P dclass).
+    all: try (intro; apply trunc_succ).
     intros x y p.
     apply path_ishprop.
   Defined.

--- a/theories/Colimits/Quotient.v
+++ b/theories/Colimits/Quotient.v
@@ -11,7 +11,7 @@ Require Import Truncations.
 Local Open Scope path_scope.
 
 
-(** * Quotient of a Type by an hprop-valued relation
+(** * Quotient of a Type by an hprop-valued Relation
 
 We aim to model:
 <<
@@ -24,24 +24,24 @@ We do this by defining the quotient as a truncated coequalizer.
 
 *)
 
-Definition Quotient@{i j k} {A : Type@{i}} (R : relation@{i j} A) : Type@{k}
+Definition Quotient@{i j k} {A : Type@{i}} (R : Relation@{i j} A) : Type@{k}
   := Trunc@{k} 0 (Coeq@{k k}
     (fun x : sig@{k k} (fun a : A => sig (R a)) => x.1)
     (fun x : sig@{k k} (fun a : A => sig (R a)) => x.2.1)).
 
-Definition class_of@{i j k} {A : Type@{i}} (R : relation@{i j} A)
+Definition class_of@{i j k} {A : Type@{i}} (R : Relation@{i j} A)
   : A -> Quotient@{i j k} R := tr o coeq.
 
-Definition qglue@{i j k} {A : Type@{i}} {R : relation@{i j} A}
+Definition qglue@{i j k} {A : Type@{i}} {R : Relation@{i j} A}
   {x y : A}
   : R x y -> class_of@{i j k} R x = class_of R y
   := fun p => ap tr (cglue (x; y; p)).
 
-Global Instance ishset_quotient {A : Type} (R : relation A)
+Global Instance ishset_quotient {A : Type} (R : Relation A)
   : IsHSet (Quotient R) := _.
 
 Definition Quotient_ind@{i j k l}
-  {A : Type@{i}} (R : relation@{i j} A)
+  {A : Type@{i}} (R : Relation@{i j} A)
   (P : Quotient@{i j k} R -> Type@{l}) {sP : forall x, IsHSet (P x)}
   (pclass : forall x, P (class_of R x))
   (peq : forall x y (H : R x y), qglue H # pclass x = pclass y)
@@ -55,7 +55,7 @@ Proof.
 Defined.
 
 Definition Quotient_ind_beta_qglue@{i j k l}
-  {A : Type@{i}} (R : relation@{i j} A)
+  {A : Type@{i}} (R : Relation@{i j} A)
   (P : Quotient@{i j k} R -> Type@{l}) {sP : forall x, IsHSet (P x)}
   (pclass : forall x, P (class_of R x))
   (peq : forall x y (H : R x y), qglue H # pclass x = pclass y)
@@ -68,7 +68,7 @@ Proof.
 Defined.
 
 Definition Quotient_rec@{i j k l}
-  {A : Type@{i}} (R : relation@{i j} A)
+  {A : Type@{i}} (R : Relation@{i j} A)
   (P : Type@{l}) `{IsHSet P} (pclass : A -> P)
   (peq : forall x y, R x y -> pclass x = pclass y)
   : Quotient@{i j k} R -> P.
@@ -79,7 +79,7 @@ Proof.
 Defined.
 
 Definition Quotient_rec_beta_qglue @{i j k l}
-  {A : Type@{i}} (R : relation@{i j} A)
+  {A : Type@{i}} (R : Relation@{i j} A)
   (P : Type@{l}) `{IsHSet P} (pclass : A -> P)
   (peq : forall x y, R x y -> pclass x = pclass y)
   (x y : A) (p : R x y)
@@ -99,7 +99,7 @@ Notation "A / R" := (Quotient (A:=A) R).
 
 Section Equiv.
 
-  Context `{Univalence} {A : Type} (R : relation A) `{is_mere_relation _ R}
+  Context `{Univalence} {A : Type} (R : Relation A) `{is_mere_relation _ R}
     `{Transitive _ R} `{Symmetric _ R} `{Reflexive _ R}.
 
   (* The proposition of being in a given class in a quotient. *)
@@ -128,7 +128,7 @@ Section Equiv.
     apply path_ishprop.
   Defined.
 
-  (* Being in a class is decidable if the relation is decidable. *)
+  (* Being in a class is decidable if the Relation is decidable. *)
   Global Instance decidable_in_class `{forall x y, Decidable (R x y)}
   : forall x a, Decidable (in_class x a).
   Proof.
@@ -228,7 +228,7 @@ Section Equiv.
 
 (** TODO: The equivalence with VVquotient [A//R].
   10.1.10.
-    Equivalence relations are effective and there is an equivalence [A/R<~>A//R].
+    Equivalence Relations are effective and there is an equivalence [A/R<~>A//R].
 
     This will need propositional resizing if we don't want to raise the universe level.
 *)
@@ -241,11 +241,11 @@ End Equiv.
 
 Section Functoriality.
 
-  (* TODO: Develop a notion of set with relation and use that instead of manually adding relation preserving conditions. *)
+  (* TODO: Develop a notion of set with Relation and use that instead of manually adding Relation preserving conditions. *)
 
   Definition Quotient_functor
-    {A : Type} (R : relation A)
-    {B : Type} (S : relation B)
+    {A : Type} (R : Relation A)
+    {B : Type} (S : Relation B)
     (f : A -> B) (fresp : forall x y, R x y -> S (f x) (f y))
     : Quotient R -> Quotient S.
   Proof.
@@ -255,16 +255,16 @@ Section Functoriality.
   Defined.
 
   Definition Quotient_functor_idmap
-    {A : Type} {R : relation A}
+    {A : Type} {R : Relation A}
     : Quotient_functor R R idmap (fun x y => idmap) == idmap.
   Proof.
     by serapply Quotient_ind_hprop.
   Defined.
 
   Definition Quotient_functor_compose
-    {A : Type} {R : relation A}
-    {B : Type} {S : relation B}
-    {C : Type} {T : relation C}
+    {A : Type} {R : Relation A}
+    {B : Type} {S : Relation B}
+    {C : Type} {T : Relation C}
     (f : A -> B) (fresp : forall x y, R x y -> S (f x) (f y))
     (g : B -> C) (gresp : forall x y, S x y -> T (g x) (g y))
     : Quotient_functor R T (g o f) (fun x y => (gresp _ _) o (fresp x y))
@@ -273,8 +273,8 @@ Section Functoriality.
     by serapply Quotient_ind_hprop.
   Defined.
 
-  Context {A : Type} (R : relation A)
-          {B : Type} (S : relation B).
+  Context {A : Type} (R : Relation A)
+          {B : Type} (S : Relation B).
 
   Global Instance isequiv_quotient_functor (f : A -> B)
     (fresp : forall x y, R x y <-> S (f x) (f y)) `{IsEquiv _ _ f}
@@ -296,7 +296,7 @@ Section Functoriality.
   Definition equiv_quotient_functor (f : A -> B) `{IsEquiv _ _ f}
     (fresp : forall x y, R x y <-> S (f x) (f y))
     : Quotient R <~> Quotient S
-    := BuildEquiv _ _ (Quotient_functor R S f (fun x y => fst (fresp x y))) _.
+    := Build_Equiv _ _ (Quotient_functor R S f (fun x y => fst (fresp x y))) _.
 
   Definition equiv_quotient_functor' (f : A <~> B)
     (fresp : forall x y, R x y <-> S (f x) (f y))
@@ -317,8 +317,8 @@ Section Kernel.
   (** A function we want to factor. *)
   Context {A : Type@{i}} {B : Type} `{IsHSet B} (f : A -> B).
 
-  (** A mere relation equivalent to its kernel. *)
-  Context (R : relation A)
+  (** A mere Relation equivalent to its kernel. *)
+  Context (R : Relation A)
           (is_ker : forall x y, f x = f y <~> R x y).
 
   Theorem quotient_kernel_factor

--- a/theories/HIT/Circle.v
+++ b/theories/HIT/Circle.v
@@ -149,7 +149,7 @@ Proof.
   - refine (S1_ind (fun x => Sect (S1_decode x) (S1_encode x))
                    S1_encode_loopexp _ _).
     (* What remains is easy since [Int] is known to be a set. *)
-    by apply path_forall; intros z; apply set_path2.
+    by apply path_forall; intros z; apply hset_path2.
   (* The other side is trivial by path induction. *)
   - intros []; reflexivity.
 Defined.

--- a/theories/HIT/Coeq.v
+++ b/theories/HIT/Coeq.v
@@ -10,8 +10,9 @@ Local Open Scope path_scope.
 
 Module Export Coeq.
 
-  Private Inductive Coeq {B A : Type@{i}} (f g : B -> A) : Type@{i} :=
-  | coeq : A -> Coeq f g.
+  Private Inductive Coeq {B : Type@{i}} {A : Type@{j}}
+    (f g : B -> A) : Type@{max(i,j)} :=
+      | coeq : A -> Coeq f g.
 
   Arguments coeq {B A f g} a.
 

--- a/theories/HIT/V.v
+++ b/theories/HIT/V.v
@@ -6,7 +6,7 @@ Require Import HoTT.Basics HoTT.Basics.Notations HoTT.Basics.Utf8.
 Require Import Types.Unit Types.Bool Types.Universe Types.Sigma Types.Arrow Types.Forall.
 Require Import HProp HSet UnivalenceImpliesFunext TruncType.
 Require Import Colimits.SpanPushout.
-Require Import HoTT.Truncations HIT.quotient.
+Require Import HoTT.Truncations Colimits.Quotient.
 Local Open Scope nat_scope.
 Local Open Scope path_scope.
 
@@ -223,7 +223,7 @@ Notation "x ⊆ y" := (subset x y) : set_scope.
 
 
 (** ** Bisimulation relation *)
-(** The equality in V lives in Type@{U'}. We define the bisimulation relation which is a U-small resizing of the equality in V: it must live in hProp_U : Type{U'}, hence the codomain is hProp@{U'}. We then prove that bisimulation is equality (bisim_equals_id), then use it to prove the key lemma monic_set_present. *)
+(** The equality in V lives in Type@{U'}. We define the bisimulation relation which is a U-small resizing of the equality in V: it must live in hProp_U : Type{U'}, hence the codomain is hProp@{U}. We then prove that bisimulation is equality (bisim_equals_id), then use it to prove the key lemma monic_set_present. *)
 
 (* We define bisimulation by double induction on V. We first fix the first argument as set(A,f) and define bisim_aux : V -> hProp, by induction. This is the inner of the two inductions. *)
 Local Definition bisim_aux (A : Type) (f : A -> V) (H_f : A -> V -> hProp) : V -> hProp.
@@ -253,7 +253,7 @@ Proof.
 Defined.
 
 (* Then we define bisim : V -> (V -> hProp) by induction again *)
-Definition bisimulation : V@{U' U} -> V@{U' U} -> hProp@{U'}.
+Definition bisimulation : V@{U' U} -> V@{U' U} -> hProp@{U}.
 Proof.
   refine (V_rec' (V -> hProp) _ bisim_aux _).
   intros A B f g eq_img H_f H_g H_img.

--- a/theories/HIT/iso.v
+++ b/theories/HIT/iso.v
@@ -25,7 +25,7 @@ Section iso.
   : IsEquiv f.
   Proof.
     pose proof (@isepi_issurj _ _ _ f epif) as surjf.
-    pose proof (ismono_isinj _ monof) as injf.
+    pose proof (isinj_ismono _ monof) as injf.
     pose proof (unique_choice
                   (fun y x => f x = y)
                   _

--- a/theories/HIT/quotient.v
+++ b/theories/HIT/quotient.v
@@ -76,7 +76,7 @@ Section Equiv.
 
   Lemma quotient_path2 : forall {x y : quotient R} (p q : x=y), p=q.
   Proof.
-    apply @set_path2. apply _.
+    apply @hset_path2. apply _.
   Defined.
 
   Definition in_class : quotient R -> A -> hProp.

--- a/theories/HSet.v
+++ b/theories/HSet.v
@@ -44,7 +44,7 @@ Proof.
   apply (trunc_equiv _ equiv_hset_axiomK).
 Defined.
 
-Theorem set_path2 {A} `{IsHSet A} {x y : A} (p q : x = y):
+Theorem hset_path2 {A} `{IsHSet A} {x y : A} (p q : x = y):
   p = q.
 Proof.
   induction q.
@@ -61,13 +61,13 @@ Lemma axiomK_idpath {A} (x : A) (K : axiomK A) :
   K x (idpath x) = idpath (idpath x).
 Proof.
   pose (T1A := @trunc_succ _ A (@hset_axiomK A K)).
-  exact (@set_path2 (x=x) (T1A x x) _ _ _ _).
+  exact (@hset_path2 (x=x) (T1A x x) _ _ _ _).
 Defined.
 
 End AssumeFunext.
 
 (** We prove that if [R] is a reflexive mere relation on [X] implying identity, then [X] is an hSet, and hence [R x y] is equivalent to [x = y]. *)
-Lemma isset_hrel_subpaths
+Lemma ishset_hrel_subpaths
       {X R}
       `{Reflexive X R}
       `{forall x y, IsHProp (R x y)}
@@ -93,7 +93,7 @@ Global Instance isequiv_hrel_subpaths
        x y
 : IsEquiv (f x y) | 10000.
 Proof.
-  pose proof (isset_hrel_subpaths f).
+  pose proof (ishset_hrel_subpaths f).
   refine (isequiv_adjointify
             (f x y)
             (fun p => transport (R x) p (reflexivity x))
@@ -129,7 +129,7 @@ Proof.
   exact (isi x y (p @ q^)).
 Defined.
 
-Lemma isinj_ismono `{Funext} {X Y} (f : X -> Y) : isinj f -> ismono f.
+Lemma ismono_isinj `{Funext} {X Y} (f : X -> Y) : isinj f -> ismono f.
 Proof.
   intros ? ? ? ? H'.
   apply path_forall.
@@ -138,7 +138,7 @@ Proof.
   eauto.
 Qed.
 
-Definition ismono_isinj {X Y} (f : X -> Y)
+Definition isinj_ismono {X Y} (f : X -> Y)
            (H : ismono f)
 : isinj f
   := fun x0 x1 H' =>

--- a/theories/Homotopy/Join.v
+++ b/theories/Homotopy/Join.v
@@ -12,7 +12,7 @@ Import TrM.
 Section Join.
 
   Definition Join (A : Type@{i}) (B : Type@{j})
-    := Pushout@{k i j k k} (@fst A B) (@snd A B).
+    := Pushout@{k i j k} (@fst A B) (@snd A B).
 
   Definition jglue {A B} a b := @pglue (A*B) A B fst snd (a,b).
 

--- a/theories/Spaces/Finite.v
+++ b/theories/Spaces/Finite.v
@@ -823,7 +823,7 @@ Section DecidableQuotients.
     assert (R'd : forall x y, Decidable (R' x y))
       by (intros ? ?; unfold R'; apply Rd).
     srefine (finite_equiv' _ (equiv_quotient_functor R' R e^-1 _) _).
-    1,2: by try (intros; split).
+    1: by try (intros; split).
     clearbody R'; clear e.
     generalize dependent (fcard X);
       intros n; induction n as [|n IH]; intros R' ? ? ? ? ?.

--- a/theories/Spaces/Finite.v
+++ b/theories/Spaces/Finite.v
@@ -841,7 +841,7 @@ Section DecidableQuotients.
       { strip_truncations.
         destruct p as [x r].
         refine (finite_equiv' (Quotient R'') _ _).
-        refine (BuildEquiv _ _ (Quotient_functor R'' R' inl inlresp) _).
+        refine (Build_Equiv _ _ (Quotient_functor R'' R' inl inlresp) _).
         apply isequiv_surj_emb.
         - apply BuildIsSurjection.
           refine (Quotient_ind_hprop R' _ _).
@@ -856,7 +856,7 @@ Section DecidableQuotients.
           apply qglue; unfold R''.
           exact (related_quotient_paths R' (inl u) (inl v) q). }
       { refine (finite_equiv' (Quotient R'' + Unit) _ _).
-        refine (BuildEquiv _ _ (sum_ind (fun _ => Quotient R')
+        refine (Build_Equiv _ _ (sum_ind (fun _ => Quotient R')
                                         (Quotient_functor R'' R' inl inlresp)
                                         (fun _ => class_of R' (inr tt))) _).
         apply isequiv_surj_emb.

--- a/theories/Spaces/No/Core.v
+++ b/theories/Spaces/No/Core.v
@@ -534,7 +534,7 @@ Defined.
 
 Global Instance isset_No `{Funext} : IsHSet No.
 Proof.
-  refine (@isset_hrel_subpaths No (fun (x y:No) => (x <= y) * (y <= x)) _ _ _).
+  refine (@ishset_hrel_subpaths No (fun (x y:No) => (x <= y) * (y <= x)) _ _ _).
   - intros x; split; apply le_reflexive.
   - intros x y [xley ylex]; apply path_No; assumption.
 Defined.


### PR DESCRIPTION
Here is a start at cleaning up quotient.v. I have added a new file Colimits/Quotient.v for the new quotient.

I have left two quotients for now for reasons discussed in #1103.

I haven't managed to change the uses of quotient in hottclasses to the new one but @SkySkimmer said he could do that.

I also couldn't change the use of quotient in V.v due to universes getting too complicated.

This closes #1103, closes #1088.

This can be merged for now but we will need to change the use of quotient.v in hottclasses and V.v, after which we can remove the old quotient.v.

Please let me know how you like the new names, I am happy to change any with discussion.

Edit: I should also add that I had an attempt at adding universe annotation to Coeq.v, Pushout.v and Quotient.v. Not 100% convinced that these are the correct ones so I would appreciate any help here.