### PR TITLE
Basic group theory, abelianization

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -271,7 +271,12 @@ theories/Spectra/Coinductive.v
 theories/Algebra/ooGroup.v
 theories/Algebra/Aut.v
 theories/Algebra/ooAction.v
+
 theories/Algebra/Group.v
+theories/Algebra/Subgroup.v
+theories/Algebra/Congruence.v
+theories/Algebra/AbelianGroup.v
+theories/Algebra/QuotientGroup.v
 
 theories/Algebra/Group.v
 #

--- a/_CoqProject
+++ b/_CoqProject
@@ -271,7 +271,9 @@ theories/Spectra/Coinductive.v
 theories/Algebra/ooGroup.v
 theories/Algebra/Aut.v
 theories/Algebra/ooAction.v
+theories/Algebra/Group.v
 
+theories/Algebra/Group.v
 #
 #   Tactics
 #

--- a/contrib/HoTTBook.v
+++ b/contrib/HoTTBook.v
@@ -2076,7 +2076,7 @@ Definition Book_10_5_8_item_ix := @HoTT.HIT.V.separation.
 (* ================================================== ordered-field *)
 (** Definition 11.2.7 *)
 
-Definition Book_11_2_7 := @HoTT.Classes.interfaces.abstract_algebra.Field.
+Definition Book_11_2_7 := @HoTT.Classes.interfaces.abstract_algebra.IsField.
 Definition Book_11_2_7' := @HoTT.Classes.interfaces.orders.FullPseudoSemiRingOrder.
 
 (* ================================================== RD-archimedean-ordered-field *)

--- a/theories/Algebra/AbelianGroup.v
+++ b/theories/Algebra/AbelianGroup.v
@@ -1,0 +1,342 @@
+Require Import Basics.
+Require Import Types.
+Require Import Truncations.
+Require Import HIT.Coeq.
+Require Import Algebra.Group.
+Require Import Algebra.Subgroup.
+Require Import Cubical.
+Import TrM.
+
+(** * Abelian groups *)
+
+(** Definition of an abelian group *)
+
+Class AbGroup := {
+  abgroup_type : Type;
+  abgroup_sgop :> SgOp abgroup_type;
+  abgroup_unit :> MonUnit abgroup_type;
+  abgroup_inverse :> Negate abgroup_type;
+  abgroup_isabgroup :> IsAbGroup abgroup_type;
+}.
+
+(** We want abelian groups to be coerced to the underlying type. *)
+Coercion abgroup_type : AbGroup >-> Sortclass.
+
+(** The underlying group of an abelian group. *)
+Definition group_abgroup : AbGroup -> Group.
+Proof.
+  intros [G].
+  serapply (Build_Group G).
+Defined.
+
+(** We also want abelian groups to be coerced to the underlying group. *)
+Coercion group_abgroup : AbGroup >-> Group. 
+
+(** Definition of Abelianization.
+
+  Given a map F that turns any group into an abelian group, and a unit homomorphism eta_X : X -> F X. This data is considered an Abelianization if and only if for all maps X -> A, there exists a unique g such that h == g o eta X. *)
+Definition IsAbelianization (F : Group -> AbGroup)
+  (eta : forall X, GroupHomomorphism X (F X))
+  := forall (X : Group) (A : AbGroup) (h : GroupHomomorphism X A),
+    Contr (exists (g : GroupHomomorphism (F X) A), h == g o eta X).
+
+Existing Class IsAbelianization.
+
+(** Here we define abelianization as a HIT. Specifically as a set-coequalizer of the following to maps: (a, b, c) |-> a (b c) and (a, b, c) |-> a (c b).
+
+From this we can show that Abel G is an abelian group.
+
+In fact this models the following HIT:
+
+HIT Abel (G : Group) := 
+ | ab : G -> Abel G
+ | ab_comm : forall x y z, ab (x & (y & z)) = ab (x & (z & y)).
+
+We also derive ab and ab_comm from our coequalizer definition, and even prove the induction and computation rules for this HIT.
+
+This HIT was suggested by Dan Christensen.
+*)
+
+Section Abel.
+
+  (** Let G be a group. *)
+  Context (G : Group).
+
+  (** We locally define a map uncurry2 that lets us uncurry A * B * C -> D twice. *)
+  Local Definition uncurry2 {A B C D : Type}
+    : (A -> B -> C -> D) -> A * B * C -> D.
+  Proof.
+    intros f [[a b] c].
+    by apply f.
+  Defined.
+
+  (** The type Abel is defined to be the set coequalizer of the following maps G^3 -> G. *)
+  Definition Abel
+    := Tr 0 (Coeq
+      (uncurry2 (fun a b c => a & (b & c)))
+      (uncurry2 (fun a b c => a & (c & b)))).
+
+  (** We have a natural map from G to Abel G *)
+  Definition ab : G -> Abel.
+  Proof.
+    intro g.
+    apply tr, coeq, g.
+  Defined.
+
+  (** This map has to satisfy the condition ab_comm *)
+  Definition ab_comm a b c
+    : ab (a & (b & c)) = ab (a & (c & b)).
+  Proof.
+    apply (ap tr).
+    exact (cglue (a, b, c)).
+  Defined.
+
+  (** It is clear that Abel is a set. *)
+  Global Instance istrunc_abel : IsHSet Abel := _.
+
+  (** We can derive the induction principle from the ones for truncation and the coequalizer. *)
+  Definition Abel_ind (P : Abel -> Type) `{forall x, IsHSet (P x)} 
+    (a : forall x, P (ab x)) (c : forall x y z, DPath P (ab_comm x y z)
+      (a (x & (y & z))) (a (x & (z & y))))
+    : forall (x : Abel), P x.
+  Proof.
+    serapply Trunc_ind.
+    serapply Coeq_ind.
+    1: apply a.
+    intros [[x y] z].
+    refine (transport_compose _ _ _ _ @ _).
+    serapply dp_path_transport^-1.
+    apply c.
+  Defined.
+
+  (** The computation rule can also be prove. *)
+  Definition Abel_ind_beta_ab_comm (P : Abel -> Type)
+    `{forall x, IsHSet (P x)}(a : forall x, P (ab x))
+    (c : forall x y z, DPath P (ab_comm x y z)
+      (a (x & (y & z))) (a (x & (z & y))))
+    (x y z : G) : dp_apD (Abel_ind P a c) (ab_comm x y z) = c x y z.
+  Proof.
+    unfold ab_comm.
+    apply dp_apD_path_transport.
+    rewrite (apD_compose' tr).
+    rewrite (Coeq_ind_beta_cglue _ _ _ (x, y, z)).
+    unfold Abel_ind.
+    refine (_ @ concat_1p _).
+    refine (concat_p_pp _ _ _ @ _).
+    apply whiskerR.
+    apply concat_Vp.
+  Defined.
+
+  (** We also have a recursion princple. *)
+  Definition Abel_rec (P : Type) `{IsHSet P} (a : G -> P)
+    (c : forall x y z, a (x & (y & z)) = a (x & (z & y)))
+    : Abel -> P.
+  Proof.
+    apply (Abel_ind _ a).
+    intros; apply dp_const, c.
+  Defined.
+
+  (** Here is a simpler version of Abel_ind when our target is a HProp. This lets us discard all the higher paths. *)
+  Definition Abel_ind_hprop (P : Abel -> Type) `{forall x, IsHProp (P x)} 
+    (a : forall x, P (ab x)) : forall (x : Abel), P x.
+  Proof.
+    serapply (Abel_ind _ a).
+    intros; apply dp_path_transport.
+    apply path_ishprop.
+  Defined.
+
+  (** And its recursion version. *)
+  Definition Abel_rec_hprop (P : Type) `{IsHProp P}
+    (a : G -> P) : Abel -> P.
+  Proof.
+    apply (Abel_rec _ a).
+    intros; apply path_ishprop.
+  Defined.
+
+End Abel.
+
+(** We make sure that G is implicit in the arguments of ab and ab_comm. *)
+Arguments ab {_}.
+Arguments ab_comm {_}.
+
+(** Now we can show that Abel G is infact an abelian group. *)
+
+Section AbelGroup.
+
+  Context `{Funext} (G : Group).
+
+  (** Firstly we derive the operation on Abel G. This is defined as follows:
+        ab x + ab y := ab (x y)
+      But we need to also check that it preserves ab_comm in the appropriate way. *)
+  Global Instance abel_sgop : SgOp (Abel G).
+  Proof.
+    serapply Abel_rec.
+    { intro a.
+      serapply Abel_rec.
+      { intro b.
+        exact (ab (a & b)). }
+      intros b c d; cbn.
+      refine (ab_comm _ _ _ @ _).
+      refine (ap _ _ @ _).
+      { refine (ap _ (associativity _ _ _)^ @ _).
+        refine (associativity _ _ _). }
+      refine (ab_comm _ _ _ @ _).
+      refine (ap _ (associativity _ _ _)^ @ _).
+      refine (ab_comm _ _ _ @ _).
+      refine (ap _ (ap _ (associativity _ _ _)^)). }
+    intros a b c.
+    apply path_forall.
+    serapply Abel_ind_hprop.
+    cbn; intro d.
+    refine (ap _ (associativity _ _ _)^ @ _).
+    refine (ap _ (ap _ (associativity _ _ _)^) @ _).
+    refine (ab_comm _ _ _ @ _).
+    refine (ap _ (ap _ (associativity _ _ _)^) @ _).
+    refine (ap _ (associativity _ _ _) @ _).
+    refine (ab_comm _ _ _ @ _).
+    refine (ap _ (associativity _ _ _)^ @ _).
+    refine (ap _ (ap _ (associativity _ _ _)) @ _).
+    refine (ap _ (associativity _ _ _)).
+  Defined.
+
+  (** We can now easily show that this operation is associative by associativity in G and the fact that being associative is a proposition. *)
+  Global Instance abel_sgop_associative : Associative abel_sgop.
+  Proof.
+    serapply Abel_ind_hprop; intro x.
+    serapply Abel_ind_hprop; intro y.
+    serapply Abel_ind_hprop; intro z.
+    cbn; apply ap, associativity.
+  Defined.
+
+  (** From this we know that Abel G is a semigroup. *)
+  Global Instance abel_issemigroup : IsSemiGroup (Abel G) := {}.
+
+  (** We define the unit as ab of the unit of G *)
+  Global Instance abel_mon_unit : MonUnit (Abel G) := ab mon_unit.
+
+  (** By using Abel_ind_hprop we can prove the left and right identity laws. *)
+  Global Instance abel_leftidentity : LeftIdentity abel_sgop abel_mon_unit.
+  Proof.
+    serapply Abel_ind_hprop; intro x.
+    cbn; apply ap, left_identity.
+  Defined.
+
+  Global Instance abel_rightidentity : RightIdentity abel_sgop abel_mon_unit.
+  Proof.
+    serapply Abel_ind_hprop; intro x.
+    cbn; apply ap, right_identity.
+  Defined.
+
+  (** Hence Abel G is a monoid *)
+  Global Instance ismonoid_abel : IsMonoid (Abel G) := {}.
+
+  (** We can also prove that the operation is commutative! This will come in handy later. *)
+  Global Instance abel_commutative : Commutative abel_sgop.
+  Proof.
+    serapply Abel_ind_hprop; intro x.
+    serapply Abel_ind_hprop; intro y.
+    cbn.
+    rewrite <- (left_identity (x & y)).
+    rewrite <- (left_identity (y & x)).
+    apply ab_comm.
+  Defined.
+
+  (** Now we can define the negation. This is just
+        - (ab g) := (ab (g^-1) 
+      However when checking that it respects ab_comm we have to show the following:
+        ab (- z & - y & - x) = ab (- y & - z & - x)
+      there is no obvious way to do this, but we note that ab (x & y) is exactly the definition of ab x + ab y! Hence by commutativity we can show this. *)
+  Global Instance abel_negate : Negate (Abel G).
+  Proof.
+    serapply Abel_rec.
+    { intro g.
+      exact (ab (-g)). }
+    intros x y z; cbn.
+    rewrite ?negate_sg_op.
+    change (ab(- z) & ab(- y) & ab (- x) = ab (- y) & ab (- z) & ab(- x)).
+    by rewrite (commutativity (ab (-z)) (ab (-y))).
+  Defined.
+
+  (** Again by Abel_ind_hprop and the corresponding laws for G we can prove the left and right inverse laws. *)
+  Global Instance abel_leftinverse : LeftInverse abel_sgop abel_negate abel_mon_unit.
+  Proof.
+    serapply Abel_ind_hprop; intro x.
+    cbn; apply ap; apply left_inverse.
+  Defined.
+
+  Instance abel_rightinverse : RightInverse abel_sgop abel_negate abel_mon_unit.
+  Proof.
+    serapply Abel_ind_hprop; intro x.
+    cbn; apply ap; apply right_inverse.
+  Defined.
+
+  (** Thus Abel G is a group *)
+  Global Instance isgroup_abel : IsGroup (Abel G) := {}.
+
+  (** And since the operation is commutative and abelian group. *)
+  Global Instance isabgroup_abel : IsAbGroup (Abel G) := {}.
+
+  (** By definition, the map ab is also a group homomorphism. *)
+  Global Instance issemigrouppreserving_ab : IsSemiGroupPreserving ab.
+  Proof.
+    by unfold IsSemiGroupPreserving.
+  Defined.
+
+End AbelGroup.
+
+(** We can easily prove that ab is a surjection. *)
+Lemma issurj_ab `{Funext} {G : Group} : IsSurjection ab.
+Proof.
+  serapply Abel_ind_hprop.
+  intro x; cbn.
+  exists (tr (x; @idpath _ (ab x))).
+  apply path_ishprop.
+Defined.
+
+(** Now we finally check that our definition of abelianization satisfies the universal property of being an abelianization. *)
+Section Abelianization.
+
+  Context `{Funext}.
+
+  (** We define abel to be the abelianization of a group. This is a map from Group to AbGroup. *)
+  Definition abel : Group -> AbGroup.
+  Proof.
+    intro G.
+    serapply (Build_AbGroup (Abel G)).
+  Defined.
+
+  (** The unit of this map is the map ab which typeclasses can pick up to be a homomorphism. We write it out explicitly here. *)
+  Definition abel_unit (X : Group)
+    : GroupHomomorphism X (abel X).
+  Proof.
+    simple notypeclasses refine (Build_GroupHomomorphism _).
+    + exact ab.
+    + exact _.
+  Defined.
+
+  (** Finally we can prove that our construction abel is an abelianization. *)
+  Global Instance isabelianization_abel
+    : IsAbelianization abel abel_unit.
+  Proof.
+    intros X A h.
+    serapply BuildContr.
+    { srefine (_;_).
+      { simple notypeclasses refine (Build_GroupHomomorphism _).
+        { serapply (Abel_rec _ _ h).
+          intros x y z.
+          refine (grp_homo_op _ _ _ @ _ @ (grp_homo_op _ _ _)^).
+          apply (ap (_ &)).
+          refine (grp_homo_op _ _ _ @ _ @ (grp_homo_op _ _ _)^).
+          apply commutativity. }
+        serapply Abel_ind_hprop; intro x.
+        serapply Abel_ind_hprop; intro y.
+        apply grp_homo_op. }
+      cbn; reflexivity. }
+    intros [g p].
+    apply path_sigma_hprop; cbn.
+    apply path_GroupHomomorphism.
+    serapply Abel_ind_hprop.
+    exact p.
+  Defined.
+
+End Abelianization.

--- a/theories/Algebra/Congruence.v
+++ b/theories/Algebra/Congruence.v
@@ -1,0 +1,10 @@
+Require Import Basics.
+Require Import Classes.interfaces.abstract_algebra.
+
+(* We say that a relation is a congruence if it respects the operation.
+  This is technically incorrect since we are not enforcing the relation to be an equivalence relation.
+*)
+
+Class IsCongruence `{SgOp G} (R : Relation G) := {
+  iscong {x x' y y'} : R x x' -> R y y' -> R (x & y) (x' & y');
+}.

--- a/theories/Algebra/Group.v
+++ b/theories/Algebra/Group.v
@@ -1,0 +1,254 @@
+Require Import Basics.
+Require Import Types.
+Require Import PathAny.
+Require Export Classes.interfaces.abstract_algebra.
+Require Export Classes.theory.groups.
+
+(** ** Groups *)
+
+(** * Definition of Group *)
+
+(** A group consists of a type, and operation on that type, and unit and an inverse, such that they satisfy the group axioms in IsGroup. *)
+Class Group := {
+  group_type : Type;
+  group_sgop :> SgOp group_type;
+  group_unit :> MonUnit group_type;
+  group_inverse :> Negate group_type;
+  group_isgroup :> IsGroup group_type;
+}.
+
+(** We coerce groups back to types. *)
+Coercion group_type : Group >-> Sortclass.
+
+Definition issig_group : _ <~> Group
+  := ltac:(issig).
+
+(** * Some basic properties of groups *)
+
+(** An element acting like the identity is unique. *)
+Definition identity_unique {A : Type} {Aop : SgOp A}
+  (x y : A) {p : LeftIdentity Aop x} {q : RightIdentity Aop y}
+  : x = y := (q x)^ @ p y.
+
+Definition identity_unique' {A : Type} {Aop : SgOp A}
+  (x y : A) {p : LeftIdentity Aop x} {q : RightIdentity Aop y}
+  : y = x := (identity_unique x y)^.
+
+(** An element acting like an inverse is unique. *)
+Definition inverse_unique `{IsMonoid A}
+  (a x y : A) {p : x & a = mon_unit} {q : a & y = mon_unit}
+  : x = y.
+Proof.
+  refine ((right_identity x)^ @ ap _ q^ @ _).
+  refine (associativity _ _ _ @ _).
+  refine (ap (& y) p @ _).
+  apply left_identity.
+Defined.
+
+(** Inverses are involutive *)
+Check negate_involutive.
+
+(** Inverses distribute over the group operation *)
+Check negate_sg_op.
+
+(** Group elements can be cancelled on the left of an equation *)
+Check group_cancelL.
+
+(** Group elements can be cancelled on the right of an equation *)
+Check group_cancelR.
+
+(** Definition of Group Homomorphism *)
+
+(* A group homomorphism consists of a map between groups and a proof that the map preserves the group operation. *)
+Class GroupHomomorphism (G H : Group) := Build_GroupHomomorphism' {
+  grp_homo_map : G -> H;
+  grp_homo_ishomo :> IsMonoidPreserving grp_homo_map;
+}.
+
+(* We coerce a homomorphism to its underlying map. *)
+Coercion grp_homo_map : GroupHomomorphism >-> Funclass.
+(* Notation "G '->G' H" := (GroupHomomorphism G H) (at level 20). *)
+
+Definition issig_GroupHomomorphism {G H : Group} : _ <~> GroupHomomorphism G H
+  := ltac:(issig).
+
+Definition path_GroupHomomorphism `{F : Funext} {G H : Group}
+  {g h : GroupHomomorphism G H} : g == h -> g = h.
+Proof.
+  intro p.
+  apply ((ap issig_GroupHomomorphism^-1)^-1).
+  serapply path_sigma_hprop.
+  by apply path_forall.
+Defined.
+
+(** * Some basic properties of group homomorphisms *)
+
+(** Group homomorphisms preserve identities *)
+Definition grp_homo_unit {G H} (f : GroupHomomorphism G H)
+  : f (mon_unit) = mon_unit.
+Proof.
+  apply monmor_unitmor.
+Defined.
+
+(** Group homomorphisms preserve group operations *)
+Definition grp_homo_op {G H} (f : GroupHomomorphism G H)
+  : forall x y : G, f (x & y) = f x & f y.
+Proof.
+  apply monmor_sgmor.
+Defined.
+
+(** Group homomorphisms preserve inverses *)
+Definition grp_homo_inv {G H} (f : GroupHomomorphism G H)
+  : forall x, f (- x) = -(f x).
+Proof.
+  intro x.
+  apply (inverse_unique (f x)).
+  + refine (_ @ grp_homo_unit f).
+    refine ((grp_homo_op f (-x) x)^ @ _).
+    apply ap.
+    apply left_inverse.
+  + apply right_inverse.
+Defined.
+
+(** When building a group homomorphism we only need that it preserves the group operation, since we can prove that the identity is preserved. *)
+Definition Build_GroupHomomorphism {G H : Group}
+  (f : G -> H) {h : IsSemiGroupPreserving f}
+  : GroupHomomorphism G H.
+Proof.
+  serapply (Build_GroupHomomorphism' _ _ f).
+  split.
+  1: exact h.
+  unfold IsUnitPreserving.
+  apply (group_cancelL (f mon_unit)).
+  refine (_ @ (right_identity _)^).
+  refine (_ @ ap _ (monoid_left_id _ mon_unit)).
+  symmetry.
+  apply h.
+Defined.
+
+Definition grp_homo_compose {G H K : Group}
+  : GroupHomomorphism H K -> GroupHomomorphism G H -> GroupHomomorphism G K.
+Proof.
+  intros f g.
+  serapply Build_GroupHomomorphism.
+  1: exact (f o g).
+  intros x y.
+  refine (ap f (grp_homo_op g _ _) @ _).
+  apply grp_homo_op.
+Defined.
+
+(* An isomorphism of groups is a group homomorphism that is an equivalence. *)
+Class GroupIsomorphism (G H : Group) := Build_GroupIsomorphism {
+  grp_iso_homo :> GroupHomomorphism G H;
+  isequiv_group_iso :> IsEquiv grp_iso_homo;
+}.
+
+Coercion grp_iso_homo : GroupIsomorphism >-> GroupHomomorphism.
+
+Definition issig_GroupIsomorphism (G H : Group)
+  : _ <~> GroupIsomorphism G H := ltac:(issig).
+
+Definition grp_iso_inverse {G H : Group}
+  : GroupIsomorphism G H -> GroupIsomorphism H G.
+Proof.
+  intros [f e].
+  serapply Build_GroupIsomorphism.
+  { serapply Build_GroupHomomorphism.
+    1: exact f^-1.
+    unfold IsSemiGroupPreserving.
+    intros x y.
+    apply (ap f)^-1.
+    rewrite grp_homo_op.
+    by rewrite !eisretr. }
+  exact _.
+Defined.
+
+(* We can build an isomorphism from an operation preserving equivalence. *)
+Definition Build_GroupIsomorphism' {G H : Group}
+  (f : G <~> H) (h : IsSemiGroupPreserving f)
+  : GroupIsomorphism G H.
+Proof.
+  serapply Build_GroupIsomorphism.
+  1: serapply Build_GroupHomomorphism.
+  exact _.
+Defined.
+
+(** Group Isomorphisms are a reflexive relation *)
+Global Instance reflexive_groupisomorphism
+  : Reflexive GroupIsomorphism.
+Proof.
+  intro x.
+  by serapply Build_GroupIsomorphism'.
+Defined.
+
+(** Group Isomorphisms are a symmetric relation *)
+Global Instance symmetric_groupisomorphism
+  : Symmetric GroupIsomorphism.
+Proof.
+  intros G H.
+  serapply grp_iso_inverse.
+Defined.
+
+Global Instance transitive_groupisomorphism
+  : Transitive GroupIsomorphism.
+Proof.
+  intros G H K f g.
+  serapply Build_GroupIsomorphism.
+  1: serapply grp_homo_compose.
+  exact _.
+Defined.
+
+(** TODO: Finish this
+Definition equiv_path_group {U : Univalence} {G H : Group}
+  : GroupIsomorphism G H <~> G = H.
+Proof.
+  refine (_ oE (issig_GroupIsomorphism _ _)^-1).
+  eqp_issig_contr issig_group.
+Admitted.
+*)
+
+(** * Simple group equivalences *)
+
+(** Left multiplication is an equivalence *)
+Global Instance isequiv_group_left_op `{IsGroup G}
+  : forall x, IsEquiv (x &).
+Proof.
+  intro x.
+  serapply isequiv_adjointify.
+  1: exact (-x &).
+  all: intro y.
+  all: refine (associativity _ _ _ @ _ @ left_identity y).
+  all: refine (ap (& y) _).
+  1: apply right_inverse.
+  apply left_inverse.
+Defined.
+
+(** Right multiplication is an equivalence *)
+Global Instance isequiv_group_right_op `{IsGroup G}
+  : forall x, IsEquiv (& x).
+Proof.
+  intro x.
+  serapply isequiv_adjointify.
+  1: exact (& - x).
+  all: intro y.
+  all: refine ((associativity _ _ _)^ @ _ @ right_identity y).
+  all: refine (ap (y &) _).
+  1: apply left_inverse.
+  apply right_inverse.
+Defined.
+
+Definition left_mult_equiv `{IsGroup G} : G -> G <~> G
+  := fun x => Build_Equiv _ _ (x &) _.
+
+(* Right multiplication is an equivalence. *)
+Definition right_mult_equiv `{IsGroup G} : G -> G <~> G
+  := fun x => Build_Equiv _ _ (& x) _.
+
+Global Instance isequiv_group_inverse `{IsGroup G}
+  : IsEquiv (-).
+Proof.
+  serapply isequiv_adjointify.
+  1: apply (-).
+  all: intro; apply negate_involutive.
+Defined.
+

--- a/theories/Algebra/Group.v
+++ b/theories/Algebra/Group.v
@@ -46,16 +46,16 @@ Proof.
 Defined.
 
 (** Inverses are involutive *)
-Check negate_involutive.
+(* Check negate_involutive. *)
 
 (** Inverses distribute over the group operation *)
-Check negate_sg_op.
+(* Check negate_sg_op. *)
 
 (** Group elements can be cancelled on the left of an equation *)
-Check group_cancelL.
+(* Check group_cancelL. *)
 
 (** Group elements can be cancelled on the right of an equation *)
-Check group_cancelR.
+(* Check group_cancelR. *)
 
 (** Definition of Group Homomorphism *)
 

--- a/theories/Algebra/QuotientGroup.v
+++ b/theories/Algebra/QuotientGroup.v
@@ -1,0 +1,121 @@
+Require Import Basics.
+Require Import Types.
+Require Import Algebra.Group.
+Require Import Algebra.Subgroup.
+Require Import Algebra.Congruence.
+Require Import Colimits.Quotient.
+
+(** * Quotient groups *)
+
+Section GroupCongruenceQuotient.
+
+  Context `{Univalence} {G : Group} {R : Relation G}
+    `{is_mere_relation _ R} `{!IsCongruence R} (* Congruence just means respects op *)
+    `{!Reflexive R} `{!Symmetric R} `{!Transitive R}.
+
+  Definition CongruenceQuotient := G / R.
+
+  Instance congquot_sgop : SgOp CongruenceQuotient.
+  Proof.
+    serapply Quotient_rec2.
+    { intros x y.
+      apply class_of.
+      exact (x & y). }
+    intros x x' p y y' q.
+    pose (iscong p q).
+    by apply path_quotient.
+  Defined.
+
+  Instance congquot_mon_unit : MonUnit CongruenceQuotient.
+  Proof.
+    apply class_of, mon_unit.
+  Defined.
+
+  Instance congquot_negate : Negate CongruenceQuotient.
+  Proof.
+    serapply Quotient_functor.
+    1: apply negate.
+    intros x y p.
+    rewrite <- (left_identity (-x)).
+    destruct (left_inverse y).
+    set (-y & y & -x).
+    rewrite <- (right_identity (-y)).
+    destruct (right_inverse x).
+    unfold g; clear g.
+    rewrite <- simple_associativity.
+    apply iscong; try reflexivity.
+    apply iscong; try reflexivity.
+    by symmetry.
+  Defined.
+
+  Instance congquot_sgop_associative : Associative congquot_sgop.
+  Proof.
+    serapply Quotient_ind_hprop; intro x.
+    serapply Quotient_ind_hprop; intro y.
+    serapply Quotient_ind_hprop; intro z.
+    by simpl; rewrite associativity.
+  Defined.
+
+  Instance issemigroup_congquot : IsSemiGroup CongruenceQuotient := {}.
+
+  Instance congquot_leftidentity
+    : LeftIdentity congquot_sgop congquot_mon_unit.
+  Proof.
+    serapply Quotient_ind_hprop; intro x.
+    by simpl; rewrite left_identity.
+  Defined.
+
+  Instance congquot_rightidentity
+    : RightIdentity congquot_sgop congquot_mon_unit.
+  Proof.
+    serapply Quotient_ind_hprop; intro x.
+    by simpl; rewrite right_identity.
+  Defined.
+
+  Instance ismonoid_quotientgroup : IsMonoid CongruenceQuotient := {}.
+
+  Instance quotientgroup_leftinverse
+    : LeftInverse congquot_sgop congquot_negate congquot_mon_unit.
+  Proof.
+    serapply Quotient_ind_hprop; intro x.
+    by simpl; rewrite left_inverse.
+  Defined.
+
+  Instance quotientgroup_rightinverse
+    : RightInverse congquot_sgop congquot_negate congquot_mon_unit.
+  Proof.
+    serapply Quotient_ind_hprop; intro x.
+    by simpl; rewrite right_inverse.
+  Defined.
+
+  Global Instance isgroup_quotientgroup : IsGroup CongruenceQuotient := {}.
+
+End GroupCongruenceQuotient.
+
+(** Now we can define the quotient group by a normal subgroup. *)
+
+Section QuotientGroup.
+
+  Context `{Univalence} (G : Group) (N : Subgroup G)
+    `{!IsNormalSubgroup N}.
+
+  Instance iscongruence_in_cosetL: IsCongruence in_cosetL.
+  Proof.
+    serapply Build_IsCongruence.
+    intros; by apply in_cosetL_cong.
+  Defined.
+
+  Instance iscongruence_in_cosetR: IsCongruence in_cosetR.
+  Proof.
+    serapply Build_IsCongruence.
+    intros; by apply in_cosetR_cong.
+  Defined.
+
+  (** Now we have to make a choice whether to pick the left or right cosets. Due to existing convention we shall pick left cosets but we note that we could equally have picked right. *)
+  Definition QuotientGroup : Group.
+  Proof.
+    erapply (Build_Group (G / in_cosetL)).
+    apply isgroup_quotientgroup.
+  Defined.
+
+End QuotientGroup.

--- a/theories/Algebra/Subgroup.v
+++ b/theories/Algebra/Subgroup.v
@@ -1,0 +1,274 @@
+Require Import Basics.
+Require Import Types.
+Require Import HSet.
+Require Import Algebra.Group.
+
+(** * Subgroups *)
+
+(** The property of being a subgroup *)
+Class IsSubgroup (G H : Group) := {
+  issubgroup_incl :> GroupHomomorphism G H;
+  isinj_issubgroup_incl :> IsInjective issubgroup_incl;
+}.
+
+(* Subgroup inclusion is an embedding. *)
+Global Instance isembedding_issubgroup_incl `{!IsSubgroup G H}
+  : IsEmbedding (@issubgroup_incl G H _).
+Proof.
+  apply isembedding_isinj_hset.
+  apply isinj_issubgroup_incl.
+Defined.
+
+Definition issig_issubgroup G H : _ <~> IsSubgroup G H
+  := ltac:(issig).
+
+(** A subgroup of a group H is a group G which is a subgroup of H. *) 
+Class Subgroup (H : Group) := {
+  subgroup_group :> Group;
+  subgroup_issubgroup :> IsSubgroup subgroup_group H;
+}.
+
+Coercion subgroup_group : Subgroup >-> Group.
+
+Section Cosets.
+
+  (** Left and right cosets give equivalence relations. *)
+
+  Context {G : Group} `{!IsSubgroup H G}.
+
+  (* The relation of being in a left coset represented by an element. *)
+  Definition in_cosetL : Relation G.
+  Proof.
+    intros x y.
+    refine (hfiber issubgroup_incl _).
+    exact (-x & y).
+  Defined.
+
+  (* The relation of being in a right coset represented by an element. *)
+  Definition in_cosetR : Relation G.
+  Proof.
+    intros x y.
+    refine (hfiber issubgroup_incl _).
+    exact (x & -y).
+  Defined.
+
+  (* These are props *)
+
+  Global Instance ishprop_in_cosetL : is_mere_relation G in_cosetL.
+  Proof.
+    exact _.
+  Defined.
+
+  Global Instance ishprop_in_cosetR : is_mere_relation G in_cosetR.
+  Proof.
+    exact _.
+  Defined.
+
+  (* Infact they are both equivalence relations. *)
+
+  Global Instance reflexive_in_cosetL : Reflexive in_cosetL.
+  Proof.
+    intro x; hnf.
+    exists mon_unit.
+    refine (_ @ _).
+    2: apply symmetry, left_inverse.
+    apply grp_homo_unit.
+  Defined.
+
+  Global Instance reflexive_in_cosetR : Reflexive in_cosetR.
+  Proof.
+    intro x; hnf.
+    exists mon_unit.
+    refine (_ @ _).
+    2: apply symmetry, right_inverse.
+    apply grp_homo_unit.
+  Defined.
+
+  Global Instance symmetric_in_cosetL : Symmetric in_cosetL.
+  Proof.
+    intros x y [h p]; hnf.
+    exists (-h).
+    refine (_ @ _).
+    1: apply grp_homo_inv.
+    apply moveR_equiv_M.
+    refine (p @ _).
+    symmetry.
+    refine (negate_sg_op _ _ @ _).
+    refine (ap (-x &) _).
+    apply negate_involutive.
+  Defined.
+
+  Global Instance symmetric_in_cosetR : Symmetric in_cosetR.
+  Proof.
+    intros x y [h p]; hnf.
+    exists (-h).
+    refine (_ @ _).
+    1: apply grp_homo_inv.
+    apply moveR_equiv_M.
+    refine (p @ _).
+    symmetry.
+    refine (negate_sg_op _ _ @ _).
+    refine (ap (& -y) _).
+    apply negate_involutive.
+  Defined.
+
+  Global Instance transitive_in_cosetL : Transitive in_cosetL.
+  Proof.
+    intros x y z [h p] [h' q].
+    exists (h & h').
+    refine (grp_homo_op _ _ _ @ _).
+    destruct p^, q^.
+    rewrite <- simple_associativity.
+    apply ap.
+    rewrite simple_associativity.
+    refine (ap (& -z) _ @ _).
+    1: apply right_inverse.
+    apply left_identity.
+  Defined.
+
+  Global Instance transitive_in_cosetR : Transitive in_cosetR.
+  Proof.
+    intros x y z [h p] [h' q].
+    exists (h & h').
+    refine (grp_homo_op _ _ _ @ _).
+    destruct p^, q^.
+    rewrite <- simple_associativity.
+    apply ap.
+    rewrite simple_associativity.
+    refine (ap (& -z) _ @ _).
+    1: apply left_inverse.
+    apply left_identity.
+  Defined.
+
+End Cosets.
+
+(** Identities related to the left and right cosets. *)
+
+Definition in_cosetL_unit {G : Group} `{!IsSubgroup N G}
+  : forall x y, in_cosetL (-x & y) mon_unit <~> in_cosetL x y.
+Proof.
+  intros x y.
+  unfold in_cosetL.
+  rewrite negate_sg_op.
+  rewrite negate_involutive.
+  rewrite (right_identity (-y & x)).
+  change (in_cosetL y x <~> in_cosetL x y).
+  serapply equiv_iff_hprop;
+  by intro; symmetry.
+Defined.
+
+Definition in_cosetR_unit {G : Group} `{!IsSubgroup N G}
+  : forall x y, in_cosetR (x & -y) mon_unit <~> in_cosetR x y.
+Proof.
+  intros x y.
+  unfold in_cosetR.
+  rewrite negate_mon_unit.
+  rewrite (right_identity (x & -y)).
+  reflexivity.
+Defined.
+
+(** Symmetry is an equivalence. *)
+Definition equiv_in_cosetL_symm {G : Group} `{!IsSubgroup N G}
+  : forall x y, in_cosetL x y <~> in_cosetL y x.
+Proof.
+  intros x y.
+  serapply equiv_iff_hprop.
+  all: by intro.
+Defined.
+
+Definition equiv_in_cosetR_symm {G : Group} `{!IsSubgroup N G}
+  : forall x y, in_cosetR x y <~> in_cosetR y x.
+Proof.
+  intros x y.
+  serapply equiv_iff_hprop.
+  all: by intro.
+Defined.
+
+(* A subgroup is normal if being in a left coset is equivalent to being in a right coset represented by the same element. *)
+Class IsNormalSubgroup {G : Group} (N : Subgroup G) := {
+  isnormal {x y} : in_cosetL x y <~> in_cosetR x y;
+}.
+
+(* Inverses are then respected *)
+Definition in_cosetL_inv {G : Group} `{!IsNormalSubgroup N}
+  : forall x y, in_cosetL (-x) (-y) <~> in_cosetL x y.
+Proof.
+  intros x y.
+  refine (_ oE (in_cosetL_unit _ _)^-1).
+  refine (_ oE isnormal).
+  refine (_ oE in_cosetR_unit _ _).
+  refine (_ oE isnormal^-1).
+  by rewrite negate_involutive.
+Defined.
+
+Definition in_cosetR_inv {G : Group} `{!IsNormalSubgroup N}
+  : forall x y, in_cosetR (-x) (-y) <~> in_cosetR x y.
+Proof.
+  intros x y.
+  refine (_ oE (in_cosetR_unit _ _)^-1).
+  refine (_ oE isnormal^-1).
+  refine (_ oE in_cosetL_unit _ _).
+  refine (_ oE isnormal).
+  by rewrite negate_involutive.
+Defined.
+
+(* There is always another element of the normal subgroup allowing us to commute with an element of the group. *)
+Definition normal_subgroup_swap {G : Group}
+  `{!IsNormalSubgroup N} (x : G) (h : N)
+  : exists h' : N, x & issubgroup_incl h = issubgroup_incl h' & x.
+Proof.
+  assert (X : in_cosetL x (x & issubgroup_incl h)).
+  { exists h.
+    rewrite simple_associativity.
+    rewrite left_inverse.
+    symmetry.
+    apply left_identity. }
+  apply isnormal in X.
+  destruct X as [a p].
+  rewrite negate_sg_op in p.
+  rewrite simple_associativity in p.
+  eexists (-a).
+  symmetry.
+  rewrite grp_homo_inv.
+  apply (moveR_equiv_M (f := (- _ &))).
+  cbn; rewrite negate_involutive.
+  rewrite simple_associativity.
+  apply (moveL_equiv_M (f := (& _))).
+  apply (moveL_equiv_M (f := (& _))).
+  symmetry.
+  assumption.
+Defined.
+
+(* This let's us prove that left and right coset relations are congruences. *)
+Definition in_cosetL_cong {G : Group} `{!IsNormalSubgroup N}
+  : forall x x' y y', in_cosetL x y -> in_cosetL x' y' -> in_cosetL (x & x') (y & y').
+Proof.
+  intros x x' y y' [a p] [b q].
+  eexists ?[c].
+  rewrite negate_sg_op.
+  rewrite <- simple_associativity.
+  rewrite (simple_associativity (-x) y).
+  rewrite <- p.
+  rewrite simple_associativity.
+  rewrite (normal_subgroup_swap _ a).2.
+  rewrite <- simple_associativity.
+  rewrite <- q.
+  apply grp_homo_op.
+Defined.
+
+Definition in_cosetR_cong {G : Group} `{!IsNormalSubgroup N}
+  : forall x x' y y', in_cosetR x y -> in_cosetR x' y' -> in_cosetR (x & x') (y & y').
+Proof.
+  intros x x' y y' [a p] [b q].
+  eexists ?[c].
+  rewrite negate_sg_op.
+  rewrite <- simple_associativity.
+  rewrite (simple_associativity x' (-y')).
+  rewrite <- q.
+  rewrite simple_associativity.
+  rewrite (normal_subgroup_swap _ b).2.
+  rewrite <- simple_associativity.
+  rewrite <- p.
+  apply grp_homo_op.
+Defined.
+

--- a/theories/Classes/implementations/binary_naturals.v
+++ b/theories/Classes/implementations/binary_naturals.v
@@ -279,7 +279,7 @@ Section semiring_laws.
     apply (trunc_equiv nat binary).
   Qed.
 
-  Global Instance binnat_semiring : SemiRing binnat.
+  Global Instance binnat_semiring : IsSemiRing binnat.
   Proof.
     split; try split; try split; try split; hnf; intros.
     1, 5: exact (binnat_set x y).
@@ -297,7 +297,7 @@ End semiring_laws.
 
 Section naturals.
 
-  Local Instance binary_preserving : SemiRingPreserving binary.
+  Local Instance binary_preserving : IsSemiRingPreserving binary.
   Proof.
     split; split.
     1, 3: hnf; intros x y; [> apply (binaryplus x y) ^ | apply (binarymult x y) ^ ].
@@ -367,7 +367,7 @@ Section naturals.
 
   Section for_another_semiring.
     Universe U.
-    Context {R:Type} `{SemiRing R}.
+    Context {R:Type} `{IsSemiRing R}.
 
     Notation toR := (naturals_to_semiring binnat R).
     Notation toR_fromnat := (naturals_to_semiring nat R).
@@ -451,12 +451,12 @@ Section naturals.
     Qed.
 
     Global Instance binnat_to_sr_morphism
-      : SemiRingPreserving toR.
+      : IsSemiRingPreserving toR.
     Proof.
       repeat (split;try apply _);trivial.
     Qed.
 
-    Lemma binnat_toR_unique (h : binnat -> R) `{!SemiRingPreserving h} : forall x,
+    Lemma binnat_toR_unique (h : binnat -> R) `{!IsSemiRingPreserving h} : forall x,
         toR x = h x.
     Proof.
       equiv_intro binary n.
@@ -513,10 +513,10 @@ Section decidable.
     | double2 k => k
     end.
 
-  Local Instance double1_inj : Injective double1
+  Local Instance double1_inj : IsInjective double1
   := { injective := fun a b E => ap undouble E }.
 
-  Local Instance double2_inj : Injective double2
+  Local Instance double2_inj : IsInjective double2
   := { injective := fun a b E => ap undouble E }.
 
   Global Instance binnat_dec : DecidablePaths binnat.

--- a/theories/Classes/implementations/bool.v
+++ b/theories/Classes/implementations/bool.v
@@ -11,7 +11,7 @@ Section contents.
   Local Ltac solve_bool :=
     repeat (intros [|]); compute; (contradiction || auto).
 
-  Global Instance lattice_bool : BoundedLattice Bool.
+  Global Instance lattice_bool : IsBoundedLattice Bool.
   Proof. repeat split; (apply _ || solve_bool). Defined.
 
 End contents.

--- a/theories/Classes/implementations/field_of_fractions.v
+++ b/theories/Classes/implementations/field_of_fractions.v
@@ -13,7 +13,7 @@ Module Frac.
 Section contents.
 Universe UR.
 Context `{Funext} `{Univalence} (R:Type@{UR})
-  `{IntegralDomain R} `{DecidablePaths R}.
+  `{IsIntegralDomain R} `{DecidablePaths R}.
 
 Record Frac@{} : Type
   := frac { num: R; den: R; den_ne_0: PropHolds (den <> 0) }.
@@ -204,14 +204,14 @@ Arguments equiv {R _ _} _ _.
 
 
 Section morphisms.
-Context `{IntegralDomain R1} `{DecidablePaths R1}.
-Context `{IntegralDomain R2} `{DecidablePaths R2}.
-Context `(f : R1 -> R2) `{!SemiRingPreserving f} `{!Injective f}.
+Context `{IsIntegralDomain R1} `{DecidablePaths R1}.
+Context `{IsIntegralDomain R2} `{DecidablePaths R2}.
+Context `(f : R1 -> R2) `{!IsSemiRingPreserving f} `{!IsInjective f}.
 
 Definition lift (x : Frac R1) : Frac R2.
 Proof.
 apply (frac (f (num x)) (f (den x))).
-apply injective_ne_0.
+apply isinjective_ne_0.
 apply (den_ne_0 x).
 Defined.
 
@@ -233,7 +233,7 @@ Section contents.
 (* NB: we need a separate IsHSet instance
    so we don't need to depend on everything to define F. *)
 Universe UR.
-Context `{Funext} `{Univalence} {R:Type@{UR} } `{IsHSet R} `{IntegralDomain R}
+Context `{Funext} `{Univalence} {R:Type@{UR} } `{IsHSet R} `{IsIntegralDomain R}
   `{DecidablePaths R}.
 
 Local Existing Instance den_ne_0.
@@ -349,7 +349,7 @@ hnf. apply (F_ind2 _).
 intros;apply path, Frac.pl_comm.
 Qed.
 
-Instance F_ring@{} : Ring F.
+Instance F_ring@{} : IsRing F.
 Proof.
 repeat split;
 first [change sg_op with mult; change mon_unit with 1|
@@ -443,7 +443,7 @@ destruct (decide_rel paths (num q) 0) as [E'|?];[destruct E;apply E'|].
 simpl. reflexivity.
 Qed.
 
-Global Instance F_field@{} : DecField F.
+Global Instance F_field@{} : IsDecField F.
 Proof.
 split;try apply _.
 - red. apply class_neq.
@@ -492,7 +492,7 @@ destruct (decide_rel paths (num q) 0) as [E|E];simpl.
 Qed.
 
 (* A final word about inject *)
-Global Instance inject_sr_morphism@{} : SemiRingPreserving (cast R F).
+Global Instance inject_sr_morphism@{} : IsSemiRingPreserving (cast R F).
 Proof.
 repeat (split; try apply _).
 - intros x y. apply path. change ((x + y) * (1 * 1) = (x * 1 + y * 1) * 1).
@@ -501,7 +501,7 @@ repeat (split; try apply _).
   rewrite !mult_1_r. reflexivity.
 Qed.
 
-Global Instance inject_injective@{} : Injective (cast R F).
+Global Instance inject_injective@{} : IsInjective (cast R F).
 Proof.
 repeat (split; try apply _).
 intros x y E. apply classes_eq_related in E.
@@ -517,9 +517,9 @@ Module Lift.
 Section morphisms.
 Universe UR1 UR2.
 Context `{Funext} `{Univalence}.
-Context {R1:Type@{UR1} } `{IntegralDomain R1} `{DecidablePaths R1}.
-Context {R2:Type@{UR2} } `{IntegralDomain R2} `{DecidablePaths R2}.
-Context `(f : R1 -> R2) `{!SemiRingPreserving f} `{!Injective f}.
+Context {R1:Type@{UR1} } `{IsIntegralDomain R1} `{DecidablePaths R1}.
+Context {R2:Type@{UR2} } `{IsIntegralDomain R2} `{DecidablePaths R2}.
+Context `(f : R1 -> R2) `{!IsSemiRingPreserving f} `{!IsInjective f}.
 
 Definition lift@{} : F R1 -> F R2.
 Proof.
@@ -527,7 +527,7 @@ apply (F_rec (fun x => class (Frac.lift f x))).
 intros;apply path,Frac.lift_respects;trivial.
 Defined.
 
-Global Instance lift_sr_morphism@{i} : SemiRingPreserving lift.
+Global Instance lift_sr_morphism@{i} : IsSemiRingPreserving lift.
 Proof.
 (* This takes a few seconds. *)
 split;split;red.
@@ -547,7 +547,7 @@ split;split;red.
   red;simpl. apply commutativity.
 Qed.
 
-Global Instance lift_injective@{i} : Injective lift.
+Global Instance lift_injective@{i} : IsInjective lift.
 Proof.
 red.
 apply (F_ind2@{UR1 i i} (fun _ _ => _ -> _)).

--- a/theories/Classes/implementations/hprop_lattice.v
+++ b/theories/Classes/implementations/hprop_lattice.v
@@ -112,6 +112,6 @@ Section contents.
       * by apply tr, inl.
   Defined.
 
-  Global Instance boundedlattice_hprop : BoundedLattice hProp.
+  Global Instance boundedlattice_hprop : IsBoundedLattice hProp.
   Proof. repeat split; apply _. Defined.
 End contents.

--- a/theories/Classes/implementations/natpair_integers.v
+++ b/theories/Classes/implementations/natpair_integers.v
@@ -259,7 +259,7 @@ trivial;apply symmetry;trivial.
 Qed.
 
 Section to_ring.
-Context {B : Type@{UNalt} } `{Ring@{UNalt} B}.
+Context {B : Type@{UNalt} } `{IsRing@{UNalt} B}.
 
 Definition to_ring@{} : T N -> B.
 Proof.
@@ -425,7 +425,7 @@ Defined.
 Definition Z_negate_compute q : - (' q) = ' (PairT.opp _ q)
   := 1.
 
-Lemma Z_ring@{} : Ring Z.
+Lemma Z_ring@{} : IsRing Z.
 Proof.
 repeat split;try apply _;
 first [change sg_op with mult; change mon_unit with 1|
@@ -466,7 +466,7 @@ first [change sg_op with mult; change mon_unit with 1|
 Qed.
 
 (* A final word about inject *)
-Lemma Z_of_N_morphism@{} : SemiRingPreserving (cast N Z).
+Lemma Z_of_N_morphism@{} : IsSemiRingPreserving (cast N Z).
 Proof.
 repeat (constructor; try apply _).
 - intros x y.
@@ -476,7 +476,7 @@ repeat (constructor; try apply _).
 Qed.
 Global Existing Instance Z_of_N_morphism.
 
-Global Instance Z_of_N_injective@{} : Injective (cast N Z).
+Global Instance Z_of_N_injective@{} : IsInjective (cast N Z).
 Proof.
 intros x y E. apply related_path in E.
 red in E. simpl in E. rewrite 2!plus_0_r in E. trivial.
@@ -860,7 +860,7 @@ eapply Z_rec.
 apply (PairT.to_ring_respects N).
 Defined.
 
-Lemma Z_to_ring_morphism' `{Ring B} : SemiRingPreserving (integers_to_ring Z B).
+Lemma Z_to_ring_morphism' `{IsRing B} : IsSemiRingPreserving (integers_to_ring Z B).
 Proof.
 split;split;red.
 - change (@sg_op B _) with (@plus B _);
@@ -897,11 +897,11 @@ split;split;red.
   rewrite negate_0,plus_0_r;trivial.
 Qed.
 
-Instance Z_to_ring_morphism@{} `{Ring B} : SemiRingPreserving (integers_to_ring Z B)
+Instance Z_to_ring_morphism@{} `{IsRing B} : IsSemiRingPreserving (integers_to_ring Z B)
   := ltac:(first [exact Z_to_ring_morphism'@{Ularge}|
                   exact Z_to_ring_morphism'@{}]).
 
-Lemma Z_to_ring_unique@{} `{Ring B} (h : Z -> B) `{!SemiRingPreserving h}
+Lemma Z_to_ring_unique@{} `{IsRing B} (h : Z -> B) `{!IsSemiRingPreserving h}
   : forall x : Z, integers_to_ring Z B x = h x.
 Proof.
 pose proof Z_ring.

--- a/theories/Classes/implementations/peano_naturals.v
+++ b/theories/Classes/implementations/peano_naturals.v
@@ -136,7 +136,7 @@ Qed.
 
 Definition pred x := match x with | 0%nat => 0 | S k => k end.
 
-Global Instance S_inj : Injective@{N N} S
+Global Instance S_inj : IsInjective@{N N} S
   := { injective := fun a b E => ap pred E }.
 
 Global Instance nat_dec: DecidablePaths@{N} nat.
@@ -158,7 +158,7 @@ Proof.
 apply hset_pathcoll, pathcoll_decpaths, nat_dec.
 Qed.
 
-Instance nat_semiring : SemiRing@{N} nat.
+Instance nat_semiring : IsSemiRing@{N} nat.
 Proof.
 repeat (split; try apply _);
 first [change sg_op with plus; change mon_unit with 0
@@ -555,7 +555,7 @@ Global Instance nat_naturals_to_semiring : NaturalsToSemiRing@{N i} nat :=
 
 Section for_another_semiring.
   Universe U.
-  Context {R:Type@{U} } `{SemiRing@{U} R}.
+  Context {R:Type@{U} } `{IsSemiRing@{U} R}.
 
   Notation toR := (naturals_to_semiring nat R).
 
@@ -597,12 +597,12 @@ Section for_another_semiring.
   Qed.
 
   Global Instance nat_to_sr_morphism
-    : SemiRingPreserving (naturals_to_semiring nat R).
+    : IsSemiRingPreserving (naturals_to_semiring nat R).
   Proof.
   repeat (split;try apply _);trivial.
   Defined.
 
-  Lemma toR_unique (h : nat -> R) `{!SemiRingPreserving h} x :
+  Lemma toR_unique (h : nat -> R) `{!IsSemiRingPreserving h} x :
     naturals_to_semiring nat R x = h x.
   Proof.
   induction x as [|n E].

--- a/theories/Classes/implementations/pointwise.v
+++ b/theories/Classes/implementations/pointwise.v
@@ -35,7 +35,7 @@ Section contents.
     reduce_fun;
     eauto 10 with lattice_hints typeclass_instances.
 
-  Global Instance lattice_fun `{!Lattice B} : Lattice (A -> B).
+  Global Instance lattice_fun `{!IsLattice B} : IsLattice (A -> B).
   Proof.
     repeat split; try apply _; try_solve_fun.
     * apply binary_idempotent.
@@ -43,8 +43,8 @@ Section contents.
   Defined.
 
   Instance boundedjoinsemilattice_fun
-   `{!BoundedJoinSemiLattice B} :
-    BoundedJoinSemiLattice (A -> B).
+   `{!IsBoundedJoinSemiLattice B} :
+    IsBoundedJoinSemiLattice (A -> B).
   Proof.
     repeat split; try apply _; try_solve_fun.
     * apply left_identity.
@@ -54,8 +54,8 @@ Section contents.
   Defined.
 
   Instance boundedmeetsemilattice_fun
-   `{!BoundedMeetSemiLattice B} :
-    BoundedMeetSemiLattice (A -> B).
+   `{!IsBoundedMeetSemiLattice B} :
+    IsBoundedMeetSemiLattice (A -> B).
   Proof.
     repeat split; try apply _; reduce_fun.
     * apply associativity.
@@ -66,7 +66,7 @@ Section contents.
   Defined.
 
   Global Instance boundedlattice_fun
-   `{!BoundedLattice B} : BoundedLattice (A -> B).
+   `{!IsBoundedLattice B} : IsBoundedLattice (A -> B).
   Proof.
     repeat split; try apply _; reduce_fun; apply absorption.
   Defined.

--- a/theories/Classes/interfaces/abstract_algebra.v
+++ b/theories/Classes/interfaces/abstract_algebra.v
@@ -65,67 +65,67 @@ Section upper_classes.
   Universe i.
   Context (A : Type@{i}).
 
-  Class SemiGroup {Aop: SgOp A} :=
+  Class IsSemiGroup {Aop: SgOp A} :=
     { sg_set :> IsHSet A
     ; sg_ass :> Associative (&) }.
 
-  Class CommutativeSemiGroup {Aop : SgOp A} :=
-    { comsg_sg :> @SemiGroup Aop
+  Class IsCommutativeSemiGroup {Aop : SgOp A} :=
+    { comsg_sg :> @IsSemiGroup Aop
     ; comsg_comm :> Commutative (&) }.
 
-  Class SemiLattice {Aop : SgOp A} :=
-    { semilattice_sg :> @CommutativeSemiGroup Aop
+  Class IsSemiLattice {Aop : SgOp A} :=
+    { semilattice_sg :> @IsCommutativeSemiGroup Aop
     ; semilattice_idempotent :> BinaryIdempotent (&)}.
 
-  Class Monoid {Aop : SgOp A} {Aunit : MonUnit A} :=
-    { monoid_semigroup :> SemiGroup
+  Class IsMonoid {Aop : SgOp A} {Aunit : MonUnit A} :=
+    { monoid_semigroup :> IsSemiGroup
     ; monoid_left_id :> LeftIdentity (&) mon_unit
     ; monoid_right_id :> RightIdentity (&) mon_unit }.
 
-  Class CommutativeMonoid {Aop Aunit} :=
-    { commonoid_mon :> @Monoid Aop Aunit
+  Class IsCommutativeMonoid {Aop Aunit} :=
+    { commonoid_mon :> @IsMonoid Aop Aunit
     ; commonoid_commutative :> Commutative (&) }.
 
-  Class Group {Aop Aunit} {Anegate : Negate A} :=
-    { group_monoid :> @Monoid Aop Aunit
+  Class IsGroup {Aop Aunit} {Anegate : Negate A} :=
+    { group_monoid :> @IsMonoid Aop Aunit
     ; negate_l :> LeftInverse (&) (-) mon_unit
     ; negate_r :> RightInverse (&) (-) mon_unit }.
 
-  Class BoundedSemiLattice {Aop Aunit} :=
-    { bounded_semilattice_mon :> @CommutativeMonoid Aop Aunit
+  Class IsBoundedSemiLattice {Aop Aunit} :=
+    { bounded_semilattice_mon :> @IsCommutativeMonoid Aop Aunit
     ; bounded_semilattice_idempotent :> BinaryIdempotent (&)}.
 
-  Class AbGroup {Aop Aunit Anegate} :=
-    { abgroup_group :> @Group Aop Aunit Anegate
+  Class IsAbGroup {Aop Aunit Anegate} :=
+    { abgroup_group :> @IsGroup Aop Aunit Anegate
     ; abgroup_commutative :> Commutative (&) }.
 
   Context {Aplus : Plus A} {Amult : Mult A} {Azero : Zero A} {Aone : One A}.
 
-  Class SemiRing :=
-    { semiplus_monoid :> @CommutativeMonoid plus_is_sg_op zero_is_mon_unit
-    ; semimult_monoid :> @CommutativeMonoid mult_is_sg_op one_is_mon_unit
+  Class IsSemiRing :=
+    { semiplus_monoid :> @IsCommutativeMonoid plus_is_sg_op zero_is_mon_unit
+    ; semimult_monoid :> @IsCommutativeMonoid mult_is_sg_op one_is_mon_unit
     ; semiring_distr :> LeftDistribute (.*.) (+)
     ; semiring_left_absorb :> LeftAbsorb (.*.) 0 }.
 
   Context {Anegate : Negate A}.
 
-  Class Ring :=
-    { ring_group :> @AbGroup plus_is_sg_op zero_is_mon_unit _
-    ; ring_monoid :> @CommutativeMonoid mult_is_sg_op one_is_mon_unit
+  Class IsRing :=
+    { ring_group :> @IsAbGroup plus_is_sg_op zero_is_mon_unit _
+    ; ring_monoid :> @IsCommutativeMonoid mult_is_sg_op one_is_mon_unit
     ; ring_dist :> LeftDistribute (.*.) (+) }.
 
   (* For now, we follow CoRN/ring_theory's example in having Ring and SemiRing
     require commutative multiplication. *)
 
-  Class IntegralDomain :=
-    { intdom_ring : Ring
+  Class IsIntegralDomain :=
+    { intdom_ring : IsRing
     ; intdom_nontrivial : PropHolds (not (1 = 0))
     ; intdom_nozeroes :> NoZeroDivisors A }.
 
   (* We do not include strong extensionality for (-) and (/)
     because it can de derived *)
-  Class Field {Aap: Apart A} {Arecip: Recip A} :=
-    { field_ring :> Ring
+  Class IsField {Aap: Apart A} {Arecip: Recip A} :=
+    { field_ring :> IsRing
     ; field_apart :> IsApart A
     ; field_plus_ext :> StrongBinaryExtensionality (+)
     ; field_mult_ext :> StrongBinaryExtensionality (.*.)
@@ -135,8 +135,8 @@ Section upper_classes.
   (* We let /0 = 0 so properties as Injective (/),
     f (/x) = / (f x), / /x = x, /x * /y = /(x * y) 
     hold without any additional assumptions *)
-  Class DecField {Adec_recip : DecRecip A} :=
-    { decfield_ring :> Ring
+  Class IsDecField {Adec_recip : DecRecip A} :=
+    { decfield_ring :> IsRing
     ; decfield_nontrivial : PropHolds (1 <> 0)
     ; dec_recip_0 : /0 = 0
     ; dec_recip_inverse : forall x, x <> 0 -> x / x = 1 }.
@@ -157,46 +157,46 @@ Hint Extern 5 (PropHolds (1 <> 0)) =>
   eapply @decfield_nontrivial : typeclass_instances.
 
 (* 
-For a strange reason Ring instances of Integers are sometimes obtained by
+For a strange reason IsRing instances of Integers are sometimes obtained by
 Integers -> IntegralDomain -> Ring and sometimes directly. Making this an
-instance with a low priority instead of using intdom_ring:> Ring forces Coq to
+instance with a low priority instead of using intdom_ring:> IsRing forces Coq to
 take the right way 
 *)
-Hint Extern 10 (Ring _) => apply @intdom_ring : typeclass_instances.
+Hint Extern 10 (IsRing _) => apply @intdom_ring : typeclass_instances.
 
-Arguments recip_inverse {A Aplus Amult Azero Aone Anegate Aap Arecip Field} _.
+Arguments recip_inverse {A Aplus Amult Azero Aone Anegate Aap Arecip IsField} _.
 Arguments dec_recip_inverse
-  {A Aplus Amult Azero Aone Anegate Adec_recip DecField} _ _.
-Arguments dec_recip_0 {A Aplus Amult Azero Aone Anegate Adec_recip DecField}.
+  {A Aplus Amult Azero Aone Anegate Adec_recip IsDecField} _ _.
+Arguments dec_recip_0 {A Aplus Amult Azero Aone Anegate Adec_recip IsDecField}.
 
 Section lattice.
   Context A {Ajoin: Join A} {Ameet: Meet A} {Abottom : Bottom A} {Atop : Top A}.
 
-  Class JoinSemiLattice := 
-    join_semilattice :> @SemiLattice A join_is_sg_op.
-  Class BoundedJoinSemiLattice := 
-    bounded_join_semilattice :> @BoundedSemiLattice A
+  Class IsJoinSemiLattice := 
+    join_semilattice :> @IsSemiLattice A join_is_sg_op.
+  Class IsBoundedJoinSemiLattice := 
+    bounded_join_semilattice :> @IsBoundedSemiLattice A
       join_is_sg_op bottom_is_mon_unit.
-  Class MeetSemiLattice := 
-    meet_semilattice :> @SemiLattice A meet_is_sg_op.
-  Class BoundedMeetSemiLattice :=
-    bounded_meet_semilattice :> @BoundedSemiLattice A
+  Class IsMeetSemiLattice := 
+    meet_semilattice :> @IsSemiLattice A meet_is_sg_op.
+  Class IsBoundedMeetSemiLattice :=
+    bounded_meet_semilattice :> @IsBoundedSemiLattice A
       meet_is_sg_op top_is_mon_unit.
 
-  Class Lattice := 
-    { lattice_join :> JoinSemiLattice
-    ; lattice_meet :> MeetSemiLattice
+  Class IsLattice := 
+    { lattice_join :> IsJoinSemiLattice
+    ; lattice_meet :> IsMeetSemiLattice
     ; join_meet_absorption :> Absorption (⊔) (⊓) 
     ; meet_join_absorption :> Absorption (⊓) (⊔)}.
 
-  Class BoundedLattice :=
-    { boundedlattice_join :> BoundedJoinSemiLattice
-    ; boundedlattice_meet :> BoundedMeetSemiLattice
+  Class IsBoundedLattice :=
+    { boundedlattice_join :> IsBoundedJoinSemiLattice
+    ; boundedlattice_meet :> IsBoundedMeetSemiLattice
     ; boundedjoin_meet_absorption :> Absorption (⊔) (⊓)
     ; boundedmeet_join_absorption :> Absorption (⊓) (⊔)}.
 
-  Class DistributiveLattice := 
-    { distr_lattice_lattice :> Lattice
+  Class IsDistributiveLattice := 
+    { distr_lattice_lattice :> IsLattice
     ; join_meet_distr_l :> LeftDistribute (⊔) (⊓) }.
 End lattice.
 
@@ -206,15 +206,15 @@ Section morphism_classes.
   Context {A B : Type} {Aop : SgOp A} {Bop : SgOp B}
     {Aunit : MonUnit A} {Bunit : MonUnit B}.
 
-  Class SemiGroupPreserving (f : A -> B) :=
+  Class IsSemiGroupPreserving (f : A -> B) :=
     preserves_sg_op : forall x y, f (x & y) = f x & f y.
 
-  Class UnitPreserving (f : A -> B) :=
+  Class IsUnitPreserving (f : A -> B) :=
     preserves_mon_unit : f mon_unit = mon_unit.
 
-  Class MonoidPreserving (f : A -> B) :=
-    { monmor_sgmor :> SemiGroupPreserving f
-    ; monmor_unitmor :> UnitPreserving f }.
+  Class IsMonoidPreserving (f : A -> B) :=
+    { monmor_sgmor :> IsSemiGroupPreserving f
+    ; monmor_unitmor :> IsUnitPreserving f }.
   End sgmorphism_classes.
 
   Section ringmorphism_classes.
@@ -222,15 +222,15 @@ Section morphism_classes.
     {Amult : Mult A} {Bmult : Mult B} {Azero : Zero A} {Bzero : Zero B}
     {Aone : One A} {Bone : One B}.
 
-  Class SemiRingPreserving (f : A -> B) :=
-    { semiringmor_plus_mor :> @MonoidPreserving A B
+  Class IsSemiRingPreserving (f : A -> B) :=
+    { semiringmor_plus_mor :> @IsMonoidPreserving A B
         plus_is_sg_op plus_is_sg_op zero_is_mon_unit zero_is_mon_unit f
-    ; semiringmor_mult_mor :> @MonoidPreserving A B
+    ; semiringmor_mult_mor :> @IsMonoidPreserving A B
         mult_is_sg_op mult_is_sg_op one_is_mon_unit one_is_mon_unit f }.
 
   Context {Aap : Apart A} {Bap : Apart B}.
-  Class SemiRingStrongPreserving (f : A -> B) :=
-    { strong_semiringmor_sr_mor :> SemiRingPreserving f
+  Class IsSemiRingStrongPreserving (f : A -> B) :=
+    { strong_semiringmor_sr_mor :> IsSemiRingPreserving f
     ; strong_semiringmor_strong_mor :> StrongExtensionality f }.
   End ringmorphism_classes.
 
@@ -238,29 +238,29 @@ Section morphism_classes.
   Context {A B : Type} {Ajoin : Join A} {Bjoin : Join B}
     {Ameet : Meet A} {Bmeet : Meet B}.
 
-  Class JoinPreserving (f : A -> B) :=
-    join_slmor_sgmor :> @SemiGroupPreserving A B join_is_sg_op join_is_sg_op f.
+  Class IsJoinPreserving (f : A -> B) :=
+    join_slmor_sgmor :> @IsSemiGroupPreserving A B join_is_sg_op join_is_sg_op f.
 
-  Class MeetPreserving (f : A -> B) :=
-    meet_slmor_sgmor :> @SemiGroupPreserving A B meet_is_sg_op meet_is_sg_op f.
+  Class IsMeetPreserving (f : A -> B) :=
+    meet_slmor_sgmor :> @IsSemiGroupPreserving A B meet_is_sg_op meet_is_sg_op f.
 
   Context {Abottom : Bottom A} {Bbottom : Bottom B}.
-  Class BoundedJoinPreserving (f : A -> B) := bounded_join_slmor_monmor
-      :> @MonoidPreserving A B join_is_sg_op join_is_sg_op
+  Class IsBoundedJoinPreserving (f : A -> B) := bounded_join_slmor_monmor
+      :> @IsMonoidPreserving A B join_is_sg_op join_is_sg_op
          bottom_is_mon_unit bottom_is_mon_unit f.
 
-  Class LatticePreserving (f : A -> B) :=
-    { latticemor_join_mor :> JoinPreserving f
-    ; latticemor_meet_mor :> MeetPreserving f }.
+  Class IsLatticePreserving (f : A -> B) :=
+    { latticemor_join_mor :> IsJoinPreserving f
+    ; latticemor_meet_mor :> IsMeetPreserving f }.
   End latticemorphism_classes.
 End morphism_classes.
 
 Section jections.
   Context {A B} (f : A -> B).
 
-  Class Injective := injective : forall x y, f x = f y -> x = y.
+  Class IsInjective := injective : forall x y, f x = f y -> x = y.
 
-  Lemma injective_ne `{!Injective} x y :
+  Lemma isinjective_ne `{!IsInjective} x y :
     x <> y -> f x <> f y.
   Proof.
     intros E1 E2. apply E1.
@@ -271,7 +271,7 @@ End jections.
 
 Section strong_injective.
   Context {A B} {Aap : Apart A} {Bap : Apart B} (f : A -> B) .
-  Class StrongInjective :=
+  Class IsStrongInjective :=
     { strong_injective : forall x y, x ≶ y -> f x ≶ f y
     ; strong_injective_mor : StrongExtensionality f }.
 End strong_injective.
@@ -282,5 +282,121 @@ Class CutMinusSpec A (cm : CutMinus A) `{Zero A} `{Plus A} `{Le A} := {
   cut_minus_le : forall x y, y ≤ x -> x ∸ y + y = x ;
   cut_minus_0 : forall x y, x ≤ y -> x ∸ y = 0
 }.
+
+
+Global Instance ishprop_issemigrouppreserving `{Funext} {A B : Type} `{IsHSet B}
+  `{SgOp A} `{SgOp B} {f : A -> B} : IsHProp (IsSemiGroupPreserving f).
+Proof.
+  unfold IsSemiGroupPreserving; exact _.
+Defined.
+
+Definition issig_IsMonoidPreserving {A B : Type} `{SgOp A} `{SgOp B}
+  `{MonUnit A} `{MonUnit B} {f : A -> B} : _ <~> IsMonoidPreserving f
+  := ltac:(issig).
+
+Global Instance ishprop_ismonoidpreserving `{Funext} {A B : Type} `{SgOp A}
+  `{SgOp B} `{IsHSet B} `{MonUnit A} `{MonUnit B} (f : A -> B)
+  : IsHProp (IsMonoidPreserving f).
+Proof.
+  serapply (trunc_equiv' _ issig_IsMonoidPreserving).
+  serapply (trunc_equiv' _ (equiv_sigma_prod0 _ _)^-1).
+  serapply trunc_prod.
+  unfold IsUnitPreserving.
+  exact _.
+Defined.
+
+Definition issig_issemigroup x y : _ <~> @IsSemiGroup x y := ltac:(issig).
+
+Global Instance ishprop_issemigroup `{Funext}
+  : forall x y, IsHProp (@IsSemiGroup x y).
+Proof.
+  intros x y a b.
+  rewrite <- (eisretr (issig_issemigroup x y) a).
+  rewrite <- (eisretr (issig_issemigroup x y) b).
+  set (a' := (issig_issemigroup x y)^-1 a).
+  set (b' := (issig_issemigroup x y)^-1 b).
+  clearbody a' b'; clear a b.
+  serapply (contr_equiv _ (ap (issig_issemigroup x y))).
+  rewrite <- (eissect (equiv_sigma_prod0 _ _) a').
+  rewrite <- (eissect (equiv_sigma_prod0 _ _) b').
+  set (a := equiv_sigma_prod0 _ _ a').
+  set (b := equiv_sigma_prod0 _ _ b').
+  clearbody a b; clear a' b'.
+  serapply (contr_equiv _ (ap (equiv_sigma_prod0 _ _)^-1)).
+  serapply (contr_equiv _ (equiv_path_prod _ _)).
+  serapply contr_prod.
+  destruct a as [a' a], b as [b' b].
+  do 3 (ntc_refine (contr_equiv' _ (@equiv_path_forall H _ _ _ _));
+  ntc_refine (@contr_forall H _ _ _); intro).
+  exact _.
+Defined.
+
+Definition issig_ismonoid x y z : _ <~> @IsMonoid x y z := ltac:(issig).
+
+Global Instance ishprop_ismonoid `{Funext} x y z : IsHProp (@IsMonoid x y z).
+Proof.
+  intros a b.
+  rewrite <- (eisretr (issig_ismonoid x y z) a).
+  rewrite <- (eisretr (issig_ismonoid x y z) b).
+  set (a' := (issig_ismonoid x y z)^-1 a).
+  set (b' := (issig_ismonoid x y z)^-1 b).
+  clearbody a' b'; clear a b.
+  serapply (contr_equiv _ (ap (issig_ismonoid x y z))).
+  rewrite <- (eissect (equiv_sigma_prod0 _ _) a').
+  rewrite <- (eissect (equiv_sigma_prod0 _ _) b').
+  set (a := equiv_sigma_prod0 _ _ a').
+  set (b := equiv_sigma_prod0 _ _ b').
+  clearbody a b; clear a' b'.
+  serapply (contr_equiv _ (ap (equiv_sigma_prod0 _ _)^-1)).
+  serapply (contr_equiv _ (equiv_path_prod _ _)).
+  serapply contr_prod.
+  destruct a as [a' a], b as [b' b]; cbn.
+  rewrite <- (eissect (equiv_sigma_prod0 _ _) a).
+  rewrite <- (eissect (equiv_sigma_prod0 _ _) b).
+  set (a'' := equiv_sigma_prod0 _ _ a).
+  set (b'' := equiv_sigma_prod0 _ _ b).
+  clearbody a'' b''; clear a b.
+  serapply (contr_equiv _ (ap (equiv_sigma_prod0 _ _)^-1)).
+  serapply (contr_equiv _ (equiv_path_prod _ _)).
+  destruct a'' as [a a''], b'' as [b b'']; cbn.
+  serapply contr_prod.
+  all: serapply contr_paths_contr.
+  all: serapply contr_inhabited_hprop.
+  all: serapply trunc_forall.
+Defined.
+
+Definition issig_isgroup w x y z : _ <~> @IsGroup w x y z := ltac:(issig).
+
+Global Instance ishprop_isgroup `{Funext} w x y z : IsHProp (@IsGroup w x y z).
+Proof.
+  intros a b.
+  rewrite <- (eisretr (issig_isgroup w x y z) a).
+  rewrite <- (eisretr (issig_isgroup w x y z) b).
+  set (a' := (issig_isgroup w x y z)^-1 a).
+  set (b' := (issig_isgroup w x y z)^-1 b).
+  clearbody a' b'; clear a b.
+  serapply (contr_equiv _ (ap (issig_isgroup w x y z))).
+  rewrite <- (eissect (equiv_sigma_prod0 _ _) a').
+  rewrite <- (eissect (equiv_sigma_prod0 _ _) b').
+  set (a := equiv_sigma_prod0 _ _ a').
+  set (b := equiv_sigma_prod0 _ _ b').
+  clearbody a b; clear a' b'.
+  serapply (contr_equiv _ (ap (equiv_sigma_prod0 _ _)^-1)).
+  serapply (contr_equiv _ (equiv_path_prod _ _)).
+  serapply contr_prod.
+  destruct a as [a' a], b as [b' b]; cbn.
+  rewrite <- (eissect (equiv_sigma_prod0 _ _) a).
+  rewrite <- (eissect (equiv_sigma_prod0 _ _) b).
+  set (a'' := equiv_sigma_prod0 _ _ a).
+  set (b'' := equiv_sigma_prod0 _ _ b).
+  clearbody a'' b''; clear a b.
+  serapply (contr_equiv _ (ap (equiv_sigma_prod0 _ _)^-1)).
+  serapply (contr_equiv _ (equiv_path_prod _ _)).
+  destruct a'' as [a a''], b'' as [b b'']; cbn.
+  serapply contr_prod.
+  all: serapply contr_paths_contr.
+  all: serapply contr_inhabited_hprop.
+  all: serapply trunc_forall.
+Defined.
 
 End extras.

--- a/theories/Classes/interfaces/canonical_names.v
+++ b/theories/Classes/interfaces/canonical_names.v
@@ -1,13 +1,7 @@
 Require Export
-  HoTT.Basics.Overture
-  HoTT.Types.Bool
-  HoTT.Basics.Decidable
-  HoTT.Basics.Trunc
+  HoTT.Basics
+  HoTT.Types
   HoTT.Truncations.
-
-Require Import
-  HoTT.Types.Sigma
-  HoTT.Types.Forall.
 
 Declare Scope mc_scope.
 Delimit Scope mc_scope with mc.

--- a/theories/Classes/interfaces/integers.v
+++ b/theories/Classes/interfaces/integers.v
@@ -5,15 +5,15 @@ Require Import
   HoTT.Classes.theory.rings (* for Ring -> SemiRing *).
 
 Class IntegersToRing@{i j} (A:Type@{i})
-  := integers_to_ring: forall (R:Type@{j}) `{Ring R}, A -> R.
+  := integers_to_ring: forall (R:Type@{j}) `{IsRing R}, A -> R.
 Arguments integers_to_ring A {_} R {_ _ _ _ _ _} _.
 
 Class Integers A {Aap:Apart A} {Aplus Amult Azero Aone Anegate Ale Alt}
   `{U : IntegersToRing A} :=
-  { integers_ring :> @Ring A Aplus Amult Azero Aone Anegate
+  { integers_ring :> @IsRing A Aplus Amult Azero Aone Anegate
   ; integers_order :> FullPseudoSemiRingOrder Ale Alt
-  ; integers_to_ring_mor:> forall `{Ring B}, SemiRingPreserving (integers_to_ring A B)
-  ; integers_initial: forall `{Ring B} {h : A -> B} `{!SemiRingPreserving h} x,
+  ; integers_to_ring_mor:> forall `{IsRing B}, IsSemiRingPreserving (integers_to_ring A B)
+  ; integers_initial: forall `{IsRing B} {h : A -> B} `{!IsSemiRingPreserving h} x,
       integers_to_ring A B x = h x}.
 
 Section specializable.

--- a/theories/Classes/interfaces/naturals.v
+++ b/theories/Classes/interfaces/naturals.v
@@ -3,17 +3,17 @@ Require Import
  HoTT.Classes.interfaces.orders.
 
 Class NaturalsToSemiRing@{i j} (A : Type@{i}) :=
-  naturals_to_semiring: forall (B : Type@{j}) `{SemiRing B}, A -> B.
+  naturals_to_semiring: forall (B : Type@{j}) `{IsSemiRing B}, A -> B.
 
 Arguments naturals_to_semiring A {_} B {_ _ _ _ _} _.
 
 Class Naturals A {Aap:Apart A} {Aplus Amult Azero Aone Ale Alt}
   `{U: NaturalsToSemiRing A} :=
-  { naturals_ring :> @SemiRing A Aplus Amult Azero Aone
+  { naturals_ring :> @IsSemiRing A Aplus Amult Azero Aone
   ; naturals_order :> FullPseudoSemiRingOrder Ale Alt
-  ; naturals_to_semiring_mor:> forall `{SemiRing B},
-    SemiRingPreserving (naturals_to_semiring A B)
-  ; naturals_initial: forall `{SemiRing B} {h : A -> B} `{!SemiRingPreserving h} x,
+  ; naturals_to_semiring_mor:> forall `{IsSemiRing B},
+    IsSemiRingPreserving (naturals_to_semiring A B)
+  ; naturals_initial: forall `{IsSemiRing B} {h : A -> B} `{!IsSemiRingPreserving h} x,
     naturals_to_semiring A B x = h x }.
 
 (* Specializable operations: *)

--- a/theories/Classes/interfaces/rationals.v
+++ b/theories/Classes/interfaces/rationals.v
@@ -11,7 +11,7 @@ Require Import
   - l universe of Field property of target types 
 *)
 Class RationalsToField@{i j k l} (A : Type@{i}) :=
-  rationals_to_field : forall (B : Type@{j}) `{Field@{j l k} B}
+  rationals_to_field : forall (B : Type@{j}) `{IsField@{j l k} B}
     `{!FieldCharacteristic B 0}, A -> B.
 
 Arguments rationals_to_field A {_} B {_ _ _ _ _ _ _ _ _} _.
@@ -21,10 +21,10 @@ Arguments rationals_to_field A {_} B {_ _ _ _ _ _ _ _ _} _.
 
 Class Rationals A {Aap : Apart A} {Aplus Amult Azero Aone Aneg Arecip Ale Alt}
   `{U : !RationalsToField A} :=
-  { rationals_field :> @DecField A Aplus Amult Azero Aone Aneg Arecip
+  { rationals_field :> @IsDecField A Aplus Amult Azero Aone Aneg Arecip
   ; rationals_order :> FullPseudoSemiRingOrder Ale Alt
-  ; rationals_to_field_mor :> forall `{Field B} `{!FieldCharacteristic B 0},
-    SemiRingPreserving (rationals_to_field A B)
-  ; rationals_initial : forall `{Field B} `{!FieldCharacteristic B 0}
-    {h : A -> B} `{!SemiRingPreserving h} x,
+  ; rationals_to_field_mor :> forall `{IsField B} `{!FieldCharacteristic B 0},
+    IsSemiRingPreserving (rationals_to_field A B)
+  ; rationals_initial : forall `{IsField B} `{!FieldCharacteristic B 0}
+    {h : A -> B} `{!IsSemiRingPreserving h} x,
     rationals_to_field A B x = h x }.

--- a/theories/Classes/isomorphisms/rings.v
+++ b/theories/Classes/isomorphisms/rings.v
@@ -34,7 +34,7 @@ Universe U V.
 Context `{Funext} `{Univalence}.
 Context (A B : Operations@{U V}).
 
-Context (f : A -> B) `{!IsEquiv f} `{!SemiRingPreserving f}.
+Context (f : A -> B) `{!IsEquiv f} `{!IsSemiRingPreserving f}.
 
 Lemma iso_same_semirings : A = B.
 Proof.
@@ -99,7 +99,7 @@ Context `{Funext} `{Univalence}.
 Context (A B : Operations@{U V}).
 
 (* NB: we need to know they're rings for preserves_negate *)
-Context (f : A -> B) `{!IsEquiv f} `{!Ring A} `{!Ring B} `{!SemiRingPreserving f}.
+Context (f : A -> B) `{!IsEquiv f} `{!IsRing A} `{!IsRing B} `{!IsSemiRingPreserving f}.
 
 Lemma iso_same_rings : A = B.
 Proof.

--- a/theories/Classes/orders/dec_fields.v
+++ b/theories/Classes/orders/dec_fields.v
@@ -9,7 +9,7 @@ Require Export
 Require Import HoTT.Classes.tactics.ring_tac.
 
 Section contents.
-Context `{DecField F} `{Apart F} `{!TrivialApart F}
+Context `{IsDecField F} `{Apart F} `{!TrivialApart F}
   `{!FullPseudoSemiRingOrder Fle Flt} `{DecidablePaths F}.
 (* Add Ring F : (stdlib_ring_theory F). *)
 

--- a/theories/Classes/orders/lattices.v
+++ b/theories/Classes/orders/lattices.v
@@ -46,7 +46,7 @@ Section join_semilattice_order.
   transitivity (y ⊔ z); apply join_ub_r.
   Qed.
 
-  Instance join_sl_order_join_sl: JoinSemiLattice L.
+  Instance join_sl_order_join_sl: IsJoinSemiLattice L.
   Proof.
   repeat split.
   - apply _.
@@ -156,7 +156,7 @@ Section join_semilattice_order.
 End join_semilattice_order.
 
 Section bounded_join_semilattice.
-  Context `{JoinSemiLatticeOrder L} `{Bottom L} `{!BoundedJoinSemiLattice L}.
+  Context `{JoinSemiLatticeOrder L} `{Bottom L} `{!IsBoundedJoinSemiLattice L}.
 
   Lemma above_bottom x : ⊥ ≤ x.
   Proof.
@@ -210,7 +210,7 @@ Section meet_semilattice_order.
   transitivity (y ⊓ z); apply meet_lb_r.
   Qed.
 
-  Instance meet_sl_order_meet_sl: MeetSemiLattice L.
+  Instance meet_sl_order_meet_sl: IsMeetSemiLattice L.
   Proof.
   repeat split.
   - apply _.
@@ -320,8 +320,8 @@ End meet_semilattice_order.
 Section lattice_order.
   Context `{LatticeOrder L}.
 
-  Instance: JoinSemiLattice L := join_sl_order_join_sl.
-  Instance: MeetSemiLattice L := meet_sl_order_meet_sl.
+  Instance: IsJoinSemiLattice L := join_sl_order_join_sl.
+  Instance: IsMeetSemiLattice L := meet_sl_order_meet_sl.
 
   Instance: Absorption (⊓) (⊔).
   Proof.
@@ -341,7 +341,7 @@ Section lattice_order.
   - apply join_ub_l.
   Qed.
 
-  Instance lattice_order_lattice: Lattice L := {}.
+  Instance lattice_order_lattice: IsLattice L := {}.
 
   Lemma meet_join_distr_l_le x y z : (x ⊓ y) ⊔ (x ⊓ z) ≤ x ⊓ (y ⊔ z).
   Proof.
@@ -372,10 +372,10 @@ Section lattice_order.
   Qed.
 End lattice_order.
 
-Definition default_join_sl_le `{JoinSemiLattice L} : Le L :=  fun x y => x ⊔ y = y.
+Definition default_join_sl_le `{IsJoinSemiLattice L} : Le L :=  fun x y => x ⊔ y = y.
 
 Section join_sl_order_alt.
-  Context `{JoinSemiLattice L} `{Le L} `{is_mere_relation L le}
+  Context `{IsJoinSemiLattice L} `{Le L} `{is_mere_relation L le}
     (le_correct : forall x y, x ≤ y <-> x ⊔ y = y).
 
   Lemma alt_Build_JoinSemiLatticeOrder : JoinSemiLatticeOrder (≤).
@@ -406,10 +406,10 @@ Section join_sl_order_alt.
   Qed.
 End join_sl_order_alt.
 
-Definition default_meet_sl_le `{MeetSemiLattice L} : Le L :=  fun x y => x ⊓ y = x.
+Definition default_meet_sl_le `{IsMeetSemiLattice L} : Le L :=  fun x y => x ⊓ y = x.
 
 Section meet_sl_order_alt.
-  Context `{MeetSemiLattice L} `{Le L} `{is_mere_relation L le}
+  Context `{IsMeetSemiLattice L} `{Le L} `{is_mere_relation L le}
     (le_correct : forall x y, x ≤ y <-> x ⊓ y = x).
 
   Lemma alt_Build_MeetSemiLatticeOrder : MeetSemiLatticeOrder (≤).
@@ -441,7 +441,7 @@ End meet_sl_order_alt.
 
 Section join_order_preserving.
   Context `{JoinSemiLatticeOrder L} `{JoinSemiLatticeOrder K} (f : L -> K)
-    `{!JoinPreserving f}.
+    `{!IsJoinPreserving f}.
 
   Lemma join_sl_mor_preserving: OrderPreserving f.
   Proof.
@@ -451,7 +451,7 @@ Section join_order_preserving.
   apply ap, E.
   Qed.
 
-  Lemma join_sl_mor_reflecting `{!Injective f}: OrderReflecting f.
+  Lemma join_sl_mor_reflecting `{!IsInjective f}: OrderReflecting f.
   Proof.
   intros x y E.
   apply join_sl_le_spec in E. apply join_sl_le_spec.
@@ -462,7 +462,7 @@ End join_order_preserving.
 
 Section meet_order_preserving.
   Context `{MeetSemiLatticeOrder L} `{MeetSemiLatticeOrder K} (f : L -> K)
-    `{!MeetPreserving f}.
+    `{!IsMeetPreserving f}.
 
   Lemma meet_sl_mor_preserving: OrderPreserving f.
   Proof.
@@ -472,7 +472,7 @@ Section meet_order_preserving.
   apply ap, E.
   Qed.
 
-  Lemma meet_sl_mor_reflecting `{!Injective f}: OrderReflecting f.
+  Lemma meet_sl_mor_reflecting `{!IsInjective f}: OrderReflecting f.
   Proof.
   intros x y E.
   apply meet_sl_le_spec in E. apply meet_sl_le_spec.
@@ -486,7 +486,7 @@ Section order_preserving_join_sl_mor.
     `{!TotalOrder (_ : Le L)} `{!TotalOrder (_ : Le K)}
     `{!OrderPreserving (f : L -> K)}.
 
-  Lemma order_preserving_join_sl_mor: JoinPreserving f.
+  Lemma order_preserving_join_sl_mor: IsJoinPreserving f.
   Proof.
   intros x y. case (total (≤) x y); intros E.
   - change (f (join x y) = join (f x) (f y)).
@@ -502,7 +502,7 @@ Section order_preserving_meet_sl_mor.
     `{!TotalOrder (_ : Le L)} `{!TotalOrder (_ : Le K)}
     `{!OrderPreserving (f : L -> K)}.
 
-  Lemma order_preserving_meet_sl_mor: SemiGroupPreserving f.
+  Lemma order_preserving_meet_sl_mor: IsSemiGroupPreserving f.
   Proof.
   intros x y. case (total (≤) x y); intros E.
   - change (f (meet x y) = meet (f x) (f y)).

--- a/theories/Classes/orders/maps.v
+++ b/theories/Classes/orders/maps.v
@@ -10,7 +10,7 @@ Section strictly_order_preserving.
   Context `{FullPartialOrder A} `{FullPartialOrder B}.
 
   Global Instance strictly_order_preserving_inj  `{!OrderPreserving (f : A -> B)}
-    `{!StrongInjective f} :
+    `{!IsStrongInjective f} :
     StrictlyOrderPreserving f | 20.
   Proof.
   intros x y E.
@@ -42,7 +42,7 @@ Section strictly_order_preserving_dec.
 
   Global Instance dec_strictly_order_preserving_inj
     `{!OrderPreserving (f : A -> B)}
-    `{!Injective f} :
+    `{!IsInjective f} :
     StrictlyOrderPreserving f | 19.
   Proof.
   pose proof (dec_strong_injective f).
@@ -71,7 +71,7 @@ Section pseudo_injective.
   Qed.
 
   Lemma pseudo_order_embedding_inj `{!StrictOrderEmbedding (f : A -> B)} :
-    StrongInjective f.
+    IsStrongInjective f.
   Proof.
   split;try apply _.
   intros x y E.
@@ -202,7 +202,7 @@ End strict_order_preserving_ops.
 
 Lemma projected_partial_order `{IsHSet A} {Ale : Le A}
   `{is_mere_relation A Ale} `{Ble : Le B}
-  (f : A -> B) `{!Injective f} `{!PartialOrder Ble}
+  (f : A -> B) `{!IsInjective f} `{!PartialOrder Ble}
   : (forall x y, x ≤ y <-> f x ≤ f y) -> PartialOrder Ale.
 Proof.
 intros P. repeat split.
@@ -235,7 +235,7 @@ Qed.
 
 Lemma projected_pseudo_order `{IsApart A} `{Alt : Lt A} `{is_mere_relation A lt}
   `{Apart B} `{Blt : Lt B}
-  (f : A -> B) `{!StrongInjective f} `{!PseudoOrder Blt}
+  (f : A -> B) `{!IsStrongInjective f} `{!PseudoOrder Blt}
   : (forall x y, x < y <-> f x < f y) -> PseudoOrder Alt.
 Proof.
 pose proof (strong_injective_mor f).
@@ -257,7 +257,7 @@ Qed.
 Lemma projected_full_pseudo_order `{IsApart A} `{Ale : Le A} `{Alt : Lt A}
   `{is_mere_relation A le} `{is_mere_relation A lt}
   `{Apart B} `{Ble : Le B} `{Blt : Lt B}
-  (f : A -> B) `{!StrongInjective f} `{!FullPseudoOrder Ble Blt}
+  (f : A -> B) `{!IsStrongInjective f} `{!FullPseudoOrder Ble Blt}
   : (forall x y, x ≤ y <-> f x ≤ f y) -> (forall x y, x < y <-> f x < f y) ->
     FullPseudoOrder Ale Alt.
 Proof.

--- a/theories/Classes/orders/nat_int.v
+++ b/theories/Classes/orders/nat_int.v
@@ -22,8 +22,8 @@ the rationals or the reals), any morphism to it is an order embedding.
 *)
 Lemma to_semiring_nonneg `{FullPseudoSemiRingOrder N}
   `{!NaturalsToSemiRing N} `{!Naturals N} `{FullPseudoSemiRingOrder R}
-  `{!SemiRing R}
-  `{!SemiRingPreserving (f : N -> R)} n : 0 ≤ f n.
+  `{!IsSemiRing R}
+  `{!IsSemiRingPreserving (f : N -> R)} n : 0 ≤ f n.
 Proof.
 revert n. apply naturals.induction.
 - rewrite (preserves_0 (f:=f)).
@@ -37,7 +37,7 @@ Qed.
 
 Section nat_int_order.
 Context `{Naturals N} `{Apart N} `{Le N} `{Lt N} `{!FullPseudoSemiRingOrder le lt}
-  `{FullPseudoSemiRingOrder R} `{!SemiRing R}
+  `{FullPseudoSemiRingOrder R} `{!IsSemiRing R}
   `{!Biinduction R} `{PropHolds (1 ≶ 0)}.
 
 (* Add Ring R : (stdlib_semiring_theory R). *)
@@ -144,9 +144,9 @@ Lemma le_iff_lt_S x y : x ≤ y <-> x < 1 + y.
 Proof. rewrite plus_comm. apply le_iff_lt_plus_1. Qed.
 
 Section another_semiring.
-  Context `{FullPseudoSemiRingOrder R2} `{!SemiRing R2}
+  Context `{FullPseudoSemiRingOrder R2} `{!IsSemiRing R2}
     `{PropHolds ((1 : R2) ≶ 0)}
-    `{!SemiRingPreserving (f : R -> R2)}.
+    `{!IsSemiRingPreserving (f : R -> R2)}.
 
   Instance: OrderPreserving f.
   Proof.

--- a/theories/Classes/orders/naturals.v
+++ b/theories/Classes/orders/naturals.v
@@ -78,8 +78,8 @@ as [E | E].
 Qed.
 
 Section another_ring.
-  Context `{Ring R} `{Apart R} `{!FullPseudoSemiRingOrder (A:=R) Rle Rlt}
-    `{!SemiRingPreserving (f : N -> R)}.
+  Context `{IsRing R} `{Apart R} `{!FullPseudoSemiRingOrder (A:=R) Rle Rlt}
+    `{!IsSemiRingPreserving (f : N -> R)}.
 
   Lemma negate_to_ring_nonpos n : -f n ≤ 0.
   Proof. apply flip_nonneg_negate. apply to_semiring_nonneg. Qed.

--- a/theories/Classes/orders/rings.v
+++ b/theories/Classes/orders/rings.v
@@ -6,7 +6,7 @@ Require Export
   HoTT.Classes.orders.semirings.
 
 Section from_ring_order.
-  Context `{Ring R} `{!PartialOrder Rle}
+  Context `{IsRing R} `{!PartialOrder Rle}
     (plus_spec : forall z, OrderPreserving (z +))
     (mult_spec : forall x y, PropHolds (0 ≤ x) -> PropHolds (0 ≤ y) ->
       PropHolds (0 ≤ x * y)).
@@ -25,7 +25,7 @@ Section from_ring_order.
 End from_ring_order.
 
 Section from_strict_ring_order.
-  Context `{Ring R} `{!StrictOrder Rlt}
+  Context `{IsRing R} `{!StrictOrder Rlt}
     (plus_spec : forall z, StrictlyOrderPreserving (z +))
     (mult_spec : forall x y, PropHolds (0 < x) -> PropHolds (0 < y) ->
       PropHolds (0 < x * y)).
@@ -44,7 +44,7 @@ Section from_strict_ring_order.
 End from_strict_ring_order.
 
 Section from_pseudo_ring_order.
-  Context `{Ring R} `{Apart R} `{!PseudoOrder Rlt}
+  Context `{IsRing R} `{Apart R} `{!PseudoOrder Rlt}
     (plus_spec : forall z, StrictlyOrderPreserving (z +))
     (mult_ext : StrongBinaryExtensionality (.*.))
     (mult_spec : forall x y, PropHolds (0 < x) -> PropHolds (0 < y) ->
@@ -65,7 +65,7 @@ Section from_pseudo_ring_order.
 End from_pseudo_ring_order.
 
 Section from_full_pseudo_ring_order.
-  Context `{Ring R} `{Apart R} `{!FullPseudoOrder Rle Rlt}
+  Context `{IsRing R} `{Apart R} `{!FullPseudoOrder Rle Rlt}
     (plus_spec : forall z, StrictlyOrderPreserving (z +))
     (mult_ext : StrongBinaryExtensionality (.*.))
     (mult_spec : forall x y, PropHolds (0 < x) -> PropHolds (0 < y) ->
@@ -81,7 +81,7 @@ Section from_full_pseudo_ring_order.
 End from_full_pseudo_ring_order.
 
 Section ring_order.
-  Context `{Ring R} `{!SemiRingOrder Rle}.
+  Context `{IsRing R} `{!SemiRingOrder Rle}.
 (*   Add Ring R : (stdlib_ring_theory R). *)
 
   Lemma flip_le_negate x y : -y ≤ -x <-> x ≤ y.
@@ -167,7 +167,7 @@ Section ring_order.
 End ring_order.
 
 Section strict_ring_order.
-  Context `{Ring R} `{!StrictSemiRingOrder Rlt}.
+  Context `{IsRing R} `{!StrictSemiRingOrder Rlt}.
 (*   Add Ring Rs : (stdlib_ring_theory R). *)
 
   Lemma flip_lt_negate x y : -y < -x <-> x < y.
@@ -242,10 +242,10 @@ Section strict_ring_order.
 End strict_ring_order.
 
 Section another_ring_order.
-  Context `{Ring R1} `{!SemiRingOrder R1le} `{Ring R2} `{R2le : Le R2}
+  Context `{IsRing R1} `{!SemiRingOrder R1le} `{IsRing R2} `{R2le : Le R2}
     `{is_mere_relation R2 R2le}.
 
-  Lemma projected_ring_order (f : R2 -> R1) `{!SemiRingPreserving f} `{!Injective f}
+  Lemma projected_ring_order (f : R2 -> R1) `{!IsSemiRingPreserving f} `{!IsInjective f}
     : (forall x y, x ≤ y <-> f x ≤ f y) -> SemiRingOrder R2le.
   Proof.
   intros P. apply (projected_srorder f P).
@@ -253,7 +253,7 @@ Section another_ring_order.
   rewrite plus_assoc, plus_negate_r, plus_0_l. reflexivity.
   Qed.
 
-  Context `{!SemiRingOrder R2le} {f : R1 -> R2} `{!SemiRingPreserving f}.
+  Context `{!SemiRingOrder R2le} {f : R1 -> R2} `{!IsSemiRingPreserving f}.
 
   Lemma reflecting_preserves_nonneg : (forall x, 0 ≤ f x -> 0 ≤ x) -> OrderReflecting f.
   Proof.
@@ -277,10 +277,10 @@ Section another_ring_order.
 End another_ring_order.
 
 Section another_strict_ring_order.
-  Context `{Ring R1} `{!StrictSemiRingOrder R1lt} `{Ring R2} `{R2lt : Lt R2}
+  Context `{IsRing R1} `{!StrictSemiRingOrder R1lt} `{IsRing R2} `{R2lt : Lt R2}
     `{is_mere_relation R2 lt}.
 
-  Lemma projected_strict_ring_order (f : R2 -> R1) `{!SemiRingPreserving f} :
+  Lemma projected_strict_ring_order (f : R2 -> R1) `{!IsSemiRingPreserving f} :
     (forall x y, x < y <-> f x < f y) -> StrictSemiRingOrder R2lt.
   Proof.
   intros P. pose proof (projected_strict_order f P).
@@ -295,12 +295,12 @@ Section another_strict_ring_order.
 End another_strict_ring_order.
 
 Section another_pseudo_ring_order.
-  Context `{Ring R1} `{Apart R1} `{!PseudoSemiRingOrder R1lt}
-    `{Ring R2} `{IsApart R2} `{R2lt : Lt R2}
+  Context `{IsRing R1} `{Apart R1} `{!PseudoSemiRingOrder R1lt}
+    `{IsRing R2} `{IsApart R2} `{R2lt : Lt R2}
     `{is_mere_relation R2 lt}.
 
-  Lemma projected_pseudo_ring_order (f : R2 -> R1) `{!SemiRingPreserving f}
-    `{!StrongInjective f}
+  Lemma projected_pseudo_ring_order (f : R2 -> R1) `{!IsSemiRingPreserving f}
+    `{!IsStrongInjective f}
     : (forall x y, x < y <-> f x < f y) -> PseudoSemiRingOrder R2lt.
   Proof.
   intros P.
@@ -320,12 +320,12 @@ Section another_pseudo_ring_order.
 End another_pseudo_ring_order.
 
 Section another_full_pseudo_ring_order.
-  Context `{Ring R1} `{Apart R1} `{!FullPseudoSemiRingOrder R1le R1lt}
-    `{Ring R2} `{IsApart R2} `{R2le : Le R2} `{R2lt : Lt R2}
+  Context `{IsRing R1} `{Apart R1} `{!FullPseudoSemiRingOrder R1le R1lt}
+    `{IsRing R2} `{IsApart R2} `{R2le : Le R2} `{R2lt : Lt R2}
     `{is_mere_relation R2 le} `{is_mere_relation R2 lt}.
 
-  Lemma projected_full_pseudo_ring_order (f : R2 -> R1) `{!SemiRingPreserving f}
-    `{!StrongInjective f}
+  Lemma projected_full_pseudo_ring_order (f : R2 -> R1) `{!IsSemiRingPreserving f}
+    `{!IsStrongInjective f}
     : (forall x y, x ≤ y <-> f x ≤ f y) -> (forall x y, x < y <-> f x < f y) ->
     FullPseudoSemiRingOrder R2le R2lt.
   Proof.

--- a/theories/Classes/orders/semirings.v
+++ b/theories/Classes/orders/semirings.v
@@ -8,7 +8,7 @@ Require Export
   HoTT.Classes.orders.maps.
 
 Section semiring_order.
-  Context `{SemiRingOrder R} `{!SemiRing R}.
+  Context `{SemiRingOrder R} `{!IsSemiRing R}.
 (*   Add Ring R : (stdlib_semiring_theory R). *)
 
   Global Instance plus_le_embed_l : forall (z : R), OrderEmbedding (+z).
@@ -183,7 +183,7 @@ Hint Extern 7 (PropHolds (0 ≤ _ + _)) =>
   eapply @nonneg_plus_compat : typeclass_instances.
 
 Section strict_semiring_order.
-  Context `{SemiRing R} `{!StrictSemiRingOrder Rlt}.
+  Context `{IsSemiRing R} `{!StrictSemiRingOrder Rlt}.
 (*   Add Ring Rs : (stdlib_semiring_theory R). *)
 
   Global Instance plus_lt_embed : forall (z : R), StrictOrderEmbedding (+z).
@@ -339,7 +339,7 @@ Hint Extern 7 (PropHolds (0 < _ + _)) =>
   eapply @pos_plus_compat : typeclass_instances.
 
 Section pseudo_semiring_order.
-  Context `{PseudoSemiRingOrder R} `{!SemiRing R}.
+  Context `{PseudoSemiRingOrder R} `{!IsSemiRing R}.
 (*   Add Ring Rp : (stdlib_semiring_theory R). *)
 
   Local Existing Instance pseudo_order_apart.
@@ -554,7 +554,7 @@ Hint Extern 7 (PropHolds (0 < 4)) => eapply @lt_0_4 : typeclass_instances.
 Hint Extern 7 (PropHolds (2 ≶ 0)) => eapply @apart_0_2 : typeclass_instances.
 
 Section full_pseudo_semiring_order.
-  Context `{FullPseudoSemiRingOrder R} `{!SemiRing R}.
+  Context `{FullPseudoSemiRingOrder R} `{!IsSemiRing R}.
 
 (*   Add Ring Rf : (stdlib_semiring_theory R). *)
 
@@ -828,9 +828,9 @@ End dec_semiring_order.
 Section another_semiring.
   Context `{SemiRingOrder R1}.
 
-  Lemma projected_srorder `{SemiRing R2} `{R2le : Le R2}
+  Lemma projected_srorder `{IsSemiRing R2} `{R2le : Le R2}
     `{is_mere_relation R2 R2le} (f : R2 -> R1)
-    `{!SemiRingPreserving f} `{!Injective f}
+    `{!IsSemiRingPreserving f} `{!IsInjective f}
     : (forall x y, x ≤ y <-> f x ≤ f y) -> (forall x y : R2, x ≤ y -> exists z, y = x + z) ->
       SemiRingOrder R2le.
   Proof.
@@ -845,8 +845,8 @@ Section another_semiring.
     apply nonneg_mult_compat; rewrite <-(preserves_0 (f:=f)); apply P;trivial.
   Qed.
 
- Context `{!SemiRing R1} `{SemiRingOrder R2} `{!SemiRing R2}
-   `{!SemiRingPreserving (f : R1 -> R2)}.
+ Context `{!IsSemiRing R1} `{SemiRingOrder R2} `{!IsSemiRing R2}
+   `{!IsSemiRingPreserving (f : R1 -> R2)}.
 
   (* If a morphism agrees on the positive cone then it is order preserving *)
   Lemma preserving_preserves_nonneg : (forall x, 0 ≤ x -> 0 ≤ f x) -> OrderPreserving f.
@@ -884,8 +884,8 @@ End another_semiring.
 
 Section another_semiring_strict.
   Context `{StrictSemiRingOrder R1} `{StrictSemiRingOrder R2}
-    `{!SemiRing R1} `{!SemiRing R2}
-    `{!SemiRingPreserving (f : R1 -> R2)}.
+    `{!IsSemiRing R1} `{!IsSemiRing R2}
+    `{!IsSemiRingPreserving (f : R1 -> R2)}.
 
   Lemma strictly_preserving_preserves_pos
     : (forall x, 0 < x -> 0 < f x) -> StrictlyOrderPreserving f.

--- a/theories/Classes/tactics/ring_quote.v
+++ b/theories/Classes/tactics/ring_quote.v
@@ -7,7 +7,7 @@ Class AlmostNegate A := almost_negate : A -> A.
 
 Class AlmostRing A {Aplus : Plus A} {Amult : Mult A}
   {Azero : Zero A} {Aone : One A} {Anegate : AlmostNegate A} :=
-  { almost_ring_semiring : SemiRing A
+  { almost_ring_semiring : IsSemiRing A
   ; almost_ring_neg_pr : forall x : A, almost_negate x = (almost_negate 1) * x }.
 
 Section almostring_mor.
@@ -16,7 +16,7 @@ Context {A B : Type} {Aplus : Plus A} {Bplus : Plus B}
   {Aone : One A} {Bone : One B} {Aneg : AlmostNegate A} {Bneg : AlmostNegate B}.
 
 Class AlmostRingPreserving (f : A -> B) :=
-  { almostring_mor_sr_mor : SemiRingPreserving f
+  { almostring_mor_sr_mor : IsSemiRingPreserving f
   ; almostring_mor_neg : forall x, f (almost_negate x) = almost_negate (f x) }.
 End almostring_mor.
 

--- a/theories/Classes/tactics/ring_tac.v
+++ b/theories/Classes/tactics/ring_tac.v
@@ -67,21 +67,21 @@ Instance negate_almostneg `{Aneg : Negate A} : AlmostNegate A
   := (-).
 Arguments negate_almostneg _ _ _ /.
 
-Instance semiring_almostring `{SemiRing A} : AlmostRing A | 10.
+Instance semiring_almostring `{IsSemiRing A} : AlmostRing A | 10.
 Proof.
 split;try apply _.
 intros. unfold almost_negate;simpl.
 symmetry;apply mult_0_l.
 Qed.
 
-Instance ring_almostring `{Ring A} : AlmostRing A.
+Instance ring_almostring `{IsRing A} : AlmostRing A.
 Proof.
 split;try apply _.
 intros. unfold almost_negate;simpl.
 apply negate_mult.
 Qed.
 
-Instance sr_mor_almostring_mor `{SemiRingPreserving A B f}
+Instance sr_mor_almostring_mor `{IsSemiRingPreserving A B f}
   : AlmostRingPreserving f | 10.
 Proof.
 split;try apply _.
@@ -89,7 +89,7 @@ unfold almost_negate;simpl. intros _. apply preserves_0.
 Qed.
 
 Section VarSec.
-Context `{Ring A} `{Ring B} {f : A -> B} `{!SemiRingPreserving f}.
+Context `{IsRing A} `{IsRing B} {f : A -> B} `{!IsSemiRingPreserving f}.
 
 Global Instance ring_mor_almostring_mor : AlmostRingPreserving f.
 Proof.
@@ -107,7 +107,7 @@ Arguments by_quoting {C _ R} phi
 Ltac ring_with_nat :=
   match goal with
   |- @paths ?R _ _ =>
-    ((pose proof (_ : SemiRing R)) || fail "target equality not on a semiring");
+    ((pose proof (_ : IsSemiRing R)) || fail "target equality not on a semiring");
     apply (by_quoting (naturals_to_semiring nat R));
     compute;reflexivity
   end.
@@ -115,7 +115,7 @@ Ltac ring_with_nat :=
 Ltac ring_with_integers Z :=
   match goal with
   |- @paths ?R _ _ =>
-    ((pose proof (_ : Ring R)) || fail "target equality not on a ring");
+    ((pose proof (_ : IsRing R)) || fail "target equality not on a ring");
     apply (by_quoting (integers_to_ring Z R));
     compute;reflexivity
   end.
@@ -123,7 +123,7 @@ Ltac ring_with_integers Z :=
 Ltac ring_with_self :=
   match goal with
   |- @paths ?R _ _ =>
-    ((pose proof (_ : SemiRing R)) || fail "target equality not on a ring");
+    ((pose proof (_ : IsSemiRing R)) || fail "target equality not on a ring");
     apply (by_quoting (@id R));
     compute;reflexivity
   end.

--- a/theories/Classes/tests/ring_tac.v
+++ b/theories/Classes/tests/ring_tac.v
@@ -2,7 +2,7 @@ Require Import
   HoTT.Classes.interfaces.abstract_algebra
   HoTT.Classes.tactics.ring_tac.
 
-Lemma test1 `{SemiRing R}
+Lemma test1 `{IsSemiRing R}
   : forall x y : R, x + (y * x) = x * (y + 1).
 Proof.
 intros.
@@ -12,7 +12,7 @@ Qed.
 Require Import
   HoTT.Classes.interfaces.naturals.
 
-Lemma test2 `{SemiRing R}
+Lemma test2 `{IsSemiRing R}
   : forall x y : R, x + (y * x) = x * (y + 1).
 Proof.
 intros.
@@ -20,7 +20,7 @@ apply (by_quoting (naturals_to_semiring nat R)).
 compute. reflexivity.
 Qed.
 
-Lemma test3 `{SemiRing R}
+Lemma test3 `{IsSemiRing R}
   (pa pb pc : R) :
   pa * (pb * pc)
 = pa * pb * pc.
@@ -30,7 +30,7 @@ apply (by_quoting (naturals_to_semiring nat R)). compute.
 reflexivity.
 Qed.
 
-Lemma test4 `{SemiRing R}
+Lemma test4 `{IsSemiRing R}
   (a b : R)
   : a * b = b * a.
 Proof.

--- a/theories/Classes/theory/apartness.v
+++ b/theories/Classes/theory/apartness.v
@@ -63,8 +63,8 @@ Qed.
 Section morphisms.
   Context `{IsApart A} `{IsApart B} `{IsApart C}.
 
-  Global Instance strong_injective_injective `{!StrongInjective (f : A -> B)} :
-    Injective f.
+  Global Instance strong_injective_injective `{!IsStrongInjective (f : A -> B)} :
+    IsInjective f.
   Proof.
   pose proof (strong_injective_mor f).
   intros ? ? e.
@@ -200,8 +200,8 @@ Section dec_setoid_morphisms.
 
   Context `{!TrivialApart B}.
 
-  Instance dec_strong_injective (f : A -> B) `{!Injective f} :
-    StrongInjective f.
+  Instance dec_strong_injective (f : A -> B) `{!IsInjective f} :
+    IsStrongInjective f.
   Proof.
   split; try apply _.
   intros x y.

--- a/theories/Classes/theory/dec_fields.v
+++ b/theories/Classes/theory/dec_fields.v
@@ -6,7 +6,7 @@ Require Export
   HoTT.Classes.theory.rings.
 
 Section contents.
-Context `{DecField F} `{forall x y: F, Decidable (x = y)}.
+Context `{IsDecField F} `{forall x y: F, Decidable (x = y)}.
 
 (* Add Ring F : (stdlib_ring_theory F). *)
 
@@ -20,7 +20,7 @@ rewrite associativity, (commutativity y), E.
 apply mult_0_l.
 Qed.
 
-Global Instance decfield_integral_domain : IntegralDomain F.
+Global Instance decfield_integral_domain : IsIntegralDomain F.
 Proof.
 split; try apply _.
 Qed.
@@ -83,7 +83,7 @@ destruct (dec (y = 0)) as [Ey|Ey].
   + rewrite dec_recip_inverse;trivial.
 Qed.
 
-Global Instance dec_recip_inj: Injective (/).
+Global Instance dec_recip_inj: IsInjective (/).
 Proof.
 repeat (split; try apply _).
 intros x y E.
@@ -180,14 +180,14 @@ Hint Extern 7 (PropHolds (/ _ <> 0)) =>
 
 (* Given a decidable field we can easily construct a constructive field. *)
 Section is_field.
-  Context `{DecField F} `{Apart F} `{!TrivialApart F}
+  Context `{IsDecField F} `{Apart F} `{!TrivialApart F}
     `{Decidable.DecidablePaths F}.
 
   Global Instance recip_dec_field: Recip F := fun x => / x.1.
 
   Local Existing Instance dec_strong_setoid.
 
-  Global Instance decfield_field : Field F.
+  Global Instance decfield_field : IsField F.
   Proof.
   split; try apply _.
   - apply (dec_strong_binary_morphism (+)).
@@ -245,10 +245,10 @@ Qed. *)
 End from_stdlib_field_theory. *)
 
 Section morphisms.
-  Context  `{DecField F} `{TrivialApart F} `{Decidable.DecidablePaths F}.
+  Context  `{IsDecField F} `{TrivialApart F} `{Decidable.DecidablePaths F}.
 
-  Global Instance dec_field_to_domain_inj `{IntegralDomain R}
-    `{!SemiRingPreserving (f : F -> R)} : Injective f.
+  Global Instance dec_field_to_domain_inj `{IsIntegralDomain R}
+    `{!IsSemiRingPreserving (f : F -> R)} : IsInjective f.
   Proof.
   apply injective_preserves_0.
   intros x Efx.
@@ -260,21 +260,21 @@ Section morphisms.
   apply left_absorb.
   Qed.
 
-  Lemma preserves_dec_recip `{DecField F2} `{forall x y: F2, Decidable (x = y)}
-    `{!SemiRingPreserving (f : F -> F2)} x : f (/ x) = / f x.
+  Lemma preserves_dec_recip `{IsDecField F2} `{forall x y: F2, Decidable (x = y)}
+    `{!IsSemiRingPreserving (f : F -> F2)} x : f (/ x) = / f x.
   Proof.
   case (dec (x = 0)) as [E | E].
   - rewrite E, dec_recip_0, preserves_0, dec_recip_0. reflexivity.
   - intros.
     apply (left_cancellation_ne_0 (.*.) (f x)).
-    + apply injective_ne_0. trivial.
+    + apply isinjective_ne_0. trivial.
     + rewrite <-preserves_mult, 2!dec_recip_inverse.
       * apply preserves_1.
-      * apply injective_ne_0. trivial.
+      * apply isinjective_ne_0. trivial.
       * trivial.
   Qed.
 
-  Lemma dec_recip_to_recip `{Field F2} `{!SemiRingStrongPreserving (f : F -> F2)}
+  Lemma dec_recip_to_recip `{IsField F2} `{!IsSemiRingStrongPreserving (f : F -> F2)}
     x Pfx : f (/ x) = // (f x;Pfx).
   Proof.
   assert (x <> 0).
@@ -282,7 +282,7 @@ Section morphisms.
     destruct (apart_ne (f x) 0 Pfx).
     rewrite Ex, (preserves_0 (f:=f)). reflexivity.
   - apply (left_cancellation_ne_0 (.*.) (f x)).
-    + apply injective_ne_0. trivial.
+    + apply isinjective_ne_0. trivial.
     + rewrite <-preserves_mult, dec_recip_inverse, reciperse_alt by assumption.
       apply preserves_1.
   Qed.

--- a/theories/Classes/theory/fields.v
+++ b/theories/Classes/theory/fields.v
@@ -6,7 +6,7 @@ Require Export
   HoTT.Classes.theory.rings.
 
 Section field_properties.
-Context `{Field F}.
+Context `{IsField F}.
 
 (* Add Ring F : (stdlib_ring_theory F). *)
 
@@ -32,7 +32,7 @@ Proof.
 intros ? E. rewrite <-E. trivial.
 Qed.
 
-Global Instance: StrongInjective (-).
+Global Instance: IsStrongInjective (-).
 Proof.
 repeat (split; try apply _); intros x y E.
 - apply (strong_extensionality (+ x + y)).
@@ -47,7 +47,7 @@ repeat (split; try apply _); intros x y E.
   apply symmetry;trivial.
 Qed.
 
-Global Instance: StrongInjective (//).
+Global Instance: IsStrongInjective (//).
 Proof.
 repeat (split; try apply _); intros x y E.
 - apply (strong_extensionality (x.1 *.)).
@@ -122,7 +122,7 @@ assert (~ ~ apart y 0) as Ey.
   apply mult_0_l.
 Qed.
 
-Global Instance: IntegralDomain F := {}.
+Global Instance : IsIntegralDomain F := {}.
 
 Global Instance apart_0_sig_apart_0: forall (x : ApartZero F), PropHolds (x.1 ≶ 0).
 Proof.
@@ -199,11 +199,11 @@ Hint Extern 8 (PropHolds (_ * _ ≶ 0)) =>
   eapply @mult_apart_zero : typeclass_instances.
 
 Section morphisms.
-  Context `{Field F1} `{Field F2} `{!SemiRingStrongPreserving (f : F1 -> F2)}.
+  Context `{IsField F1} `{IsField F2} `{!IsSemiRingStrongPreserving (f : F1 -> F2)}.
 
 (*   Add Ring F1 : (stdlib_ring_theory F1). *)
 
-  Lemma strong_injective_preserves_0 : (forall x, x ≶ 0 -> f x ≶ 0) -> StrongInjective f.
+  Lemma strong_injective_preserves_0 : (forall x, x ≶ 0 -> f x ≶ 0) -> IsStrongInjective f.
   Proof.
   intros E1. split; try apply _. intros x y E2.
   apply (strong_extensionality (+ -f y)).
@@ -216,7 +216,7 @@ Section morphisms.
 
   (* We have the following for morphisms to non-trivial strong rings as well.
     However, since we do not have an interface for strong rings, we ignore it. *)
-  Global Instance: StrongInjective f.
+  Global Instance: IsStrongInjective f.
   Proof.
   apply strong_injective_preserves_0.
   intros x Ex.

--- a/theories/Classes/theory/groups.v
+++ b/theories/Classes/theory/groups.v
@@ -2,104 +2,108 @@ Require Import
   HoTT.Classes.interfaces.abstract_algebra.
 
 Section group_props.
-Context `{Group G}.
+  Context `{IsGroup G}.
 
-Global Instance negate_involutive: Involutive (-).
-Proof.
-intros x.
-path_via (mon_unit & x).
-1:path_via ((- - x & - x) & x).
-1:path_via (- - x & (- x & x)).
-1:path_via (- - x & mon_unit).
-- apply symmetry. apply right_identity.
-- apply ap. apply symmetry. apply left_inverse.
-- apply associativity.
-- apply (@ap _ _ (fun y => y & x)).
-  apply left_inverse.
-- apply left_identity.
-Qed.
+  (** Group inverses are involutive *)
+  Global Instance negate_involutive : Involutive (-).
+  Proof.
+    intros x.
+    transitivity (mon_unit & x).
+    2: apply left_identity.
+    transitivity ((- - x & - x) & x).
+    2: apply (@ap _ _ (fun y => y & x)),
+          left_inverse.
+    transitivity (- - x & (- x & x)).
+    2: apply associativity.
+    transitivity (- - x & mon_unit).
+    2: apply ap, symmetry, left_inverse.
+    apply symmetry, right_identity.
+  Qed.
 
-Global Instance: Injective (-).
-Proof.
-intros x y E.
-rewrite <-(involutive x), <-(involutive y), E. reflexivity.
-Qed.
+  Global Instance isinj_group_negate : IsInjective (-).
+  Proof.
+    intros x y E.
+    refine ((involutive x)^ @ _ @ involutive y).
+    apply ap, E.
+  Qed.
 
-Lemma negate_mon_unit : -mon_unit = mon_unit.
-Proof.
-change ((fun x => - mon_unit = x) mon_unit).
-apply (transport _ (left_inverse mon_unit)).
-rewrite right_identity. reflexivity.
-Qed.
+  Lemma negate_mon_unit : - mon_unit = mon_unit.
+  Proof.
+    change ((fun x => - mon_unit = x) mon_unit).
+    apply (transport _ (left_inverse mon_unit)).
+    apply symmetry, right_identity.
+  Qed.
 
-Global Instance: forall z : G, LeftCancellation (&) z.
-Proof.
-  intros z x y E.
-  rewrite <-(left_identity x).
-  rewrite <-(left_inverse (unit:=mon_unit) z).
-  rewrite <-simple_associativity.
-  rewrite E.
-  rewrite simple_associativity, (left_inverse z), left_identity.
-  reflexivity.
-Qed.
+  Global Instance group_cancelL : forall z : G, LeftCancellation (&) z.
+  Proof.
+    intros z x y E.
+    rewrite <- (left_identity x).
+    rewrite <- (left_inverse (unit:=mon_unit) z).
+    rewrite <- simple_associativity.
+    rewrite E.
+    rewrite simple_associativity, (left_inverse z), left_identity.
+    reflexivity.
+  Qed.
 
-Global Instance: forall z : G, RightCancellation (&) z.
-Proof.
-  intros z x y E.
-  rewrite <-(right_identity x).
-  rewrite <-(right_inverse (unit:=mon_unit) z).
-  rewrite associativity.
-  rewrite E.
-  rewrite <-(associativity y ), right_inverse, right_identity.
-  reflexivity.
-Qed.
+  Global Instance group_cancelR: forall z : G, RightCancellation (&) z.
+  Proof.
+    intros z x y E.
+    rewrite <-(right_identity x).
+    rewrite <-(right_inverse (unit:=mon_unit) z).
+    rewrite associativity.
+    rewrite E.
+    rewrite <-(associativity y ), right_inverse, right_identity.
+    reflexivity.
+  Qed.
 
-Lemma negate_sg_op x y : - (x & y) = -y & -x.
-Proof.
-rewrite <-(left_identity (-y & -x)).
-rewrite <-(left_inverse (unit:=mon_unit) (x & y)).
-rewrite <-(associativity (_:G)).
-rewrite <-(associativity (_:G)).
-rewrite (associativity y).
-rewrite right_inverse.
-rewrite (left_identity (-x)).
-rewrite right_inverse.
-apply symmetry, right_identity.
-Qed.
+  Lemma negate_sg_op x y : - (x & y) = -y & -x.
+  Proof.
+    rewrite <- (left_identity (-y & -x)).
+    rewrite <- (left_inverse (unit:=mon_unit) (x & y)).
+    rewrite <- simple_associativity.
+    rewrite <- simple_associativity.
+    rewrite (associativity y).
+    rewrite right_inverse.
+    rewrite (left_identity (-x)).
+    rewrite right_inverse.
+    apply symmetry, right_identity.
+  Qed.
 
 End group_props.
 
 Section abgroup_props.
 
-Lemma negate_sg_op_distr `{AbGroup G} x y : -(x & y) = -x & -y.
-Proof.
-path_via (-y & -x).
-- apply negate_sg_op.
-- apply commutativity.
-Qed.
+  Lemma negate_sg_op_distr `{IsAbGroup G} x y : -(x & y) = -x & -y.
+  Proof.
+    path_via (-y & -x).
+    - apply negate_sg_op.
+    - apply commutativity.
+  Qed.
 
 End abgroup_props.
 
 Section groupmor_props.
 
-  Context `{Group A} `{Group B} {f : A -> B} `{!MonoidPreserving f}.
+  Context `{IsGroup A} `{IsGroup B} {f : A -> B} `{!IsMonoidPreserving f}.
 
   Lemma preserves_negate x : f (-x) = -f x.
   Proof.
-  apply (left_cancellation (&) (f x)).
-  rewrite <-preserves_sg_op.
-  rewrite 2!right_inverse.
-  apply preserves_mon_unit.
+    apply (left_cancellation (&) (f x)).
+    rewrite <-preserves_sg_op.
+    rewrite 2!right_inverse.
+    apply preserves_mon_unit.
   Qed.
 
 End groupmor_props.
 
 Section from_another_sg.
-  Context `{SemiGroup A} `{IsHSet B}
-   `{Bop : SgOp B} (f : B -> A) `{!Injective f}
-   (op_correct : forall x y, f (x & y) = f x & f y).
 
-  Lemma projected_sg: SemiGroup B.
+  Context
+    `{IsSemiGroup A} `{IsHSet B}
+    `{Bop : SgOp B} (f : B -> A) `{!IsInjective f}
+    (op_correct : forall x y, f (x & y) = f x & f y).
+
+  Lemma projected_sg: IsSemiGroup B.
   Proof.
   split.
   - apply _.
@@ -111,166 +115,179 @@ End from_another_sg.
 Section from_another_com.
 
   Context `{SgOp A} `{!Commutative (A:=A) sg_op} {B}
-   `{Bop : SgOp B} (f : B -> A) `{!Injective f}
+   `{Bop : SgOp B} (f : B -> A) `{!IsInjective f}
    (op_correct : forall x y, f (x & y) = f x & f y).
 
   Lemma projected_comm : Commutative (A:=B) sg_op.
   Proof.
-  intros x y.
-  apply (injective f).
-  rewrite 2!op_correct.
-  apply commutativity.
+    intros x y.
+    apply (injective f).
+    rewrite 2!op_correct.
+    apply commutativity.
   Qed.
 
 End from_another_com.
 
 Section from_another_com_sg.
-  Context `{CommutativeSemiGroup A} `{IsHSet B}
-   `{Bop : SgOp B} (f : B -> A) `{!Injective f}
-   (op_correct : forall x y, f (x & y) = f x & f y).
 
-  Lemma projected_com_sg: CommutativeSemiGroup B.
+  Context
+    `{IsCommutativeSemiGroup A} `{IsHSet B}
+    `{Bop : SgOp B} (f : B -> A) `{!IsInjective f}
+    (op_correct : forall x y, f (x & y) = f x & f y).
+
+  Lemma projected_com_sg : IsCommutativeSemiGroup B.
   Proof.
-  split.
-  - apply (projected_sg f);assumption.
-  - apply (projected_comm f);assumption.
+    split.
+    - apply (projected_sg f);assumption.
+    - apply (projected_comm f);assumption.
   Qed.
+
 End from_another_com_sg.
 
 Section from_another_monoid.
-  Context `{Monoid A} `{IsHSet B}
-   `{Bop : SgOp B} `{Bunit : MonUnit B} (f : B -> A) `{!Injective f}
+
+  Context `{IsMonoid A} `{IsHSet B}
+   `{Bop : SgOp B} `{Bunit : MonUnit B} (f : B -> A) `{!IsInjective f}
    (op_correct : forall x y, f (x & y) = f x & f y) (unit_correct : f mon_unit = mon_unit).
 
-  Lemma projected_monoid: Monoid B.
+  Lemma projected_monoid : IsMonoid B.
   Proof.
-  split.
-  - apply (projected_sg f). assumption.
-  - repeat intro; apply (injective f).
-    rewrite op_correct, unit_correct, left_identity.
-    reflexivity.
-  - repeat intro; apply (injective f).
-    rewrite op_correct, unit_correct, right_identity.
-    reflexivity.
+    split.
+    - apply (projected_sg f). assumption.
+    - repeat intro; apply (injective f).
+      rewrite op_correct, unit_correct, left_identity.
+      reflexivity.
+    - repeat intro; apply (injective f).
+      rewrite op_correct, unit_correct, right_identity.
+      reflexivity.
   Qed.
+
 End from_another_monoid.
 
 Section from_another_com_monoid.
-  Context `{CommutativeMonoid A} `{IsHSet B}
-   `{Bop : SgOp B} `{Bunit : MonUnit B} (f : B -> A) `{!Injective f}
+
+  Context
+   `{IsCommutativeMonoid A} `{IsHSet B}
+   `{Bop : SgOp B} `{Bunit : MonUnit B} (f : B -> A) `{!IsInjective f}
    (op_correct : forall x y, f (x & y) = f x & f y)
    (unit_correct : f mon_unit = mon_unit).
 
-  Lemma projected_com_monoid: CommutativeMonoid B.
+  Lemma projected_com_monoid : IsCommutativeMonoid B.
   Proof.
-  split.
-  - apply (projected_monoid f);assumption.
-  - apply (projected_comm f);assumption.
+    split.
+    - apply (projected_monoid f);assumption.
+    - apply (projected_comm f);assumption.
   Qed.
+
 End from_another_com_monoid.
 
 Section from_another_group.
-  Context `{Group A} `{IsHSet B}
-   `{Bop : SgOp B} `{Bunit : MonUnit B} `{Bnegate : Negate B}
-   (f : B -> A) `{!Injective f}
-   (op_correct : forall x y, f (x & y) = f x & f y)
-   (unit_correct : f mon_unit = mon_unit)
-   (negate_correct : forall x, f (-x) = -f x).
 
-  Lemma projected_group: Group B.
+  Context
+    `{IsGroup A} `{IsHSet B}
+    `{Bop : SgOp B} `{Bunit : MonUnit B} `{Bnegate : Negate B}
+    (f : B -> A) `{!IsInjective f}
+    (op_correct : forall x y, f (x & y) = f x & f y)
+    (unit_correct : f mon_unit = mon_unit)
+    (negate_correct : forall x, f (-x) = -f x).
+
+  Lemma projected_group : IsGroup B.
   Proof.
-  split.
-  - apply (projected_monoid f);assumption.
-  - repeat intro; apply (injective f).
-    rewrite op_correct, negate_correct, unit_correct, left_inverse.
-    apply reflexivity.
-  - repeat intro; apply (injective f).
-    rewrite op_correct, negate_correct, unit_correct, right_inverse.
-    reflexivity.
+    split.
+    - apply (projected_monoid f);assumption.
+    - repeat intro; apply (injective f).
+      rewrite op_correct, negate_correct, unit_correct, left_inverse.
+      apply reflexivity.
+    - repeat intro; apply (injective f).
+      rewrite op_correct, negate_correct, unit_correct, right_inverse.
+      reflexivity.
   Qed.
+
 End from_another_group.
 
 Section from_another_ab_group.
-  Context `{AbGroup A} `{IsHSet B}
+  Context `{IsAbGroup A} `{IsHSet B}
    `{Bop : SgOp B} `{Bunit : MonUnit B} `{Bnegate : Negate B}
-   (f : B -> A) `{!Injective f}
+   (f : B -> A) `{!IsInjective f}
    (op_correct : forall x y, f (x & y) = f x & f y)
    (unit_correct : f mon_unit = mon_unit)
    (negate_correct : forall x, f (-x) = -f x).
 
-  Lemma projected_ab_group: AbGroup B.
+  Lemma projected_ab_group : IsAbGroup B.
   Proof.
-  split.
-  - apply (projected_group f);assumption.
-  - apply (projected_comm f);assumption.
+    split.
+    - apply (projected_group f);assumption.
+    - apply (projected_comm f);assumption.
   Qed.
+
 End from_another_ab_group.
 
-Instance id_sg_morphism `{SemiGroup A}: SemiGroupPreserving (@id A).
+Instance id_sg_morphism `{IsSemiGroup A} : IsSemiGroupPreserving (@id A).
 Proof.
-red. split.
+  red. split.
 Qed.
 
-Instance id_monoid_morphism `{Monoid A}: MonoidPreserving (@id A).
+Instance id_monoid_morphism `{IsMonoid A} : IsMonoidPreserving (@id A).
 Proof.
 split;split.
 Qed.
 
 Section compose_mor.
 
-  Context `{SgOp A} `{MonUnit A}
+  Context
+    `{SgOp A} `{MonUnit A}
     `{SgOp B} `{MonUnit B}
     `{SgOp C} `{MonUnit C}
     (f : A -> B) (g : B -> C).
 
-  Instance compose_sg_morphism : SemiGroupPreserving f -> SemiGroupPreserving g ->
-    SemiGroupPreserving (g ∘ f).
+  Instance compose_sg_morphism : IsSemiGroupPreserving f -> IsSemiGroupPreserving g ->
+    IsSemiGroupPreserving (g ∘ f).
   Proof.
-  red;intros.
-  unfold Compose.
-  rewrite (preserves_sg_op x y).
-  apply preserves_sg_op.
+    red;intros.
+    unfold Compose.
+    rewrite (preserves_sg_op x y).
+    apply preserves_sg_op.
   Qed.
 
-  Instance compose_monoid_morphism : MonoidPreserving f -> MonoidPreserving g ->
-    MonoidPreserving (g ∘ f).
+  Instance compose_monoid_morphism : IsMonoidPreserving f -> IsMonoidPreserving g ->
+    IsMonoidPreserving (g ∘ f).
   Proof.
-  intros;split.
-  - apply _.
-  - red;unfold Compose.
-    etransitivity;[|apply preserves_mon_unit].
-    apply ap,preserves_mon_unit.
+    intros;split.
+    - apply _.
+    - red;unfold Compose.
+      etransitivity;[|apply preserves_mon_unit].
+      apply ap,preserves_mon_unit.
   Qed.
 
-  Instance invert_sg_morphism:
-    forall `{!IsEquiv f}, SemiGroupPreserving f ->
-      SemiGroupPreserving (f^-1).
+  Instance invert_sg_morphism
+    : forall `{!IsEquiv f}, IsSemiGroupPreserving f ->
+      IsSemiGroupPreserving (f^-1).
   Proof.
-  red;intros.
-  apply (Paths.equiv_inj f).
-  rewrite (preserves_sg_op (f:=f)).
-  rewrite !eisretr.
-  reflexivity.
+    red;intros.
+    apply (Paths.equiv_inj f).
+    rewrite (preserves_sg_op (f:=f)).
+    rewrite !eisretr.
+    reflexivity.
   Qed.
 
   Instance invert_monoid_morphism :
-    forall `{!IsEquiv f}, MonoidPreserving f -> MonoidPreserving (f^-1).
+    forall `{!IsEquiv f}, IsMonoidPreserving f -> IsMonoidPreserving (f^-1).
   Proof.
-  intros;split.
-  - apply _.
-  - apply (Paths.equiv_inj f).
-    rewrite eisretr.
-    rewrite (preserves_mon_unit (f:=f)). reflexivity.
+    intros;split.
+    - apply _.
+    - apply (Paths.equiv_inj f).
+      rewrite eisretr.
+      rewrite (preserves_mon_unit (f:=f)). reflexivity.
   Qed.
 
 End compose_mor.
 
-Hint Extern 4 (SemiGroupPreserving (_ ∘ _)) =>
+Hint Extern 4 (IsSemiGroupPreserving (_ ∘ _)) =>
   class_apply @compose_sg_morphism : typeclass_instances.
-Hint Extern 4 (MonoidPreserving (_ ∘ _)) =>
+Hint Extern 4 (IsMonoidPreserving (_ ∘ _)) =>
   class_apply @compose_monoid_morphism : typeclass_instances.
 
-Hint Extern 4 (SemiGroupPreserving (_^-1)) =>
+Hint Extern 4 (IsSemiGroupPreserving (_^-1)) =>
   class_apply @invert_sg_morphism : typeclass_instances.
-Hint Extern 4 (MonoidPreserving (_^-1)) =>
+Hint Extern 4 (IsMonoidPreserving (_^-1)) =>
   class_apply @invert_monoid_morphism : typeclass_instances.

--- a/theories/Classes/theory/int_abs.v
+++ b/theories/Classes/theory/int_abs.v
@@ -39,7 +39,7 @@ Qed.
 
 Context `{!IntAbs Z N}.
 
-Context `{!SemiRingPreserving (f : N -> Z)}.
+Context `{!IsSemiRingPreserving (f : N -> Z)}.
 
 Lemma int_abs_spec x :
   (0 ≤ x /\ f (int_abs Z N x) = x) |_| (x ≤ 0 /\ f (int_abs Z N x) = -x).

--- a/theories/Classes/theory/integers.v
+++ b/theories/Classes/theory/integers.v
@@ -14,15 +14,15 @@ Require Export
  HoTT.Classes.interfaces.integers.
 
 
-Lemma to_ring_unique `{Integers Z} `{Ring R} (f: Z -> R)
-  {h: SemiRingPreserving f} x
+Lemma to_ring_unique `{Integers Z} `{IsRing R} (f: Z -> R)
+  {h: IsSemiRingPreserving f} x
   : f x = integers_to_ring Z R x.
 Proof.
 symmetry. apply integers_initial.
 Qed.
 
-Lemma to_ring_unique_alt `{Integers Z} `{Ring R} (f g: Z -> R)
-  `{!SemiRingPreserving f} `{!SemiRingPreserving g} x :
+Lemma to_ring_unique_alt `{Integers Z} `{IsRing R} (f g: Z -> R)
+  `{!IsSemiRingPreserving f} `{!IsSemiRingPreserving g} x :
   f x = g x.
 Proof.
 rewrite (to_ring_unique f), (to_ring_unique g);reflexivity.
@@ -35,24 +35,24 @@ change (Compose (integers_to_ring Z2 Z) (integers_to_ring Z Z2) x = id x).
 apply to_ring_unique_alt;apply _.
 Qed.
 
-Lemma morphisms_involutive `{Integers Z} `{Ring R} (f: R -> Z) (g: Z -> R)
-  `{!SemiRingPreserving f} `{!SemiRingPreserving g} x : f (g x) = x.
+Lemma morphisms_involutive `{Integers Z} `{IsRing R} (f: R -> Z) (g: Z -> R)
+  `{!IsSemiRingPreserving f} `{!IsSemiRingPreserving g} x : f (g x) = x.
 Proof. exact (to_ring_unique_alt (f ∘ g) id _). Qed.
 
-Lemma to_ring_twice `{Integers Z} `{Ring R1} `{Ring R2}
+Lemma to_ring_twice `{Integers Z} `{IsRing R1} `{IsRing R2}
   (f : R1 -> R2) (g : Z -> R1) (h : Z -> R2)
-  `{!SemiRingPreserving f} `{!SemiRingPreserving g} `{!SemiRingPreserving h} x
+  `{!IsSemiRingPreserving f} `{!IsSemiRingPreserving g} `{!IsSemiRingPreserving h} x
   : f (g x) = h x.
 Proof. exact (to_ring_unique_alt (f ∘ g) h _). Qed.
 
-Lemma to_ring_self `{Integers Z} (f : Z -> Z) `{!SemiRingPreserving f} x : f x = x.
+Lemma to_ring_self `{Integers Z} (f : Z -> Z) `{!IsSemiRingPreserving f} x : f x = x.
 Proof. exact (to_ring_unique_alt f id _). Qed.
 
 (* A ring morphism from integers to another ring is injective
    if there's an injection in the other direction: *)
-Lemma to_ring_injective `{Integers Z} `{Ring R} (f: R -> Z) (g: Z -> R)
-  `{!SemiRingPreserving f} `{!SemiRingPreserving g}
-  : Injective g.
+Lemma to_ring_injective `{Integers Z} `{IsRing R} (f: R -> Z) (g: Z -> R)
+  `{!IsSemiRingPreserving f} `{!IsSemiRingPreserving g}
+  : IsInjective g.
 Proof.
 intros x y E.
 change (id x = id y).
@@ -61,14 +61,14 @@ apply ap,E.
 Qed.
 
 Instance integers_to_integers_injective `{Integers Z} `{Integers Z2}
-  (f: Z -> Z2) `{!SemiRingPreserving f}
-  : Injective f.
+  (f: Z -> Z2) `{!IsSemiRingPreserving f}
+  : IsInjective f.
 Proof. exact (to_ring_injective (integers_to_ring Z2 Z) _). Qed.
 
 Instance naturals_to_integers_injective `{Funext} `{Univalence}
   `{Integers@{i i i i i i i i} Z} `{Naturals@{i i i i i i i i} N}
-  (f: N -> Z) `{!SemiRingPreserving f}
-  : Injective f.
+  (f: N -> Z) `{!IsSemiRingPreserving f}
+  : IsInjective f.
 Proof.
 intros x y E.
 apply (injective (cast N (NatPair.Z N))).
@@ -79,20 +79,20 @@ Qed.
 
 Section retract_is_int.
   Context `{Funext} `{Univalence}.
-  Context `{Integers Z} `{Ring Z2}
+  Context `{Integers Z} `{IsRing Z2}
     {Z2ap : Apart Z2} {Z2le Z2lt} `{!FullPseudoSemiRingOrder (A:=Z2) Z2le Z2lt}.
-  Context (f : Z -> Z2) `{!IsEquiv f} `{!SemiRingPreserving f}
-    `{!SemiRingPreserving (f^-1)}.
+  Context (f : Z -> Z2) `{!IsEquiv f} `{!IsSemiRingPreserving f}
+    `{!IsSemiRingPreserving (f^-1)}.
 
   (* If we make this an instance, then instance resolution will often loop *)
   Definition retract_is_int_to_ring : IntegersToRing Z2 := fun Z2 _ _ _ _ _ _ =>
     integers_to_ring Z Z2 ∘ f^-1.
 
   Section for_another_ring.
-    Context `{Ring R}.
+    Context `{IsRing R}.
 
-    Instance: SemiRingPreserving (integers_to_ring Z R ∘ f^-1) := {}.
-    Context (h :  Z2 -> R) `{!SemiRingPreserving h}.
+    Instance: IsSemiRingPreserving (integers_to_ring Z R ∘ f^-1) := {}.
+    Context (h :  Z2 -> R) `{!IsSemiRingPreserving h}.
 
     Lemma same_morphism x : (integers_to_ring Z R ∘ f^-1) x = h x.
     Proof.
@@ -177,6 +177,6 @@ destruct (zero_product (integers_to_ring Z (NatPair.Z nat) x)
   rewrite rings.preserves_0. trivial.
 Qed.
 
-Global Instance int_integral_domain : IntegralDomain Z := {}.
+Global Instance int_integral_domain : IsIntegralDomain Z := {}.
 
 End contents.

--- a/theories/Classes/theory/lattices.v
+++ b/theories/Classes/theory/lattices.v
@@ -2,60 +2,60 @@ Require Import
   HoTT.Classes.interfaces.abstract_algebra
   HoTT.Classes.theory.groups.
 
-Instance bounded_sl_is_sl `{BoundedSemiLattice L} : SemiLattice L.
+Instance bounded_sl_is_sl `{IsBoundedSemiLattice L} : IsSemiLattice L.
 Proof.
 repeat (split; try apply _).
 Qed.
 
-Instance bounded_join_sl_is_join_sl `{BoundedJoinSemiLattice L} : JoinSemiLattice L.
+Instance bounded_join_sl_is_join_sl `{IsBoundedJoinSemiLattice L} : IsJoinSemiLattice L.
 Proof.
 repeat (split; try apply _).
 Qed.
 
-Instance bounded_meet_sl_is_meet_sl `{BoundedMeetSemiLattice L} : MeetSemiLattice L.
+Instance bounded_meet_sl_is_meet_sl `{IsBoundedMeetSemiLattice L} : IsMeetSemiLattice L.
 Proof.
 repeat (split; try apply _).
 Qed.
 
-Instance bounded_lattice_is_lattice `{BoundedLattice L} : Lattice L.
+Instance bounded_lattice_is_lattice `{IsBoundedLattice L} : IsLattice L.
 Proof.
 repeat split; apply _.
 Qed.
 
-Instance bounded_sl_mor_is_sl_mor `{H : BoundedJoinPreserving A B f}
-  : JoinPreserving f.
+Instance bounded_sl_mor_is_sl_mor `{H : IsBoundedJoinPreserving A B f}
+  : IsJoinPreserving f.
 Proof.
 red;apply _.
 Qed.
 
-Lemma preserves_join `{JoinPreserving L K f} x y
+Lemma preserves_join `{IsJoinPreserving L K f} x y
   : f (x ⊔ y) = f x ⊔ f y.
 Proof. apply preserves_sg_op. Qed.
 
-Lemma preserves_bottom `{BoundedJoinPreserving L K f}
+Lemma preserves_bottom `{IsBoundedJoinPreserving L K f}
   : f ⊥ = ⊥.
 Proof. apply preserves_mon_unit. Qed.
 
-Lemma preserves_meet `{MeetPreserving L K f} x y :
+Lemma preserves_meet `{IsMeetPreserving L K f} x y :
   f (x ⊓ y) = f x ⊓ f y.
 Proof. apply preserves_sg_op. Qed.
 
 Section bounded_join_sl_props.
-  Context `{BoundedJoinSemiLattice L}.
+  Context `{IsBoundedJoinSemiLattice L}.
 
   Instance join_bottom_l: LeftIdentity (⊔) ⊥ := _.
   Instance join_bottom_r: RightIdentity (⊔) ⊥ := _.
 End bounded_join_sl_props.
 
 Section lattice_props.
-  Context `{Lattice L}.
+  Context `{IsLattice L}.
 
   Definition meet_join_absorption x y : x ⊓ (x ⊔ y) = x := absorption x y.
   Definition join_meet_absorption x y : x ⊔ (x ⊓ y) = x := absorption x y.
 End lattice_props.
 
 Section distributive_lattice_props.
-  Context `{DistributiveLattice L}.
+  Context `{IsDistributiveLattice L}.
 
   Instance join_meet_distr_l: LeftDistribute (⊔) (⊓).
   Proof. exact (join_meet_distr_l _). Qed.
@@ -105,7 +105,7 @@ Section distributive_lattice_props.
 End distributive_lattice_props.
 
 Section lower_bounded_lattice.
-  Context `{Lattice L} `{Bottom L} `{!BoundedJoinSemiLattice L}.
+  Context `{IsLattice L} `{Bottom L} `{!IsBoundedJoinSemiLattice L}.
 
   Global Instance meet_bottom_l: LeftAbsorb (⊓) ⊥.
   Proof.
@@ -122,11 +122,11 @@ Section lower_bounded_lattice.
 End lower_bounded_lattice.
 
 Section from_another_sl.
-  Context `{SemiLattice A} `{IsHSet B}
-   `{Bop : SgOp B} (f : B -> A) `{!Injective f}
+  Context `{IsSemiLattice A} `{IsHSet B}
+   `{Bop : SgOp B} (f : B -> A) `{!IsInjective f}
    (op_correct : forall x y, f (x & y) = f x & f y).
 
-  Lemma projected_sl: SemiLattice B.
+  Lemma projected_sl: IsSemiLattice B.
   Proof.
   split.
   - apply (projected_com_sg f). assumption.
@@ -136,12 +136,12 @@ Section from_another_sl.
 End from_another_sl.
 
 Section from_another_bounded_sl.
-  Context `{BoundedSemiLattice A} `{IsHSet B}
-   `{Bop : SgOp B} `{Bunit : MonUnit B} (f : B -> A) `{!Injective f}
+  Context `{IsBoundedSemiLattice A} `{IsHSet B}
+   `{Bop : SgOp B} `{Bunit : MonUnit B} (f : B -> A) `{!IsInjective f}
    (op_correct : forall x y, f (x & y) = f x & f y)
    (unit_correct : f mon_unit = mon_unit).
 
-  Lemma projected_bounded_sl: BoundedSemiLattice B.
+  Lemma projected_bounded_sl: IsBoundedSemiLattice B.
   Proof.
   split.
   - apply (projected_com_monoid f);trivial.
@@ -151,17 +151,17 @@ Section from_another_bounded_sl.
   Qed.
 End from_another_bounded_sl.
 
-Instance id_join_sl_morphism `{JoinSemiLattice A} : JoinPreserving (@id A)
+Instance id_join_sl_morphism `{IsJoinSemiLattice A} : IsJoinPreserving (@id A)
   := {}.
 
-Instance id_meet_sl_morphism `{MeetSemiLattice A} : MeetPreserving (@id A)
+Instance id_meet_sl_morphism `{IsMeetSemiLattice A} : IsMeetPreserving (@id A)
   := {}.
 
-Instance id_bounded_join_sl_morphism `{BoundedJoinSemiLattice A}
-  : BoundedJoinPreserving (@id A)
+Instance id_bounded_join_sl_morphism `{IsBoundedJoinSemiLattice A}
+  : IsBoundedJoinPreserving (@id A)
   := {}.
 
-Instance id_lattice_morphism `{Lattice A} : LatticePreserving (@id A)
+Instance id_lattice_morphism `{IsLattice A} : IsLatticePreserving (@id A)
   := {}.
 
 Section morphism_composition.
@@ -171,73 +171,73 @@ Section morphism_composition.
     (f : A -> B) (g : B -> C).
 
   Instance compose_join_sl_morphism:
-    JoinPreserving f -> JoinPreserving g ->
-    JoinPreserving (g ∘ f).
+    IsJoinPreserving f -> IsJoinPreserving g ->
+    IsJoinPreserving (g ∘ f).
   Proof.
   red; apply _.
   Qed.
 
   Instance compose_meet_sl_morphism:
-    MeetPreserving f -> MeetPreserving g ->
-    MeetPreserving (g ∘ f).
+    IsMeetPreserving f -> IsMeetPreserving g ->
+    IsMeetPreserving (g ∘ f).
   Proof.
   red;apply _.
   Qed.
 
   Instance compose_bounded_join_sl_morphism:
-    BoundedJoinPreserving f -> BoundedJoinPreserving g ->
-    BoundedJoinPreserving (g ∘ f).
+    IsBoundedJoinPreserving f -> IsBoundedJoinPreserving g ->
+    IsBoundedJoinPreserving (g ∘ f).
   Proof.
   red; apply _.
   Qed.
 
   Instance compose_lattice_morphism:
-    LatticePreserving f -> LatticePreserving g -> LatticePreserving (g ∘ f).
+    IsLatticePreserving f -> IsLatticePreserving g -> IsLatticePreserving (g ∘ f).
   Proof.
   split; apply _.
   Qed.
 
   Instance invert_join_sl_morphism:
-    forall `{!IsEquiv f}, JoinPreserving f ->
-    JoinPreserving (f^-1).
+    forall `{!IsEquiv f}, IsJoinPreserving f ->
+    IsJoinPreserving (f^-1).
   Proof.
   red; apply _.
   Qed.
 
   Instance invert_meet_sl_morphism:
-    forall `{!IsEquiv f}, MeetPreserving f ->
-    MeetPreserving (f^-1).
+    forall `{!IsEquiv f}, IsMeetPreserving f ->
+    IsMeetPreserving (f^-1).
   Proof.
   red; apply _.
   Qed.
 
   Instance invert_bounded_join_sl_morphism:
-    forall `{!IsEquiv f}, BoundedJoinPreserving f ->
-    BoundedJoinPreserving (f^-1).
+    forall `{!IsEquiv f}, IsBoundedJoinPreserving f ->
+    IsBoundedJoinPreserving (f^-1).
   Proof.
   red; apply _.
   Qed.
 
   Instance invert_lattice_morphism:
-    forall `{!IsEquiv f}, LatticePreserving f -> LatticePreserving (f^-1).
+    forall `{!IsEquiv f}, IsLatticePreserving f -> IsLatticePreserving (f^-1).
   Proof.
   split; apply _.
   Qed.
 End morphism_composition.
 
-Hint Extern 4 (JoinPreserving (_ ∘ _)) =>
+Hint Extern 4 (IsJoinPreserving (_ ∘ _)) =>
   class_apply @compose_join_sl_morphism : typeclass_instances.
-Hint Extern 4 (MeetPreserving (_ ∘ _)) =>
+Hint Extern 4 (IsMeetPreserving (_ ∘ _)) =>
   class_apply @compose_meet_sl_morphism : typeclass_instances.
-Hint Extern 4 (BoundedJoinPreserving (_ ∘ _)) =>
+Hint Extern 4 (IsBoundedJoinPreserving (_ ∘ _)) =>
   class_apply @compose_bounded_join_sl_morphism : typeclass_instances.
-Hint Extern 4 (LatticePreserving (_ ∘ _)) =>
+Hint Extern 4 (IsLatticePreserving (_ ∘ _)) =>
   class_apply @compose_lattice_morphism : typeclass_instances.
-Hint Extern 4 (JoinPreserving (_^-1)) =>
+Hint Extern 4 (IsJoinPreserving (_^-1)) =>
   class_apply @invert_join_sl_morphism : typeclass_instances.
-Hint Extern 4 (MeetPreserving (_^-1)) =>
+Hint Extern 4 (IsMeetPreserving (_^-1)) =>
   class_apply @invert_meet_sl_morphism : typeclass_instances.
-Hint Extern 4 (BoundedJoinPreserving (_^-1)) =>
+Hint Extern 4 (IsBoundedJoinPreserving (_^-1)) =>
   class_apply @invert_bounded_join_sl_morphism : typeclass_instances.
-Hint Extern 4 (LatticePreserving (_^-1)) =>
+Hint Extern 4 (IsLatticePreserving (_^-1)) =>
   class_apply @invert_lattice_morphism : typeclass_instances.

--- a/theories/Classes/theory/naturals.v
+++ b/theories/Classes/theory/naturals.v
@@ -13,15 +13,15 @@ Require Export
 (* This grabs a coercion. *)
 Import SemiRings.
 
-Lemma to_semiring_unique `{Naturals N} `{SemiRing SR} (f: N -> SR)
-  `{!SemiRingPreserving f} x
+Lemma to_semiring_unique `{Naturals N} `{IsSemiRing SR} (f: N -> SR)
+  `{!IsSemiRingPreserving f} x
   : f x = naturals_to_semiring N SR x.
 Proof.
 symmetry. apply naturals_initial.
 Qed.
 
-Lemma to_semiring_unique_alt `{Naturals N} `{SemiRing SR} (f g: N -> SR)
-  `{!SemiRingPreserving f} `{!SemiRingPreserving g} x
+Lemma to_semiring_unique_alt `{Naturals N} `{IsSemiRing SR} (f g: N -> SR)
+  `{!IsSemiRingPreserving f} `{!IsSemiRingPreserving g} x
   : f x = g x.
 Proof.
 rewrite (to_semiring_unique f), (to_semiring_unique g);reflexivity.
@@ -34,23 +34,23 @@ change (Compose (naturals_to_semiring N2 N) (naturals_to_semiring N N2) x = id x
 apply to_semiring_unique_alt;apply _.
 Qed.
 
-Lemma morphisms_involutive `{Naturals N} `{SemiRing R} (f : R -> N) (g : N -> R)
-  `{!SemiRingPreserving f} `{!SemiRingPreserving g} x : f (g x) = x.
+Lemma morphisms_involutive `{Naturals N} `{IsSemiRing R} (f : R -> N) (g : N -> R)
+  `{!IsSemiRingPreserving f} `{!IsSemiRingPreserving g} x : f (g x) = x.
 Proof. exact (to_semiring_unique_alt (f ∘ g) id _). Qed.
 
-Lemma to_semiring_twice `{Naturals N} `{SemiRing R1} `{SemiRing R2}
+Lemma to_semiring_twice `{Naturals N} `{IsSemiRing R1} `{IsSemiRing R2}
   (f : R1 -> R2) (g : N -> R1) (h : N -> R2)
-  `{!SemiRingPreserving f} `{!SemiRingPreserving g} `{!SemiRingPreserving h} x
+  `{!IsSemiRingPreserving f} `{!IsSemiRingPreserving g} `{!IsSemiRingPreserving h} x
   : f (g x) = h x.
 Proof. exact (to_semiring_unique_alt (f ∘ g) h _). Qed.
 
-Lemma to_semiring_self `{Naturals N} (f : N -> N) `{!SemiRingPreserving f} x
+Lemma to_semiring_self `{Naturals N} (f : N -> N) `{!IsSemiRingPreserving f} x
   : f x = x.
 Proof. exact (to_semiring_unique_alt f id _). Qed.
 
-Lemma to_semiring_injective `{Naturals N} `{SemiRing A}
-   (f: A -> N) (g: N -> A) `{!SemiRingPreserving f} `{!SemiRingPreserving g}
-   : Injective g.
+Lemma to_semiring_injective `{Naturals N} `{IsSemiRing A}
+   (f: A -> N) (g: N -> A) `{!IsSemiRingPreserving f} `{!IsSemiRingPreserving g}
+   : IsInjective g.
 Proof.
 intros x y E.
 change (id x = id y).
@@ -59,26 +59,26 @@ apply ap,E.
 Qed.
 
 Instance naturals_to_naturals_injective `{Naturals N} `{Naturals N2} (f: N -> N2)
-  `{!SemiRingPreserving f}
-  : Injective f | 15.
+  `{!IsSemiRingPreserving f}
+  : IsInjective f | 15.
 Proof. exact (to_semiring_injective (naturals_to_semiring N2 N) _). Qed.
 
 Section retract_is_nat.
-  Context `{Naturals N} `{SemiRing SR}
+  Context `{Naturals N} `{IsSemiRing SR}
     {SRap : Apart SR} {SRle SRlt} `{!FullPseudoSemiRingOrder (A:=SR) SRle SRlt}.
   Context (f : N -> SR) `{!IsEquiv f}
-    `{!SemiRingPreserving f} `{!SemiRingPreserving (f^-1)}.
+    `{!IsSemiRingPreserving f} `{!IsSemiRingPreserving (f^-1)}.
 
   (* If we make this an instance, instance resolution will loop *)
   Definition retract_is_nat_to_sr : NaturalsToSemiRing SR
     := fun R _ _ _ _ _ => naturals_to_semiring N R ∘ f^-1.
 
   Section for_another_semirings.
-    Context `{SemiRing R}.
+    Context `{IsSemiRing R}.
 
-    Instance: SemiRingPreserving (naturals_to_semiring N R ∘ f^-1) := {}.
+    Instance: IsSemiRingPreserving (naturals_to_semiring N R ∘ f^-1) := {}.
 
-    Context (h :  SR -> R) `{!SemiRingPreserving h}.
+    Context (h :  SR -> R) `{!IsSemiRingPreserving h}.
 
     Lemma same_morphism x : (naturals_to_semiring N R ∘ f^-1) x = h x.
     Proof.
@@ -220,7 +220,7 @@ apply decidablepaths_equiv with nat (naturals_to_semiring nat N);apply _.
 Qed.
 
 Section with_a_ring.
-  Context `{Ring R} `{!SemiRingPreserving (f : N -> R)} `{!Injective f}.
+  Context `{IsRing R} `{!IsSemiRingPreserving (f : N -> R)} `{!IsInjective f}.
 
   Lemma to_ring_zero_sum x y :
     -f x = f y -> x = 0 /\ y = 0.

--- a/theories/Classes/theory/rings.v
+++ b/theories/Classes/theory/rings.v
@@ -72,7 +72,7 @@ Section strong_cancellation.
 End strong_cancellation.
 
 Section semiring_props.
-  Context `{SemiRing R}.
+  Context `{IsSemiRing R}.
 (*   Add Ring SR : (stdlib_semiring_theory R). *)
 
   Instance mult_ne_0 `{!NoZeroDivisors R} x y
@@ -117,7 +117,7 @@ Section semiring_props.
   apply _.
   Qed.
 
-  Global Instance: forall r : R, @MonoidPreserving R R (+) (+) 0 0 (r *.).
+  Global Instance: forall r : R, @IsMonoidPreserving R R (+) (+) 0 0 (r *.).
   Proof.
   repeat (constructor; try apply _).
   - red. apply distribute_l.
@@ -129,7 +129,7 @@ End semiring_props.
 Hint Extern 3 (PropHolds (_ * _ <> 0)) => eapply @mult_ne_0 : typeclass_instances.
 
 Section semiringmor_props.
-  Context `{SemiRingPreserving A B f}.
+  Context `{IsSemiRingPreserving A B f}.
 
   Lemma preserves_0: f 0 = 0.
   Proof. apply preserves_mon_unit. Qed.
@@ -161,24 +161,24 @@ Section semiringmor_props.
   reflexivity.
   Qed.
 
-  Context `{!Injective f}.
-  Instance injective_ne_0 x : PropHolds (x <> 0) -> PropHolds (f x <> 0).
+  Context `{!IsInjective f}.
+  Instance isinjective_ne_0 x : PropHolds (x <> 0) -> PropHolds (f x <> 0).
   Proof.
-  intros. rewrite <-preserves_0. apply (injective_ne f).
+  intros. rewrite <-preserves_0. apply (isinjective_ne f).
   assumption.
   Qed.
 
   Lemma injective_ne_1 x : x <> 1 -> f x <> 1.
   Proof.
   intros. rewrite <-preserves_1.
-  apply (injective_ne f).
+  apply (isinjective_ne f).
   assumption.
   Qed.
 End semiringmor_props.
 
 (* Due to bug #2528 *)
 Hint Extern 12 (PropHolds (_ _ <> 0)) =>
-  eapply @injective_ne_0 : typeclass_instances.
+  eapply @isinjective_ne_0 : typeclass_instances.
 
 (* Lemma stdlib_ring_theory R `{Ring R} :
   Ring_theory.ring_theory 0 1 (+) (.*.) (fun x y => x - y) (-) (=).
@@ -187,7 +187,7 @@ Qed.
 *)
 
 Section ring_props.
-  Context `{Ring R}.
+  Context `{IsRing R}.
 
 (*   Add Ring R: (stdlib_ring_theory R). *)
 
@@ -202,7 +202,7 @@ Section ring_props.
   - apply ap. apply right_identity.
   Qed.
 
-  Global Instance Ring_Semi: SemiRing R.
+  Global Instance Ring_Semi: IsSemiRing R.
   Proof.
   repeat (constructor; try apply _).
   Qed.
@@ -354,7 +354,7 @@ Section ring_props.
 End ring_props.
 
 Section integral_domain_props.
-  Context `{IntegralDomain R}.
+  Context `{IsIntegralDomain R}.
 
   Instance intdom_nontrivial_apart `{Apart R} `{!TrivialApart R} :
     PropHolds (1 ≶ 0).
@@ -368,7 +368,7 @@ Hint Extern 6 (PropHolds (1 ≶ 0)) =>
   eapply @intdom_nontrivial_apart : typeclass_instances.
 
 Section ringmor_props.
-  Context `{Ring A} `{Ring B} `{!SemiRingPreserving (f : A -> B)}.
+  Context `{IsRing A} `{IsRing B} `{!IsSemiRingPreserving (f : A -> B)}.
 
   Definition preserves_negate x : f (-x) = -f x := groups.preserves_negate x.
   (* alias for convenience *)
@@ -379,7 +379,7 @@ Section ringmor_props.
   apply preserves_plus.
   Qed.
 
-  Lemma injective_preserves_0 : (forall x, f x = 0 -> x = 0) -> Injective f.
+  Lemma injective_preserves_0 : (forall x, f x = 0 -> x = 0) -> IsInjective f.
   Proof.
   intros E1 x y E.
   apply equal_by_zero_sum.
@@ -390,14 +390,14 @@ Section ringmor_props.
 End ringmor_props.
 
 Section from_another_ring.
-  Context `{Ring A} `{IsHSet B}
+  Context `{IsRing A} `{IsHSet B}
    `{Bplus : Plus B} `{Zero B} `{Bmult : Mult B} `{One B} `{Bnegate : Negate B}
-    (f : B -> A) `{!Injective f}
+    (f : B -> A) `{!IsInjective f}
     (plus_correct : forall x y, f (x + y) = f x + f y) (zero_correct : f 0 = 0)
     (mult_correct : forall x y, f (x * y) = f x * f y) (one_correct : f 1 = 1)
     (negate_correct : forall x, f (-x) = -f x).
 
-  Lemma projected_ring: Ring B.
+  Lemma projected_ring: IsRing B.
   Proof.
   split.
   - apply (groups.projected_ab_group f);assumption.
@@ -443,7 +443,7 @@ Section from_stdlib_ring_theory.
   Qed.
 End from_stdlib_ring_theory. *)
 
-Instance id_sr_morphism `{SemiRing A}: SemiRingPreserving (@id A) := {}.
+Instance id_sr_morphism `{IsSemiRing A}: IsSemiRingPreserving (@id A) := {}.
 
 Section morphism_composition.
   Context `{Mult A} `{Plus A} `{One A} `{Zero A}
@@ -452,19 +452,19 @@ Section morphism_composition.
     (f : A -> B) (g : B -> C).
 
   Instance compose_sr_morphism:
-    SemiRingPreserving f -> SemiRingPreserving g -> SemiRingPreserving (g ∘ f).
+    IsSemiRingPreserving f -> IsSemiRingPreserving g -> IsSemiRingPreserving (g ∘ f).
   Proof.
   split; apply _.
   Qed.
 
   Instance invert_sr_morphism:
-    forall `{!IsEquiv f}, SemiRingPreserving f -> SemiRingPreserving (f^-1).
+    forall `{!IsEquiv f}, IsSemiRingPreserving f -> IsSemiRingPreserving (f^-1).
   Proof.
   split; apply _.
   Qed.
 End morphism_composition.
 
-Hint Extern 4 (SemiRingPreserving (_ ∘ _)) =>
+Hint Extern 4 (IsSemiRingPreserving (_ ∘ _)) =>
   class_apply @compose_sr_morphism : typeclass_instances.
-Hint Extern 4 (SemiRingPreserving (_^-1)) =>
+Hint Extern 4 (IsSemiRingPreserving (_^-1)) =>
   class_apply @invert_sr_morphism : typeclass_instances.

--- a/theories/Homotopy/HomotopyGroup.v
+++ b/theories/Homotopy/HomotopyGroup.v
@@ -1,8 +1,8 @@
 Require Import Basics.
 Require Import Types.
-Require Import HoTT.Truncations.
 Require Import Pointed.
-Require Import abstract_algebra.
+Require Import Algebra.Group.
+Require Import Truncations.
 Require Import Spaces.Nat.
 
 Import TrM.
@@ -65,7 +65,7 @@ Section PiGroup.
     apply ap, concat_pV.
   Defined.
 
-  Global Instance pi_is_Group : Group (Pi n.+1 X).
+  Global Instance pi_is_Group : IsGroup (Pi n.+1 X).
   Proof.
     repeat split; exact _.
   Defined.
@@ -78,9 +78,9 @@ Proof.
   apply ap, eckmann_hilton.
 Defined.
 
-Global Instance pi_is_AbGroup n X : AbGroup (Pi n.+2 X).
+Global Instance pi_is_AbGroup n X : IsAbGroup (Pi n.+2 X).
 Proof.
-  serapply Build_AbGroup.
+  serapply Build_IsAbGroup.
 Defined.
 
 Section PiFunctor.
@@ -99,9 +99,9 @@ Section PiFunctor.
     exact f.
   Defined.
 
-  Global Instance functor_pi_homomorphism : MonoidPreserving functor_pi.
+  Global Instance functor_pi_homomorphism : IsMonoidPreserving functor_pi.
   Proof.
-    apply Build_MonoidPreserving.
+    apply Build_IsMonoidPreserving.
     + intros x y.
       strip_truncations.
       apply path_Tr, tr, loops_functor_pp.
@@ -122,8 +122,4 @@ Proof.
   apply Trunc_functor_equiv.
   by refine (pequiv_compose _ (iterated_loops_prod _ _)).
 Qed.
-
-
-
-
 

--- a/theories/Spaces/Card.v
+++ b/theories/Spaces/Card.v
@@ -80,7 +80,7 @@ Section contents.
   Instance leftabsorb_card : LeftAbsorb mult_card zero_card.
   Proof. reduce. apply prod_empty_l. Defined.
 
-  Global Instance semiring_card : SemiRing Card.
+  Global Instance issemiring_card : IsSemiRing Card.
   Proof.
     repeat split; try apply _.
     - repeat intro. simpl_ops.


### PR DESCRIPTION
As of the time of submitting this PR there will be a lot of commits that come from #1106. The only commits that matter here are the last two. I trust that once #1106 is merged, I can rebase and make this easier to review. You should be able to click on the individual commits to only see the changes there.

I can summarize the changes as follows:

 * Changed X to IsX for many properties in hottclasses. This may have not been done perfectly and I don't think I caught them all but I have done most of them. This closes #1107. I have also shown that many of these properties are hprops, i.e. (what used to be Group but now) IsGroup is a hprop.

* I have started a file called Group.v in Algebra. The purpose of this file is to be a basic start on group related things. It defines what a group is (basically a record which is the total space of IsGroup). There are basic properties of groups in there and documented too. If you want to do group theory in the HoTT library, you can just import this file and you should have everything important. Later if we develop any actual group theory, say Lagrange's theorem, we can store such results in a separate directory. But you would expect that all group related things use Group.v.

* Subgroup.v defines subgroups, normal subgroups and collects results about them. Notably I have shown that normal subgroups give a congruence.

* Congruence.v defines a congruence. Classically this is required to be an equivalence relation, but I have just defined it to mean op preserving. This might bite me later so I have made a note of it here and in the file.

* QuotientGroup.v defines the group given by the quotient of a group by a congruence relation. It also defines the quotient of a group by a normal subgroup as the quotient by the congruence corresponding to the normal subgroup.

* AbelianGroup.v defines abelian groups, the property of being an abelianization and a construction of abelianization using a HIT. We define this as a set-coequalizer and it allows us to prove that abelianizations exist and are notably surjective. This was a key part in the argument that was needed to finish #1086. So once this gets merged I will send another PR for Eilenberg-MacLane spaces that is complete.

There are things I would like to do but I couldn't manage.

* Define order of a group. I imagine this will only require Card.v and when the cardinality is finite, we need notions of divisibility. This will eventually let us prove Lagrange's theorem.

* Show that the type of group isomorphisms is equivalent to the path space of groups. This will look something like:
```coq
Definition equiv_path_group {U : Univalence} {G H : Group}
  : GroupIsomorphism G H <~> G = H.
Proof.
  refine (_ oE (issig_GroupIsomorphism _ _)^-1).
  eqp_issig_contr issig_group.
Admitted.
```
but I didn't have enough time to finish it. Since the property of being a group is a proposition we essentially need to show that the sigma type containing a type, an identity element, an inverse map and an operation are equivalent to the path space using univalence.