### PR TITLE
renamed BuildIsEquiv to Build_IsEquiv and BuildEquiv to Build_Equiv

### DIFF
--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -968,7 +968,7 @@ Section Book_4_6_i.
   Defined.
   Definition equiv_qinv_path (qua: QInv_Univalence_type) (A B : Type)
     : (A = B) <~> qinv A B
-    := BuildEquiv _ _ (qinv_path A B) (isequiv_qinv (qua A B)).
+    := Build_Equiv _ _ (qinv_path A B) (isequiv_qinv (qua A B)).
 
   Definition qinv_isequiv {A B} (f : A -> B) `{IsEquiv _ _ f}
     : qinv A B
@@ -1091,7 +1091,7 @@ Section EquivFunctorFunextType.
         (g : forall b:B, P (f b) -> Q b)
         `{forall b, @IsEquiv (P (f b)) (Q b) (g b)}
   : (forall a, P a) <~> (forall b, Q b)
-    := BuildEquiv _ _ (functor_forall f g) _.
+    := Build_Equiv _ _ (functor_forall f g) _.
 
   Definition ft_equiv_functor_forall_id 
         {A:Type} `{P : A -> Type} `{Q : A -> Type}
@@ -1397,7 +1397,7 @@ Section Book_6_9.
     - refine (match H' _ with end).
       eexists (existT (fun f : Bool <~> Bool =>
                          ~(forall x, f x = x))
-                      (BuildEquiv _ _ negb _)
+                      (Build_Equiv _ _ negb _)
                       (fun H => false_ne_true (H true)));
         simpl.
       intro f.

--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -14,9 +14,9 @@ Generalizable Variables A B C f g.
 
 (** The identity map is an equivalence. *)
 Global Instance isequiv_idmap (A : Type) : IsEquiv idmap | 0 :=
-  BuildIsEquiv A A idmap idmap (fun _ => 1) (fun _ => 1) (fun _ => 1).
+  Build_IsEquiv A A idmap idmap (fun _ => 1) (fun _ => 1) (fun _ => 1).
 
-Definition equiv_idmap (A : Type) : A <~> A := BuildEquiv A A idmap _.
+Definition equiv_idmap (A : Type) : A <~> A := Build_Equiv A A idmap _.
 
 Arguments equiv_idmap {A} , A.
 
@@ -27,7 +27,7 @@ Global Instance reflexive_equiv : Reflexive Equiv | 0 := @equiv_idmap.
 (** The composition of equivalences is an equivalence. *)
 Global Instance isequiv_compose `{IsEquiv A B f} `{IsEquiv B C g}
   : IsEquiv (compose g f) | 1000
-  := BuildIsEquiv A C (compose g f)
+  := Build_IsEquiv A C (compose g f)
     (compose f^-1 g^-1)
     (fun c => ap g (eisretr f (g^-1 c)) @ eisretr g c)
     (fun a => ap (f^-1) (eissect g (f a)) @ eissect f a)
@@ -52,7 +52,7 @@ Definition isequiv_compose'
 Definition equiv_compose {A B C : Type} (g : B -> C) (f : A -> B)
   `{IsEquiv B C g} `{IsEquiv A B f}
   : A <~> C
-  := BuildEquiv A C (compose g f) _.
+  := Build_Equiv A C (compose g f) _.
 
 Definition equiv_compose' {A B C : Type} (g : B <~> C) (f : A <~> B)
   : A <~> C
@@ -94,10 +94,10 @@ Section IsEquivHomotopic.
 
   (* This should not be an instance; it can cause the unifier to spin forever searching for functions to be hoomotpic to. *)
   Definition isequiv_homotopic : IsEquiv g
-    := BuildIsEquiv _ _ g (f ^-1) sect retr adj.
+    := Build_IsEquiv _ _ g (f ^-1) sect retr adj.
 
   Definition equiv_homotopic : A <~> B
-    := BuildEquiv _ _ g isequiv_homotopic.
+    := Build_Equiv _ _ g isequiv_homotopic.
 
 End IsEquivHomotopic.
 
@@ -140,7 +140,7 @@ Section EquivInverse.
   Qed.
 
   Global Instance isequiv_inverse : IsEquiv f^-1 | 10000
-    := BuildIsEquiv B A f^-1 f (eissect f) (eisretr f) other_adj.
+    := Build_IsEquiv B A f^-1 f (eissect f) (eisretr f) other_adj.
 End EquivInverse.
 
 (** If the goal is [IsEquiv _^-1], then use [isequiv_inverse]; otherwise, don't pretend worry about if the goal is an evar and we want to add a [^-1]. *)
@@ -168,7 +168,7 @@ Definition cancelR_isequiv {A B C} (f : A -> B) {g : B -> C}
 Definition cancelR_equiv {A B C} (f : A -> B) {g : B -> C}
   `{IsEquiv A B f} `{IsEquiv A C (g o f)}
   : B <~> C
-  := BuildEquiv B C g (cancelR_isequiv f).
+  := Build_Equiv B C g (cancelR_isequiv f).
 
 (** If [g \o f] and [g] are equivalences, so is [f]. *)
 Definition cancelL_isequiv {A B C} (g : B -> C) {f : A -> B}
@@ -180,7 +180,7 @@ Definition cancelL_isequiv {A B C} (g : B -> C) {f : A -> B}
 Definition cancelL_equiv {A B C} (g : B -> C) {f : A -> B}
   `{IsEquiv B C g} `{IsEquiv A C (g o f)}
   : A <~> B
-  := BuildEquiv _ _ f (cancelL_isequiv g).
+  := Build_Equiv _ _ f (cancelL_isequiv g).
 
 (** Combining these with [isequiv_compose], we see that equivalences can be transported across commutative squares. *)
 Definition isequiv_commsq {A B C D}
@@ -209,11 +209,11 @@ Section EquivTransport.
   Context {A : Type} (P : A -> Type) (x y : A) (p : x = y).
 
   Global Instance isequiv_transport : IsEquiv (transport P p) | 0
-    := BuildIsEquiv (P x) (P y) (transport P p) (transport P p^)
+    := Build_IsEquiv (P x) (P y) (transport P p) (transport P p^)
     (transport_pV P p) (transport_Vp P p) (transport_pVp P p).
 
   Definition equiv_transport : P x <~> P y
-    := BuildEquiv _ _ (transport P p) _.
+    := Build_Equiv _ _ (transport P p) _.
 
 End EquivTransport.
 
@@ -246,10 +246,10 @@ Section Adjointify.
 
   (** We don't make this a typeclass instance, because we want to control when we are applying it. *)
   Definition isequiv_adjointify : IsEquiv f
-    := BuildIsEquiv A B f g isretr issect' is_adjoint'.
+    := Build_IsEquiv A B f g isretr issect' is_adjoint'.
 
   Definition equiv_adjointify : A <~> B
-    := BuildEquiv A B f isequiv_adjointify.
+    := Build_Equiv A B f isequiv_adjointify.
 
 End Adjointify.
 
@@ -300,7 +300,7 @@ Definition contr_equiv' A {B} `(f : A <~> B) `{Contr A}
 Global Instance isequiv_contr_contr {A B : Type}
        `{Contr A} `{Contr B} (f : A -> B)
   : IsEquiv f
-  := BuildIsEquiv _ _ f (fun _ => (center A))
+  := Build_IsEquiv _ _ f (fun _ => (center A))
                   (fun x => path_contr _ _)
                   (fun x => path_contr _ _)
                   (fun x => path_contr _ _).
@@ -316,7 +316,7 @@ Defined.
 Global Instance isequiv_pr1 {A : Type} (P : A -> Type) `{forall x, Contr (P x)}
   : IsEquiv (@pr1 A P).
 Proof.
-  apply (BuildIsEquiv
+  apply (Build_IsEquiv
            _ _ (@pr1 A P)
            (fun x => (x ; center (P x)))
            (fun x => 1)
@@ -330,7 +330,7 @@ Defined.
 
 Definition equiv_pr1 {A : Type} (P : A -> Type) `{forall x, Contr (P x)}
   : { x : A & P x } <~> A
-  := BuildEquiv _ _ (@pr1 A P) _.
+  := Build_Equiv _ _ (@pr1 A P) _.
 
 
 (** Assuming function extensionality, composing with an equivalence is itself an equivalence *)
@@ -346,11 +346,11 @@ Global Instance isequiv_precompose `{Funext} {A B C : Type}
 Definition equiv_precompose `{Funext} {A B C : Type}
   (f : A -> B) `{IsEquiv A B f}
   : (B -> C) <~> (A -> C)
-  := BuildEquiv _ _ (fun (g:B->C) => g o f) _.
+  := Build_Equiv _ _ (fun (g:B->C) => g o f) _.
 
 Definition equiv_precompose' `{Funext} {A B C : Type} (f : A <~> B)
   : (B -> C) <~> (A -> C)
-  := BuildEquiv _ _ (fun (g:B->C) => g o f) _.
+  := Build_Equiv _ _ (fun (g:B->C) => g o f) _.
 
 Global Instance isequiv_postcompose `{Funext} {A B C : Type}
   (f : B -> C) `{IsEquiv B C f}
@@ -363,11 +363,11 @@ Global Instance isequiv_postcompose `{Funext} {A B C : Type}
 Definition equiv_postcompose `{Funext} {A B C : Type}
   (f : B -> C) `{IsEquiv B C f}
   : (A -> B) <~> (A -> C)
-  := BuildEquiv _ _ (fun (g:A->B) => f o g) _.
+  := Build_Equiv _ _ (fun (g:A->B) => f o g) _.
 
 Definition equiv_postcompose' `{Funext} {A B C : Type} (f : B <~> C)
   : (A -> B) <~> (A -> C)
-  := BuildEquiv _ _ (fun (g:A->B) => f o g) _.
+  := Build_Equiv _ _ (fun (g:A->B) => f o g) _.
 
 (** Conversely, if pre- or post-composing with a function is always an equivalence, then that function is also an equivalence.  It's convenient to know that we only need to assume the equivalence when the other type is the domain or the codomain. *)
 

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -453,7 +453,7 @@ Definition Sect {A B : Type} (s : A -> B) (r : B -> A) :=
 Global Arguments Sect {A B}%type_scope / (s r)%function_scope.
 
 (** A typeclass that includes the data making [f] into an adjoint equivalence. *)
-Cumulative Class IsEquiv {A B : Type} (f : A -> B) := BuildIsEquiv {
+Cumulative Class IsEquiv {A B : Type} (f : A -> B) := {
   equiv_inv : B -> A ;
   eisretr : Sect equiv_inv f;
   eissect : Sect f equiv_inv;
@@ -466,7 +466,7 @@ Arguments eisadj {A B}%type_scope f%function_scope {_} _.
 Arguments IsEquiv {A B}%type_scope f%function_scope.
 
 (** A record that includes all the data of an adjoint equivalence. *)
-Cumulative Record Equiv A B := BuildEquiv {
+Cumulative Record Equiv A B := {
   equiv_fun : A -> B ;
   equiv_isequiv : IsEquiv equiv_fun
 }.

--- a/theories/Basics/UniverseLevel.v
+++ b/theories/Basics/UniverseLevel.v
@@ -22,7 +22,7 @@ Definition lower2 {A B} (f : forall x : Lift A, Lift (B (lower x))) : forall x :
 Typeclasses Opaque lift lower lift2 lower2.
 
 Global Instance isequiv_lift T : IsEquiv (@lift T)
-  := @BuildIsEquiv
+  := @Build_IsEquiv
        _ _
        (@lift T)
        (@lower T)
@@ -31,7 +31,7 @@ Global Instance isequiv_lift T : IsEquiv (@lift T)
        (fun _ => idpath).
 
 Global Instance isequiv_lift2 A B : IsEquiv (@lift2 A B)
-  := @BuildIsEquiv
+  := @Build_IsEquiv
        _ _
        (@lift2 A B)
        (@lower2 A B)
@@ -40,7 +40,7 @@ Global Instance isequiv_lift2 A B : IsEquiv (@lift2 A B)
        (fun _ => idpath).
 
 Global Instance lift_isequiv {A B} (f : A -> B) {H : IsEquiv f} : @IsEquiv (Lift A) (Lift B) (lift2 f)
-  := @BuildIsEquiv
+  := @Build_IsEquiv
        (Lift A) (Lift B)
        (lift2 f)
        (lift2 (f^-1))
@@ -51,7 +51,7 @@ Global Instance lift_isequiv {A B} (f : A -> B) {H : IsEquiv f} : @IsEquiv (Lift
                    @ (@ap_compose A (Lift A) (Lift B) lift (lift2 f) _ _ _)).
 
 Global Instance lower_isequiv {A B} (f : Lift A -> Lift B) {H : IsEquiv f} : @IsEquiv A B (lower2 f)
-  := @BuildIsEquiv
+  := @Build_IsEquiv
        _ _
        (lower2 f)
        (lower2 (f^-1))
@@ -62,7 +62,7 @@ Global Instance lower_isequiv {A B} (f : Lift A -> Lift B) {H : IsEquiv f} : @Is
                    @ (@ap_compose (Lift A) A B lower (lower2 f) _ _ _)).
 
 Definition lower_equiv {A B} (e : Equiv (Lift A) (Lift B)) : Equiv A B
-  := @BuildEquiv A B (lower2 e) _.
+  := @Build_Equiv A B (lower2 e) _.
 
 (** This version doesn't force strict containment, i.e. it allows the two universes to possibly be the same.  No fancy type is necessary here other than the universe annotations, because of cumulativity. *)
 
@@ -86,7 +86,7 @@ Definition lower'2@{i i' j j'} {A : Type@{i}} {B : A -> Type@{i'}}
 Typeclasses Opaque lift' lower' lift'2 lower'2.
 
 Definition isequiv_lift'@{i j} (T : Type@{i}) : IsEquiv (@lift'@{i j} T)
-  := @BuildIsEquiv
+  := @Build_IsEquiv
        _ _
        (@lift' T)
        (@lower' T)
@@ -96,7 +96,7 @@ Definition isequiv_lift'@{i j} (T : Type@{i}) : IsEquiv (@lift'@{i j} T)
 Global Existing Instance isequiv_lift'. (* work around https://coq.inria.fr/bugs/show_bug.cgi?id=4411 *)
 
 Definition isequiv_lift'2@{e0 e1 i i' j j'} (A : Type@{i}) (B : A -> Type@{j}) : IsEquiv@{e0 e1} (@lift'2@{i i' j j'} A B)
-  := @BuildIsEquiv
+  := @Build_IsEquiv
        _ _
        (@lift'2 A B)
        (@lower'2 A B)
@@ -106,7 +106,7 @@ Definition isequiv_lift'2@{e0 e1 i i' j j'} (A : Type@{i}) (B : A -> Type@{j}) :
 Global Existing Instance isequiv_lift'2. (* work around https://coq.inria.fr/bugs/show_bug.cgi?id=4411 *)
 
 Definition lift'_isequiv@{a b i j i' j'}  {A : Type@{a}} {B : Type@{b}} (f : A -> B) {H : IsEquiv f} : @IsEquiv (Lift'@{i j} A) (Lift'@{i' j'} B) (lift'2 f)
-  := @BuildIsEquiv
+  := @Build_IsEquiv
        (Lift' A) (Lift' B)
        (lift'2 f)
        (lift'2 (f^-1))
@@ -118,7 +118,7 @@ Definition lift'_isequiv@{a b i j i' j'}  {A : Type@{a}} {B : Type@{b}} (f : A -
 Global Existing Instance lift'_isequiv. (* work around https://coq.inria.fr/bugs/show_bug.cgi?id=4411 *)
 
 Definition lower'_isequiv@{i j i' j'} {A : Type@{i}} {B : Type@{j}} (f : Lift'@{i j} A -> Lift'@{i' j'} B) {H : IsEquiv f} : @IsEquiv A B (lower'2 f)
-  := @BuildIsEquiv
+  := @Build_IsEquiv
        _ _
        (lower'2 f)
        (lower'2 (f^-1))
@@ -130,7 +130,7 @@ Definition lower'_isequiv@{i j i' j'} {A : Type@{i}} {B : Type@{j}} (f : Lift'@{
 Global Existing Instance lower'_isequiv. (* work around https://coq.inria.fr/bugs/show_bug.cgi?id=4411 *)
 
 Definition lower'_equiv@{i j i' j'} {A : Type@{i}} {B : Type@{j}} (e : Equiv (Lift'@{i j} A) (Lift'@{i' j'} B)) : Equiv A B
-  := @BuildEquiv A B (lower'2 e) _.
+  := @Build_Equiv A B (lower'2 e) _.
 
 (*Fail Check Lift nat : Type0.
 Check 1 : Lift nat.*)

--- a/theories/Categories/Category/Paths.v
+++ b/theories/Categories/Category/Paths.v
@@ -189,7 +189,7 @@ Section path_category.
   Definition equiv_path_precategory_uncurried `{Funext} (C D : PreCategory)
   : path_precategory'_T C D <~> C = D
     := ((equiv_path_precategory_uncurried' C D)
-          oE (BuildEquiv
+          oE (Build_Equiv
                 _ _ _
                 (isequiv__path_precategory''_T__of__path_precategory'_T C D))).
 

--- a/theories/Categories/Functor/Paths.v
+++ b/theories/Categories/Functor/Paths.v
@@ -136,7 +136,7 @@ Section path_functor.
 
   Definition equiv_path_functor_uncurried (F G : Functor C D)
   : path_functor'_T F G <~> F = G
-    := BuildEquiv _ _ (@path_functor_uncurried F G) _.
+    := Build_Equiv _ _ (@path_functor_uncurried F G) _.
 
   Local Open Scope function_scope.
 

--- a/theories/Categories/SetCategory/Morphisms.v
+++ b/theories/Categories/SetCategory/Morphisms.v
@@ -50,7 +50,7 @@ Section equiv_iso_set_cat.
   Definition isequiv_isiso s d (m : morphism set_cat s d)
              `{IsIsomorphism _ _ _ m}
   : IsEquiv m
-    := BuildIsEquiv
+    := Build_IsEquiv
          _ _
          m m^-1%morphism
          (ap10 right_inverse)
@@ -67,7 +67,7 @@ Section equiv_iso_set_cat.
   Proof.
     refine (isequiv_adjointify
               (@iso_equiv s d)
-              (fun m => BuildEquiv _ _ _ (@isequiv_isiso s d m m))
+              (fun m => Build_Equiv _ _ _ (@isequiv_isiso s d m m))
               _
               _);
     simpl in *;
@@ -105,7 +105,7 @@ Section equiv_iso_prop_cat.
   Definition isequiv_isiso_prop s d (m : morphism prop_cat s d)
              `{IsIsomorphism _ _ _ m}
   : IsEquiv m
-    := BuildIsEquiv
+    := Build_IsEquiv
          _ _
          m m^-1%morphism
          (ap10 right_inverse)
@@ -122,7 +122,7 @@ Section equiv_iso_prop_cat.
   Proof.
     refine (isequiv_adjointify
               (@iso_equiv_prop s d)
-              (fun m => BuildEquiv _ _ _ (@isequiv_isiso_prop s d m _))
+              (fun m => Build_Equiv _ _ _ (@isequiv_isiso_prop s d m _))
               _
               _);
     simpl in *;

--- a/theories/Classes/implementations/binary_naturals.v
+++ b/theories/Classes/implementations/binary_naturals.v
@@ -109,7 +109,7 @@ Section binary_equiv.
     isequiv_adjointify binary unary' binaryunary unarybinary.
 
   Definition equiv_binary : nat <~> binnat :=
-    BuildEquiv _ _  binary isequiv_binary.
+    Build_Equiv _ _  binary isequiv_binary.
 
 End binary_equiv.
 

--- a/theories/Classes/interfaces/canonical_names.v
+++ b/theories/Classes/interfaces/canonical_names.v
@@ -260,7 +260,7 @@ Class AntiSymmetric `(R : relation A) : Type
   := antisymmetry: forall x y, R x y -> R y x -> x = y.
 Arguments antisymmetry {A} _ {AntiSymmetric} _ _ _ _.
 
-Class EquivRel `(R : relation A) : Type := BuildEquivRel
+Class EquivRel `(R : relation A) : Type := Build_EquivRel
   { EquivRel_Reflexive :> Reflexive R ;
     EquivRel_Symmetric :> Symmetric R ;
     EquivRel_Transitive :> Transitive R }.
@@ -281,7 +281,7 @@ Lemma issig_equiv_rel {A:Type} (R : relation A)
   : SigEquivRel R <~> EquivRel R.
 Proof.
   unfold SigEquivRel.
-  issig (@BuildEquivRel A R) (@EquivRel_Reflexive A R)
+  issig (@Build_EquivRel A R) (@EquivRel_Reflexive A R)
           (@EquivRel_Symmetric A R) (@EquivRel_Transitive A R).
 Defined.
 

--- a/theories/Classes/theory/ua_homomorphism.v
+++ b/theories/Classes/theory/ua_homomorphism.v
@@ -144,7 +144,7 @@ Definition equiv_isomorphism {σ : Signature} {A B : Algebra σ}
   (f : ∀ s, A s → B s) `{IsIsomorphism σ A B f}
   : ∀ (s : Sort σ), A s <~> B s.
 Proof.
-  intro s. rapply (BuildEquiv _ _ (f s)).
+  intro s. rapply (Build_Equiv _ _ (f s)).
 Defined.
 
 Global Instance hprop_is_isomorphism `{Funext} {σ : Signature}

--- a/theories/Colimits/Colimit.v
+++ b/theories/Colimits/Colimit.v
@@ -110,7 +110,7 @@ Proof.
 Defined.
 
 Definition equiv_colimit_rec `{Funext} {G : Graph} {D : Diagram G} (P : Type)
-  : Cocone D P <~> (Colimit D -> P) := BuildEquiv _ _ _ (isequiv_colimit_rec P).
+  : Cocone D P <~> (Colimit D -> P) := Build_Equiv _ _ _ (isequiv_colimit_rec P).
 
 (** And we can now show that the HIT is actually a colimit. *)
 
@@ -227,7 +227,7 @@ Section FunctorialityColimit.
       functor_colimit_eissect functor_colimit_eisretr.
 
   Definition equiv_functor_colimit : Q1 <~> Q2
-    := BuildEquiv _ _ _ isequiv_functor_colimit.
+    := Build_Equiv _ _ _ isequiv_functor_colimit.
 
 End FunctorialityColimit.
 

--- a/theories/Colimits/Pushout.v
+++ b/theories/Colimits/Pushout.v
@@ -131,7 +131,7 @@ Definition equiv_Pushout_rec `{Funext} {A B C} (f : A -> B) (g : A -> C) P
   : {psh : (B -> P) * (C -> P) &
            forall a, fst psh (f a) = snd psh (g a) }
       <~> (Pushout f g -> P)
-  := BuildEquiv _ _ _ (isequiv_Pushout_rec f g P).
+  := Build_Equiv _ _ _ (isequiv_Pushout_rec f g P).
 
 Definition equiv_pushout_unrec `{Funext} {A B C} (f : A -> B) (g : A -> C) P
   : (Pushout f g -> P)

--- a/theories/Comodalities/CoreflectiveSubuniverse.v
+++ b/theories/Comodalities/CoreflectiveSubuniverse.v
@@ -138,7 +138,7 @@ Section CoOpen.
 
   Definition coopen_equiv_open X
   : Op U (coOp X) <~> Op U X
-    := BuildEquiv _ _ (O_functor (Op U) (fromF coOp X))
+    := Build_Equiv _ _ (O_functor (Op U) (fromF coOp X))
                   (coopen_isequiv_open X).
 
 End CoOpen.

--- a/theories/Cubical/DPath.v
+++ b/theories/Cubical/DPath.v
@@ -180,35 +180,35 @@ End DGroupoid.
 Definition dp_paths_l {A : Type} {x1 x2 y : A} (p : x1 = x2) (q : x1 = y) r
   : p^ @ q = r <~> DPath (fun x => x = y) p q r.
 Proof.
-  refine (equiv_composeR' _ (BuildEquiv _ _ dp_path_transport _)).
+  refine (equiv_composeR' _ (Build_Equiv _ _ dp_path_transport _)).
   apply equiv_concat_l, transport_paths_l.
 Defined.
 
 Definition dp_paths_r {A : Type} {x y1 y2 : A} (p : y1 = y2) (q : x = y1) r
   :  q @ p = r <~> DPath (fun y => x = y) p q r.
 Proof.
-  refine (equiv_composeR' _ (BuildEquiv _ _ dp_path_transport _)).
+  refine (equiv_composeR' _ (Build_Equiv _ _ dp_path_transport _)).
   apply equiv_concat_l, transport_paths_r.
 Defined.
 
 Definition dp_paths_lr {A : Type} {x1 x2 : A} (p : x1 = x2) (q : x1 = x1) r
   : (p^ @ q) @ p = r <~> DPath (fun x : A => x = x) p q r.
 Proof.
-  srefine (equiv_composeR' _ (BuildEquiv _ _ dp_path_transport _)).
+  srefine (equiv_composeR' _ (Build_Equiv _ _ dp_path_transport _)).
   apply equiv_concat_l, transport_paths_lr.
 Defined.
 
 Definition dp_paths_Fl {A B} {f : A -> B} {x1 x2 : A} {y : B} (p : x1 = x2)
   (q : f x1 = y) r :  (ap f p)^ @ q = r <~> DPath (fun x => f x = y) p q r.
 Proof.
-  srefine (equiv_composeR' _ (BuildEquiv _ _ dp_path_transport _)).
+  srefine (equiv_composeR' _ (Build_Equiv _ _ dp_path_transport _)).
   apply equiv_concat_l, transport_paths_Fl.
 Defined.
 
 Definition dp_paths_Fr {A B} {g : A -> B} {y1 y2 : A} {x : B} (p : y1 = y2)
   (q : x = g y1) r :  q @ ap g p = r <~> DPath (fun y : A => x = g y) p q r.
 Proof.
-  srefine (equiv_composeR' _ (BuildEquiv _ _ dp_path_transport _)).
+  srefine (equiv_composeR' _ (Build_Equiv _ _ dp_path_transport _)).
   apply equiv_concat_l, transport_paths_Fr.
 Defined.
 
@@ -216,7 +216,7 @@ Definition dp_paths_FFlr {A B} {f : A -> B} {g : B -> A} {x1 x2 : A}
   (p : x1 = x2) (q : g (f x1) = x1) r
   : ((ap g (ap f p))^ @ q) @ p = r <~> DPath (fun x : A => g (f x) = x) p q r.
 Proof.
-  refine (equiv_composeR' _ (BuildEquiv _ _ dp_path_transport _)).
+  refine (equiv_composeR' _ (Build_Equiv _ _ dp_path_transport _)).
   apply equiv_concat_l, transport_paths_FFlr.
 Defined.
 
@@ -224,7 +224,7 @@ Definition dp_paths_FlFr {A B} {f g : A -> B} {x1 x2 : A} (p : x1 = x2)
   (q : f x1 = g x1) r
   : ((ap f p)^ @ q) @ ap g p = r <~> DPath (fun x : A => f x = g x) p q r.
 Proof.
-  srefine (equiv_composeR' _ (BuildEquiv _ _ dp_path_transport _)).
+  srefine (equiv_composeR' _ (Build_Equiv _ _ dp_path_transport _)).
   apply equiv_concat_l, transport_paths_FlFr.
 Defined.
 
@@ -232,7 +232,7 @@ Definition dp_paths_lFFr {A B} {f : A -> B} {g : B -> A} {x1 x2 : A}
   (p : x1 = x2) (q : x1 = g (f x1)) r
   :  (p^ @ q) @ ap g (ap f p) = r <~> DPath (fun x : A => x = g (f x)) p q r.
 Proof.
-  srefine (equiv_composeR' _ (BuildEquiv _ _ dp_path_transport _)).
+  srefine (equiv_composeR' _ (Build_Equiv _ _ dp_path_transport _)).
   apply equiv_concat_l, transport_paths_lFFr.
 Defined.
 
@@ -241,7 +241,7 @@ Definition dp_paths_FlFr_D {A B} (f g : forall a : A, B a)
   : ((apD f p)^ @ ap (transport B p) q) @ apD g p = r
     <~> DPath (fun x : A => f x = g x) p q r.
 Proof.
-  srefine (equiv_composeR' _ (BuildEquiv _ _ dp_path_transport _)).
+  srefine (equiv_composeR' _ (Build_Equiv _ _ dp_path_transport _)).
   apply equiv_concat_l, transport_paths_FlFr_D.
 Defined.
 

--- a/theories/DProp.v
+++ b/theories/DProp.v
@@ -118,7 +118,7 @@ Defined.
 
 Definition equiv_dprop_to_bool `{Univalence}
 : DProp <~> Bool
-  := BuildEquiv _ _ dprop_to_bool _.
+  := Build_Equiv _ _ dprop_to_bool _.
 
 (** ** Operations *)
 

--- a/theories/Diagrams/Diagram.v
+++ b/theories/Diagrams/Diagram.v
@@ -142,11 +142,11 @@ Section Diagram.
     : DiagramMap D2 D1.
   Proof.
     apply (Build_DiagramMap
-             (fun i => (BuildEquiv _ _ _ (diag_equiv_isequiv w i))^-1)).
+             (fun i => (Build_Equiv _ _ _ (diag_equiv_isequiv w i))^-1)).
     intros i j f.
     apply (@comm_square_inverse _ _ _ _ _ _
-                                (BuildEquiv _ _ _ (diag_equiv_isequiv w i))
-                                (BuildEquiv _ _ _ (diag_equiv_isequiv w j))).
+                                (Build_Equiv _ _ _ (diag_equiv_isequiv w i))
+                                (Build_Equiv _ _ _ (diag_equiv_isequiv w j))).
     intros x; apply DiagramMap_comm.
   Defined.
 
@@ -155,7 +155,7 @@ Section Diagram.
     : diagram_comp w (diagram_equiv_inv w) = diagram_idmap D2.
   Proof.
     destruct w as [[w_obj w_comm] is_eq_w]. simpl in *.
-    set (we i := BuildEquiv _ _ _ (is_eq_w i)).
+    set (we i := Build_Equiv _ _ _ (is_eq_w i)).
     simple refine (path_DiagramMap _ _).
     - exact (fun i => eisretr (we i)).
     - simpl.
@@ -168,7 +168,7 @@ Section Diagram.
     : diagram_comp (diagram_equiv_inv w) w = diagram_idmap D1.
   Proof.
     destruct w as [[w_obj w_comm] is_eq_w]. simpl in *.
-    set (we i := BuildEquiv _ _ _ (is_eq_w i)).
+    set (we i := Build_Equiv _ _ _ (is_eq_w i)).
     simple refine (path_DiagramMap _ _).
     - exact (fun i => eissect (we i)).
     - simpl.

--- a/theories/EquivalenceVarieties.v
+++ b/theories/EquivalenceVarieties.v
@@ -36,7 +36,7 @@ Defined.
 Definition isequiv_fcontr `(f : A -> B)
   : (forall b:B, Contr {a : A & f a = b}) -> IsEquiv f.
 Proof.
-  intros ?. refine (BuildIsEquiv _ _ _
+  intros ?. refine (Build_IsEquiv _ _ _
     (fun b => (center {a : A & f a = b}).1)
     (fun b => (center {a : A & f a = b}).2)
     (fun a => (@contr {x : A & f x = f a} _ (a;1))..1)

--- a/theories/Extensions.v
+++ b/theories/Extensions.v
@@ -212,7 +212,7 @@ Section Extensions.
              {A B : Type} (C D : B -> Type) (f : A -> B)
              (g : forall b, C b -> D b) `{forall b, IsEquiv (g b)}
   : ExtendableAlong n f C -> ExtendableAlong n f D
-    := extendable_postcompose' n C D f (fun b => BuildEquiv _ _ (g b) _).
+    := extendable_postcompose' n C D f (fun b => Build_Equiv _ _ (g b) _).
 
   (** Composition of the maps we extend along.  This also does not require funext. *)
   Definition extendable_compose (n : nat)

--- a/theories/Fibrations.v
+++ b/theories/Fibrations.v
@@ -51,7 +51,7 @@ Definition equiv_hfiber_homotopic
            {A B : Type} (f g : A -> B) (h : f == g) (b : B)
 : hfiber f b <~> hfiber g b.
 Proof.
-  refine (BuildEquiv _ _ (fun fx => (fx.1 ; (h fx.1)^ @ fx.2)) _).
+  refine (Build_Equiv _ _ (fun fx => (fx.1 ; (h fx.1)^ @ fx.2)) _).
   refine (isequiv_adjointify _ (fun gx => (gx.1 ; (h gx.1) @ gx.2)) _ _);
     intros [a p]; simpl.
   - apply ap, concat_V_pp.
@@ -107,7 +107,7 @@ Defined.
 Definition equiv_fibration_replacement  {B C} (f:C ->B):
   C <~> {y:B & hfiber f y}.
 Proof.
-  simple refine (BuildEquiv _ _ _ (BuildIsEquiv
+  simple refine (Build_Equiv _ _ _ (Build_IsEquiv
                C {y:B & {x:C & f x = y}}
                (fun c => (f c; (c; idpath)))
                (fun c => c.2.1)
@@ -121,7 +121,7 @@ Defined.
 Definition hfiber_fibration {X} (x : X) (P:X->Type):
     P x <~> @hfiber (sigT P) X pr1 x.
 Proof.
-  simple refine (BuildEquiv _ _ _ (BuildIsEquiv
+  simple refine (Build_Equiv _ _ _ (Build_IsEquiv
                (P x) { z : sigT P & z.1 = x }
                (fun Px => ((x; Px); idpath))
                (fun Px => transport P Px.2 Px.1.2)

--- a/theories/Functorish.v
+++ b/theories/Functorish.v
@@ -19,7 +19,7 @@ Context {FF : Functorish F}.
 Proposition isequiv_fmap {A B} (f : A -> B) `{IsEquiv _ _ f}
   : IsEquiv (fmap F f).
 Proof.
-  refine (equiv_induction (fun A' e => IsEquiv (fmap F e)) _ _ (BuildEquiv _ _ f _)).
+  refine (equiv_induction (fun A' e => IsEquiv (fmap F e)) _ _ (Build_Equiv _ _ f _)).
   refine (transport _ (fmap_idmap F)^ _);
     try apply isequiv_idmap. (* This line may not be needed in a new enough coq. *)
 Defined.
@@ -29,7 +29,7 @@ Proposition fmap_agrees_with_univalence {A B} (f : A -> B) `{IsEquiv _ _ f}
 Proof.
   refine (equiv_induction
     (fun A' e => fmap F e = equiv_path _ _ (ap F (path_universe e)))
-    _ _ (BuildEquiv _ _ f _)).
+    _ _ (Build_Equiv _ _ f _)).
   transitivity (idmap : F A -> F A).
   - apply fmap_idmap.
   - change (equiv_idmap A) with (equiv_path A A 1).

--- a/theories/FunextVarieties.v
+++ b/theories/FunextVarieties.v
@@ -133,7 +133,7 @@ Definition NaiveFunext_implies_Funext : NaiveFunext -> Funext_type
 Definition equiv_postcompose_from_NaiveNondepFunext
            (nf : NaiveNondepFunext) {A B C : Type} (f : B <~> C)
   : (A -> B) <~> (A -> C)
-  := BuildEquiv
+  := Build_Equiv
        _ _ (fun (g:A->B) => f o g)
        (isequiv_adjointify
           (fun (g:A->B) => f o g)

--- a/theories/HIT/Circle.v
+++ b/theories/HIT/Circle.v
@@ -155,7 +155,7 @@ Proof.
 Defined.
 
 Definition equiv_loopS1_int : (base = base) <~> Int
-  := BuildEquiv _ _ (S1_encode base) (S1_encode_isequiv base).
+  := Build_Equiv _ _ (S1_encode base) (S1_encode_isequiv base).
 
 (** ** Connectedness and truncatedness *)
 

--- a/theories/HIT/Coeq.v
+++ b/theories/HIT/Coeq.v
@@ -203,7 +203,7 @@ Section IsEquivFunctorCoeq.
 
   Definition equiv_functor_coeq
   : @Coeq B A f g <~> @Coeq B' A' f' g'
-    := BuildEquiv _ _ (functor_coeq h k p q) _.
+    := Build_Equiv _ _ (functor_coeq h k p q) _.
 
 End IsEquivFunctorCoeq.
 

--- a/theories/HIT/V.v
+++ b/theories/HIT/V.v
@@ -535,7 +535,7 @@ Definition V_singleton (u : V) : V@{U' U} := set (Unit_ind u).
 Global Instance isequiv_ap_V_singleton {u v : V}
 : IsEquiv (@ap _ _ V_singleton u v).
 Proof.
-  simple refine (BuildIsEquiv _ _ _ _ _ _ _); try solve [ intro; apply path_ishprop ].
+  simple refine (Build_IsEquiv _ _ _ _ _ _ _); try solve [ intro; apply path_ishprop ].
   { intro H. specialize (path_V_eqimg H). intros (H1, H2).
     refine (Trunc_rec _ (H1 tt)). intros [t p]. destruct t; exact p. }
 Defined.

--- a/theories/HIT/quotient.v
+++ b/theories/HIT/quotient.v
@@ -265,7 +265,7 @@ Section Functoriality.
              (f : A -> B) (fresp : forall x y, R x y <-> S (f x) (f y))
              `{IsEquiv _ _ f}
   : quotient R <~> quotient S
-    := BuildEquiv _ _
+    := Build_Equiv _ _
          (quotient_functor R S f (fun x y => fst (fresp x y))) _.
 
   Definition quotient_functor_equiv'

--- a/theories/HProp.v
+++ b/theories/HProp.v
@@ -164,7 +164,7 @@ Defined.
 Definition equiv_equiv_iff_hprop
        `{Funext} (A B : Type) `{IsHProp A} `{IsHProp B}
   : (A <-> B) <~> (A <~> B)
-  := BuildEquiv _ _ (@equiv_iff_hprop_uncurried A _ B _) _.
+  := Build_Equiv _ _ (@equiv_iff_hprop_uncurried A _ B _) _.
 
 (** ** Inhabited and uninhabited hprops *)
 
@@ -181,7 +181,7 @@ Defined.
 Lemma if_not_hprop_then_equiv_Empty (hprop : Type) `{IsHProp hprop} : ~hprop -> hprop <~> Empty.
 Proof.
   intro np.
-  exact (BuildEquiv _ _ np _).
+  exact (Build_Equiv _ _ np _).
 Defined.
 
 (** Thus, a decidable hprop is either equivalent to [Unit] or [Empty]. *)

--- a/theories/Homotopy/BlakersMassey.v
+++ b/theories/Homotopy/BlakersMassey.v
@@ -437,7 +437,7 @@ Now we claim that the left-hand map of this span is also an equivalence.  Rather
                      (equiv_inverse
                         (equiv_pushout (f := Ocodeleft2a1) (g := Ocodeleft2ac)
                                        1%equiv _ 1%equiv _ _))).
-          - exact (BuildEquiv _ _ (pushl' codeleft01 Ocodeleft02b) _).
+          - exact (Build_Equiv _ _ (pushl' codeleft01 Ocodeleft02b) _).
           - intros x.
             refine (ap _ (Ocodeleft2a1_through_2b0 x) @ _).
             refine (pglue' codeleft01 Ocodeleft02b _ @ _).
@@ -454,7 +454,7 @@ Now we claim that the left-hand map of this span is also an equivalence.  Rather
           : O (Pushout Ocodeleft2a1 Ocodeleft2ac) <~> O Ocodeleft2c
           := equiv_O_functor
                O (equiv_inverse
-                    (BuildEquiv _ _ (pushr' Ocodeleft2a1 Ocodeleft2ac) _)).
+                    (Build_Equiv _ _ (pushr' Ocodeleft2a1 Ocodeleft2ac) _)).
 
         Definition codeglue6_pushl (s : x0 = x1) (v : ap left s = r)
           : codeglue6 (to O _ (pushl (s;v)))

--- a/theories/Homotopy/Suspension.v
+++ b/theories/Homotopy/Suspension.v
@@ -134,7 +134,7 @@ Definition Susp_rec_eta `{Funext} {X Y : Type} (f : Susp X -> Y)
 Definition equiv_Susp_rec `{Funext} (X Y : Type)
 : (Susp X -> Y) <~> { NS : Y * Y & X -> fst NS = snd NS }.
 Proof.
-  simple refine (BuildEquiv (Susp X -> Y)
+  simple refine (Build_Equiv (Susp X -> Y)
                      { NS : Y * Y & X -> fst NS = snd NS } _ _).
   { intros f.
     exists (f North , f South).

--- a/theories/Idempotents.v
+++ b/theories/Idempotents.v
@@ -569,8 +569,8 @@ Section AlreadySplit.
   Definition equiv_split_idem_retract
   : split_idem (s o r) <~> A.
   Proof.
-    simple refine (BuildEquiv _ _ (r o split_idem_sect (s o r))
-              (BuildIsEquiv _ _ _ (split_idem_retr (s o r) o s) _ _ _)).
+    simple refine (Build_Equiv _ _ (r o split_idem_sect (s o r))
+              (Build_IsEquiv _ _ _ (split_idem_retr (s o r) o s) _ _ _)).
     - intros a; simpl.
       refine (H _ @ H _).
     - intros a; simpl.

--- a/theories/Limits/Limit.v
+++ b/theories/Limits/Limit.v
@@ -152,7 +152,7 @@ Section FunctorialityLimit.
       functor_limit_eissect functor_limit_eisretr.
 
   Definition equiv_functor_limit : Q1 <~> Q2
-    := BuildEquiv _ _ _ isequiv_functor_limit.
+    := Build_Equiv _ _ _ isequiv_functor_limit.
 
 End FunctorialityLimit.
 

--- a/theories/Modalities/Fracture.v
+++ b/theories/Modalities/Fracture.v
@@ -138,7 +138,7 @@ Module Fracture (Os : Modalities).
     : fracture_glue_uncurried (fracture_unglue A) = A.
     Proof.
       apply path_universe_uncurried, equiv_inverse.
-      exact (BuildEquiv _ _ (pullback_corec (fracture_square A))
+      exact (Build_Equiv _ _ (pullback_corec (fracture_square A))
                         (ispullback_fracture_square A)).
     Qed.
 
@@ -152,7 +152,7 @@ Module Fracture (Os : Modalities).
 
     Definition equiv_fracture_unglue `{Univalence}
     : Type <~> { B : Type_ O1 & { C : Type_ O2 & C -> O2 B }}
-      := BuildEquiv _ _ fracture_unglue isequiv_fracture_unglue.
+      := Build_Equiv _ _ fracture_unglue isequiv_fracture_unglue.
 
   End FractureTheorem.
 

--- a/theories/Modalities/Lex.v
+++ b/theories/Modalities/Lex.v
@@ -145,7 +145,7 @@ Module Lex_Modalities_Theory (Os : Modalities).
   Definition equiv_O_functor_hfiber (O : Modality) `{Lex O}
              {A B} (f : A -> B) (b : B)
   : O (hfiber f b) <~> hfiber (O_functor O f) (to O B b)
-    := BuildEquiv _ _ (O_functor_hfiber O f b) _.
+    := Build_Equiv _ _ (O_functor_hfiber O f b) _.
 
   (** 7. Lex modalities preserve path-spaces. *)
   Definition O_path_cmp (O : Modality) {A} (x y : A)
@@ -232,7 +232,7 @@ Module Lex_Modalities_Theory (Os : Modalities).
     : {Q : Type & In O Q * forall x, P x <~> Q}.
   Proof.
     exists (O {x:A & P x}); split; [ exact _ | intros x].
-    refine (BuildEquiv _ _ (fun p => to O _ (x ; p)) _).
+    refine (Build_Equiv _ _ (fun p => to O _ (x ; p)) _).
     refine (isequiv_conn_map_ino O _).
     revert x.
     apply conn_map_fiber.
@@ -316,7 +316,7 @@ Module Lex_Reflective_Subuniverses
     transparent assert (h : (Equiv@{k k} (hfiber@{k i} (@pr1 A B) (g x))
                                          (hfiber@{k i} g (g x)))).
     { refine (_ oE equiv_to_O@{u a k k} O _).
-      refine (_ oE BuildEquiv _ _
+      refine (_ oE Build_Equiv _ _
                 (O_functor_hfiber O (@pr1 A B) (g x)) _).
       unfold hfiber.
       refine (equiv_functor_sigma' 1 _). intros y; cbn.

--- a/theories/Modalities/Localization.v
+++ b/theories/Modalities/Localization.v
@@ -114,7 +114,7 @@ Definition extendable_over_postcompose (n : nat)
 : ExtendableAlong_Over n f C D ext
   -> ExtendableAlong_Over n f C E ext
 := extendable_over_postcompose' n C f ext D E
-     (fun b c => BuildEquiv _ _ (g b c) _).
+     (fun b c => Build_Equiv _ _ (g b c) _).
 
 (** And if the dependency is trivial, we obtain them from an ordinary [ExtendableAlong]. *)
 Definition extendable_over_const

--- a/theories/Modalities/Modality.v
+++ b/theories/Modalities/Modality.v
@@ -362,7 +362,7 @@ Section OIndEquiv.
 
     Definition equiv_O_ind
     : (forall a, B (to O A a)) <~> (forall oa, B oa)
-    := BuildEquiv _ _ (O_ind B) _.
+    := Build_Equiv _ _ (O_ind B) _.
 
     (** Theorem 7.7.7 *)
     Definition isequiv_oD_to_O

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -248,7 +248,7 @@ Global Instance isequiv_o_to_O `{Funext}
 Definition equiv_o_to_O `{Funext}
            (O : ReflectiveSubuniverse) (P Q : Type) `{In O Q}
 : (O P -> Q) <~> (P -> Q)
-:= BuildEquiv _ _ (fun g : O P -> Q => g o to O P) _.
+:= Build_Equiv _ _ (fun g : O P -> Q => g o to O P) _.
 
 (** ** Properties of Reflective Subuniverses *)
 
@@ -285,7 +285,7 @@ Section Reflective_Subuniverse.
   Global Existing Instance isequiv_to_O_inO.
 
   Definition equiv_to_O (T : Type) `{In O T} : T <~> O T
-    := BuildEquiv T (O T) (to O T) _.
+    := Build_Equiv T (O T) (to O T) _.
 
   Section Functor.
 
@@ -444,7 +444,7 @@ Section Reflective_Subuniverse.
 
     Definition equiv_O_functor {A B : Type} (f : A <~> B)
     : O A <~> O B
-    := BuildEquiv _ _ (O_functor f) _.
+    := Build_Equiv _ _ (O_functor f) _.
 
     (** This is sometimes useful to have a separate name for, to facilitate rewriting along it. *)
     Definition to_O_equiv_natural {A B} (f : A <~> B)
@@ -469,7 +469,7 @@ Section Reflective_Subuniverse.
     Definition ap_O_path_universe `{Univalence}
                {A B : Type} (f : A -> B) `{IsEquiv _ _ f}
     : ap O (path_universe f) = path_universe (O_functor f)
-    := ap_O_path_universe' (BuildEquiv _ _ f _).
+    := ap_O_path_universe' (Build_Equiv _ _ f _).
 
     (** Postcomposition respects [O_rec] *)
     Definition O_rec_postcompose {A B C : Type} `{In O B} {C_inO : In O C}
@@ -541,7 +541,7 @@ Section Reflective_Subuniverse.
     Definition equiv_O_inverts {A B : Type} `{In O A} `{In O B}
       (f : A -> B) `{O_inverts f}
     : A <~> B
-    := BuildEquiv _ _ f (isequiv_O_inverts f).
+    := Build_Equiv _ _ f (isequiv_O_inverts f).
 
     Definition isequiv_O_rec_O_inverts
            {A B : Type} `{In O B} (f : A -> B) `{O_inverts f}
@@ -728,7 +728,7 @@ Section Reflective_Subuniverse.
 
     Definition equiv_O_prod_cmp (A B : Type)
     : O (A * B) <~> (O A * O B)
-    := BuildEquiv _ _ (O_prod_cmp A B) _.
+    := Build_Equiv _ _ (O_prod_cmp A B) _.
 
     (** ** Dependent sums *)
     (** Theorem 7.7.4 *)
@@ -1018,7 +1018,7 @@ Section Reflective_Subuniverse.
 
       Definition equiv_O_coeq
       : O (Coeq f g) <~> O (Coeq (O_functor f) (O_functor g))
-        := BuildEquiv _ _ O_coeq_cmp _.
+        := Build_Equiv _ _ O_coeq_cmp _.
 
       Definition equiv_O_coeq_to_O (a : A)
         : equiv_O_coeq (to O (Coeq f g) (coeq a))

--- a/theories/Modalities/Topological.v
+++ b/theories/Modalities/Topological.v
@@ -51,7 +51,7 @@ Module Topological_Modalities_Theory
       pose (e := isequiv_ooextendable _ _
                                       (fst (inO_iff_isnull O (B tt)) (inO_TypeO (B tt)) i)).
       unfold composeD in e; simpl in e.
-      refine (_ oE (BuildEquiv _ _ _ e)^-1).
+      refine (_ oE (Build_Equiv _ _ _ e)^-1).
       exact (equiv_contr_forall _).
   Defined.
 

--- a/theories/PathAny.v
+++ b/theories/PathAny.v
@@ -10,7 +10,7 @@ Definition equiv_path_from_contr {A : Type} (P : A -> A -> Type)
   : P a b <~> a = b.
 Proof.
   apply equiv_inverse.
-  srefine (BuildEquiv _ _ _ _).
+  srefine (Build_Equiv _ _ _ _).
   { intros []; apply Prefl. }
   revert b; apply isequiv_from_functor_sigma.
   (* For some reason, typeclass search can't find the Contr instances unless we give the types explicitly. *)

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -85,7 +85,7 @@ Coercion pointed_equiv_fun : pEquiv >-> pMap.
 Global Existing Instance pointed_isequiv.
 
 Coercion pointed_equiv_equiv {A B} (f : A <~>* B)
-  : A <~> B := BuildEquiv A B f _.
+  : A <~> B := Build_Equiv A B f _.
 
 (* Pointed type family *)
 Definition pFam (A : pType) := {P : A -> Type & P (point A)}.

--- a/theories/PropResizing/Nat.v
+++ b/theories/PropResizing/Nat.v
@@ -597,7 +597,7 @@ Section AssumeStuff.
     apply ((equiv_path_graph _ _)^-1), pr1 in H.
     pose proof ((fun x => H (inr x)) : (vert n.1) -> Empty) as f.
     apply path_N, equiv_path_graph.
-    srefine ((BuildEquiv _ _ f _);_); cbn.
+    srefine ((Build_Equiv _ _ f _);_); cbn.
     intros x y; destruct (f x).
   Qed.
 

--- a/theories/Spaces/BAut/Bool.v
+++ b/theories/Spaces/BAut/Bool.v
@@ -149,7 +149,7 @@ First we define the function that will be the equivalence. *)
   Definition equiv_inhab_baut_bool_bool (t : Bool)
              (Z : BAut Bool) (z : Z)
   : Bool <~> Z
-    := BuildEquiv _ _ (inhab_baut_bool_from_bool t Z z) _.
+    := Build_Equiv _ _ (inhab_baut_bool_from_bool t Z z) _.
 
   Definition path_baut_bool_inhab (Z : BAut Bool) (z : Z)
   : (point (BAut Bool)) = Z.
@@ -190,18 +190,18 @@ First we define the function that will be the equivalence. *)
   Definition equiv_equiv_inhab_baut_bool_bool (t : Bool)
              (Z : BAut Bool)
   : Z <~> (Bool <~> Z)
-    := BuildEquiv _ _ (equiv_inhab_baut_bool_bool t Z) _.
+    := Build_Equiv _ _ (equiv_inhab_baut_bool_bool t Z) _.
 
   (** We compute its inverse in the case of [Bool]. *)
   Definition equiv_equiv_inhab_baut_bool_bool_bool_inv (t : Bool)
              (e : Bool <~> Bool)
   : equiv_inverse (equiv_equiv_inhab_baut_bool_bool t (point _)) e = e t.
   Proof.
-    pose (alt := BuildEquiv _ _ (equiv_inhab_baut_bool_bool t (point _))
+    pose (alt := Build_Equiv _ _ (equiv_inhab_baut_bool_bool t (point _))
                    (isequiv_equiv_inhab_baut_bool_bool_lemma
                       t (point _) (tr 1))).
     assert (p : equiv_equiv_inhab_baut_bool_bool t (point _) = alt).
-    { apply (ap (fun i => BuildEquiv _ _ _ i)).
+    { apply (ap (fun i => Build_Equiv _ _ _ i)).
       apply (ap (isequiv_equiv_inhab_baut_bool_bool_lemma t (point _))).
       apply path_ishprop. }
     exact (ap10_equiv (ap equiv_inverse p) e).

--- a/theories/Spaces/BAut/Cantor.v
+++ b/theories/Spaces/BAut/Cantor.v
@@ -16,17 +16,17 @@ Module BAut_Cantor_Idempotent.
 Section Assumptions.
   Context `{Univalence}.
 
-  Definition f : BAut cantor -> BAut cantor.
+  Definition f : BAut Cantor -> BAut Cantor.
   Proof.
     intros Z.
     (** Here is the important part of this definition. *)
-    exists (Z + cantor)%type.
-    (** The rest is just a proof that [Z+cantor] is again equivalent to [cantor], using [fold_cantor] and the assumption that [Z] is equivalent to [cantor]. *)
+    exists (Z + Cantor)%type.
+    (** The rest is just a proof that [Z+Cantor] is again equivalent to [Cantor], using [cantor_fold] and the assumption that [Z] is equivalent to [Cantor]. *)
     pose (e := Z.2); simpl in e; clearbody e.
     strip_truncations.
     apply tr.
     apply path_universe_uncurried.
-    refine (equiv_fold_cantor oE _).
+    refine (equiv_cantor_fold oE _).
     refine (equiv_path _ _ e +E 1).
   Defined.
 
@@ -36,12 +36,12 @@ Section Assumptions.
     intros Z.
     apply path_baut.
     unfold f; simpl.
-    refine (_ oE equiv_sum_assoc Z cantor cantor).
-    apply (1 +E equiv_fold_cantor).
+    refine (_ oE equiv_sum_assoc Z Cantor Cantor).
+    apply (1 +E equiv_cantor_fold).
   Defined.
 
   (** We record how the action of [f] and [f o f] on paths corresponds to an action on equivalences. *)
-  Definition ap_f {Z Z' : BAut cantor} (p : Z = Z')
+  Definition ap_f {Z Z' : BAut Cantor} (p : Z = Z')
   : equiv_path _ _ (ap f p)..1
     = equiv_path Z Z' p..1 +E 1.
   Proof.
@@ -49,7 +49,7 @@ Section Assumptions.
     intros [z|a]; reflexivity.
   Defined.
 
-  Definition ap_ff {Z Z' : BAut cantor} (p : Z = Z')
+  Definition ap_ff {Z Z' : BAut Cantor} (p : Z = Z')
   : equiv_path _ _ (ap (f o f) p)..1
     = equiv_path Z Z' p..1 +E 1 +E 1.
   Proof.
@@ -60,16 +60,16 @@ Section Assumptions.
   (** Now let's assume [f] is quasi-idempotent, but not necessarily using the same witness of pre-idempotency. *)
   Context (Ip : IsPreIdempotent f) (Jp : @IsQuasiIdempotent _ f Ip).
 
-  Definition I (Z : BAut cantor)
-  : (Z + cantor) + cantor <~> Z + cantor
+  Definition I (Z : BAut Cantor)
+  : (Z + Cantor) + Cantor <~> Z + Cantor
     := equiv_path _ _ (Ip Z)..1.
 
   Definition I0
-  : cantor + cantor + cantor + cantor <~> cantor + cantor + cantor
-    := I (f (point (BAut cantor))).
+  : Cantor + Cantor + Cantor + Cantor <~> Cantor + Cantor + Cantor
+    := I (f (point (BAut Cantor))).
 
   (** We don't know much about [I0], but we can show that it maps the rightmost two summands to the rightmost one, using the naturality of [I].  Here is the naturality. *)
-  Definition Inat (Z Z' : BAut cantor) (e : Z <~> Z')
+  Definition Inat (Z Z' : BAut Cantor) (e : Z <~> Z')
   : I Z' oE (e +E 1 +E 1)
     = (e +E 1) oE I Z.
   Proof.
@@ -82,23 +82,23 @@ Section Assumptions.
     apply ap. apply (concat_Ap Ip).
   Qed.
 
-  (** To show our claim about the action of [I0], we will apply this naturality to the flip automorphism of [cantor + cantor].  Here are the images of that automorphism under [f] and [f o f]. *)
+  (** To show our claim about the action of [I0], we will apply this naturality to the flip automorphism of [Cantor + Cantor].  Here are the images of that automorphism under [f] and [f o f]. *)
   Definition f_flip :=
-    equiv_sum_symm cantor cantor +E equiv_idmap cantor.
+    equiv_sum_symm Cantor Cantor +E equiv_idmap Cantor.
   Definition ff_flip :=
-    (equiv_sum_symm cantor cantor +E equiv_idmap cantor) +E (equiv_idmap cantor).
+    (equiv_sum_symm Cantor Cantor +E equiv_idmap Cantor) +E (equiv_idmap Cantor).
 
   (** The naturality of [I] implies that [I0] commutes with these images of the flip. *)
   Definition I0nat_flip
-        (x : ((cantor + cantor) + cantor) + cantor)
+        (x : ((Cantor + Cantor) + Cantor) + Cantor)
   : I0 (ff_flip x) = f_flip (I0 x)
     := ap10_equiv
-         (Inat (f (point (BAut cantor))) (f (point (BAut cantor)))
-               (equiv_sum_symm cantor cantor))
+         (Inat (f (point (BAut Cantor))) (f (point (BAut Cantor)))
+               (equiv_sum_symm Cantor Cantor))
          x.
 
   (** The value of this is that we can detect which summand an element is in depending on whether or not it is fixed by [f_flip] or [ff_flip]. *)
-  Definition f_flip_fixed_iff_inr (x : cantor + cantor + cantor)
+  Definition f_flip_fixed_iff_inr (x : Cantor + Cantor + Cantor)
   : (f_flip x = x) <-> is_inr x.
   Proof.
     split; intros p; destruct x as [[c|c]|c]; simpl in p.
@@ -113,7 +113,7 @@ Section Assumptions.
   Defined.
 
   Definition ff_flip_fixed_iff_inr
-        (x : cantor + cantor + cantor + cantor)
+        (x : Cantor + Cantor + Cantor + Cantor)
   : (ff_flip x = x) <-> (is_inr x + is_inl_and is_inr x).
   Proof.
     split; intros p; destruct x as [[[c|c]|c]|c]; simpl in p.
@@ -131,7 +131,7 @@ Section Assumptions.
 
   (** And the naturality guarantees that [I0] preserves fixed points. *)
   Definition I0_fixed_iff_fixed
-        (x : cantor + cantor + cantor + cantor)
+        (x : Cantor + Cantor + Cantor + Cantor)
   : (ff_flip x = x) <-> (f_flip (I0 x) = I0 x).
   Proof.
     split; intros p.
@@ -142,7 +142,7 @@ Section Assumptions.
 
   (** Putting it all together, here is the proof of our claim about [I0]. *)
   Definition I0_preserves_inr
-        (x : cantor + cantor + cantor + cantor)
+        (x : Cantor + Cantor + Cantor + Cantor)
   : (is_inr x + is_inl_and is_inr x) <-> is_inr (I0 x).
   Proof.
     refine (iff_compose _ (f_flip_fixed_iff_inr (I0 x))).
@@ -151,7 +151,7 @@ Section Assumptions.
   Defined.
 
   (** Now we bring quasi-idempotence into play. *)
-  Definition J (Z : BAut cantor)
+  Definition J (Z : BAut Cantor)
   : I Z +E 1
     = I (f Z).
   Proof.
@@ -165,10 +165,10 @@ Section Assumptions.
   Definition impossible : Empty.
   Proof.
     pose (x := inl (inr (fun n => true))
-               : ((f (point (BAut cantor))) + cantor) + cantor).
-    apply (not_is_inl_and_inr' (I (f (point (BAut cantor))) x)).
+               : ((f (point (BAut Cantor))) + Cantor) + Cantor).
+    apply (not_is_inl_and_inr' (I (f (point (BAut Cantor))) x)).
     - exact (transport is_inl
-                       (ap10_equiv (J (point (BAut cantor))) x) tt).
+                       (ap10_equiv (J (point (BAut Cantor))) x) tt).
     - exact (fst (I0_preserves_inr x) (inr tt)).
   Defined.
 
@@ -178,7 +178,7 @@ End BAut_Cantor_Idempotent.
 (** Let's make the important conclusions available globally. *)
 
 Definition baut_cantor_idem `{Univalence}
-: BAut cantor -> BAut cantor
+: BAut Cantor -> BAut Cantor
   := BAut_Cantor_Idempotent.f.
 
 Definition preidem_baut_cantor_idem `{Univalence}

--- a/theories/Spaces/BAut/Rigid.v
+++ b/theories/Spaces/BAut/Rigid.v
@@ -73,7 +73,7 @@ Proof.
   { intros f ?.
     refine (isequiv_adjointify (M f) (M f^-1) _ _);
       apply MS; [ apply eisretr | apply eissect ]. }
-  exact (fun f => (BuildEquiv _ _ (M f) (ME f _))).
+  exact (fun f => (Build_Equiv _ _ (M f) (ME f _))).
 Defined.
 
 Definition baut_prod_rigid_equiv `{Univalence}
@@ -81,7 +81,7 @@ Definition baut_prod_rigid_equiv `{Univalence}
            `{IsTrunc n.+1 X} `{IsRigid A} `{IsConnected n.+1 A}
   : BAut X <~> BAut (X * A).
 Proof.
-  refine (BuildEquiv _ _ (baut_prod_r X A) _).
+  refine (Build_Equiv _ _ (baut_prod_r X A) _).
   apply isequiv_surj_emb.
   { apply BuildIsSurjection; intros Z.
     baut_reduce.
@@ -123,7 +123,7 @@ Proof.
         intros [x a]; cbn.
         apply path_prod; [ apply fh | reflexivity ]. }
       intros [x a].
-      pose (gisid := path_aut_rigid (BuildEquiv _ _ (g x) (ge x)) 1).
+      pose (gisid := path_aut_rigid (Build_Equiv _ _ (g x) (ge x)) 1).
       apply path_prod.
       - apply fh.
       - apply gisid. }

--- a/theories/Spaces/Cantor.v
+++ b/theories/Spaces/Cantor.v
@@ -4,12 +4,11 @@ Require Import HoTT.Basics HoTT.Types.
 Local Open Scope nat_scope.
 Local Open Scope path_scope.
 
-
 (** * Cantor space 2^N *)
 
-Definition cantor : Type := nat -> Bool.
+Definition Cantor : Type := nat -> Bool.
 
-Definition fold_cantor : cantor + cantor -> cantor.
+Definition cantor_fold : Cantor + Cantor -> Cantor.
 Proof.
   intros [c|c]; intros n.
   - destruct n as [|n].
@@ -20,7 +19,7 @@ Proof.
     + exact (c n).
 Defined.
 
-Definition unfold_cantor : cantor -> cantor + cantor.
+Definition cantor_unfold : Cantor -> Cantor + Cantor.
 Proof.
   intros c.
   case (c 0).
@@ -28,17 +27,20 @@ Proof.
   - exact (inr (fun n => c n.+1)).
 Defined.
 
-Global Instance isequiv_fold_cantor `{Funext} : IsEquiv fold_cantor.
+Global Instance isequiv_cantor_fold `{Funext} : IsEquiv cantor_fold.
 Proof.
-  refine (isequiv_adjointify fold_cantor unfold_cantor _ _).
+  refine (isequiv_adjointify _ cantor_unfold _ _).
   - intros c; apply path_arrow; intros n.
     induction n as [|n IH].
-    + unfold unfold_cantor.
+    + unfold cantor_unfold.
       case (c 0); reflexivity.
-    + unfold unfold_cantor.
+    + unfold cantor_unfold.
       case (c 0); reflexivity.
   - intros [c|c]; apply path_sum; reflexivity.
 Defined.
 
-Definition equiv_fold_cantor `{Funext} : cantor + cantor <~> cantor
-  := BuildEquiv _ _ fold_cantor _.
+Definition equiv_cantor_fold `{Funext} : Cantor + Cantor <~> Cantor
+  := Build_Equiv _ _ cantor_fold _.
+
+Definition equiv_cantor_unfold `{Funext} : Cantor <~> Cantor + Cantor
+  := Build_Equiv _ _ cantor_unfold (isequiv_inverse equiv_cantor_fold).

--- a/theories/Spaces/Finite.v
+++ b/theories/Spaces/Finite.v
@@ -273,7 +273,7 @@ Qed.
 
 Definition equiv_fin_equiv `{Funext} (n m : nat)
 : ((Fin m.+1) * (Fin n <~> Fin m)) <~> (Fin n.+1 <~> Fin m.+1)
-  := BuildEquiv _ _ (fin_equiv' n m) _.
+  := Build_Equiv _ _ (fin_equiv' n m) _.
 
 (** In particular, this implies that if two canonical finite sets are equivalent, then their cardinalities are equal. *)
 Definition nat_eq_fin_equiv (n m : nat)
@@ -832,7 +832,7 @@ Section DecidableQuotients.
       { strip_truncations.
         destruct p as [x r].
         refine (finite_equiv' (quotient R'') _ _).
-        refine (BuildEquiv _ _ (quotient_functor R'' R' inl inlresp) _).
+        refine (Build_Equiv _ _ (quotient_functor R'' R' inl inlresp) _).
         apply isequiv_surj_emb.
         - apply BuildIsSurjection.
           refine (quotient_ind_prop R' _ _).
@@ -847,7 +847,7 @@ Section DecidableQuotients.
           apply related_classes_eq; unfold R''.
           exact (classes_eq_related R' (inl u) (inl v) q). }
       { refine (finite_equiv' (quotient R'' + Unit) _ _).
-        refine (BuildEquiv _ _ (sum_ind (fun _ => quotient R')
+        refine (Build_Equiv _ _ (sum_ind (fun _ => quotient R')
                                         (quotient_functor R'' R' inl inlresp)
                                         (fun _ => class_of R' (inr tt))) _).
         apply isequiv_surj_emb.

--- a/theories/Spaces/Nat.v
+++ b/theories/Spaces/Nat.v
@@ -99,7 +99,7 @@ Proof.
 Defined.
 
 Definition equiv_path_nat {n m} : (n =n m) <~> (n = m)
-  := BuildEquiv _ _ (@path_nat n m) _.
+  := Build_Equiv _ _ (@path_nat n m) _.
 
 Global Instance decidable_paths_nat : DecidablePaths nat
   := fun n m => decidable_equiv _ (@path_nat n m) _.

--- a/theories/Spaces/No/Core.v
+++ b/theories/Spaces/No/Core.v
@@ -1166,6 +1166,6 @@ Defined.
 
 Definition equiv_DecNo_raise `{Univalence}
   : DecNo <~> No
-  := BuildEquiv _ _ No_raise _.
+  := Build_Equiv _ _ No_raise _.
 
 (** Note that this does not extend to other sorts.  For instance, it is *not* true that any plump ordinal is equal to a cut whose types of left and right options are respectively hereditarily decidable and hereditarily empty.  In particular, when making the type of left options inhabited, we have to use surreals whose type of right options is also inhabited.  For instance, [{{ fun _:P => zero | Empty_rec // rempty_cut }}], for a proposition [P], is a plump ordinal, but to make its left options inhabited we have to use a negative surreal, which is not itself a plump ordinal.  *)

--- a/theories/TruncType.v
+++ b/theories/TruncType.v
@@ -42,7 +42,7 @@ Definition equiv_path_trunctype {n : trunc_index} (A B : TruncType n)
 Proof.
   equiv_via (A = B :> Type).
   - apply equiv_path_universe.
-  - exact ((BuildEquiv _ _ (@ap _ _ (@trunctype_type n) A B) _)^-1)%equiv.
+  - exact ((Build_Equiv _ _ (@ap _ _ (@trunctype_type n) A B) _)^-1)%equiv.
 Defined.
 
 Definition path_trunctype@{a b c} {n : trunc_index} {A B : TruncType n}

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -131,7 +131,7 @@ Section TruncationModality.
 
   Definition equiv_tr (A : Type) `{IsTrunc n A}
   : A <~> Tr n A
-  := BuildEquiv _ _ (@tr n A) _.
+  := Build_Equiv _ _ (@tr n A) _.
 
   Definition untrunc_istrunc {A : Type} `{IsTrunc n A}
   : Tr n A -> A

--- a/theories/Types/Arrow.v
+++ b/theories/Types/Arrow.v
@@ -42,7 +42,7 @@ Definition path_arrow_1 {A B : Type} (f : A -> B)
 
 Definition equiv_ap10 `{Funext} {A B : Type} f g
 : (f = g) <~> (f == g)
-  := BuildEquiv _ _ (@ap10 A B f g) _.
+  := Build_Equiv _ _ (@ap10 A B f g) _.
 
 Global Instance isequiv_path_arrow {A B : Type} (f g : A -> B)
   : IsEquiv (path_arrow f g) | 0

--- a/theories/Types/Bool.v
+++ b/theories/Types/Bool.v
@@ -121,7 +121,7 @@ End BoolForall.
 (** The nonidentity equivalence is negation (the flip). *)
 Global Instance isequiv_negb : IsEquiv negb.
 Proof.
-  refine (@BuildIsEquiv
+  refine (@Build_IsEquiv
             _ _
             negb negb
             (fun b => if b as b return negb (negb b) = b then idpath else idpath)
@@ -131,7 +131,7 @@ Proof.
 Defined.
 
 Definition equiv_negb : Bool <~> Bool
-  := BuildEquiv Bool Bool negb _.
+  := Build_Equiv Bool Bool negb _.
 
 (** Any equivalence [Bool <~> Bool] sends [true] and [false] to different things. *)
 Lemma eval_bool_isequiv (f : Bool -> Bool) `{IsEquiv Bool Bool f}

--- a/theories/Types/Empty.v
+++ b/theories/Types/Empty.v
@@ -31,7 +31,7 @@ Global Instance isequiv_empty_rec `{Funext} (A : Type)
 
 Definition equiv_empty_rec `{Funext} (A : Type)
   : Unit <~> (Empty -> A)
-  := (BuildEquiv _ _ (fun (_ : Unit) => @Empty_rec A) _).
+  := (Build_Equiv _ _ (fun (_ : Unit) => @Empty_rec A) _).
 
 (** ** Behavior with respect to truncation *)
 
@@ -40,7 +40,7 @@ Proof. intro x. destruct x. Defined.
 
 Global Instance all_to_empty_isequiv (T : Type) (f : T -> Empty) : IsEquiv f.
 Proof.
-  refine (BuildIsEquiv _ _ _ 
+  refine (Build_IsEquiv _ _ _ 
     (Empty_ind (fun _ => T))                (* := equiv_inf *)
     (fun fals:Empty => match fals with end) (* : Sect equiv_inf f *)
     (fun t:T => match (f t) with end)       (* : Sect f equiv_inf *)
@@ -50,7 +50,7 @@ Proof.
 Defined.
 
 Definition equiv_to_empty {T : Type} (f : T -> Empty) : T <~> Empty
-  := BuildEquiv T Empty f _.
+  := Build_Equiv T Empty f _.
 
 (** ** Paths *)
 

--- a/theories/Types/Equiv.v
+++ b/theories/Types/Equiv.v
@@ -31,7 +31,7 @@ Section AssumeFunext.
       intros s; simpl.
       (* What remains is to show that under these equivalences, the remaining datum [eisadj] reduces simply to [r == s].  Pleasingly, Coq can compute for us exactly what this means. *)
       apply equiv_inverse;
-        refine (equiv_functor_forall' (BuildEquiv _ _ f _) _);
+        refine (equiv_functor_forall' (Build_Equiv _ _ f _) _);
         intros a; simpl; unfold functor_forall.
       rewrite transport_paths_FlFr.
       (* At this point it's just naturality wrangling, potentially automatable.  It's a little unusual because what we have to prove is not just the existence of some path, but that one path-type is equivalent to another one, but we can mostly still use [rewrite]. *)
@@ -120,7 +120,7 @@ Section AssumeFunext.
 
   Definition equiv_functor_equiv {A B C D} (h : A <~> C) (k : B <~> D)
   : (A <~> B) <~> (C <~> D)
-  := BuildEquiv _ _ (functor_equiv h k) _.
+  := Build_Equiv _ _ (functor_equiv h k) _.
 
   (** Reversing equivalences is an equivalence *)
   Global Instance isequiv_equiv_inverse {A B}
@@ -132,6 +132,6 @@ Section AssumeFunext.
 
   Definition equiv_equiv_inverse A B
   : (A <~> B) <~> (B <~> A)
-    := BuildEquiv _ _ (@equiv_inverse A B) _.
+    := Build_Equiv _ _ (@equiv_inverse A B) _.
 
 End AssumeFunext.

--- a/theories/Types/Forall.v
+++ b/theories/Types/Forall.v
@@ -38,7 +38,7 @@ Definition path_forall_1 `{P : A -> Type} (f : forall x, P x)
 
 Definition equiv_apD10 `{Funext} {A : Type} (P : A -> Type) f g
 : (f = g) <~> (f == g)
-  := BuildEquiv _ _ (@apD10 A P f g) _.
+  := Build_Equiv _ _ (@apD10 A P f g) _.
 
 Global Instance isequiv_path_forall `{P : A -> Type} (f g : forall x, P x)
   : IsEquiv (path_forall f g) | 0
@@ -46,7 +46,7 @@ Global Instance isequiv_path_forall `{P : A -> Type} (f g : forall x, P x)
 
 Definition equiv_path_forall `{P : A -> Type} (f g : forall x, P x)
   : (f == g)  <~>  (f = g)
-  := BuildEquiv _ _ (path_forall f g) _.
+  := Build_Equiv _ _ (path_forall f g) _.
 
 Global Arguments equiv_path_forall {A%type_scope P} (f g)%function_scope.
 
@@ -224,7 +224,7 @@ Definition equiv_functor_forall `{P : A -> Type} `{Q : B -> Type}
   (g : forall b, P (f b) -> Q b)
   `{forall b, @IsEquiv (P (f b)) (Q b) (g b)}
   : (forall a, P a) <~> (forall b, Q b)
-  := BuildEquiv _ _ (functor_forall f g) _.
+  := Build_Equiv _ _ (functor_forall f g) _.
 
 Definition equiv_functor_forall' `{P : A -> Type} `{Q : B -> Type}
   (f : B <~> A) (g : forall b, P (f b) <~> Q b)
@@ -341,6 +341,6 @@ Defined.
 
 Definition equiv_flip `(P : A -> B -> Type)
   : (forall a b, P a b) <~> (forall b a, P a b)
-  := BuildEquiv _ _ (@flip _ _ P) _.
+  := Build_Equiv _ _ (@flip _ _ P) _.
 
 End AssumeFunext.

--- a/theories/Types/Paths.v
+++ b/theories/Types/Paths.v
@@ -119,7 +119,7 @@ Defined.
 
 Definition equiv_ap `(f : A -> B) `{IsEquiv A B f} (x y : A)
   : (x = y) <~> (f x = f y)
-  := BuildEquiv _ _ (ap f) _.
+  := Build_Equiv _ _ (ap f) _.
 
 Global Arguments equiv_ap (A B)%type_scope f%function_scope _ _ _.
 
@@ -137,38 +137,38 @@ Definition equiv_inj `(f : A -> B) `{IsEquiv A B f} {x y : A}
 Global Instance isequiv_path_inverse {A : Type} (x y : A)
   : IsEquiv (@inverse A x y) | 0.
 Proof.
-  refine (BuildIsEquiv _ _ _ (@inverse A y x)
+  refine (Build_IsEquiv _ _ _ (@inverse A y x)
                        (@inv_V A y x) (@inv_V A x y) _).
   intros p; destruct p; reflexivity.
 Defined.
 
 Definition equiv_path_inverse {A : Type} (x y : A)
   : (x = y) <~> (y = x)
-  := BuildEquiv _ _ (@inverse A x y) _.
+  := Build_Equiv _ _ (@inverse A x y) _.
 
 Global Instance isequiv_concat_l {A : Type} `(p : x = y:>A) (z : A)
   : IsEquiv (@transitivity A _ _ x y z p) | 0.
 Proof.
-  refine (BuildIsEquiv _ _ _ (concat p^)
+  refine (Build_IsEquiv _ _ _ (concat p^)
                        (concat_p_Vp p) (concat_V_pp p) _).
   intros q; destruct p; destruct q; reflexivity.
 Defined.
 
 Definition equiv_concat_l {A : Type} `(p : x = y) (z : A)
   : (y = z) <~> (x = z)
-  := BuildEquiv _ _ (concat p) _.
+  := Build_Equiv _ _ (concat p) _.
 
 Global Instance isequiv_concat_r {A : Type} `(p : y = z) (x : A)
   : IsEquiv (fun q:x=y => q @ p) | 0.
 Proof.
-  refine (BuildIsEquiv _ _ (fun q => q @ p) (fun q => q @ p^)
+  refine (Build_IsEquiv _ _ (fun q => q @ p) (fun q => q @ p^)
            (fun q => concat_pV_p q p) (fun q => concat_pp_V q p) _).
   intros q; destruct p; destruct q; reflexivity.
 Defined.
 
 Definition equiv_concat_r {A : Type} `(p : y = z) (x : A)
   : (x = y) <~> (x = z)
-  := BuildEquiv _ _ (fun q => q @ p) _.
+  := Build_Equiv _ _ (fun q => q @ p) _.
 
 Global Instance isequiv_concat_lr {A : Type} {x x' y y' : A} (p : x' = x) (q : y = y')
   : IsEquiv (fun r:x=y => p @ r @ q) | 0
@@ -176,7 +176,7 @@ Global Instance isequiv_concat_lr {A : Type} {x x' y y' : A} (p : x' = x) (q : y
 
 Definition equiv_concat_lr {A : Type} {x x' y y' : A} (p : x' = x) (q : y = y')
   : (x = y) <~> (x' = y')
-  := BuildEquiv _ _ (fun r:x=y => p @ r @ q) _.
+  := Build_Equiv _ _ (fun r:x=y => p @ r @ q) _.
 
 Global Instance isequiv_whiskerL {A} {x y z : A} (p : x = y) {q r : y = z}
 : IsEquiv (@whiskerL A x y z p q r).
@@ -196,7 +196,7 @@ Defined.
 
 Definition equiv_whiskerL {A} {x y z : A} (p : x = y) (q r : y = z)
 : (q = r) <~> (p @ q = p @ r)
-  := BuildEquiv _ _ (whiskerL p) _.
+  := Build_Equiv _ _ (whiskerL p) _.
 
 Definition equiv_cancelL {A} {x y z : A} (p : x = y) (q r : y = z)
 : (p @ q = p @ r) <~> (q = r)
@@ -226,7 +226,7 @@ Defined.
 
 Definition equiv_whiskerR {A} {x y z : A} (p q : x = y) (r : y = z)
 : (p = q) <~> (p @ r = q @ r)
-  := BuildEquiv _ _ (fun h => whiskerR h r) _.
+  := Build_Equiv _ _ (fun h => whiskerR h r) _.
 
 Definition equiv_cancelR {A} {x y z : A} (p q : x = y) (r : y = z)
 : (p @ r = q @ r) <~> (p = q)
@@ -255,7 +255,7 @@ Defined.
 Definition equiv_moveR_Mp
   {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : y = x)
 : (p = r^ @ q) <~> (r @ p = q)
-:= BuildEquiv _ _ (moveR_Mp p q r) _.
+:= Build_Equiv _ _ (moveR_Mp p q r) _.
 
 Global Instance isequiv_moveR_pM
   {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : y = x)
@@ -268,7 +268,7 @@ Defined.
 Definition equiv_moveR_pM
   {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : y = x)
 : (r = q @ p^) <~> (r @ p = q)
-:= BuildEquiv _ _ (moveR_pM p q r) _.
+:= Build_Equiv _ _ (moveR_pM p q r) _.
 
 Global Instance isequiv_moveR_Vp
   {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : x = y)
@@ -281,7 +281,7 @@ Defined.
 Definition equiv_moveR_Vp
   {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : x = y)
 : (p = r @ q) <~> (r^ @ p = q)
-:= BuildEquiv _ _ (moveR_Vp p q r) _.
+:= Build_Equiv _ _ (moveR_Vp p q r) _.
 
 Global Instance isequiv_moveR_pV
   {A : Type} {x y z : A} (p : z = x) (q : y = z) (r : y = x)
@@ -294,7 +294,7 @@ Defined.
 Definition equiv_moveR_pV
   {A : Type} {x y z : A} (p : z = x) (q : y = z) (r : y = x)
 : (r = q @ p) <~> (r @ p^ = q)
-:= BuildEquiv _ _ (moveR_pV p q r) _.
+:= Build_Equiv _ _ (moveR_pV p q r) _.
 
 Global Instance isequiv_moveL_Mp
   {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : y = x)
@@ -307,7 +307,7 @@ Defined.
 Definition equiv_moveL_Mp
   {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : y = x)
 : (r^ @ q = p) <~> (q = r @ p)
-:= BuildEquiv _ _ (moveL_Mp p q r) _.
+:= Build_Equiv _ _ (moveL_Mp p q r) _.
 
 Definition isequiv_moveL_pM
   {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : y = x)
@@ -320,7 +320,7 @@ Defined.
 Definition equiv_moveL_pM
   {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : y = x) :
   q @ p^ = r <~> q = r @ p
-  := BuildEquiv _ _ _ (isequiv_moveL_pM p q r).
+  := Build_Equiv _ _ _ (isequiv_moveL_pM p q r).
 
 Global Instance isequiv_moveL_Vp
   {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : x = y)
@@ -333,7 +333,7 @@ Defined.
 Definition equiv_moveL_Vp
   {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : x = y)
 : r @ q = p <~> q = r^ @ p
-:= BuildEquiv _ _ (moveL_Vp p q r) _.
+:= Build_Equiv _ _ (moveL_Vp p q r) _.
 
 Global Instance isequiv_moveL_pV
   {A : Type} {x y z : A} (p : z = x) (q : y = z) (r : y = x)
@@ -346,7 +346,7 @@ Defined.
 Definition equiv_moveL_pV
   {A : Type} {x y z : A} (p : z = x) (q : y = z) (r : y = x)
 : q @ p = r <~> q = r @ p^
-:= BuildEquiv _ _ (moveL_pV p q r) _.
+:= Build_Equiv _ _ (moveL_pV p q r) _.
 
 Definition isequiv_moveL_1M {A : Type} {x y : A} (p q : x = y)
 : IsEquiv (moveL_1M p q).
@@ -386,7 +386,7 @@ Defined.
 
 Definition equiv_moveR_1M {A : Type} {x y : A} (p q : x = y)
   : (1 = q @ p^) <~> (p = q)
-  := BuildEquiv _ _ (moveR_1M p q) _.
+  := Build_Equiv _ _ (moveR_1M p q) _.
 
 Definition isequiv_moveR_1V {A : Type} {x y : A} (p : x = y) (q : y = x)
 : IsEquiv (moveR_1V p q).
@@ -428,7 +428,7 @@ Defined.
 Definition equiv_moveR_transport_p {A : Type} (P : A -> Type) {x y : A}
   (p : x = y) (u : P x) (v : P y)
 : u = transport P p^ v <~> transport P p u = v
-:= BuildEquiv _ _ (moveR_transport_p P p u v) _.
+:= Build_Equiv _ _ (moveR_transport_p P p u v) _.
 
 
 Definition moveR_moveL_transport_p {A : Type} (P : A -> Type) {x y : A}
@@ -458,7 +458,7 @@ Defined.
 Definition equiv_moveR_transport_V {A : Type} (P : A -> Type) {x y : A}
   (p : y = x) (u : P x) (v : P y)
 : u = transport P p v <~> transport P p^ u = v
-:= BuildEquiv _ _ (moveR_transport_V P p u v) _.
+:= Build_Equiv _ _ (moveR_transport_V P p u v) _.
 
 Global Instance isequiv_moveL_transport_V {A : Type} (P : A -> Type) {x y : A}
   (p : x = y) (u : P x) (v : P y)
@@ -473,7 +473,7 @@ Defined.
 Definition equiv_moveL_transport_V {A : Type} (P : A -> Type) {x y : A}
   (p : x = y) (u : P x) (v : P y)
 : transport P p u = v <~> u = transport P p^ v
-:= BuildEquiv _ _ (moveL_transport_V P p u v) _.
+:= Build_Equiv _ _ (moveL_transport_V P p u v) _.
 
 Global Instance isequiv_moveL_transport_p {A : Type} (P : A -> Type) {x y : A}
   (p : y = x) (u : P x) (v : P y)
@@ -488,7 +488,7 @@ Defined.
 Definition equiv_moveL_transport_p {A : Type} (P : A -> Type) {x y : A}
   (p : y = x) (u : P x) (v : P y)
 : transport P p^ u = v <~> u = transport P p v
-:= BuildEquiv _ _ (moveL_transport_p P p u v) _.
+:= Build_Equiv _ _ (moveL_transport_p P p u v) _.
 
 Global Instance isequiv_moveR_equiv_M `{IsEquiv A B f} (x : A) (y : B)
 : IsEquiv (@moveR_equiv_M A B f _ x y).
@@ -499,7 +499,7 @@ Defined.
 
 Definition equiv_moveR_equiv_M `{IsEquiv A B f} (x : A) (y : B)
   : (x = f^-1 y) <~> (f x = y)
-  := BuildEquiv _ _ (@moveR_equiv_M A B f _ x y) _.
+  := Build_Equiv _ _ (@moveR_equiv_M A B f _ x y) _.
 
 Global Instance isequiv_moveR_equiv_V `{IsEquiv A B f} (x : B) (y : A)
 : IsEquiv (@moveR_equiv_V A B f _ x y).
@@ -510,7 +510,7 @@ Defined.
 
 Definition equiv_moveR_equiv_V `{IsEquiv A B f} (x : B) (y : A)
   : (x = f y) <~> (f^-1 x = y)
-  := BuildEquiv _ _ (@moveR_equiv_V A B f _ x y) _.
+  := Build_Equiv _ _ (@moveR_equiv_V A B f _ x y) _.
 
 Global Instance isequiv_moveL_equiv_M `{IsEquiv A B f} (x : A) (y : B)
 : IsEquiv (@moveL_equiv_M A B f _ x y).
@@ -521,7 +521,7 @@ Defined.
 
 Definition equiv_moveL_equiv_M `{IsEquiv A B f} (x : A) (y : B)
   : (f^-1 y = x) <~> (y = f x)
-  := BuildEquiv _ _ (@moveL_equiv_M A B f _ x y) _.
+  := Build_Equiv _ _ (@moveL_equiv_M A B f _ x y) _.
 
 Global Instance isequiv_moveL_equiv_V `{IsEquiv A B f} (x : B) (y : A)
 : IsEquiv (@moveL_equiv_V A B f _ x y).
@@ -532,7 +532,7 @@ Defined.
 
 Definition equiv_moveL_equiv_V `{IsEquiv A B f} (x : B) (y : A)
   : (f y = x) <~> (y = f^-1 x)
-  := BuildEquiv _ _ (@moveL_equiv_V A B f _ x y) _.
+  := Build_Equiv _ _ (@moveL_equiv_V A B f _ x y) _.
 
 (** *** Dependent paths *)
 
@@ -661,7 +661,7 @@ Defined.
 Definition equiv_paths_ind `{Funext} {A : Type} (a : A)
   (P : forall x, (a = x) -> Type)
   : P a 1 <~> forall x p, P x p
-  := BuildEquiv _ _ (paths_ind a P) _.
+  := Build_Equiv _ _ (paths_ind a P) _.
 
 (** ** Truncation *)
 

--- a/theories/Types/Prod.v
+++ b/theories/Types/Prod.v
@@ -141,7 +141,7 @@ Definition transport_path_prod'
 Global Instance isequiv_path_prod {A B : Type} {z z' : A * B}
 : IsEquiv (path_prod_uncurried z z') | 0.
 Proof.
-  refine (BuildIsEquiv _ _ _
+  refine (Build_IsEquiv _ _ _
             (fun r => (ap fst r, ap snd r))
             eta_path_prod
             (fun pq => path_prod'
@@ -155,7 +155,7 @@ Defined.
 
 Definition equiv_path_prod {A B : Type} (z z' : A * B)
   : (fst z = fst z') * (snd z = snd z')  <~>  (z = z')
-  := BuildEquiv _ _ (path_prod_uncurried z z') _.
+  := Build_Equiv _ _ (path_prod_uncurried z z') _.
 
 (** Path algebra *)
 
@@ -221,7 +221,7 @@ Defined.
 Global Instance isequiv_functor_prod `{IsEquiv A A' f} `{IsEquiv B B' g}
 : IsEquiv (functor_prod f g) | 1000.
 Proof.
-  refine (BuildIsEquiv
+  refine (Build_IsEquiv
             _ _ (functor_prod f g) (functor_prod f^-1 g^-1)
             (fun z => path_prod' (eisretr f (fst z)) (eisretr g (snd z))
                       @ eta_prod z)
@@ -265,9 +265,9 @@ Definition equiv_functor_prod_r {A A' B : Type} (f : A <~> A')
 (** This is a special property of [prod], of course, not an instance of a general family of facts about types. *)
 
 Definition equiv_prod_symm (A B : Type) : A * B <~> B * A
-  := BuildEquiv
+  := Build_Equiv
        _ _ _
-       (BuildIsEquiv
+       (Build_IsEquiv
           (A*B) (B*A)
           (fun ab => (snd ab, fst ab))
           (fun ba => (snd ba, fst ba))
@@ -279,9 +279,9 @@ Definition equiv_prod_symm (A B : Type) : A * B <~> B * A
 
 (** This, too, is a special property of [prod], of course, not an instance of a general family of facts about types. *)
 Definition equiv_prod_assoc (A B C : Type) : A * (B * C) <~> (A * B) * C
-  := BuildEquiv
+  := Build_Equiv
        _ _ _
-       (BuildIsEquiv
+       (Build_IsEquiv
           (A * (B * C)) ((A * B) * C)
           (fun abc => ((fst abc, fst (snd abc)), snd (snd abc)))
           (fun abc => (fst (fst abc), (snd (fst abc), snd abc)))
@@ -292,15 +292,15 @@ Definition equiv_prod_assoc (A B C : Type) : A * (B * C) <~> (A * B) * C
 (** ** Unit and annihilation *)
 
 Definition prod_empty_r X : X * Empty <~> Empty
-  := (BuildEquiv _ _ snd _).
+  := (Build_Equiv _ _ snd _).
 
 Definition prod_empty_l X : Empty * X <~> Empty
-  := (BuildEquiv _ _ fst _).
+  := (Build_Equiv _ _ fst _).
 
 Definition prod_unit_r X : X * Unit <~> X.
 Proof.
-  refine (BuildEquiv _ _ fst _).
-  simple refine (BuildIsEquiv _ _ _ (fun x => (x,tt)) _ _ _).
+  refine (Build_Equiv _ _ fst _).
+  simple refine (Build_IsEquiv _ _ _ (fun x => (x,tt)) _ _ _).
   - intros x; reflexivity.
   - intros [x []]; reflexivity.
   - intros [x []]; reflexivity.
@@ -308,8 +308,8 @@ Defined.
 
 Definition prod_unit_l X : Unit * X <~> X.
 Proof.
-  refine (BuildEquiv _ _ snd _).
-  simple refine (BuildIsEquiv _ _ _ (fun x => (tt,x)) _ _ _).
+  refine (Build_Equiv _ _ snd _).
+  simple refine (Build_IsEquiv _ _ _ (fun x => (tt,x)) _ _ _).
   - intros x; reflexivity.
   - intros [[] x]; reflexivity.
   - intros [[] x]; reflexivity.
@@ -322,7 +322,7 @@ Defined.
 (* First the positive universal property. *)
 Global Instance isequiv_prod_ind `(P : A * B -> Type)
 : IsEquiv (prod_ind P) | 0
-  := BuildIsEquiv
+  := Build_IsEquiv
        _ _
        (prod_ind P)
        (fun f x y => f (x, y))
@@ -332,7 +332,7 @@ Global Instance isequiv_prod_ind `(P : A * B -> Type)
 
 Definition equiv_prod_ind `(P : A * B -> Type)
   : (forall (a : A) (b : B), P (a, b)) <~> (forall p : A * B, P p)
-  := BuildEquiv _ _ (prod_ind P) _.
+  := Build_Equiv _ _ (prod_ind P) _.
 
 (* The non-dependent version, which is a special case, is the currying equivalence. *)
 Definition equiv_uncurry (A B C : Type)
@@ -350,7 +350,7 @@ Definition prod_coind `(f : forall x:X, A x) `(g : forall x:X, B x)
 
 Global Instance isequiv_prod_coind `(A : X -> Type) (B : X -> Type)
 : IsEquiv (@prod_coind_uncurried X A B) | 0
-  := BuildIsEquiv
+  := Build_IsEquiv
        _ _
        (@prod_coind_uncurried X A B)
        (fun h => (fun x => fst (h x), fun x => snd (h x)))
@@ -360,7 +360,7 @@ Global Instance isequiv_prod_coind `(A : X -> Type) (B : X -> Type)
 
 Definition equiv_prod_coind `(A : X -> Type) (B : X -> Type)
   : ((forall x, A x) * (forall x, B x)) <~> (forall x, A x * B x)
-  := BuildEquiv _ _ (@prod_coind_uncurried X A B) _.
+  := Build_Equiv _ _ (@prod_coind_uncurried X A B) _.
 
 (** ** Products preserve truncation *)
 

--- a/theories/Types/Record.v
+++ b/theories/Types/Record.v
@@ -18,8 +18,8 @@ Ltac issig2 build pr1 pr2 :=
   (** Extract the fibration of which our Sigma-type is the total space, as well as the record type. We pull the terms out of a [match], rather than leaving everything inside the [match] because this gives us better error messages. *)
   let fibration := match goal with |- sigT ?fibration <~> ?record => constr:(fibration) end in
   let record := match goal with |- sigT ?fibration <~> ?record => constr:(record) end in
-  exact (BuildEquiv _ _ _
-                    (BuildIsEquiv
+  exact (Build_Equiv _ _ _
+                    (Build_IsEquiv
                        (sigT fibration) record
                        (fun u => build u.1 u.2)
                        (fun v => existT fibration (pr1 v) (pr2 v))
@@ -43,7 +43,7 @@ Defined.
 Definition issig_equiv (A B : Type)
   : { f : A -> B & IsEquiv f } <~> Equiv A B.
 Proof.
-  issig (BuildEquiv A B) (@equiv_fun A B) (@equiv_isequiv A B).
+  issig (Build_Equiv A B) (@equiv_fun A B) (@equiv_isequiv A B).
 Defined.
 
 (** Here is a version of the [issig] tactic for three-component records, which proves goals that look like
@@ -56,8 +56,8 @@ Ltac issig3 build pr1 pr2 pr3 :=
   hnf;
   let A := match goal with |- ?A <~> ?B => constr:(A) end in
   let B := match goal with |- ?A <~> ?B => constr:(B) end in
-  exact (BuildEquiv _ _ _
-                    (BuildIsEquiv
+  exact (Build_Equiv _ _ _
+                    (Build_IsEquiv
                        A B
                        (fun u => build u.1 u.2.1 u.2.2)
                        (fun v => (pr1 v; pr2 v; pr3 v))
@@ -73,8 +73,8 @@ Ltac issig4 build pr1 pr2 pr3 pr4 :=
   hnf;
   let A := match goal with |- ?A <~> ?B => constr:(A) end in
   let B := match goal with |- ?A <~> ?B => constr:(B) end in
-  exact (BuildEquiv _ _ _
-                    (BuildIsEquiv
+  exact (Build_Equiv _ _ _
+                    (Build_IsEquiv
                        A B
                        (fun u => build u.1 u.2.1 u.2.2.1 u.2.2.2)
                        (fun v => (pr1 v; pr2 v; pr3 v; pr4 v))
@@ -90,8 +90,8 @@ Ltac issig5 build pr1 pr2 pr3 pr4 pr5 :=
   hnf;
   let A := match goal with |- ?A <~> ?B => constr:(A) end in
   let B := match goal with |- ?A <~> ?B => constr:(B) end in
-  exact (BuildEquiv _ _ _
-                    (BuildIsEquiv
+  exact (Build_Equiv _ _ _
+                    (Build_IsEquiv
                        A B
                        (fun u => build u.1 u.2.1 u.2.2.1 u.2.2.2.1 u.2.2.2.2)
                        (fun v => (pr1 v; pr2 v; pr3 v; pr4 v ; pr5 v))
@@ -106,8 +106,8 @@ Ltac issig6 build pr1 pr2 pr3 pr4 pr5 pr6 :=
   hnf;
   let A := match goal with |- ?A <~> ?B => constr:(A) end in
   let B := match goal with |- ?A <~> ?B => constr:(B) end in
-  exact (BuildEquiv _ _ _
-                    (BuildIsEquiv
+  exact (Build_Equiv _ _ _
+                    (Build_IsEquiv
                        A B
                        (fun u => build u.1 u.2.1 u.2.2.1 u.2.2.2.1 u.2.2.2.2.1 u.2.2.2.2.2)
                        (fun v => (pr1 v; pr2 v; pr3 v; pr4 v ; pr5 v ; pr6 v))
@@ -124,6 +124,6 @@ Definition issig_isequiv {A B : Type} (f : A -> B) :
   { g:B->A & { r:Sect g f & { s:Sect f g & forall x : A, r (f x) = ap f (s x) }}}
   <~> IsEquiv f.
 Proof.
-  issig (BuildIsEquiv A B f) (@equiv_inv A B f) (@eisretr A B f)
+  issig (Build_IsEquiv A B f) (@equiv_inv A B f) (@eisretr A B f)
         (@eissect A B f) (@eisadj A B f).
 Defined.

--- a/theories/Types/Sigma.v
+++ b/theories/Types/Sigma.v
@@ -188,7 +188,7 @@ Definition transport_pr1_path_sigma
 Global Instance isequiv_path_sigma `{P : A -> Type} {u v : sigT P}
 : IsEquiv (path_sigma_uncurried P u v) | 0.
 Proof.
-  simple refine (BuildIsEquiv
+  simple refine (Build_IsEquiv
             _ _
             _ (fun r => (r..1; r..2))
             eta_path_sigma
@@ -201,7 +201,7 @@ Defined.
 
 Definition equiv_path_sigma `(P : A -> Type) (u v : sigT P)
 : {p : u.1 = v.1 &  p # u.2 = v.2} <~> (u = v)
-  := BuildEquiv _ _ (path_sigma_uncurried P u v) _.
+  := Build_Equiv _ _ (path_sigma_uncurried P u v) _.
 
 (* A contravariant version of [isequiv_path_sigma'] *)
 Instance isequiv_path_sigma_contra `{P : A -> Type} {u v : sigT P}
@@ -218,7 +218,7 @@ Defined.
 (* A contravariant version of [equiv_path_sigma] *)
 Definition equiv_path_sigma_contra {A : Type} `(P : A -> Type) (u v : sigT P)
   : {p : u.1 = v.1 & u.2 = p^ # v.2} <~> (u = v)
-  := BuildEquiv _ _ (path_sigma_uncurried_contra P u v) _.
+  := Build_Equiv _ _ (path_sigma_uncurried_contra P u v) _.
 
 (** This identification respects path concatenation. *)
 
@@ -440,7 +440,7 @@ Definition equiv_functor_sigma `{P : A -> Type} `{Q : B -> Type}
            (g : forall a, P a -> Q (f a))
            `{forall a, @IsEquiv (P a) (Q (f a)) (g a)}
 : sigT P <~> sigT Q
-  := BuildEquiv _ _ (functor_sigma f g) _.
+  := Build_Equiv _ _ (functor_sigma f g) _.
 
 Definition equiv_functor_sigma' `{P : A -> Type} `{Q : B -> Type}
            (f : A <~> B)
@@ -469,7 +469,7 @@ Defined.
 Definition equiv_sigma_contr {A : Type} (P : A -> Type)
            `{forall a, Contr (P a)}
 : sigT P <~> A
-  := BuildEquiv _ _ pr1 _.
+  := Build_Equiv _ _ pr1 _.
 
 (** Lemma 3.11.9(ii): Dually, summing up over a contractible type does nothing. *)
 
@@ -489,9 +489,9 @@ Defined.
 
 Definition equiv_sigma_assoc `(P : A -> Type) (Q : {a : A & P a} -> Type)
 : {a : A & {p : P a & Q (a;p)}} <~> sigT Q
-  := @BuildEquiv
+  := @Build_Equiv
        _ _ _
-       (@BuildIsEquiv
+       (@Build_IsEquiv
           {a : A & {p : P a & Q (a;p)}} (sigT Q)
           (fun apq => ((apq.1; apq.2.1); apq.2.2))
           (fun apq => (apq.1.1; (apq.1.2; apq.2)))
@@ -501,9 +501,9 @@ Definition equiv_sigma_assoc `(P : A -> Type) (Q : {a : A & P a} -> Type)
 
 Definition equiv_sigma_prod `(Q : (A * B) -> Type)
 : {a : A & {b : B & Q (a,b)}} <~> sigT Q
-  := @BuildEquiv
+  := @Build_Equiv
        _ _ _
-       (@BuildIsEquiv
+       (@Build_IsEquiv
           {a : A & {b : B & Q (a,b)}} (sigT Q)
           (fun apq => ((apq.1, apq.2.1); apq.2.2))
           (fun apq => (fst apq.1; (snd apq.1; apq.2)))
@@ -513,8 +513,8 @@ Definition equiv_sigma_prod `(Q : (A * B) -> Type)
 
 Definition equiv_sigma_prod0 A B
 : {a : A & B} <~> A * B
-  := BuildEquiv _ _ _
-       (BuildIsEquiv
+  := Build_Equiv _ _ _
+       (Build_IsEquiv
           {a : A & B} (A * B)
           (fun (ab : {a:A & B}) => (ab.1 , ab.2))
           (fun (ab : A*B) => (fst ab ; snd ab))
@@ -532,8 +532,8 @@ Definition equiv_sigma_symm `(P : A -> B -> Type)
 Definition equiv_sigma_symm0 (A B : Type)
 : {a : A & B} <~> {b : B & A}.
 Proof.
-  refine (BuildEquiv _ _ (fun (w:{a:A & B}) => (w.2 ; w.1)) _).
-  simple refine (BuildIsEquiv _ _ _ (fun (z:{b:B & A}) => (z.2 ; z.1))
+  refine (Build_Equiv _ _ (fun (w:{a:A & B}) => (w.2 ; w.1)) _).
+  simple refine (Build_IsEquiv _ _ _ (fun (z:{b:B & A}) => (z.2 ; z.1))
                        _ _ _); intros [x y]; reflexivity.
 Defined.
 
@@ -543,7 +543,7 @@ Defined.
 Global Instance isequiv_sigT_ind `{P : A -> Type}
          (Q : sigT P -> Type)
 : IsEquiv (sigT_ind Q) | 0
-  := BuildIsEquiv
+  := Build_IsEquiv
        _ _
        (sigT_ind Q)
        (fun f x y => f (x;y))
@@ -554,7 +554,7 @@ Global Instance isequiv_sigT_ind `{P : A -> Type}
 Definition equiv_sigT_ind `{P : A -> Type}
            (Q : sigT P -> Type)
 : (forall (x:A) (y:P x), Q (x;y)) <~> (forall xy, Q xy)
-  := BuildEquiv _ _ (sigT_ind Q) _.
+  := Build_Equiv _ _ (sigT_ind Q) _.
 
 (** *** The negative universal property. *)
 
@@ -573,7 +573,7 @@ Definition sigT_coind
 Global Instance isequiv_sigT_coind
          `{A : X -> Type} {P : forall x, A x -> Type}
 : IsEquiv (sigT_coind_uncurried P) | 0
-  := BuildIsEquiv
+  := Build_IsEquiv
        _ _
        (sigT_coind_uncurried P)
        (fun h => existT (fun f => forall x, P x (f x))
@@ -587,7 +587,7 @@ Definition equiv_sigT_coind
            `(A : X -> Type) (P : forall x, A x -> Type)
 : { f : forall x, A x & forall x, P x (f x) }
     <~> (forall x, sigT (P x))
-  := BuildEquiv _ _ (sigT_coind_uncurried P) _.
+  := Build_Equiv _ _ (sigT_coind_uncurried P) _.
 
 (** ** Sigmas preserve truncation *)
 
@@ -632,7 +632,7 @@ Hint Immediate isequiv_path_sigma_hprop : typeclass_instances.
 Definition equiv_path_sigma_hprop {A : Type} {P : A -> Type}
            {HP : forall a, IsHProp (P a)} (u v : sigT P)
 : (u.1 = v.1) <~> (u = v)
-  := BuildEquiv _ _ (path_sigma_hprop _ _) _.
+  := Build_Equiv _ _ (path_sigma_hprop _ _) _.
 
 Definition isequiv_pr1_path_hprop {A} {P : A -> Type}
          `{forall a, IsHProp (P a)}

--- a/theories/Types/Sum.v
+++ b/theories/Types/Sum.v
@@ -96,7 +96,7 @@ Defined.
 Global Instance isequiv_path_sum {A B : Type} {z z' : A + B}
 : IsEquiv (path_sum z z') | 0.
 Proof.
-  refine (BuildIsEquiv _ _
+  refine (Build_IsEquiv _ _
                        (path_sum z z')
                        (@path_sum_inv _ _ z z')
                        (@eisretr_path_sum A B z z')
@@ -108,7 +108,7 @@ Proof.
 Defined.
 
 Definition equiv_path_sum {A B : Type} (z z' : A + B)
-  := BuildEquiv _ _ _ (@isequiv_path_sum A B z z').
+  := Build_Equiv _ _ _ (@isequiv_path_sum A B z z').
 
 (** ** Fibers of [inl] and [inr] *)
 
@@ -174,7 +174,7 @@ Section DecidableSum.
       destruct (dec (P x)) as [p|np].
       - exact (inl (x;p)).
       - exact (inr (x;np)). }
-    refine (BuildEquiv _ _ f _).
+    refine (Build_Equiv _ _ f _).
     refine (isequiv_adjointify
               _ (fun z => match z with
                           | inl (x;p) => x
@@ -530,7 +530,7 @@ Defined.
 
 Definition equiv_functor_sum `{IsEquiv A A' f} `{IsEquiv B B' g}
 : A + B <~> A' + B'
-  := BuildEquiv _ _ (functor_sum f g) _.
+  := Build_Equiv _ _ (functor_sum f g) _.
 
 Definition equiv_functor_sum' {A A' B B' : Type} (f : A <~> A') (g : B <~> B')
 : A + B <~> A' + B'
@@ -578,7 +578,7 @@ Definition equiv_unfunctor_sum_l {A A' B B' : Type}
            (Ha : forall a:A, is_inl (h (inl a)))
            (Hb : forall b:B, is_inr (h (inr b)))
 : A <~> A'
-  := BuildEquiv _ _ (unfunctor_sum_l h Ha)
+  := Build_Equiv _ _ (unfunctor_sum_l h Ha)
                 (isequiv_unfunctor_sum_l h Ha Hb).
 
 Global Instance isequiv_unfunctor_sum_r {A A' B B' : Type}
@@ -611,7 +611,7 @@ Definition equiv_unfunctor_sum_r {A A' B B' : Type}
            (Ha : forall a:A, is_inl (h (inl a)))
            (Hb : forall b:B, is_inr (h (inr b)))
 : B <~> B'
-  := BuildEquiv _ _ (unfunctor_sum_r h Hb)
+  := Build_Equiv _ _ (unfunctor_sum_r h Hb)
                 (isequiv_unfunctor_sum_r h Ha Hb).
 
 Definition equiv_unfunctor_sum {A A' B B' : Type}
@@ -675,13 +675,13 @@ Defined.
 Definition sum_distrib_l A B C
 : A * (B + C) <~> (A * B) + (A * C).
 Proof.
-  refine (BuildEquiv (A * (B + C)) ((A * B) + (A * C))
+  refine (Build_Equiv (A * (B + C)) ((A * B) + (A * C))
             (fun abc => let (a,bc) := abc in
                         match bc with
                           | inl b => inl (a,b)
                           | inr c => inr (a,c)
                         end) _).
-  simple refine (BuildIsEquiv (A * (B + C)) ((A * B) + (A * C)) _
+  simple refine (Build_IsEquiv (A * (B + C)) ((A * B) + (A * C)) _
             (fun ax => match ax with
                          | inl (a,b) => (a,inl b)
                          | inr (a,c) => (a,inr c)
@@ -694,13 +694,13 @@ Defined.
 Definition sum_distrib_r A B C
 : (B + C) * A <~> (B * A) + (C * A).
 Proof.
-  refine (BuildEquiv ((B + C) * A) ((B * A) + (C * A))
+  refine (Build_Equiv ((B + C) * A) ((B * A) + (C * A))
             (fun abc => let (bc,a) := abc in
                         match bc with
                           | inl b => inl (b,a)
                           | inr c => inr (c,a)
                         end) _).
-  simple refine (BuildIsEquiv ((B + C) * A) ((B * A) + (C * A)) _
+  simple refine (Build_IsEquiv ((B + C) * A) ((B * A) + (C * A)) _
             (fun ax => match ax with
                          | inl (b,a) => (inl b,a)
                          | inr (c,a) => (inr c,a)
@@ -719,7 +719,7 @@ Definition equiv_sigma_sum A B (C : A + B -> Type)
 : { x : A+B & C x } <~>
   { a : A & C (inl a) } + { b : B & C (inr b) }.
 Proof.
-  refine (BuildEquiv { x : A+B & C x }
+  refine (Build_Equiv { x : A+B & C x }
                      ({ a : A & C (inl a) } + { b : B & C (inr b) })
            (fun xc => let (x,c) := xc in
                       match x return
@@ -728,7 +728,7 @@ Proof.
                         | inl a => fun c => inl (a;c)
                         | inr b => fun c => inr (b;c)
                       end c) _).
-  simple refine (BuildIsEquiv { x : A+B & C x }
+  simple refine (Build_IsEquiv { x : A+B & C x }
                        ({ a : A & C (inl a) } + { b : B & C (inr b) }) _
            (fun abc => match abc with
                          | inl (a;c) => (inl a ; c)
@@ -869,7 +869,7 @@ Proof.
 Defined.
 
 Definition equiv_sum_ind `{Funext} `(P : A + B -> Type)
-  := BuildEquiv _ _ _ (isequiv_sum_ind P).
+  := Build_Equiv _ _ _ (isequiv_sum_ind P).
 
 (* The non-dependent version, which is a special case, is the sum-distributive equivalence. *)
 Definition equiv_sum_distributive `{Funext} (A B C : Type)

--- a/theories/Types/Unit.v
+++ b/theories/Types/Unit.v
@@ -28,7 +28,7 @@ Proof.
 Defined.
 
 Global Instance isequiv_path_unit (z z' : Unit) : IsEquiv (path_unit_uncurried z z') | 0.
-  refine (BuildIsEquiv _ _ (path_unit_uncurried z z') (fun _ => tt)
+  refine (Build_IsEquiv _ _ (path_unit_uncurried z z') (fun _ => tt)
     (fun p:z=z' =>
       match p in (_ = z') return (path_unit_uncurried z z' tt = p) with
         | idpath => match z as z return (path_unit_uncurried z z tt = 1) with
@@ -40,7 +40,7 @@ Global Instance isequiv_path_unit (z z' : Unit) : IsEquiv (path_unit_uncurried z
 Defined.
 
 Definition equiv_path_unit (z z' : Unit) : Unit <~> (z = z')
-  := BuildEquiv _ _ (path_unit_uncurried z z') _.
+  := Build_Equiv _ _ (path_unit_uncurried z z') _.
 
 (** ** Transport *)
 
@@ -65,7 +65,7 @@ Global Instance isequiv_unit_rec `{Funext} (A : Type)
 
 Definition equiv_unit_rec `{Funext} (A : Type)
   : A <~> (Unit -> A)
-  := (BuildEquiv _ _ (@Unit_ind (fun _ => A)) _).
+  := (Build_Equiv _ _ (@Unit_ind (fun _ => A)) _).
 
 (* For various reasons, it is typically more convenient to define functions out of the unit as constant maps, rather than [Unit_ind]. *)
 Notation unit_name x := (fun (_ : Unit) => x).
@@ -92,7 +92,7 @@ Defined.
 
 Definition equiv_unit_coind `{Funext} (A : Type)
   : Unit <~> (A -> Unit)
-  := BuildEquiv _ _ (@unit_coind A) _.
+  := Build_Equiv _ _ (@unit_coind A) _.
 
 (** ** Truncation *)
 
@@ -108,9 +108,9 @@ Global Instance contr_unit : Contr Unit | 0 := let x := {|
 (** A contractible type is equivalent to [Unit]. *)
 Definition equiv_contr_unit `{Contr A} : A <~> Unit.
 Proof.
-  refine (BuildEquiv _ _
+  refine (Build_Equiv _ _
     (fun (_ : A) => tt)
-    (BuildIsEquiv _ _ _
+    (Build_IsEquiv _ _ _
       (fun (_ : Unit) => center A)
       (fun t : Unit => match t with tt => 1 end)
       (fun x : A => contr x) _)).

--- a/theories/Types/Universe.v
+++ b/theories/Types/Universe.v
@@ -12,7 +12,7 @@ Generalizable Variables A B f.
 
 Global Instance isequiv_path {A B : Type} (p : A = B)
   : IsEquiv (transport (fun X:Type => X) p) | 0
-  := BuildIsEquiv _ _ _ (transport (fun X:Type => X) p^)
+  := Build_IsEquiv _ _ _ (transport (fun X:Type => X) p^)
   (transport_pV idmap p)
   (transport_Vp idmap p)
   (fun a => match p in _ = C return
@@ -22,7 +22,7 @@ Global Instance isequiv_path {A B : Type} (p : A = B)
                 transport2 idmap (concat_pV p) a) with idpath => 1 end).
 
 Definition equiv_path (A B : Type) (p : A = B) : A <~> B
-  := BuildEquiv _ _ (transport (fun X:Type => X) p) _.
+  := Build_Equiv _ _ (transport (fun X:Type => X) p) _.
 
 Definition equiv_path_V `{Funext} (A B : Type) (p : A = B) :
   equiv_path B A (p^) = (equiv_path A B p)^-1%equiv.
@@ -44,7 +44,7 @@ Definition path_universe_uncurried {A B : Type} (f : A <~> B) : A = B
   := (equiv_path A B)^-1 f.
 
 Definition path_universe {A B : Type} (f : A -> B) {feq : IsEquiv f} : (A = B)
-  := path_universe_uncurried (BuildEquiv _ _ f feq).
+  := path_universe_uncurried (Build_Equiv _ _ f feq).
 
 Global Arguments path_universe {A B}%type_scope f%function_scope {feq}.
 
@@ -61,7 +61,7 @@ Definition isequiv_path_universe {A B : Type}
  := _.
 
 Definition equiv_path_universe (A B : Type) : (A <~> B) <~> (A = B)
-  := BuildEquiv _ _ (@path_universe_uncurried A B) isequiv_path_universe.
+  := Build_Equiv _ _ (@path_universe_uncurried A B) isequiv_path_universe.
 
 
 Definition equiv_equiv_path  (A B : Type) : (A = B) <~> (A <~> B)
@@ -143,7 +143,7 @@ Defined.
 
 Definition path_universe_V `{Funext} `(f : A -> B) `{IsEquiv A B f}
   : path_universe (f^-1) = (path_universe f)^
-  := path_universe_V_uncurried (BuildEquiv A B f _).
+  := path_universe_V_uncurried (Build_Equiv A B f _).
 
 (** ** Path operations vs Type operations *)
 
@@ -196,8 +196,8 @@ Defined.
 Definition transport_path_universe
            {A B : Type} (f : A -> B) {feq : IsEquiv f} (z : A)
   : transport (fun X:Type => X) (path_universe f) z = f z
-  := transport_path_universe_uncurried (BuildEquiv A B f feq) z.
-(* Alternatively, [ap10_equiv (eisretr (equiv_path A B) (BuildEquiv _ _ f feq)) z]. *)
+  := transport_path_universe_uncurried (Build_Equiv A B f feq) z.
+(* Alternatively, [ap10_equiv (eisretr (equiv_path A B) (Build_Equiv _ _ f feq)) z]. *)
 
 Definition transport_path_universe_equiv_path
            {A B : Type} (p : A = B) (z : A)
@@ -227,7 +227,7 @@ Defined.
 Definition transport_path_universe_V `{Funext}
            {A B : Type} (f : A -> B) {feq : IsEquiv f} (z : B)
   : transport (fun X:Type => X) (path_universe f)^ z = f^-1 z
-  := transport_path_universe_V_uncurried (BuildEquiv _ _ f feq) z.
+  := transport_path_universe_V_uncurried (Build_Equiv _ _ f feq) z.
 (* Alternatively, [(transport2 idmap (path_universe_V f) z)^ @ (transport_path_universe (f^-1) z)]. *)
 
 Definition transport_path_universe_V_equiv_path `{Funext}
@@ -261,7 +261,7 @@ Definition transport_path_universe_Vp `{Funext}
   @ transport_path_universe_V f (f z)
   @ eissect f z
   = transport_Vp idmap (path_universe f) z
-:= transport_path_universe_Vp_uncurried (BuildEquiv A B f feq) z.
+:= transport_path_universe_Vp_uncurried (Build_Equiv A B f feq) z.
 
 (** ** 2-paths *)
 
@@ -444,7 +444,7 @@ Definition transport_path_universe_pV `{Funext}
   @ ap f (transport_path_universe_V f z)
   @ eisretr f z
   = transport_pV idmap (path_universe f) z
-:= transport_path_universe_pV_uncurried (BuildEquiv A B f feq) z.
+:= transport_path_universe_pV_uncurried (Build_Equiv A B f feq) z.
 
 (** ** Equivalence induction *)
 

--- a/theories/Types/Wtype.v
+++ b/theories/Types/Wtype.v
@@ -68,7 +68,7 @@ Proof.
 Defined.
 
 Definition equiv_path_wtype {A B} (z z' : W A B)
-  := BuildEquiv _ _ _ (@isequiv_path_wtype A B z z').
+  := Build_Equiv _ _ _ (@isequiv_path_wtype A B z z').
 
 (** ** W-types preserve truncation *)
 

--- a/theories/UnivalenceImpliesFunext.v
+++ b/theories/UnivalenceImpliesFunext.v
@@ -28,7 +28,7 @@ Section UnivalenceImpliesFunext.
               _
               _);
     intro;
-    pose (BuildEquiv _ _ w _) as w';
+    pose (Build_Equiv _ _ w _) as w';
     change H0 with (@equiv_isequiv _ _ w');
     change w with (@equiv_fun _ _ w');
     clearbody w'; clear H0 w;


### PR DESCRIPTION
As the title says.

I also capitalised in Cantor.v and added the equivalence going the other way.