### PR TITLE
Get rid of Global Generalizable Variables

### DIFF
--- a/theories/Algebra/Congruence.v
+++ b/theories/Algebra/Congruence.v
@@ -7,6 +7,6 @@ Require Import Classes.interfaces.abstract_algebra.
 
 Local Open Scope mc_mult_scope.
 
-Class IsCongruence `{SgOp G} (R : Relation G) := {
+Class IsCongruence {G} `{SgOp G} (R : Relation G) := {
   iscong {x x' y y'} : R x x' -> R y y' -> R (x * y) (x' * y');
 }.

--- a/theories/Algebra/Group.v
+++ b/theories/Algebra/Group.v
@@ -6,6 +6,8 @@ Require Export Classes.theory.groups.
 Require Import Pointed.Core.
 Require Basics.Utf8.
 
+Generalizable Variables G H A B C f g.
+
 (** ** Groups *)
 
 Local Open Scope mc_mult_scope.

--- a/theories/Algebra/Subgroup.v
+++ b/theories/Algebra/Subgroup.v
@@ -4,6 +4,7 @@ Require Import HSet.
 Require Import Algebra.Group.
 
 Local Open Scope mc_mult_scope.
+Generalizable Variables G H A B C N f g.
 
 (** * Subgroups *)
 

--- a/theories/Classes/implementations/field_of_fractions.v
+++ b/theories/Classes/implementations/field_of_fractions.v
@@ -204,8 +204,8 @@ Arguments equiv {R _ _} _ _.
 
 
 Section morphisms.
-Context `{IsIntegralDomain R1} `{DecidablePaths R1}.
-Context `{IsIntegralDomain R2} `{DecidablePaths R2}.
+Context {R1} `{IsIntegralDomain R1} `{DecidablePaths R1}.
+Context {R2} `{IsIntegralDomain R2} `{DecidablePaths R2}.
 Context `(f : R1 -> R2) `{!IsSemiRingPreserving f} `{!IsInjective f}.
 
 Definition lift (x : Frac R1) : Frac R2.

--- a/theories/Classes/implementations/list.v
+++ b/theories/Classes/implementations/list.v
@@ -2,6 +2,8 @@ Require Import
   HoTT.Classes.interfaces.abstract_algebra
   HoTT.Types.Unit HoTT.Types.Prod.
 
+Generalizable Variables A B C.
+
 Open Scope list_scope.
 
 (** Standard notations for lists. 

--- a/theories/Classes/implementations/natpair_integers.v
+++ b/theories/Classes/implementations/natpair_integers.v
@@ -18,6 +18,8 @@ Require Import
   HoTT.Classes.interfaces.naturals
   HoTT.Classes.theory.naturals.
 
+Generalizable Variables B.
+
 Local Set Universe Minimization ToSet.
 
 Module NatPair.

--- a/theories/Classes/interfaces/abstract_algebra.v
+++ b/theories/Classes/interfaces/abstract_algebra.v
@@ -2,6 +2,8 @@ Require Coq.Init.Peano.
 Require Export
   HoTT.Classes.interfaces.canonical_names.
 
+Generalizable Variables A B f g x y.
+
 (* 
 For various structures we omit declaration of substructures. For example, if we 
 say:

--- a/theories/Classes/interfaces/canonical_names.v
+++ b/theories/Classes/interfaces/canonical_names.v
@@ -7,15 +7,7 @@ Declare Scope mc_scope.
 Delimit Scope mc_scope with mc.
 Global Open Scope mc_scope.
 
-(* 'o' is used for the compose notation. *)
-Global Generalizable Variables
-  A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
-  a b c d e f g h i j k l m n p q r s t u v w x y z
-  Fa Ga
-  Fle Flt Nle Nlt Rle Rlt
-  R1le R2le
-  Alt Blt R1lt R2lt Vlt Zle Zlt
-  SR.
+Generalizable Variables A B f g x y.
 
 Monomorphic Universe Ularge Uhuge.
 Monomorphic Constraint Ularge < Uhuge.

--- a/theories/Classes/interfaces/integers.v
+++ b/theories/Classes/interfaces/integers.v
@@ -12,8 +12,8 @@ Class Integers A {Aap:Apart A} {Aplus Amult Azero Aone Anegate Ale Alt}
   `{U : IntegersToRing A} :=
   { integers_ring :> @IsRing A Aplus Amult Azero Aone Anegate
   ; integers_order :> FullPseudoSemiRingOrder Ale Alt
-  ; integers_to_ring_mor:> forall `{IsRing B}, IsSemiRingPreserving (integers_to_ring A B)
-  ; integers_initial: forall `{IsRing B} {h : A -> B} `{!IsSemiRingPreserving h} x,
+  ; integers_to_ring_mor:> forall {B} `{IsRing B}, IsSemiRingPreserving (integers_to_ring A B)
+  ; integers_initial: forall {B} `{IsRing B} {h : A -> B} `{!IsSemiRingPreserving h} x,
       integers_to_ring A B x = h x}.
 
 Section specializable.

--- a/theories/Classes/interfaces/naturals.v
+++ b/theories/Classes/interfaces/naturals.v
@@ -11,16 +11,16 @@ Class Naturals A {Aap:Apart A} {Aplus Amult Azero Aone Ale Alt}
   `{U: NaturalsToSemiRing A} :=
   { naturals_ring :> @IsSemiRing A Aplus Amult Azero Aone
   ; naturals_order :> FullPseudoSemiRingOrder Ale Alt
-  ; naturals_to_semiring_mor:> forall `{IsSemiRing B},
+  ; naturals_to_semiring_mor:> forall {B} `{IsSemiRing B},
     IsSemiRingPreserving (naturals_to_semiring A B)
-  ; naturals_initial: forall `{IsSemiRing B} {h : A -> B} `{!IsSemiRingPreserving h} x,
+  ; naturals_initial: forall {B} `{IsSemiRing B} {h : A -> B} `{!IsSemiRingPreserving h} x,
     naturals_to_semiring A B x = h x }.
 
 (* Specializable operations: *)
 Class NatDistance N `{Plus N}
   := nat_distance_sig : forall x y : N, { z : N | (x + z = y)%mc } |_|
                                    { z : N | (y + z = x)%mc }.
-Definition nat_distance `{nd : NatDistance N} (x y : N) :=
+Definition nat_distance {N} `{nd : NatDistance N} (x y : N) :=
   match nat_distance_sig x y with
   | inl (n;_) => n
   | inr (n;_) => n

--- a/theories/Classes/interfaces/orders.v
+++ b/theories/Classes/interfaces/orders.v
@@ -1,5 +1,7 @@
 Require Import HoTT.Classes.interfaces.abstract_algebra.
 
+Generalizable Variables A.
+
 (*
 In this file we describe interfaces for ordered structures. Since we are in a
 constructive setting we use a pseudo order instead of a total order. Therefore

--- a/theories/Classes/interfaces/rationals.v
+++ b/theories/Classes/interfaces/rationals.v
@@ -23,8 +23,8 @@ Class Rationals A {Aap : Apart A} {Aplus Amult Azero Aone Aneg Arecip Ale Alt}
   `{U : !RationalsToField A} :=
   { rationals_field :> @IsDecField A Aplus Amult Azero Aone Aneg Arecip
   ; rationals_order :> FullPseudoSemiRingOrder Ale Alt
-  ; rationals_to_field_mor :> forall `{IsField B} `{!FieldCharacteristic B 0},
+  ; rationals_to_field_mor :> forall {B} `{IsField B} `{!FieldCharacteristic B 0},
     IsSemiRingPreserving (rationals_to_field A B)
-  ; rationals_initial : forall `{IsField B} `{!FieldCharacteristic B 0}
+  ; rationals_initial : forall {B} `{IsField B} `{!FieldCharacteristic B 0}
     {h : A -> B} `{!IsSemiRingPreserving h} x,
     rationals_to_field A B x = h x }.

--- a/theories/Classes/orders/dec_fields.v
+++ b/theories/Classes/orders/dec_fields.v
@@ -8,6 +8,8 @@ Require Export
   HoTT.Classes.orders.rings.
 Require Import HoTT.Classes.tactics.ring_tac.
 
+Generalizable Variables F f R Fle Flt.
+
 Section contents.
 Context `{IsDecField F} `{Apart F} `{!TrivialApart F}
   `{!FullPseudoSemiRingOrder Fle Flt} `{DecidablePaths F}.

--- a/theories/Classes/orders/integers.v
+++ b/theories/Classes/orders/integers.v
@@ -14,6 +14,8 @@ Require Import
 Require Export
   HoTT.Classes.orders.nat_int.
 
+Generalizable Variables N Z R f.
+
 Section integers.
 Context `{Funext} `{Univalence}.
 Context `{Integers Z} `{!TrivialApart Z}.

--- a/theories/Classes/orders/lattices.v
+++ b/theories/Classes/orders/lattices.v
@@ -4,6 +4,8 @@ Require Import
   HoTT.Classes.orders.maps
   HoTT.Classes.theory.lattices.
 
+Generalizable Variables K L f.
+
 (*
 We prove that the algebraic definition of a lattice corresponds to the
 order theoretic one. Note that we do not make any of these instances global,

--- a/theories/Classes/orders/maps.v
+++ b/theories/Classes/orders/maps.v
@@ -4,6 +4,8 @@ Require Import
   HoTT.Classes.orders.orders
   HoTT.Classes.theory.apartness.
 
+Generalizable Variables A B C R S f g z.
+
 (* If a function between strict partial orders is order preserving (back), we can
   derive that it is strictly order preserving (back) *)
 Section strictly_order_preserving.

--- a/theories/Classes/orders/nat_int.v
+++ b/theories/Classes/orders/nat_int.v
@@ -9,6 +9,8 @@ Require Import
 Require Export
   HoTT.Classes.orders.semirings.
 
+Generalizable Variables N R f.
+
 Section Univ.
 Context `{Funext} `{Univalence}.
 

--- a/theories/Classes/orders/naturals.v
+++ b/theories/Classes/orders/naturals.v
@@ -14,6 +14,8 @@ Require Import
 Require Export
   HoTT.Classes.orders.nat_int.
 
+Generalizable Variables N R Rle Rlt f.
+
 Section naturals_order.
 Context `{Funext} `{Univalence}.
 Context `{Naturals N} `{!TrivialApart N}.

--- a/theories/Classes/orders/orders.v
+++ b/theories/Classes/orders/orders.v
@@ -4,6 +4,8 @@ Require Import
   HoTT.Classes.interfaces.orders
   HoTT.Classes.theory.apartness.
 
+Generalizable Variables A.
+
 Lemma irrefl_neq `{R : Relation A} `{!Irreflexive R}
   : forall x y, R x y -> ~ x = y.
 Proof.

--- a/theories/Classes/orders/rings.v
+++ b/theories/Classes/orders/rings.v
@@ -5,6 +5,8 @@ Require Import
 Require Export
   HoTT.Classes.orders.semirings.
 
+Generalizable Variables R Rle Rlt R1le R1lt.
+
 Section from_ring_order.
   Context `{IsRing R} `{!PartialOrder Rle}
     (plus_spec : forall z, OrderPreserving (z +))

--- a/theories/Classes/orders/semirings.v
+++ b/theories/Classes/orders/semirings.v
@@ -7,6 +7,8 @@ Require Export
   HoTT.Classes.orders.orders
   HoTT.Classes.orders.maps.
 
+Generalizable Variables R Rlt f.
+
 Section semiring_order.
   Context `{SemiRingOrder R} `{!IsSemiRing R}.
 (*   Add Ring R : (stdlib_semiring_theory R). *)

--- a/theories/Classes/orders/sum.v
+++ b/theories/Classes/orders/sum.v
@@ -2,6 +2,8 @@ Require Import
   HoTT.Classes.interfaces.canonical_names
   HoTT.Classes.interfaces.orders.
 
+Generalizable Variables A B.
+
 Global Instance Empty_lt : Lt@{Set Set} Empty.
 Proof. intros []. Defined.
 

--- a/theories/Classes/tactics/ring_pol.v
+++ b/theories/Classes/tactics/ring_pol.v
@@ -5,6 +5,8 @@ Require Import
   HoTT.Classes.tactics.ring_quote
   HoTT.Classes.theory.rings.
 
+Generalizable Variables Vlt.
+
 Import Quoting.
 Local Set Universe Minimization ToSet.
 

--- a/theories/Classes/tactics/ring_tac.v
+++ b/theories/Classes/tactics/ring_tac.v
@@ -10,6 +10,8 @@ Require Import
   HoTT.Classes.interfaces.naturals
   HoTT.Classes.interfaces.integers.
 
+Generalizable Variables A B C R V f l n m Vlt.
+
 Section content.
 Context `{DecidablePaths C}.
 

--- a/theories/Classes/tests/ring_tac.v
+++ b/theories/Classes/tests/ring_tac.v
@@ -2,6 +2,8 @@ Require Import
   HoTT.Classes.interfaces.abstract_algebra
   HoTT.Classes.tactics.ring_tac.
 
+Generalizable Variables R.
+
 Lemma test1 `{IsSemiRing R}
   : forall x y : R, x + (y * x) = x * (y + 1).
 Proof.

--- a/theories/Classes/theory/additional_operations.v
+++ b/theories/Classes/theory/additional_operations.v
@@ -1,5 +1,7 @@
 Require Import HoTT.Classes.interfaces.abstract_algebra.
 
+Generalizable Variables A R.
+
 Local Set Universe Minimization ToSet.
 
 Instance decide_eqb `{DecidablePaths A} : Eqb A

--- a/theories/Classes/theory/apartness.v
+++ b/theories/Classes/theory/apartness.v
@@ -1,6 +1,8 @@
 Require Import HoTT.Basics.Decidable HoTT.Truncations.
 Require Import HoTT.Classes.interfaces.abstract_algebra.
 
+Generalizable Variables A B C f g.
+
 Section contents.
 Context `{IsApart A}.
 

--- a/theories/Classes/theory/dec_fields.v
+++ b/theories/Classes/theory/dec_fields.v
@@ -5,6 +5,8 @@ Require Import
 Require Export
   HoTT.Classes.theory.rings.
 
+Generalizable Variables F f R.
+
 Section contents.
 Context `{IsDecField F} `{forall x y: F, Decidable (x = y)}.
 

--- a/theories/Classes/theory/fields.v
+++ b/theories/Classes/theory/fields.v
@@ -5,6 +5,8 @@ Require Import
 Require Export
   HoTT.Classes.theory.rings.
 
+Generalizable Variables F f.
+
 Section field_properties.
 Context `{IsField F}.
 

--- a/theories/Classes/theory/groups.v
+++ b/theories/Classes/theory/groups.v
@@ -2,6 +2,7 @@ Require Import
   HoTT.Classes.interfaces.abstract_algebra.
 
 Local Open Scope mc_mult_scope.
+Generalizable Variables G H A B C f g.
 
 Section group_props.
   Context `{IsGroup G}.

--- a/theories/Classes/theory/int_abs.v
+++ b/theories/Classes/theory/int_abs.v
@@ -8,6 +8,8 @@ Require Import
   HoTT.Classes.theory.rings
   HoTT.Classes.orders.rings.
 
+Generalizable Variables N Z Zle Zlt R f.
+
 Section contents.
 Context `{Funext} `{Univalence}.
 Context `{Integers Z} `{Apart Z} `{!TrivialApart Z}

--- a/theories/Classes/theory/integers.v
+++ b/theories/Classes/theory/integers.v
@@ -13,6 +13,7 @@ Require Import
 Require Export
  HoTT.Classes.interfaces.integers.
 
+Generalizable Variables N Z R f.
 
 Lemma to_ring_unique `{Integers Z} `{IsRing R} (f: Z -> R)
   {h: IsSemiRingPreserving f} x

--- a/theories/Classes/theory/lattices.v
+++ b/theories/Classes/theory/lattices.v
@@ -2,6 +2,8 @@ Require Import
   HoTT.Classes.interfaces.abstract_algebra
   HoTT.Classes.theory.groups.
 
+Generalizable Variables A B C K L f.
+
 Instance bounded_sl_is_sl `{IsBoundedSemiLattice L} : IsSemiLattice L.
 Proof.
 repeat (split; try apply _).

--- a/theories/Classes/theory/nat_distance.v
+++ b/theories/Classes/theory/nat_distance.v
@@ -8,6 +8,8 @@ Require Import
   HoTT.Classes.interfaces.orders
   HoTT.Classes.theory.additional_operations.
 
+Generalizable Variables N.
+
 Section contents.
 Context `{Funext} `{Univalence}.
 Context `{Naturals N}.

--- a/theories/Classes/theory/naturals.v
+++ b/theories/Classes/theory/naturals.v
@@ -10,6 +10,8 @@ Require Import
 Require Export
   HoTT.Classes.interfaces.naturals.
 
+Generalizable Variables A N R SR f.
+
 (* This grabs a coercion. *)
 Import SemiRings.
 

--- a/theories/Classes/theory/premetric.v
+++ b/theories/Classes/theory/premetric.v
@@ -16,6 +16,8 @@ Require Import
   HoTT.Classes.theory.additional_operations
   HoTT.Classes.implementations.assume_rationals.
 
+Generalizable Variables A B.
+
 Local Set Universe Minimization ToSet.
 
 

--- a/theories/Classes/theory/rings.v
+++ b/theories/Classes/theory/rings.v
@@ -4,6 +4,8 @@ Require
 Require Import
   HoTT.Classes.interfaces.abstract_algebra.
 
+Generalizable Variables R A B C f z.
+
 Definition is_ne_0 `(x : R) `{Zero R} `{p : PropHolds (x <> 0)}
   : x <> 0 := p.
 Definition is_nonneg `(x : R) `{Le R} `{Zero R} `{p : PropHolds (0 ≤ x)}


### PR DESCRIPTION
Setting `Global Generalizable Variables` in `canonical_names` means that any file anywhere in the library that uses hottclasses implicitly inherits those generalizable variables, perhaps to the surprise of the user.  I think we should be less lazy and explicitly indicate in each file whether we want generalizable variables.