### PR TITLE
Various truncation lemmas

### DIFF
--- a/theories/Basics/Notations.v
+++ b/theories/Basics/Notations.v
@@ -48,6 +48,8 @@ Reserved Notation "n .+2" (at level 2, left associativity, format "n .+2").
 Reserved Notation "n .+3" (at level 2, left associativity, format "n .+3").
 Reserved Notation "n .+4" (at level 2, left associativity, format "n .+4").
 Reserved Notation "n .+5" (at level 2, left associativity, format "n .+5").
+Reserved Notation "n '.-1'" (at level 2, left associativity, format "n .-1").
+Reserved Notation "n '.-2'" (at level 2, left associativity, format "n .-2").
 Reserved Notation "n -Type" (at level 1).
 Reserved Notation "p ..1" (at level 3).
 Reserved Notation "p ..2" (at level 3).

--- a/theories/Basics/Trunc.v
+++ b/theories/Basics/Trunc.v
@@ -64,7 +64,7 @@ Fixpoint trunc_index_inc (n : nat) (k : trunc_index)
 Definition trunc_index_pred : trunc_index -> trunc_index.
 Proof.
   intros [|m].
-  1: exact -2.
+  1: exact (-2).
   exact m.
 Defined.
 
@@ -119,14 +119,14 @@ Fixpoint trunc_index_min (n m : trunc_index)
   : trunc_index.
 Proof.
   destruct n.
-  1: exact -2.
+  1: exact (-2).
   destruct m.
-  1: exact -2.
+  1: exact (-2).
   exact (trunc_index_min n m).+1.
 Defined.
 
 Definition trunc_index_min_minus_two n
-  : trunc_index_min n -2 = -2.
+  : trunc_index_min n (-2) = -2.
 Proof.
   by destruct n.
 Defined.

--- a/theories/Basics/Trunc.v
+++ b/theories/Basics/Trunc.v
@@ -17,6 +17,25 @@ Fixpoint trunc_index_add (m n : trunc_index) : trunc_index
 
 Notation "m +2+ n" := (trunc_index_add m n) : trunc_scope.
 
+Definition trunc_index_add_minus_two m
+  : m +2+ -2 = m.
+Proof.
+  induction m.
+  1: reflexivity.
+  cbn; apply ap.
+  assumption.
+Defined.
+
+Definition trunc_index_add_succ m n
+  : m +2+ n.+1 = (m +2+ n).+1.
+Proof.
+  revert m.
+  induction n; induction m.
+  1,3: reflexivity.
+  all: cbn; apply ap.
+  all: assumption.
+Defined.
+
 Fixpoint trunc_index_leq (m n : trunc_index) : Type0
   := match m, n with
        | -2, _ => Unit
@@ -24,10 +43,140 @@ Fixpoint trunc_index_leq (m n : trunc_index) : Type0
        | m'.+1, n'.+1 => trunc_index_leq m' n'
      end.
 
+Existing Class trunc_index_leq.
+
 Notation "m <= n" := (trunc_index_leq m n) : trunc_scope.
 
-Fixpoint trunc_index_inc (n : nat) (k : trunc_index) : trunc_index
-  := match n with O => k | S m => (trunc_index_inc m k).+1 end.
+Global Instance trunc_index_leq_minus_two_n n : -2 <= n := tt.
+
+Global Instance trunc_index_leq_succ n : n <= n.+1.
+Proof.
+  by induction n as [|n IHn] using trunc_index_ind.
+Defined.
+
+Fixpoint trunc_index_inc (n : nat) (k : trunc_index)
+  : trunc_index
+  := match n with
+      | O => k
+      | S m => (trunc_index_inc m k).+1
+    end.
+
+Definition trunc_index_pred : trunc_index -> trunc_index.
+Proof.
+  intros [|m].
+  1: exact -2.
+  exact m.
+Defined.
+
+Notation "n '.-1'" := (trunc_index_pred n) : trunc_scope.
+Notation "n '.-2'" := (n.-1.-1) : trunc_scope.
+
+Definition trunc_index_leq_minus_two {n}
+  : n <= -2 -> n = -2.
+Proof.
+  destruct n.
+  1: reflexivity.
+  contradiction.
+Defined.
+
+Definition trunc_index_leq_succ' n m
+  : n <= m -> n <= m.+1.
+Proof.
+  revert m.
+  induction n as [|n IHn] using trunc_index_ind.
+  1: exact _.
+  intros m p; cbn.
+  induction m as [|m IHm] using trunc_index_ind.
+  1: destruct p.
+  apply IHn, p.
+Defined.
+
+Global Instance trunc_index_leq_refl
+  : Reflexive trunc_index_leq.
+Proof.
+  intro n.
+  by induction n as [|n IHn] using trunc_index_ind.
+Defined.
+
+Global Instance trunc_index_leq_transitive
+  : Transitive trunc_index_leq.
+Proof.
+  intros a b c p q.
+  revert b a c p q.
+  induction b as [|b IHb] using trunc_index_ind.
+  { intros a c p.
+    by destruct (trunc_index_leq_minus_two p). }
+  induction a as [|a IHa] using trunc_index_ind;
+  induction c as [|c IHc] using trunc_index_ind.
+  all: intros.
+  1,2: exact tt.
+  1: contradiction.
+  cbn in p, q; cbn.
+  by apply IHb.
+Defined.
+
+Fixpoint trunc_index_min (n m : trunc_index)
+  : trunc_index.
+Proof.
+  destruct n.
+  1: exact -2.
+  destruct m.
+  1: exact -2.
+  exact (trunc_index_min n m).+1.
+Defined.
+
+Definition trunc_index_min_minus_two n
+  : trunc_index_min n -2 = -2.
+Proof.
+  by destruct n.
+Defined.
+
+Definition trunc_index_min_swap n m
+  : trunc_index_min n m = trunc_index_min m n.
+Proof.
+  revert m.
+  induction n.
+  { intro.
+    symmetry.
+    apply trunc_index_min_minus_two. }
+  induction m.
+  1: reflexivity.
+  cbn; apply ap, IHn.
+Defined.
+
+Definition trunc_index_min_path n m
+  : (trunc_index_min n m = n) + (trunc_index_min n m = m).
+Proof.
+  revert m.
+  induction n.
+  1: by intro; apply inl.
+  induction m.
+  1: by apply inr.
+  destruct (IHn m).
+  1: apply inl.
+  2: apply inr.
+  1,2: cbn; by apply ap.
+Defined.
+
+Definition trunc_index_min_leq_left (n m : trunc_index)
+  : trunc_index_min n m <= n.
+Proof.
+  revert n m.
+  refine (trunc_index_ind _ _ _); [ | intros n IHn ].
+  all: refine (trunc_index_ind _ _ _); [ | intros m IHm ].
+  all: try exact tt.
+  exact (IHn m).
+Defined.
+
+Definition trunc_index_min_leq_right (n m : trunc_index)
+  : trunc_index_min n m <= m.
+Proof.
+  revert n m.
+  refine (trunc_index_ind _ _ _); [ | intros n IHn ].
+  all: refine (trunc_index_ind _ _ _); [ | intros m IHm ].
+  all: try exact tt.
+  exact (IHn m).
+Defined.
 
 (** ** Truncatedness proper. *)
 
@@ -36,7 +185,8 @@ Definition contr_trunc_minus_two `{H : IsTrunc (-2) A} : Contr A
   := H.
 
 (** Truncation levels are cumulative. *)
-Global Instance trunc_succ `{IsTrunc n A} : IsTrunc n.+1 A | 1000.
+Global Instance trunc_succ `{IsTrunc n A}
+  : IsTrunc n.+1 A | 1000.
 Proof.
   generalize dependent A.
   simple_induction n n IH; simpl; intros A H x y.
@@ -52,8 +202,18 @@ Proof.
   + exact IHn.+1.
 Defined.
 
+Lemma nat_to_trunc_index_2_eq n
+  : nat_to_trunc_index_2 n.+2 = nat_to_trunc_index n.
+Proof.
+  induction n.
+  1: reflexivity.
+  cbn; apply ap.
+  assumption.
+Defined.
+
 (** This could be an [Instance] (with very high priority, so it doesn't get applied trivially).  However, we haven't given typeclass search any hints allowing it to solve goals like [m <= n], so it would only ever be used trivially.  *)
-Definition trunc_leq {m n} (Hmn : m <= n) `{IsTrunc m A} : IsTrunc n A.
+Definition trunc_leq {m n} (Hmn : m <= n) `{IsTrunc m A}
+  : IsTrunc n A.
 Proof.
   generalize dependent A; generalize dependent m.
   simple_induction n n' IH;
@@ -73,7 +233,8 @@ Definition trunc_contr {n} {A} `{Contr A} : IsTrunc n.+1 A
 Definition trunc_hprop {n} {A} `{IsHProp A} : IsTrunc n.+2 A
   := (@trunc_leq (-1) n.+2 tt _ _).
 
-Definition trunc_hset {n} {A} `{IsHSet A} : IsTrunc n.+3 A
+Definition trunc_hset {n} {A} `{IsHSet A}
+  : IsTrunc n.+3 A
   := (@trunc_leq 0 n.+3 tt _ _).
 
 (** Consider the preceding definitions as instances for typeclass search, but only if the requisite hypothesis is already a known assumption; otherwise they result in long or interminable searches. *)
@@ -92,7 +253,8 @@ Proof.
   simple_induction n n IH; simpl; intros A ? B f ?.
   - exact (contr_equiv _ f).
   - intros x y.
-    exact (IH (f^-1 x = f^-1 y) (H (f^-1 x) (f^-1 y)) (x = y) ((ap (f^-1))^-1) _).
+    exact (IH (f^-1 x = f^-1 y) (H (f^-1 x) (f^-1 y))
+      (x = y) ((ap (f^-1))^-1) _).
 Qed.
 
 Definition trunc_equiv' A {B} (f : A <~> B) `{IsTrunc n A}
@@ -101,8 +263,8 @@ Definition trunc_equiv' A {B} (f : A <~> B) `{IsTrunc n A}
 
 (** ** Truncated morphisms *)
 
-Class IsTruncMap (n : trunc_index) {X Y : Type} (f : X -> Y) :=
-  istruncmap_fiber : forall y:Y, IsTrunc n (hfiber f y).
+Class IsTruncMap (n : trunc_index) {X Y : Type} (f : X -> Y)
+  := istruncmap_fiber : forall y:Y, IsTrunc n (hfiber f y).
 
 Global Existing Instance istruncmap_fiber.
 
@@ -149,7 +311,8 @@ Proof.
 Defined.
 
 (** If inhabitation implies contractibility, then we have an h-proposition.  We probably won't often have a hypothesis of the form [A -> Contr A], so we make sure we give priority to other instances. *)
-Global Instance hprop_inhabited_contr (A : Type) : (A -> Contr A) -> IsHProp A | 10000.
+Global Instance hprop_inhabited_contr (A : Type)
+  : (A -> Contr A) -> IsHProp A | 10000.
 Proof.
   intros H x y.
   pose (C := H x).
@@ -157,13 +320,15 @@ Proof.
 Defined.
 
 (** Any two points in an hprop are connected by a path. *)
-Theorem path_ishprop `{H : IsHProp A} : forall x y : A, x = y.
+Theorem path_ishprop `{H : IsHProp A}
+  : forall x y : A, x = y.
 Proof.
   apply H.
 Defined.
 
 (** Conversely, this property characterizes hprops. *)
-Theorem hprop_allpath (A : Type) : (forall (x y : A), x = y) -> IsHProp A.
+Theorem hprop_allpath (A : Type)
+  : (forall (x y : A), x = y) -> IsHProp A.
   intros H x y.
   pose (C := Build_Contr A x (H x)).
   apply contr_paths_contr.
@@ -172,7 +337,7 @@ Defined.
 (** Two propositions are equivalent as soon as there are maps in both directions. *)
 Definition isequiv_iff_hprop `{IsHProp A} `{IsHProp B}
   (f : A -> B) (g : B -> A)
-: IsEquiv f.
+  : IsEquiv f.
 Proof.
   apply (isequiv_adjointify f g);
     intros ?; apply path_ishprop.

--- a/theories/Homotopy/Suspension.v
+++ b/theories/Homotopy/Suspension.v
@@ -5,7 +5,9 @@
 Require Import Basics Types.
 Require Import Colimits.Pushout.
 Require Import NullHomotopy.
+Require Import Truncations.
 Local Open Scope path_scope.
+Import TrM.
 
 Generalizable Variables X A B f g n.
 
@@ -174,4 +176,20 @@ Proof.
   - apply whiskerR, inverse, Susp_rec_beta_merid.
   - refine (concat_Ap n.2 (merid x) @ _).
     apply (concatR (concat_p1 _)), whiskerL. apply ap_const.
+Defined.
+
+(* ** Connectedness of the suspension *)
+
+Global Instance isconnected_susp {n : trunc_index} {X : Type}
+  `{H : IsConnected n X} : IsConnected n.+1 (Susp X).
+Proof.
+  apply isconnected_from_elim.
+  intros C H' f. exists (f North).
+  assert ({ p0 : f North = f South & forall x:X, ap f (merid x) = p0 })
+    as [p0 allpath_p0] by (apply (isconnected_elim n); apply H').
+  apply (Susp_ind (fun a => f a = f North) 1 p0^).
+  intros x.
+  apply (concat (transport_paths_Fl _ _)).
+  apply (concat (concat_p1 _)).
+  apply ap, allpath_p0.
 Defined.

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -1818,6 +1818,14 @@ Section ConnectedMaps.
     : IsEquiv f
     := isequiv_commsq' f (O_functor O f) (to O A) (to O B) (to_O_natural O f).
 
+  (** Connectedness is preserved by [O_functor]. *)
+  Global Instance conn_map_O_functor {A B} (f : A -> B) `{IsConnMap O _ _ f}
+    : IsConnMap O (O_functor O f).
+  Proof.
+    unfold O_functor.
+    erapply conn_map_compose.
+  Defined.
+
 End ConnectedMaps.
 
 

--- a/theories/Pointed/pSusp.v
+++ b/theories/Pointed/pSusp.v
@@ -4,7 +4,12 @@ Require Import Pointed.Core.
 Require Import Pointed.Loops.
 Require Import Pointed.pMap.
 Require Import Pointed.pHomotopy.
+Require Import Pointed.pTrunc.
+Require Import Pointed.pEquiv.
 Require Import Homotopy.Suspension.
+Require Import Homotopy.Freudenthal.
+Require Import Truncations.
+Import TrM.
 
 Generalizable Variables X A B f g n.
 
@@ -57,6 +62,35 @@ Proof.
       concat_p1, concat_Vp. }
   reflexivity.
 Qed.
+
+Definition psusp_2functor {X Y} {f g : X ->* Y} (p : f ==* g)
+  : psusp_functor f ==* psusp_functor g.
+Proof.
+  pointed_reduce.
+  serapply Build_pHomotopy.
+  { simpl.
+    serapply Susp_ind.
+    1,2: reflexivity.
+    intro x; cbn.
+    rewrite transport_paths_FlFr.
+    rewrite concat_p1.
+    rewrite 2 Susp_rec_beta_merid.
+    destruct (p x).
+    apply concat_Vp. }
+  reflexivity.
+Defined.
+
+Definition pequiv_psusp_functor {X Y : pType} (f : X <~>* Y)
+  : psusp X <~>* psusp Y.
+Proof.
+  serapply pequiv_adjointify.
+  1: apply psusp_functor, f.
+  1: apply psusp_functor, f^-1*.
+  1,2: refine ((psusp_functor_compose _ _)^* @* _ @* psusp_functor_idmap).
+  1,2: apply psusp_2functor.
+  1: apply peisretr.
+  apply peissect.
+Defined.
 
 (** ** Loop-Suspension Adjunction *)
 
@@ -139,6 +173,23 @@ End Book_Loop_Susp_Adjunction.
 Definition loop_susp_unit (X : pType) : X ->* loops (psusp X)
   := Build_pMap X (loops (psusp X))
       (fun x => merid x @ (merid (point X))^) (concat_pV _).
+
+(** By Freudenthal, we have that this map is 2n-connected for a n-connected X *)
+Instance conn_map_loop_susp_unit `{Univalence} (X : pType) `{IsConnected n.+1 X}
+  : IsConnMap (n +2+ n) (fun x => merid x @ (merid (point X))^).
+Proof.
+  refine (conn_map_compose _ _ (equiv_concat_r (merid (point _))^ _)).
+Defined.
+
+(** We also have this corollary *)
+Lemma pequiv_ptr_loop_psusp `{Univalence} (X : pType) n `{IsConnected n.+1 X}
+  : pTr (n +2+ n) X <~>* pTr (n +2+ n) (loops (psusp X)).
+Proof.
+  serapply (Build_pEquiv _ _ _ (isequiv_conn_map_ino (n +2+ n) _)).
+  { apply ptr_functor.
+    apply loop_susp_unit. }
+  exact _.
+Defined.
 
 Definition loop_susp_unit_natural {X Y : pType} (f : X ->* Y)
   : loop_susp_unit Y o* f

--- a/theories/Pointed/pTrunc.v
+++ b/theories/Pointed/pTrunc.v
@@ -34,3 +34,13 @@ Defined.
 Definition ptr_loops_eq `{Univalence} (n : trunc_index) (A : pType)
   : pTr n (loops A) = loops (pTr n.+1 A) :> pType
   := path_ptype (ptr_loops n A).
+
+Definition pequiv_ptr_functor {X Y : pType} n
+  : X <~>* Y -> pTr n X <~>* pTr n Y.
+Proof.
+  intro e.
+  serapply Build_pEquiv.
+  { apply ptr_functor, e. }
+  exact _.
+Defined.
+

--- a/theories/TruncType.v
+++ b/theories/TruncType.v
@@ -91,6 +91,17 @@ Proof.
   refine (ap_pp _ _ _).
 Qed.
 
+Definition ap_trunctype {n : trunc_index} {A B : TruncType n} {f : A <~> B}
+  : ap trunctype_type (path_trunctype f) = path_universe_uncurried f.
+Proof.
+  destruct A, B.
+  cbn in *.
+  cbn; destruct (path_universe_uncurried f).
+  rewrite concat_1p, concat_p1.
+  rewrite <- 2 ap_compose.
+  apply ap_const.
+Qed.
+
 Definition path_hset {A B} := @path_trunctype 0 A B.
 Definition path_hprop {A B} := @path_trunctype (-1) A B.
 

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -109,6 +109,16 @@ Proof.
   - apply IHn, isconnected_pred; assumption.
 Defined.
 
+Definition isconnected_pred_add n m A `{H : IsConnected (n +2+ m) A}
+  : IsConnected m A.
+Proof.
+  induction n.
+  1: assumption.
+  apply IHn.
+  apply isconnected_pred.
+  assumption.
+Defined.
+
 (** ** Connectedness of path spaces *)
 
 Global Instance isconnected_paths `{Univalence} {n A}
@@ -164,6 +174,14 @@ Proof.
   - intros nx.
     apply (Trunc_rec (n := -1) nx).
     exact (center (merely X)).
+Defined.
+
+(* Truncation preserves connectedness. Note that this is for different levels. *)
+Global Instance isconnected_trunc {X : Type} n m `{IsConnected n X}
+  : IsConnected n (Tr m X).
+Proof.
+  unfold IsConnected.
+  serapply (contr_equiv' _ (Trunc_swap n m X)^-1).
 Defined.
 
 Section Wedge_Incl_Conn.

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -1,11 +1,12 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 
+Require Import Basics Types.
+Require Import TruncType HProp.
+Require Import Modalities.Modality Modalities.Identity.
+
 (** * Truncations of types, in all dimensions. *)
 
-Require Import HoTT.Basics Types.Sigma Types.Universe TruncType HProp.
-Require Import Modalities.Modality Modalities.Identity.
 Local Open Scope path_scope.
-
 Generalizable Variables A X n.
 
 (** ** Definition. *)
@@ -123,62 +124,63 @@ Section TruncationModality.
   Context (n : trunc_index).
 
   Definition trunc_iff_isequiv_truncation (A : Type)
-  : IsTrunc n A <-> IsEquiv (@tr n A)
-  := inO_iff_isequiv_to_O n A.
+    : IsTrunc n A <-> IsEquiv (@tr n A)
+    := inO_iff_isequiv_to_O n A.
 
   Global Instance isequiv_tr A `{IsTrunc n A} : IsEquiv (@tr n A)
-  := fst (trunc_iff_isequiv_truncation A) _.
+    := fst (trunc_iff_isequiv_truncation A) _.
 
   Definition equiv_tr (A : Type) `{IsTrunc n A}
-  : A <~> Tr n A
+    : A <~> Tr n A
   := Build_Equiv _ _ (@tr n A) _.
 
   Definition untrunc_istrunc {A : Type} `{IsTrunc n A}
-  : Tr n A -> A
-  := (@tr n A)^-1.
+    : Tr n A -> A
+    := (@tr n A)^-1.
 
   (** ** Functoriality *)
 
   Definition Trunc_functor {X Y : Type} (f : X -> Y)
-  : Tr n X -> Tr n Y
-  := O_functor n f.
+    : Tr n X -> Tr n Y
+    := O_functor n f.
 
-  Global Instance Trunc_functor_isequiv {X Y : Type} (f : X -> Y) `{IsEquiv _ _ f}
-  : IsEquiv (Trunc_functor f)
+  Global Instance Trunc_functor_isequiv {X Y : Type}
+    (f : X -> Y) `{IsEquiv _ _ f}
+    : IsEquiv (Trunc_functor f)
     := isequiv_O_functor n f.
 
   Definition Trunc_functor_equiv {X Y : Type} (f : X <~> Y)
-  : Tr n X <~> Tr n Y
+    : Tr n X <~> Tr n Y
     := equiv_O_functor n f.
 
   Definition Trunc_functor_compose {X Y Z} (f : X -> Y) (g : Y -> Z)
-  : Trunc_functor (g o f) == Trunc_functor g o Trunc_functor f
-  := O_functor_compose n f g.
+    : Trunc_functor (g o f) == Trunc_functor g o Trunc_functor f
+    := O_functor_compose n f g.
 
   Definition Trunc_functor_idmap (X : Type)
-  : @Trunc_functor X X idmap == idmap
-  := O_functor_idmap n X.
+    : @Trunc_functor X X idmap == idmap
+    := O_functor_idmap n X.
 
   Definition isequiv_Trunc_functor {X Y} (f : X -> Y) `{IsEquiv _ _ f}
-  : IsEquiv (Trunc_functor f)
-  := isequiv_O_functor n f.
+    : IsEquiv (Trunc_functor f)
+    := isequiv_O_functor n f.
 
   Definition equiv_Trunc_prod_cmp `{Funext} {X Y}
-  : Tr n (X * Y) <~> Tr n X * Tr n Y
-  := equiv_O_prod_cmp n X Y.
+    : Tr n (X * Y) <~> Tr n X * Tr n Y
+    := equiv_O_prod_cmp n X Y.
 
 End TruncationModality.
 
 (** We have to teach Coq to translate back and forth between [IsTrunc n] and [In (Tr n)]. *)
 Global Instance inO_tr_istrunc {n : trunc_index} (A : Type) `{IsTrunc n A}
-: In (Tr n) A.
+  : In (Tr n) A.
 Proof.
   assumption.
 Defined.
 
 (** Having both of these as [Instance]s would cause infinite loops. *)
 Definition istrunc_inO_tr {n : trunc_index} (A : Type) `{In (Tr n) A}
-: IsTrunc n A.
+  : IsTrunc n A.
 Proof.
   assumption.
 Defined.
@@ -190,15 +192,15 @@ Hint Immediate istrunc_inO_tr : typeclass_instances.
 
 (** We do the same for [IsTruncMap n] and [MapIn (Tr n)]. *)
 Global Instance mapinO_tr_istruncmap {n : trunc_index} {A B : Type}
-       (f : A -> B) `{IsTruncMap n A B f}
-: MapIn (Tr n) f.
+  (f : A -> B) `{IsTruncMap n A B f}
+  : MapIn (Tr n) f.
 Proof.
   assumption.
 Defined.
 
 Definition istruncmap_mapinO_tr {n : trunc_index} {A B : Type}
-           (f : A -> B) `{MapIn (Tr n) _ _ f}
-: IsTruncMap n f.
+  (f : A -> B) `{MapIn (Tr n) _ _ f}
+  : IsTruncMap n f.
 Proof.
   assumption.
 Defined.
@@ -237,16 +239,16 @@ Defined.
 (** Surjections are the (-1)-connected maps, but they can be characterized more simply since an inhabited hprop is automatically contractible. *)
 Notation IsSurjection := (IsConnMap (-1)).
 
-Definition BuildIsSurjection {A B} (f : A -> B) :
-  (forall b, merely (hfiber f b)) -> IsSurjection f.
+Definition BuildIsSurjection {A B} (f : A -> B)
+  : (forall b, merely (hfiber f b)) -> IsSurjection f.
 Proof.
   intros H b; refine (contr_inhabited_hprop _ _).
   apply H.
 Defined.
 
 Definition isequiv_surj_emb {A B} (f : A -> B)
-           `{IsSurjection f} `{IsEmbedding f}
-: IsEquiv f.
+  `{IsSurjection f} `{IsEmbedding f}
+  : IsEquiv f.
 Proof.
   apply (@isequiv_conn_ino_map (-1)); assumption.
 Defined.
@@ -276,7 +278,7 @@ Defined.
 
 (** But the full characterization does. *)
 Definition equiv_path_Tr `{Univalence} {n A} (x y : A)
-: Tr n (x = y) <~> (tr x = tr y :> Tr n.+1 A).
+  : Tr n (x = y) <~> (tr x = tr y :> Tr n.+1 A).
 Proof.
   (** Encode-decode *)
   transparent assert (code : (Tr n.+1 A -> Tr n.+1 A -> TruncType n)).
@@ -301,6 +303,47 @@ Proof.
     revert w; refine (Trunc_ind _ _); intro w.
     intros c; simpl in *.
     strip_truncations. destruct c. reflexivity.
+Defined.
+
+Definition Trunc_min n m X : Tr n (Tr m X) <~> Tr (trunc_index_min n m) X.
+Proof.
+  destruct (trunc_index_min_path n m) as [p|q].
+  + assert (l := trunc_index_min_leq_right n m).
+    destruct p^; clear p.
+    symmetry.
+    serapply equiv_adjointify.
+    { serapply Trunc_rec.
+      exact (fun x => tr (tr x)). }
+    { serapply Trunc_rec.
+      serapply Trunc_rec.
+      1: serapply trunc_leq.
+      exact tr. }
+    { serapply Trunc_ind.
+      simpl.
+      serapply (Trunc_ind (n:=m)).
+      2: reflexivity.
+      intro.
+      apply istrunc_paths.
+      serapply (trunc_leq (m:=n)).
+      by apply trunc_index_leq_succ'. }
+    serapply Trunc_ind; reflexivity.
+  + set (min := trunc_index_min n m).
+    refine (paths_ind _
+      (fun m _ => Tr n (Tr m X) <~> Tr min X) _ m q).
+    unfold min; clear min.
+    symmetry.
+    serapply equiv_tr.
+    serapply trunc_leq.
+    3: exact _.
+    apply trunc_index_min_leq_left.
+Defined.
+
+Definition Trunc_swap n m X : Tr n (Tr m X) <~> Tr m (Tr n X).
+Proof.
+  refine (_ oE equiv_transport (fun x => Tr x _) _ _ _ oE Trunc_min n m _).
+  2: apply trunc_index_min_swap.
+  symmetry.
+  apply Trunc_min.
 Defined.
 
 (** If you are looking for a theorem about truncation, you may want to read the note "Finding Theorems" in "STYLE.md". *)


### PR DESCRIPTION
Here are various truncation lemmas, they mostly come from my EM spaces development. Instead of shoving them all in that PR I will give them their own PR.

I will start with the small changes:

 1. Connectedness of suspension added into Homotopy/Suspension.v. Peter Lumsdaine gave a proof of this in the old Freudenthal.v file. I included the proof here, which uses the wedge connectivity lemma.
 2. Added `psusp_2functor`, `pequiv_psusp_functor` to Pointed/pSusp.v. Also added two corollaries of the Freudenthal suspension theorem:
    - The map `loop_susp_unit` is 2n-connected.
    - We have that Tr 2n X <~> Tr 2n (loops susp X)
 3. Added a more general connected predecessor lemma to Truncation/Connectedness.v stating that if a type is (n+2+m)-connected then it is m-connected.
 4. Added the equivalence given by the functor pTr in Pointed/pTr.v.
 5. Added that f is O-connected then O_functor O f is also O-connected to Modalities/ReflectiveSubuniverse.v
 6. To TruncType.v, added the lemma ap_trunctype, which says `ap`ing `trunctype_type` onto `path_trunctype` turns into a `path_universe_uncurried`.

Now for the big ones:

 7. To Basics/Trunc.v I have added `trunc_index_leq` which is what you think. It comes with various lemmas too. I have added `trunc_index_min` which is the minimum of the trunc indexes. I have also added a predecessor function for trunc_index. There is also some cleanup in this file.

 8. In Truncations/Core.v I have proven Trunc_min which is the following equivalence:
`Trunc_min n m X : Tr n (Tr m X) <~> Tr (trunc_index_min n m) X`. And also ` Trunc_swap n m X : Tr n (Tr m X) <~> Tr m (Tr n X)`. This closes #1084.