### PR TITLE
Various facts about spheres and H-space on S1

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -249,9 +249,10 @@ theories/Homotopy/Wedge.v
 theories/Homotopy/Join.v
 
 theories/Homotopy/WhiteheadsPrinciple.v
+theories/Homotopy/HSpace.v
+theories/Homotopy/HSpaceS1.v
 theories/Homotopy/BlakersMassey.v
 theories/Homotopy/Freudenthal.v
-theories/Homotopy/HSpace.v
 theories/Homotopy/ClassifyingSpace.v
 theories/Homotopy/EMSpace.v
 

--- a/theories/Cubical/DPath.v
+++ b/theories/Cubical/DPath.v
@@ -41,6 +41,13 @@ Proof.
   apply (trunc_equiv _ dp_path_transport).
 Defined.
 
+Definition dp_ishprop {A : Type} (P : A -> Type) {a0 a1} {p : a0 = a1}
+  {b0 : P a0} {b1 : P a1} `{IsHProp (P a0)} `{IsHProp (P a1)}
+  : DPath P p b0 b1.
+Proof.
+  apply dp_path_transport, path_ishprop.
+Defined.
+
 (* Here is a notation for DPaths that can make it easier to use *)
 Notation "x =[ q ] y" := (DPath (fun t => DPath _ t _ _) q x y) (at level 10)
   : dpath_scope.

--- a/theories/Cubical/Square.v
+++ b/theories/Cubical/Square.v
@@ -91,6 +91,16 @@ Proof.
   by destruct p, p1x.
 Defined.
 
+(** Squares in (n+2)-truncated types are n-truncated *)
+Global Instance istrunc_sq n
+  {A} `{!IsTrunc n.+2 A} {a00 a10 a01 a11 : A}
+  {px0 : a00 = a10} {px1 : a01 = a11}
+  {p0x : a00 = a01} {p1x : a10 = a11}
+  : IsTrunc n (Square px0 px1 p0x p1x).
+Proof.
+  serapply (trunc_equiv _ sq_path).
+Defined.
+
 (* We can give degenerate squares *)
 Section SquaresFromPaths.
 

--- a/theories/HIT/Spheres.v
+++ b/theories/HIT/Spheres.v
@@ -2,11 +2,13 @@
 
 (** * The spheres, in all dimensions. *)
 
-Require Import HoTT.Basics.
-Require Import Types.Sigma Types.Forall Types.Paths Types.Bool.
+Require Import Basics.
+Require Import Types.
 Require Import HProp NullHomotopy.
 Require Import Homotopy.Suspension HIT.Circle HIT.TwoSphere.
 Require Import Pointed.pSusp Pointed.Core.
+Require Import Truncations.
+Import TrM.
 
 Local Open Scope pointed_scope.
 Local Open Scope trunc_scope.
@@ -157,7 +159,7 @@ Proof.
                       (fun x => ap Sph2_to_S2 (merid x @ (merid North)^))
                       (fun x => Susp_rec 1 1 
                                 (Susp_rec surf 1 
-                                (Empty_rec (surf = 1))) x 
+                                Empty_rec) x 
                                 @ 1)
                       (fun x => ap_pp Sph2_to_S2 (merid x) (merid North)^ 
                                 @ ((1 @@ ap_V Sph2_to_S2 (merid North)) 
@@ -168,7 +170,7 @@ Proof.
   { refine (_ @ (ap_pp_concat_pV _ _)).
     refine (ap (fun w => _ @ (_ @ w)) (concat_pV_inverse2 _ _ _)). }
   refine ((concat2_ap_ap (Susp_rec 1 1 (Susp_rec surf 1 
-                                         (Empty_rec (surf = 1)))) 
+                                         Empty_rec)) 
                          (fun _ => 1) 
                          (merid North @ (merid South)^))^ @ _).
   refine ((ap (fun w => _ @@ w) (ap_const _ _)) @ _).
@@ -194,7 +196,7 @@ Proof.
   path_via (ap S2_to_Sph2 (ap Sph2_to_S2 (merid x))).
   { apply (ap_compose Sph2_to_S2 S2_to_Sph2 (merid x)). }
   path_via (ap S2_to_Sph2 
-               (Susp_rec 1 1 (Susp_rec surf 1 (Empty_rec (surf = 1))) x)). 
+               (Susp_rec 1 1 (Susp_rec surf 1 Empty_rec) x)). 
   { repeat f_ap. apply Susp_rec_beta_merid. }
   symmetry. generalize dependent x. 
 
@@ -207,7 +209,7 @@ Proof.
     refine ((ap (transport _ _) (ap_pp _ (merid x) (merid South)^)^) @ _).
     refine (_ @ (ap_compose (Susp_rec 1 1 
                               (Susp_rec surf 1 
-                                (Empty_rec (surf = 1)))) 
+                                Empty_rec)) 
                             (ap S2_to_Sph2) (merid x))^).
     refine (_ @ (ap (ap02 S2_to_Sph2) (Susp_rec_beta_merid _)^)).
     symmetry. generalize dependent x.
@@ -228,7 +230,28 @@ Proof.
   - apply issect_S2_to_Sph2.
   - apply issect_Sph2_to_S2.
 Defined.
-        
+
+(** Truncation and connectedness of spheres. *)
+
+(** S0 is 0-truncated. *)
+Global Instance istrunc_s0 : IsHSet (Sphere 0).
+Proof.
+  serapply (trunc_equiv _ Sph0_to_Bool^-1).
+Defined.
+
+(** S1 is 1-truncated. *)
+Global Instance istrunc_s1 `{Univalence} : IsTrunc 1 (Sphere 1).
+Proof.
+  serapply (trunc_equiv _ Sph1_to_S1^-1).
+Defined.
+
+Global Instance isconnected_sn n : IsConnected n.+1 (Sphere n.+2).
+Proof.
+  induction n.
+  { serapply contr_inhabited_hprop.
+    apply tr, North. }
+  apply isconnected_susp.
+Defined.
 
 (** ** Truncatedness via spheres  *)
 

--- a/theories/HIT/Spheres.v
+++ b/theories/HIT/Spheres.v
@@ -33,6 +33,9 @@ Fixpoint psphere (n : nat) : pType
       | S n' => psusp (psphere n')
      end.
 
+Arguments Sphere : simpl never.
+Arguments psphere : simpl never.
+
 (** ** Explicit equivalences in low dimensions  *)
 
 (** *** [Sphere 0] *)

--- a/theories/Homotopy/HSpaceS1.v
+++ b/theories/Homotopy/HSpaceS1.v
@@ -1,0 +1,117 @@
+Require Import Basics.
+Require Import Types.
+Require Import Cubical.
+Require Import Homotopy.Suspension.
+Require Import HIT.Spheres.
+Require Import HSpace.
+
+(** H-space structure on circle. *)
+
+Section HSpace_S1.
+
+  Context `{Univalence}.
+
+  Definition Sph1_ind (P : Sphere 1 -> Type) (b : P North)
+    (p : DPath P (merid North @ (merid South)^) b b)
+    : forall x : Sphere 1, P x.
+  Proof.
+    serapply Susp_ind.
+    1: exact b.
+    1: exact (merid South # b).
+    serapply Susp_ind; hnf.
+    { apply moveL_transport_p.
+      refine ((transport_pp _ _ _ _)^ @ _).
+      apply dp_path_transport^-1.
+      apply p. }
+    1: reflexivity.
+    apply Empty_ind.
+  Defined.
+
+  Definition Sph1_rec (P : Type) (b : P) (p : b = b)
+    : Sphere 1 -> P.
+  Proof.
+    serapply Susp_rec.
+    1,2: exact b.
+    simpl.
+    serapply Susp_rec.
+    1: exact p.
+    1: reflexivity.
+    apply Empty_rec.
+  Defined.
+
+  Definition Sph1_rec_beta_loop (P : Type) (b : P) (p : b = b)
+    : ap (Sph1_rec P b p) (merid North @ (merid South)^) = p.
+  Proof.
+    rewrite ap_pp.
+    rewrite ap_V.
+    rewrite 2 Susp_rec_beta_merid.
+    apply concat_p1.
+  Defined.
+
+  Definition s1_turn : forall x : Sphere 1, x = x.
+  Proof.
+    serapply Sph1_ind.
+    + exact (merid North @ (merid South)^).
+    + apply dp_paths_lr.
+      by rewrite concat_Vp, concat_1p.
+  Defined.
+
+  Global Instance sgop_s1 : SgOp (psphere 1)
+    := fun x y => Sph1_rec _ y (s1_turn y) x.
+
+  Global Instance leftidentity_s1
+    : LeftIdentity sgop_s1 (point (psphere 1)).
+  Proof.
+    serapply Sph1_ind.
+    1: reflexivity.
+    apply dp_paths_lr.
+    rewrite concat_p1.
+    apply concat_Vp.
+  Defined.
+
+  Global Instance rightidentity_s1
+    : RightIdentity sgop_s1 (point (psphere 1)).
+  Proof.
+    serapply Sph1_ind.
+    1: reflexivity.
+    apply dp_paths_FlFr.
+    rewrite concat_p1.
+    rewrite ap_idmap.
+    rewrite Sph1_rec_beta_loop.
+    apply concat_Vp.
+  Defined.
+
+  Global Instance hspace_s1 : IsHSpace (psphere 1) := {}.
+
+  Global Instance associative_sgop_s1
+    : Associative sgop_s1.
+  Proof.
+    intros x y z.
+    revert x.
+    serapply Sph1_ind.
+    1: reflexivity.
+    apply sq_dp^-1.
+    revert y.
+    serapply Sph1_ind.
+    { apply (sq_flip_v (px0:=1) (px1:=1)).
+      exact (ap_nat' (fun a => ap (fun b => sgop_s1 b z)
+        (rightidentity_s1 a)) (merid North @ (merid South)^)). }
+    simpl.
+    serapply dp_ishprop.
+  Defined.
+
+  Global Instance commutative_sgop_s1
+    : Commutative sgop_s1.
+  Proof.
+    intros x y.
+    revert x.
+    serapply Sph1_ind.
+    1: cbn; symmetry; apply right_identity.
+    apply sq_dp^-1.
+    revert y.
+    serapply Sph1_ind.
+    1: exact (ap_nat' rightidentity_s1 _).
+    serapply dp_ishprop.
+  Defined.
+
+End HSpace_S1.


### PR DESCRIPTION
This relies on #1150 and #1147. See the last 5 commits to review.

Here's what I've done:
* Show that `Sphere 1` is 1-truncated
* Show that `Sphere n.+1` is n-connected
* Stop spheres from unfolding, closes #1018 
* Corrected istrunc for DPath's, and added the default dpath between any families of hprops connected by a path in the base space.
* Shown that a square type in a n.+2 truncated type is n-truncated.
* Shown that S1 has a H-space structure which is associative and commutative.