### PR TITLE
[hoqidetop] Create a shim for coqidetop

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,6 +4,9 @@ bin_SCRIPTS = hoqtop hoqc hoqdep hoq-config
 if make_hoqide
   bin_SCRIPTS += hoqide
 endif
+if make_hoqidetop
+  bin_SCRIPTS += hoqidetop
+endif
 if make_hoqtopbyte
   bin_SCRIPTS += hoqtop.byte
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -108,6 +108,34 @@ AS_IF([test "x$make_coqide" = "xno"],
 
 AM_CONDITIONAL(make_hoqide, [test "$make_coqide" = "yes"])
 
+# Checking for coqidetop, which can be optional
+make_coqidetop="no"
+AC_ARG_WITH([coqidetop],
+            [AS_HELP_STRING([--without-coqidetop], [disable support for coqidetop])],
+            [],
+            [make_coqidetop="yes"])
+
+AS_IF([test "x$make_coqidetop" = "xno"],
+      [AC_MSG_NOTICE([Will not make hoqidetop])],
+      [AC_ARG_VAR([COQIDETOP], [the absolute path of the coqidetop executable])
+       AS_IF([test "x$COQIDETOP" != "x"],
+             [AC_MSG_CHECKING([for coqidetop])
+              AC_MSG_RESULT([(preset) $COQIDETOP])
+              AC_SUBST([COQIDETOP])],
+             [AC_PATH_PROG([COQIDETOP],[coqidetop.opt],[no],[$COQBIN_PATH])])
+       AS_IF([test "x$COQIDETOP" = "xno"],
+             [AC_MSG_NOTICE([Could not find coqidetop])
+              make_coqidetop="no"],
+             [AC_MSG_NOTICE([Trusting that coqidetop version is $COQVERSION])
+              COQIDETOPVERSION="$COQVERSION"
+              AC_SUBST([COQIDETOPVERSION])
+              AS_IF([test "x$COQIDETOPVERSION" != "x$COQVERSION"],
+                    [AC_MSG_ERROR([Version mismatch between coqtop $COQVERSION and coqidetop $COQIDETOPVERSION])])
+             ])
+      ])
+
+AM_CONDITIONAL(make_hoqidetop, [test "$make_coqidetop" = "yes"])
+
 # Checking for coqchk, which can be optional
 make_coqchk="no"
 AC_ARG_WITH([coqchk],

--- a/hoq-config.in
+++ b/hoq-config.in
@@ -11,6 +11,7 @@ export COQDEP="@COQDEP@"
 export COQDOC="@COQDOC@"
 export COQIDE="@COQIDE@"
 export COQTOP="@COQTOP@"
+export COQIDETOP="@COQIDETOP@"
 
 function readlink_f() {
     # readlink -f doesn't work on Mac OS.  So we roll our own readlink

--- a/hoqidetop
+++ b/hoqidetop
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# This is a wrapper around coqidetop which tricks Coq into using the HoTT
+# standard library and enables the HoTT-specific options.
+
+function readlink_f() {
+    # readlink -f doesn't work on Mac OS.  So we roll our own readlink
+    # -f, from
+    # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
+    TARGET_FILE="$1"
+
+    cd "$(dirname "$TARGET_FILE")"
+    TARGET_FILE=`basename "$TARGET_FILE"`
+
+    # Iterate down a (possible) chain of symlinks
+    while [ -L "$TARGET_FILE" ]
+    do
+	TARGET_FILE=`readlink "$TARGET_FILE"`
+	cd "$(dirname "$TARGET_FILE")"
+	TARGET_FILE=`basename "$TARGET_FILE"`
+    done
+
+    # Compute the canonicalized name by finding the physical path
+    # for the directory we're in and appending the target file.
+    PHYS_DIR=`pwd -P`
+    RESULT="$PHYS_DIR/$TARGET_FILE"
+    echo "$RESULT"
+}
+
+mydir="$(dirname "$(readlink_f "${BASH_SOURCE[0]}")")"
+if [ ! -f "$mydir/hoq-config" ]
+then
+  echo "Could not find hoq-config. Did you run ./configure?"
+  exit 1
+fi
+
+. "$mydir/hoq-config"
+if [ "x$COQIDETOP" = "xno" ]
+then
+  echo "Fatal error: coqidetop with -indices-matter was not found during configuration."
+  exit 1
+fi
+
+# We could stick the arguments in hoq-config in COQ_ARGS, and then,
+# using (non-portable) bash arrays, do
+# $ exec "$COQIDETOP" "${COQ_ARGS[@]}" "$@"
+# or using more evil (but portable) 'eval', do
+# $ eval 'exec "$COQIDETOP" '"$COQ_ARGS"' "$@"'
+# Instead, we duplicate code, because it's simpler.
+exec "$COQIDETOP" -coqlib "$COQLIB" -R "$HOTTLIB" HoTT -Q "$HOTTCONTRIB" "" -indices-matter "$@"


### PR DESCRIPTION
The [vscoq](https://github.com/coq-community/vscoq) extension uses coqidetop.opt, so let's create a shim for this.