### PR TITLE
Classifying spaces

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -252,6 +252,7 @@ theories/Homotopy/WhiteheadsPrinciple.v
 theories/Homotopy/BlakersMassey.v
 theories/Homotopy/Freudenthal.v
 theories/Homotopy/HSpace.v
+theories/Homotopy/ClassifyingSpace.v
 
 #
 #   Pointed

--- a/theories/Algebra/AbelianGroup.v
+++ b/theories/Algebra/AbelianGroup.v
@@ -374,18 +374,6 @@ Proof.
     reflexivity. }
 Defined.
 
-Global Instance isequiv_groupiso_isabelianization
-  (F1 F2 : Group -> AbGroup)
-  (eta1 : forall X, GroupHomomorphism X (F1 X))
-  (eta2 : forall X, GroupHomomorphism X (F2 X))
-  `{IsAbelianization F1 eta1}
-  `{IsAbelianization F2 eta2}
-  (G : Group)
-  : IsEquiv (groupiso_isabelianization F1 F2 eta1 eta2 G).
-Proof.
-  exact _.
-Defined.
-
 Theorem homotopic_isabelianization (F1 F2 : Group -> AbGroup)
   (eta1 : forall X, GroupHomomorphism X (F1 X))
   (eta2 : forall X, GroupHomomorphism X (F2 X))
@@ -410,10 +398,8 @@ Global Instance issurj_isabelianization `{Funext}
 Proof.
   intros k G.
   pose (homotopic_isabelianization F abel eta abel_unit G) as p.
-  simpl in p.
   refine (@cancelR_isequiv_conn_map _ _ _ _ _ _ _
     (conn_map_homotopic _ _ _ p _)).
-  apply (isequiv_groupiso_isabelianization F abel eta abel_unit G).
 Qed.
 
 Definition isequiv_abgroup_abelianization `{U : Univalence}
@@ -437,10 +423,3 @@ Proof.
   + change (a o eta A == idmap); symmetry.
     apply ah.
 Defined.
-
-
-
-
-
-
-

--- a/theories/Algebra/Group.v
+++ b/theories/Algebra/Group.v
@@ -161,6 +161,11 @@ Proof.
   apply grp_homo_op.
 Defined.
 
+Definition grp_homo_id {G : Group} : GroupHomomorphism G G.
+Proof.
+  serapply (Build_GroupHomomorphism idmap).
+Defined.
+
 (* An isomorphism of groups is a group homomorphism that is an equivalence. *)
 Class GroupIsomorphism (G H : Group) := Build_GroupIsomorphism {
   grp_iso_homo :> GroupHomomorphism G H;

--- a/theories/Classes/interfaces/canonical_names.v
+++ b/theories/Classes/interfaces/canonical_names.v
@@ -191,10 +191,10 @@ Class Abs A `{Le A} `{Zero A} `{Negate A}
 Definition abs `{Abs A} := fun x : A => (abs_sig x).1.
 
 (* Common properties: *)
-Class Inverse `(A -> B) : Type := inverse: B -> A.
+(* Class Inverse `(A -> B) : Type := inverse: B -> A.
 Arguments inverse {A B} _ {Inverse} _.
 Typeclasses Transparent Inverse.
-Notation "f ⁻¹" := (inverse f) (at level 30) : mc_scope.
+Notation "f ⁻¹" := (inverse f) (at level 30) : mc_scope. *)
 
 Class Idempotent `(f: A -> A -> A) (x : A) : Type := idempotency: f x x = x.
 Arguments idempotency {A} _ _ {Idempotent}.

--- a/theories/HoTT.v
+++ b/theories/HoTT.v
@@ -125,7 +125,7 @@ Require Export HoTT.Homotopy.Smash.
 Require Export HoTT.Homotopy.Wedge.
 Require Export HoTT.Homotopy.Join.
 Require Export HoTT.Homotopy.HSpace.
-Require Export HoTT.Homotopy.ClassifyingSpace.
+(* Require Export HoTT.Homotopy.ClassifyingSpace. *)
 
 Require Export HoTT.Spectra.Spectrum.
 

--- a/theories/HoTT.v
+++ b/theories/HoTT.v
@@ -125,7 +125,7 @@ Require Export HoTT.Homotopy.Smash.
 Require Export HoTT.Homotopy.Wedge.
 Require Export HoTT.Homotopy.Join.
 Require Export HoTT.Homotopy.HSpace.
-(* Require Export HoTT.Homotopy.ClassifyingSpace. *)
+Require Export HoTT.Homotopy.ClassifyingSpace.
 
 Require Export HoTT.Spectra.Spectrum.
 

--- a/theories/HoTT.v
+++ b/theories/HoTT.v
@@ -92,6 +92,8 @@ Require Export HoTT.Comodalities.CoreflectiveSubuniverse.
 
 Require Export HoTT.Spaces.Nat.
 Require Export HoTT.Spaces.Int.
+Require Export HoTT.Spaces.Pos.
+
 Require Export HoTT.Spaces.Cantor.
 
 Require Export HoTT.Spaces.BAut.
@@ -122,6 +124,8 @@ Require Export HoTT.Homotopy.Suspension.
 Require Export HoTT.Homotopy.Smash.
 Require Export HoTT.Homotopy.Wedge.
 Require Export HoTT.Homotopy.Join.
+Require Export HoTT.Homotopy.HSpace.
+Require Export HoTT.Homotopy.ClassifyingSpace.
 
 Require Export HoTT.Spectra.Spectrum.
 

--- a/theories/Homotopy/ClassifyingSpace.v
+++ b/theories/Homotopy/ClassifyingSpace.v
@@ -7,7 +7,6 @@ Require Import Algebra.AbelianGroup.
 Require Import Homotopy.HSpace.
 Require Import TruncType.
 Require Import Truncations.
-Require Import HIT.Coeq.
 Import TrM.
 
 Local Open Scope pointed_scope.
@@ -16,9 +15,9 @@ Local Open Scope trunc_scope.
 Declare Scope bg_scope.
 Local Open Scope bg_scope.
 
-(** * We define the Classifying space of a type with operation (a magma) to be the following HIT:
+(** * We define the Classifying space of a group to be the following HIT:
 
-  HIT ClassifyingSpace (X : Type) {op : X -> X -> X} : 1-Type
+  HIT ClassifyingSpace (G : Group) : 1-Type
    | bbase : ClassifyingSpace
    | bloop : X -> bbase = bbase
    | bloop_pp : forall x y, bloop (x & y) = bloop x @ bloop y.
@@ -29,30 +28,32 @@ Module Export ClassifyingSpace.
 
   Section ClassifyingSpace.
 
-    Private Inductive ClassifyingSpace {X : Type} `{SgOp X} :=
+    Private Inductive ClassifyingSpace {G : Group} :=
       | bbase : ClassifyingSpace.
 
-    Definition bloop {X : Type} `{SgOp X} : X -> bbase = bbase. 
+    Context {G : Group}.
+
+    Definition bloop : G -> bbase = bbase. 
     Proof. Admitted.
 
-    Definition bloop_pp {X : Type} `{SgOp X}
+    Definition bloop_pp
       : forall x y, bloop (x & y) = bloop x @ bloop y.
     Proof. Admitted.
 
-    Global Instance istrunc_ClassifyingSpace {X : Type} `{SgOp X}
+    Global Instance istrunc_ClassifyingSpace
       : IsTrunc 1 ClassifyingSpace.
     Proof. Admitted.
 
   End ClassifyingSpace.
 
-  Arguments ClassifyingSpace X {_}.
+  Arguments ClassifyingSpace G : clear implicits.
 
   (** Now we can state the expected dependent elimination principle, and derive other versions of the elimination principle from it. *)
   Section ClassifyingSpace_ind.
 
     Local Open Scope dpath_scope.
 
-    Context `{SgOp G}.
+    Context {G : Group}.
 
     (** Note that since our classifying space is 1-truncated, we can only eliminate into 1-truncated type families. *)
     Definition ClassifyingSpace_ind
@@ -84,7 +85,7 @@ End ClassifyingSpace.
 (** Other eliminators *)
 Section Eliminators.
 
-  Context `{SgOp G}.
+  Context {G : Group}.
 
   (** The non-dependent eliminator *)
   Definition ClassifyingSpace_rec
@@ -138,8 +139,8 @@ Section Eliminators.
 End Eliminators.
 
 (** We can prove that the classifying space is 0-connected. *)
-Global Instance isconnected_classifyingspace {X : Type} `{SgOp X}
-  : IsConnected 0 (ClassifyingSpace X).
+Global Instance isconnected_classifyingspace {G : Group}
+  : IsConnected 0 (ClassifyingSpace G).
 Proof.
   exists (tr bbase).
   serapply Trunc_ind.
@@ -283,7 +284,7 @@ Section HSpace_bg.
     apply ap; cbn.
     apply path_forall.
     serapply ClassifyingSpace_ind_hset.
-    1: apply bloop_pp.
+    1: exact (bloop_pp x y).
     intro z.
     serapply dp_paths_FlFr_D.
     serapply path_ishprop.

--- a/theories/Homotopy/ClassifyingSpace.v
+++ b/theories/Homotopy/ClassifyingSpace.v
@@ -13,6 +13,9 @@ Import TrM.
 Local Open Scope pointed_scope.
 Local Open Scope trunc_scope.
 
+Declare Scope bg_scope.
+Local Open Scope bg_scope.
+
 (** * We define the Classifying space of a type with operation (a magma) to be the following HIT:
 
   HIT ClassifyingSpace (X : Type) {op : X -> X -> X} : 1-Type
@@ -74,58 +77,65 @@ Module Export ClassifyingSpace.
         = bloop' x.
     Proof. Admitted.
 
-    (** The non-dependent eliminator *)
-    Definition ClassifyingSpace_rec
-      (P : Type) `{IsTrunc 1 P} (bbase' : P) (bloop' : G -> bbase' = bbase')
-      (bloop_pp' : forall x y : G, bloop' (x & y) = bloop' x @ bloop' y)
-      : ClassifyingSpace G -> P.
-    Proof.
-      srefine (ClassifyingSpace_ind (fun _ => P) bbase' _ _).
-      1: intro; apply dp_const, bloop', x.
-      intros x y.
-      apply ds_const'.
-      erapply sq_GGcc.
-      2: refine (_ @ ap _ (dp_const_pp _ _)).
-      1,2: symmetry; apply eissect.
-      by apply sq_G1.
-    Defined.
-
-    (** Computation rule for non-dependent eliminator *)
-    Definition ClassifyingSpace_rec_beta_bloop
-      (P : Type) `{IsTrunc 1 P} (bbase' : P) (bloop' : G -> bbase' = bbase')
-      (bloop_pp' : forall x y : G, bloop' (x & y) = bloop' x @ bloop' y) (x : G)
-      : ap (ClassifyingSpace_rec P bbase' bloop' bloop_pp') (bloop x) = bloop' x.
-    Proof.
-      rewrite <- dp_apD_const'.
-      unfold ClassifyingSpace_rec.
-      rewrite ClassifyingSpace_ind_beta_bloop.
-      apply eissect.
-    Qed.
-
-    (** Sometimes we want to induct into a set which means we can ignore the bloop_pp arguments. Since this is a routine argument, we turn it into a special case of our induction principle. *)
-    Definition ClassifyingSpace_ind_hset
-      (P : ClassifyingSpace G -> Type)
-     `{forall x, IsTrunc 0 (P x)}
-      (bbase' : P bbase) (bloop' : forall x, DPath P (bloop x) bbase' bbase')
-      : forall x, P x.
-    Proof.
-      refine (ClassifyingSpace_ind P bbase' bloop' _).
-      intros.
-      apply ds_G1, dp_path_transport.
-      serapply path_ishprop.
-    Defined.
-
-    Definition ClassifyingSpace_rec_hset
-      (P : Type) `{IsTrunc 0 P} (bbase' : P) (bloop' : G -> bbase' = bbase')
-      : ClassifyingSpace G -> P.
-    Proof.
-      serapply (ClassifyingSpace_rec P bbase' bloop' _).
-      intros; apply path_ishprop.
-    Defined.
-
   End ClassifyingSpace_ind.
 
 End ClassifyingSpace.
+
+(** Other eliminators *)
+Section Eliminators.
+
+  Context `{SgOp G}.
+
+  (** The non-dependent eliminator *)
+  Definition ClassifyingSpace_rec
+    (P : Type) `{IsTrunc 1 P} (bbase' : P) (bloop' : G -> bbase' = bbase')
+    (bloop_pp' : forall x y : G, bloop' (x & y) = bloop' x @ bloop' y)
+    : ClassifyingSpace G -> P.
+  Proof.
+    srefine (ClassifyingSpace_ind (fun _ => P) bbase' _ _).
+    1: intro; apply dp_const, bloop', x.
+    intros x y.
+    apply ds_const'.
+    erapply sq_GGcc.
+    2: refine (_ @ ap _ (dp_const_pp _ _)).
+    1,2: symmetry; apply eissect.
+    by apply sq_G1.
+  Defined.
+
+  (** Computation rule for non-dependent eliminator *)
+  Definition ClassifyingSpace_rec_beta_bloop
+    (P : Type) `{IsTrunc 1 P} (bbase' : P) (bloop' : G -> bbase' = bbase')
+    (bloop_pp' : forall x y : G, bloop' (x & y) = bloop' x @ bloop' y) (x : G)
+    : ap (ClassifyingSpace_rec P bbase' bloop' bloop_pp') (bloop x) = bloop' x.
+  Proof.
+    rewrite <- dp_apD_const'.
+    unfold ClassifyingSpace_rec.
+    rewrite ClassifyingSpace_ind_beta_bloop.
+    apply eissect.
+  Qed.
+
+  (** Sometimes we want to induct into a set which means we can ignore the bloop_pp arguments. Since this is a routine argument, we turn it into a special case of our induction principle. *)
+  Definition ClassifyingSpace_ind_hset
+    (P : ClassifyingSpace G -> Type)
+   `{forall x, IsTrunc 0 (P x)}
+    (bbase' : P bbase) (bloop' : forall x, DPath P (bloop x) bbase' bbase')
+    : forall x, P x.
+  Proof.
+    refine (ClassifyingSpace_ind P bbase' bloop' _).
+    intros.
+    apply ds_G1, dp_path_transport.
+    serapply path_ishprop.
+  Defined.
+
+  Definition ClassifyingSpace_rec_hset
+    (P : Type) `{IsTrunc 0 P} (bbase' : P) (bloop' : G -> bbase' = bbase')
+    : ClassifyingSpace G -> P.
+  Proof.
+    serapply (ClassifyingSpace_rec P bbase' bloop' _).
+    intros; apply path_ishprop.
+  Defined.
+
+End Eliminators.
 
 (** We can prove that the classifying space is 0-connected. *)
 Global Instance isconnected_classifyingspace {X : Type} `{SgOp X}
@@ -143,7 +153,9 @@ Defined.
 (** Now we focus on the classifying space of a group. *)
 
 (** The classifying space of a group is the following pointed type. *)
-Definition B (G : Group) := Build_pType (ClassifyingSpace G) bbase.
+Definition B_group (G : Group) := Build_pType (ClassifyingSpace G) bbase.
+
+Notation "'B' G" := (B_group G) (at level 0) : bg_scope.
 
 (** We can show that [bloop] takes the unit of the group to reflexivity. *)
 Definition bloop_id {G : Group} : bloop mon_unit = idpath.

--- a/theories/Homotopy/ClassifyingSpace.v
+++ b/theories/Homotopy/ClassifyingSpace.v
@@ -153,9 +153,10 @@ Defined.
 (** Now we focus on the classifying space of a group. *)
 
 (** The classifying space of a group is the following pointed type. *)
-Definition B_group (G : Group) := Build_pType (ClassifyingSpace G) bbase.
+Definition pClassifingSpace (G : Group)
+  := Build_pType (ClassifyingSpace G) bbase.
 
-Notation "'B' G" := (B_group G) (at level 0) : bg_scope.
+Notation "'B' G" := (pClassifingSpace G) (at level 0) : bg_scope.
 
 (** We can show that [bloop] takes the unit of the group to reflexivity. *)
 Definition bloop_id {G : Group} : bloop mon_unit = idpath.

--- a/theories/Homotopy/ClassifyingSpace.v
+++ b/theories/Homotopy/ClassifyingSpace.v
@@ -33,12 +33,9 @@ Module Export ClassifyingSpace.
 
     Context {G : Group}.
 
-    Definition bloop : G -> bbase = bbase. 
-    Proof. Admitted.
+    Axiom bloop : G -> bbase = bbase.
 
-    Definition bloop_pp
-      : forall x y, bloop (x & y) = bloop x @ bloop y.
-    Proof. Admitted.
+    Axiom bloop_pp : forall x y, bloop (x & y) = bloop x @ bloop y.
 
     Global Instance istrunc_ClassifyingSpace
       : IsTrunc 1 ClassifyingSpace.
@@ -63,11 +60,11 @@ Module Export ClassifyingSpace.
       (bloop' : forall x, DPath P (bloop x) bbase' bbase')
       (bloop_pp' : forall x y,  DSquare P (sq_G1 (bloop_pp x y))
         (bloop' (x & y)) ((bloop' x) @D (bloop' y)) 1 1) x : P x
-      := match x return (_ -> P x) with
-            bbase => (fun _ => bbase')
-         end bloop'.
+      := match x with
+            bbase => (fun _ _ => bbase')
+         end bloop' bloop_pp'.
 
-    (** Here we state the computation rule for [ClassifyingSpace_ind] over [bloop] as an axiom. We don't need one for bloop_pp since we have a 1-type. **)
+    (** Here we state the computation rule for [ClassifyingSpace_ind] over [bloop] as an axiom. We don't need one for bloop_pp since we have a 1-type. We leave this as admitted since the computation rule is an axiom. **)
     Definition ClassifyingSpace_ind_beta_bloop
       (P : ClassifyingSpace G -> Type)
      `{forall x, IsTrunc 1 (P x)}

--- a/theories/Homotopy/ClassifyingSpace.v
+++ b/theories/Homotopy/ClassifyingSpace.v
@@ -11,6 +11,7 @@ Import TrM.
 
 Local Open Scope pointed_scope.
 Local Open Scope trunc_scope.
+Local Open Scope mc_mult_scope.
 
 Declare Scope bg_scope.
 Local Open Scope bg_scope.
@@ -20,7 +21,7 @@ Local Open Scope bg_scope.
   HIT ClassifyingSpace (G : Group) : 1-Type
    | bbase : ClassifyingSpace
    | bloop : X -> bbase = bbase
-   | bloop_pp : forall x y, bloop (x & y) = bloop x @ bloop y.
+   | bloop_pp : forall x y, bloop (x * y) = bloop x @ bloop y.
 
   We implement this is a private inductive type.
 *)
@@ -35,7 +36,7 @@ Module Export ClassifyingSpace.
 
     Axiom bloop : G -> bbase = bbase.
 
-    Axiom bloop_pp : forall x y, bloop (x & y) = bloop x @ bloop y.
+    Axiom bloop_pp : forall x y, bloop (x * y) = bloop x @ bloop y.
 
     Global Instance istrunc_ClassifyingSpace
       : IsTrunc 1 ClassifyingSpace.
@@ -59,7 +60,7 @@ Module Export ClassifyingSpace.
       (bbase' : P bbase)
       (bloop' : forall x, DPath P (bloop x) bbase' bbase')
       (bloop_pp' : forall x y,  DSquare P (sq_G1 (bloop_pp x y))
-        (bloop' (x & y)) ((bloop' x) @D (bloop' y)) 1 1) x : P x
+        (bloop' (x * y)) ((bloop' x) @D (bloop' y)) 1 1) x : P x
       := match x with
             bbase => (fun _ _ => bbase')
          end bloop' bloop_pp'.
@@ -70,7 +71,7 @@ Module Export ClassifyingSpace.
      `{forall x, IsTrunc 1 (P x)}
       (bbase' : P bbase) (bloop' : forall x, DPath P (bloop x) bbase' bbase')
       (bloop_pp' : forall x y,  DSquare P (sq_G1 (bloop_pp x y))
-        (bloop' (x & y)) ((bloop' x) @D (bloop' y)) 1 1) (x : G)
+        (bloop' (x * y)) ((bloop' x) @D (bloop' y)) 1 1) (x : G)
       : dp_apD (ClassifyingSpace_ind P bbase' bloop' bloop_pp') (bloop x)
         = bloop' x.
     Proof. Admitted.
@@ -87,7 +88,7 @@ Section Eliminators.
   (** The non-dependent eliminator *)
   Definition ClassifyingSpace_rec
     (P : Type) `{IsTrunc 1 P} (bbase' : P) (bloop' : G -> bbase' = bbase')
-    (bloop_pp' : forall x y : G, bloop' (x & y) = bloop' x @ bloop' y)
+    (bloop_pp' : forall x y : G, bloop' (x * y) = bloop' x @ bloop' y)
     : ClassifyingSpace G -> P.
   Proof.
     srefine (ClassifyingSpace_ind (fun _ => P) bbase' _ _).
@@ -103,7 +104,7 @@ Section Eliminators.
   (** Computation rule for non-dependent eliminator *)
   Definition ClassifyingSpace_rec_beta_bloop
     (P : Type) `{IsTrunc 1 P} (bbase' : P) (bloop' : G -> bbase' = bbase')
-    (bloop_pp' : forall x y : G, bloop' (x & y) = bloop' x @ bloop' y) (x : G)
+    (bloop_pp' : forall x y : G, bloop' (x * y) = bloop' x @ bloop' y) (x : G)
     : ap (ClassifyingSpace_rec P bbase' bloop' bloop_pp') (bloop x) = bloop' x.
   Proof.
     rewrite <- dp_apD_const'.
@@ -203,7 +204,7 @@ Section EncodeDecode.
   Defined.
 
   Local Definition codes_transport
-    : forall x y, transport codes (bloop x) y = y & x.
+    : forall x y, transport codes (bloop x) y = y * x.
   Proof.
     intros x y.
     rewrite transport_idmap_ap.

--- a/theories/Homotopy/ClassifyingSpace.v
+++ b/theories/Homotopy/ClassifyingSpace.v
@@ -155,7 +155,12 @@ Defined.
 Definition pClassifingSpace (G : Group)
   := Build_pType (ClassifyingSpace G) bbase.
 
-Notation "'B' G" := (pClassifingSpace G) (at level 0) : bg_scope.
+(** To use the B G notation for pClassifyingSpace import this module. *)
+Module Import ClassifyingSpaceNotation.
+  Definition B G := pClassifingSpace G.
+End ClassifyingSpaceNotation.
+
+Import ClassifyingSpaceNotation.
 
 (** We can show that [bloop] takes the unit of the group to reflexivity. *)
 Definition bloop_id {G : Group} : bloop mon_unit = idpath.

--- a/theories/Homotopy/ClassifyingSpace.v
+++ b/theories/Homotopy/ClassifyingSpace.v
@@ -1,0 +1,337 @@
+Require Import Basics.
+Require Import Types.
+Require Import Pointed.
+Require Import Cubical.
+Require Import Algebra.Group.
+Require Import Algebra.AbelianGroup.
+Require Import Homotopy.HSpace.
+Require Import TruncType.
+Require Import Truncations.
+Require Import HIT.Coeq.
+Import TrM.
+
+Local Open Scope pointed_scope.
+Local Open Scope trunc_scope.
+
+(** * We define the Classifying space of a type with operation (a magma) to be the following HIT:
+
+  HIT ClassifyingSpace (X : Type) {op : X -> X -> X} : 1-Type
+   | bbase : ClassifyingSpace
+   | bloop : X -> bbase = bbase
+   | bloop_pp : forall x y, bloop (x & y) = bloop x @ bloop y.
+
+  We implement this is a private inductive type.
+*)
+Module Export ClassifyingSpace.
+
+  Section ClassifyingSpace.
+
+    Private Inductive ClassifyingSpace {X : Type} `{SgOp X} :=
+      | bbase : ClassifyingSpace.
+
+    Definition bloop {X : Type} `{SgOp X} : X -> bbase = bbase. 
+    Proof. Admitted.
+
+    Definition bloop_pp {X : Type} `{SgOp X}
+      : forall x y, bloop (x & y) = bloop x @ bloop y.
+    Proof. Admitted.
+
+    Global Instance istrunc_ClassifyingSpace {X : Type} `{SgOp X}
+      : IsTrunc 1 ClassifyingSpace.
+    Proof. Admitted.
+
+  End ClassifyingSpace.
+
+  Arguments ClassifyingSpace X {_}.
+
+  (** Now we can state the expected dependent elimination principle, and derive other versions of the elimination principle from it. *)
+  Section ClassifyingSpace_ind.
+
+    Local Open Scope dpath_scope.
+
+    Context `{SgOp G}.
+
+    (** Note that since our classifying space is 1-truncated, we can only eliminate into 1-truncated type families. *)
+    Definition ClassifyingSpace_ind
+      (P : ClassifyingSpace G -> Type)
+     `{forall x, IsTrunc 1 (P x)}
+      (bbase' : P bbase)
+      (bloop' : forall x, DPath P (bloop x) bbase' bbase')
+      (bloop_pp' : forall x y,  DSquare P (sq_G1 (bloop_pp x y))
+        (bloop' (x & y)) ((bloop' x) @D (bloop' y)) 1 1) x : P x
+      := match x return (_ -> P x) with
+            bbase => (fun _ => bbase')
+         end bloop.
+
+    (** Here we state the computation rule for [ClassifyingSpace_ind] over [bloop] as an axiom. We don't need one for bloop_pp since we have a 1-type. **)
+    Definition ClassifyingSpace_ind_beta_bloop
+      (P : ClassifyingSpace G -> Type)
+     `{forall x, IsTrunc 1 (P x)}
+      (bbase' : P bbase) (bloop' : forall x, DPath P (bloop x) bbase' bbase')
+      (bloop_pp' : forall x y,  DSquare P (sq_G1 (bloop_pp x y))
+        (bloop' (x & y)) ((bloop' x) @D (bloop' y)) 1 1) (x : G)
+      : dp_apD (ClassifyingSpace_ind P bbase' bloop' bloop_pp') (bloop x)
+        = bloop' x.
+    Proof. Admitted.
+
+    (** The non-dependent eliminator *)
+    Definition ClassifyingSpace_rec
+      (P : Type) `{IsTrunc 1 P} (bbase' : P) (bloop' : G -> bbase' = bbase')
+      (bloop_pp' : forall x y : G, bloop' (x & y) = bloop' x @ bloop' y)
+      : ClassifyingSpace G -> P.
+    Proof.
+      srefine (ClassifyingSpace_ind (fun _ => P) bbase' _ _).
+      1: intro; apply dp_const, bloop', x.
+      intros x y.
+      apply ds_const'.
+      erapply sq_GGcc.
+      2: refine (_ @ ap _ (dp_const_pp _ _)).
+      1,2: symmetry; apply eissect.
+      by apply sq_G1.
+    Defined.
+
+    (** Computation rule for non-dependent eliminator *)
+    Definition ClassifyingSpace_rec_beta_bloop
+      (P : Type) `{IsTrunc 1 P} (bbase' : P) (bloop' : G -> bbase' = bbase')
+      (bloop_pp' : forall x y : G, bloop' (x & y) = bloop' x @ bloop' y) (x : G)
+      : ap (ClassifyingSpace_rec P bbase' bloop' bloop_pp') (bloop x) = bloop' x.
+    Proof.
+      rewrite <- dp_apD_const'.
+      unfold ClassifyingSpace_rec.
+      rewrite ClassifyingSpace_ind_beta_bloop.
+      apply eissect.
+    Qed.
+
+    (** Sometimes we want to induct into a set which means we can ignore the bloop_pp arguments. Since this is a routine argument, we turn it into a special case of our induction principle. *)
+    Definition ClassifyingSpace_ind_hset
+      (P : ClassifyingSpace G -> Type)
+     `{forall x, IsTrunc 0 (P x)}
+      (bbase' : P bbase) (bloop' : forall x, DPath P (bloop x) bbase' bbase')
+      : forall x, P x.
+    Proof.
+      refine (ClassifyingSpace_ind P bbase' bloop' _).
+      intros.
+      apply ds_G1, dp_path_transport.
+      serapply path_ishprop.
+    Defined.
+
+    Definition ClassifyingSpace_rec_hset
+      (P : Type) `{IsTrunc 0 P} (bbase' : P) (bloop' : G -> bbase' = bbase')
+      : ClassifyingSpace G -> P.
+    Proof.
+      serapply (ClassifyingSpace_rec P bbase' bloop' _).
+      intros; apply path_ishprop.
+    Defined.
+
+  End ClassifyingSpace_ind.
+
+End ClassifyingSpace.
+
+(** We can prove that the classifying space is 0-connected. *)
+Global Instance isconnected_classifyingspace {X : Type} `{SgOp X}
+  : IsConnected 0 (ClassifyingSpace X).
+Proof.
+  exists (tr bbase).
+  serapply Trunc_ind.
+  serapply ClassifyingSpace_ind_hset; cbn.
+  1: reflexivity.
+  intro x.
+  apply dp_paths_FlFr.
+  apply path_ishprop.
+Defined.
+
+(** Now we focus on the classifying space of a group. *)
+
+(** The classifying space of a group is the following pointed type. *)
+Definition B (G : Group) := Build_pType (ClassifyingSpace G) bbase.
+
+(** We can show that [bloop] takes the unit of the group to reflexivity. *)
+Definition bloop_id {G : Group} : bloop mon_unit = idpath.
+Proof.
+  symmetry.
+  apply (cancelL (bloop mon_unit)).
+  refine (_ @ bloop_pp _ _).
+  refine (_ @ ap _ (left_identity _)^).
+  apply concat_p1.
+Defined.
+
+(** We can show that [bloop] "preserves inverses" by taking inverses in G to inverses of paths in BG *)
+Definition bloop_inv {G : Group} : forall x, bloop (-x) = (bloop x)^.
+Proof.
+  intro x.
+  refine (_ @ concat_p1 _).
+  apply moveL_Vp.
+  refine (_ @ bloop_id).
+  refine ((bloop_pp _ _)^ @ _).
+  apply ap, right_inverse.
+Defined.
+
+(** Here we pove that BG is the delooping of G, in that loops BG <~> G. *)
+Section EncodeDecode.
+
+  Context `{Univalence} {G : Group}.
+
+  Local Definition codes : B G -> 0 -Type.
+  Proof.
+    serapply ClassifyingSpace_rec.
+    + serapply (BuildhSet G).
+    + intro x.
+      apply path_trunctype.
+      apply (right_mult_equiv x).
+    + intros x y.
+      refine (_ @ path_trunctype_pp _ _).
+      apply ap, path_equiv, path_forall.
+      intro; cbn.
+      apply associativity.
+  Defined.
+
+  Local Definition encode : forall z, bbase = z -> codes z.
+  Proof.
+    intros z p.
+    exact (transport codes p mon_unit).
+  Defined.
+
+  Local Definition codes_transport
+    : forall x y, transport codes (bloop x) y = y & x.
+  Proof.
+    intros x y.
+    rewrite transport_idmap_ap.
+    rewrite ap_compose.
+    rewrite ClassifyingSpace_rec_beta_bloop.
+    rewrite ap_trunctype.
+    by rewrite transport_path_universe_uncurried.
+  Qed.
+
+  Local Definition decode : forall (z : B G), codes z -> bbase = z.
+  Proof.
+    serapply ClassifyingSpace_ind_hset.
+    + exact bloop.
+    + intro x.
+      apply dp_arrow.
+      intro y; cbn in *.
+      apply dp_paths_r.
+      refine ((bloop_pp _ _)^ @ _).
+      symmetry.
+      apply ap, codes_transport.
+  Defined.
+
+  Local Lemma decode_encode : forall z p, decode z (encode z p) = p.
+  Proof.
+    intros z p.
+    destruct p.
+    apply bloop_id.
+  Defined.
+
+  (** Universal property of BG *)
+  Lemma equiv_loops_bg_g : loops (B G) <~> G.
+  Proof.
+    serapply equiv_adjointify.
+    + exact (encode _).
+    + exact bloop.
+    + intro x.
+      refine (codes_transport _ _ @ _).
+      apply left_identity.
+    + intro.
+      apply (decode_encode bbase x).
+  Defined.
+
+  (** Pointed version of the universal property. *)
+  Lemma pequiv_loops_bg_g
+    : loops (B G) <~>* Build_pType G _.
+  Proof.
+    serapply Build_pEquiv'.
+    1: apply equiv_loops_bg_g.
+    reflexivity.
+  Defined.
+
+End EncodeDecode.
+
+(** When G is an abelian group, BG is a H-space. *)
+Section HSpace_bg.
+
+  Context `{Funext} {G : AbGroup}.
+
+  Definition bg_mul : B G -> B G -> B G.
+  Proof.
+    serapply ClassifyingSpace_rec.
+    1: exact idmap.
+    { intro x.
+      apply path_forall.
+      serapply ClassifyingSpace_ind_hset.
+      1: exact (bloop x).
+      cbn; intro y.
+      apply dp_paths_lr.
+      refine (concat_pp_p _ _ _ @ _).
+      apply moveR_Vp.
+      refine ((bloop_pp _ _)^ @ _ @ bloop_pp _ _).
+      apply ap, commutativity. }
+    intros x y.
+    rewrite <- path_forall_pp.
+    apply ap; cbn.
+    apply path_forall.
+    serapply ClassifyingSpace_ind_hset.
+    1: apply bloop_pp.
+    intro z.
+    serapply dp_paths_FlFr_D.
+    serapply path_ishprop.
+  Defined.
+
+  Definition bg_mul_beta x
+    : ap (fun x0 => bg_mul x0 bbase) (bloop x) = bloop x.
+  Proof.
+    rewrite ap_apply_Fl.
+    rewrite ClassifyingSpace_rec_beta_bloop.
+    by rewrite eisretr.
+  Defined.
+
+  Definition bg_mul_symm : forall x y, bg_mul x y = bg_mul y x.
+  Proof.
+    serapply ClassifyingSpace_ind_hset.
+    { serapply ClassifyingSpace_ind_hset.
+      1: reflexivity.
+      intro x.
+      apply sq_dp^-1, sq_1G.
+      rewrite ap_idmap.
+      symmetry.
+      apply bg_mul_beta. }
+    intro.
+    apply dp_forall_domain.
+    intro y; apply dp_paths_FlFr; revert y.
+    serapply ClassifyingSpace_ind_hset.
+    { cbn; rewrite concat_p1.
+      rewrite ap_idmap.
+      apply moveR_Vp.
+      symmetry.
+      rewrite concat_p1.
+      apply bg_mul_beta. }
+    intro y.
+    apply dp_paths_FlFr_D.
+    apply path_ishprop.
+  Defined.
+
+  Definition bg_mul_left_id
+    : forall a : B G, bg_mul (point (B G)) a = a.
+  Proof.
+    serapply ClassifyingSpace_ind_hset.
+    1: reflexivity.
+    intro; cbn; apply dp_paths_lr.
+    refine (concat_pp_p _ _ _ @ _).
+    apply moveR_Vp.
+    refine (concat_1p _ @ (concat_p1 _)^).
+  Defined.
+
+  Definition bg_mul_right_id
+    : forall a : B G, bg_mul a (point (B G)) = a.
+  Proof.
+    intro.
+    rewrite bg_mul_symm.
+    apply bg_mul_left_id.
+  Defined.
+
+  Global Instance hspace_bg : HSpace (B G)
+    := Build_HSpace _
+          bg_mul
+          bg_mul_left_id
+          bg_mul_right_id.
+
+End HSpace_bg.

--- a/theories/Homotopy/ClassifyingSpace.v
+++ b/theories/Homotopy/ClassifyingSpace.v
@@ -61,7 +61,7 @@ Module Export ClassifyingSpace.
         (bloop' (x & y)) ((bloop' x) @D (bloop' y)) 1 1) x : P x
       := match x return (_ -> P x) with
             bbase => (fun _ => bbase')
-         end bloop.
+         end bloop'.
 
     (** Here we state the computation rule for [ClassifyingSpace_ind] over [bloop] as an axiom. We don't need one for bloop_pp since we have a 1-type. **)
     Definition ClassifyingSpace_ind_beta_bloop
@@ -328,8 +328,8 @@ Section HSpace_bg.
     apply bg_mul_left_id.
   Defined.
 
-  Global Instance hspace_bg : HSpace (B G)
-    := Build_HSpace _
+  Global Instance ishspace_bg : IsHSpace (B G)
+    := Build_IsHSpace _
           bg_mul
           bg_mul_left_id
           bg_mul_right_id.


### PR DESCRIPTION
This relies on #1147, therefore only check the last commit for review.

Changes:

 * Added (1-truncated) classifying space of type with operation HIT using private inductive types.
 * Defined classifying space of a group.
 * Showed that loop space of BG is equivalent to G.
 * Some extra properties of abelianizations

Eventually we should replace this private inductive type and construct BG out of coequalizers.