### PR TITLE
Basics of wild 1-categories

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -43,6 +43,22 @@ theories/Basics/Trunc.v
 theories/Basics/Decidable.v
 
 #
+#   Wildcat
+#
+theories/WildCat.v
+theories/WildCat/Core.v
+theories/WildCat/UnitCat.v
+theories/WildCat/EmptyCat.v
+theories/WildCat/Prod.v
+theories/WildCat/Equiv.v
+theories/WildCat/Sum.v
+theories/WildCat/Opposite.v
+theories/WildCat/Type.v
+theories/WildCat/Induced.v
+theories/WildCat/FunctorCat.v
+theories/WildCat/Yoneda.v
+
+#
 #   Types
 #
 
@@ -268,6 +284,7 @@ theories/Pointed/pEquiv.v
 theories/Pointed/pTrunc.v
 theories/Pointed/pHomotopy.v
 theories/Pointed/pSusp.v
+theories/Pointed/pType.v
 
 #
 #   Spectra

--- a/theories/Basics/Notations.v
+++ b/theories/Basics/Notations.v
@@ -13,6 +13,16 @@ Reserved Infix "=n" (at level 70, no associativity).
 Reserved Infix "o*" (at level 40).
 Reserved Infix "oL" (at level 40, left associativity).
 Reserved Infix "oR" (at level 40, left associativity).
+Reserved Infix "$->" (at level 99).
+Reserved Infix "$<~>" (at level 85).
+Reserved Infix "$o" (at level 40).
+Reserved Infix "$oE" (at level 40).
+Reserved Infix "$==" (at level 70).
+Reserved Infix "$o@" (at level 30).
+Reserved Infix "$@" (at level 30).
+Reserved Infix "$@L" (at level 30).
+Reserved Infix "$@R" (at level 30).
+Reserved Infix "$=>" (at level 99).
 Reserved Notation "~~ A" (at level 75, right associativity, only parsing).
 Reserved Notation "A <~> B" (at level 85).
 Reserved Notation "a // 'CAT'" (at level 40, left associativity).
@@ -28,8 +38,10 @@ Reserved Notation "F '_0' x" (at level 10, no associativity).
 Reserved Notation "F '_0' x" (at level 10, no associativity, only parsing).
 Reserved Notation "f ^-1" (at level 3, format "f '^-1'").
 Reserved Notation "f ^-1*" (at level 3, format "f '^-1*'").
+Reserved Notation "f ^-1$" (at level 3, format "f '^-1$'").
 Reserved Notation "F '_1' m" (at level 10, no associativity).
 Reserved Notation "f ^*" (at level 20).
+Reserved Notation "f ^$" (at level 20).
 Reserved Notation "f *E g" (at level 40, no associativity).
 Reserved Notation "f +E g" (at level 50, left associativity).
 Reserved Notation "f == g" (at level 70, no associativity).

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -164,7 +164,7 @@ Notation pr2 := projT2.
 Notation "x .1" := (pr1 x) : fibration_scope.
 Notation "x .2" := (pr2 x) : fibration_scope.
 
-Definition uncurry {A B C} (f: A -> B -> C) (p: A * B): C := f (fst p) (snd p).
+Definition uncurry {A B C} (f : A -> B -> C) (p : A * B) : C := f (fst p) (snd p).
 
 (** Composition of functions. *)
 

--- a/theories/Categories.v
+++ b/theories/Categories.v
@@ -65,7 +65,7 @@ Require CategoryOfSections.
 (** ** The Dependent Product *)
 Require DependentProduct.
 (** ** The Yoneda Lemma *)
-Require Yoneda.
+Require Categories.Yoneda.
 (** ** The Structure Identity Principle *)
 Require Structure.
 (** ** Fundamental Pregroupoids *)
@@ -105,7 +105,7 @@ Include LaxComma.Core.
 Include DualFunctor.
 Include CategoryOfSections.Core.
 Include DependentProduct.
-Include Yoneda.
+Include Categories.Yoneda.
 Include Structure.Core.
 Include FundamentalPreGroupoidCategory.
 Include HomotopyPreCategory.

--- a/theories/HoTT.v
+++ b/theories/HoTT.v
@@ -5,6 +5,7 @@
 
 Require Export HoTT.Basics.
 Require Export HoTT.Types.
+Require Export HoTT.WildCat.
 Require Export HoTT.Cubical.
 Require Export HoTT.Pointed.
 Require Export HoTT.Truncations.

--- a/theories/Pointed/Loops.v
+++ b/theories/Pointed/Loops.v
@@ -346,7 +346,7 @@ Local Notation "( X , x )" := (Build_pType X x).
 Definition loops_type `{Univalence} (A : Type)
   : loops (Type,A) <~>* (A <~> A, equiv_idmap).
 Proof.
-  apply issig_pequiv.
+  apply issig_pequiv'.
   exists (equiv_equiv_path A A).
   reflexivity.
 Defined.
@@ -357,7 +357,7 @@ Lemma local_global_looping `{Univalence} (A : Type) (n : nat)
 Proof.
   induction n.
   { refine (_ o*E pequiv_loops_functor (loops_type A)).
-    apply issig_pequiv.
+    apply issig_pequiv'.
     exists (equiv_inverse (equiv_path_arrow 1%equiv 1%equiv)
             oE equiv_inverse (equiv_path_equiv 1%equiv 1%equiv)).
     reflexivity. }

--- a/theories/Pointed/pEquiv.v
+++ b/theories/Pointed/pEquiv.v
@@ -1,6 +1,7 @@
 Require Import Basics.
 Require Import Types.
-Require Import Pointed.Core.
+Require Import Pointed.Core Pointed.pMap Pointed.pHomotopy.
+Require Import UnivalenceImpliesFunext.
 
 Local Open Scope pointed_scope.
 
@@ -44,8 +45,28 @@ Defined.
 
 Notation "g o*E f" := (pequiv_compose f g) : pointed_scope.
 
-(* The record for pointed equivalences is equivalently a sigma type *)
 Definition issig_pequiv (A B : pType)
+  : { f : A ->* B & IsEquiv f } <~> (A <~>* B).
+Proof.
+  issig.
+Defined.
+
+(* Two pointed equivalences are equal if their underlying pointed functions are pointed homotopic. *)
+Definition equiv_path_pequiv `{Funext} {A B : pType} (f g : A <~>* B)
+  : (f ==* g) <~> (f = g).
+Proof.
+  transitivity ((issig_pequiv A B)^-1 f = (issig_pequiv A B)^-1 g).
+  - refine (equiv_path_sigma_hprop _ _ oE _).
+    apply (equiv_path_pmap f g).
+  - symmetry; exact (equiv_ap' (issig_pequiv A B)^-1 f g).
+Defined.
+
+Definition path_pequiv `{Funext} {A B : pType} (f g : A <~>* B)
+  : (f ==* g) -> (f = g)
+  := fun p => equiv_path_pequiv f g p.
+
+(* The record for pointed equivalences is equivalently a different sigma type *)
+Definition issig_pequiv' (A B : pType)
   : { f : A <~> B & f (point A) = point B } <~> (A <~>* B).
 Proof.
   transitivity { f : A ->* B & IsEquiv f }.
@@ -71,7 +92,7 @@ Proof.
   destruct A as [A a], B as [B b].
   refine (equiv_ap issig_ptype (A;a) (B;b) oE _).
   refine (equiv_path_sigma _ _ _ oE _).
-  refine (_ oE (issig_pequiv _ _)^-1); simpl.
+  refine (_ oE (issig_pequiv' _ _)^-1); simpl.
   refine (equiv_functor_sigma' (equiv_path_universe A B) _); intros f.
   apply equiv_concat_l.
   apply transport_path_universe.

--- a/theories/Pointed/pFiber.v
+++ b/theories/Pointed/pFiber.v
@@ -23,7 +23,7 @@ Definition pfib {A B : pType} (f : A ->* B) : pfiber f ->* A
 Definition pfiber2_loops {A B : pType} (f : A ->* B)
 : pfiber (pfib f) <~>* loops B.
 Proof.
-  apply issig_pequiv; simple refine (_;_).
+  apply issig_pequiv'; simple refine (_;_).
   - simpl; unfold hfiber.
     refine (_ oE (equiv_sigma_assoc _ _)^-1); simpl.
     refine (_ oE (equiv_functor_sigma'

--- a/theories/Pointed/pType.v
+++ b/theories/Pointed/pType.v
@@ -1,0 +1,75 @@
+(* -*- mode: coq; mode: visual-line -*- *)
+Require Import Basics Types.
+Require Import Pointed.Core.
+Require Import WildCat.
+Require Import pHomotopy pMap pEquiv.
+
+Local Open Scope pointed_scope.
+Local Open Scope path_scope.
+
+(** * pType as a wild category *)
+
+Global Instance is01cat_ptype : Is01Cat pType
+  := Build_Is01Cat pType pMap (@pmap_idmap) (@pmap_compose).
+
+Global Instance is01cat_pmap (A B : pType) : Is01Cat (A ->* B).
+Proof.
+  srapply (Build_Is01Cat (A ->* B) (@pHomotopy A B)).
+  - reflexivity.
+  - intros a b c f g; transitivity b; assumption.
+Defined.
+
+Global Instance is0gpd_pmap (A B : pType) : Is0Gpd (A ->* B).
+Proof.
+  srapply Build_Is0Gpd.
+  intros; symmetry; assumption.
+Defined.
+
+Global Instance is1cat_ptype : Is1Cat pType.
+Proof.
+  simple refine (Build_Is1Cat _ _ _ _ _ _ _ _); try exact _.
+  - intros A B C; rapply Build_Is0Functor.
+    intros [f1 f2] [g1 g2] [p q]; cbn.
+    transitivity (f1 o* g2).
+    + apply pmap_postwhisker; assumption.
+    + apply pmap_prewhisker; assumption.
+  - intros ? ? ? ? f g h; exact (pmap_compose_assoc h g f).
+  - intros ? ? f; exact (pmap_postcompose_idmap f).
+  - intros ? ? f; exact (pmap_precompose_idmap f).
+Defined.
+
+Global Instance hasmorext_ptype `{Funext} : HasMorExt pType.
+Proof.
+  srapply Build_HasMorExt; intros A B f g.
+  refine (isequiv_homotopic (equiv_path_pmap f g)^-1 _).
+  intros []; reflexivity.
+Defined.
+
+
+Global Instance hasequivs_ptype : HasEquivs pType.
+Proof.
+  srapply (Build_HasEquivs _ _ _ pEquiv (fun A B f => IsEquiv f));
+    intros A B f; cbn; intros.
+  - exact f.
+  - exact _.
+  - exact (Build_pEquiv _ _ f _).
+  - reflexivity.
+  - exact ((Build_pEquiv _ _ f _)^-1*).
+  - apply peissect.
+  - cbn. refine (peisretr (Build_pEquiv _ _ f _)).
+  - rapply (isequiv_adjointify f g).
+    + intros x; exact (pointed_htpy r x).
+    + intros x; exact (pointed_htpy s x).
+Defined.
+
+Global Instance isunivalent_ptype `{Univalence} : IsUnivalent1Cat pType.
+Proof.
+  srapply Build_IsUnivalent1Cat; intros A B.
+  refine (isequiv_homotopic (equiv_path_ptype A B)^-1 _).
+  intros []; apply path_pequiv.
+  cbn.
+  srefine (Build_pHomotopy _ _).
+  - intros x; reflexivity.
+  - cbn.
+    (* Some messy path algebra here. *)
+Abort.

--- a/theories/WildCat.v
+++ b/theories/WildCat.v
@@ -1,0 +1,11 @@
+Require Export WildCat.Core.
+Require Export WildCat.Equiv.
+Require Export WildCat.UnitCat.
+Require Export WildCat.EmptyCat.
+Require Export WildCat.Opposite.
+Require Export WildCat.Type.
+Require Export WildCat.Induced.
+Require Export WildCat.FunctorCat.
+Require Export WildCat.Yoneda.
+Require Export WildCat.Prod.
+Require Export WildCat.Sum.

--- a/theories/WildCat/Core.v
+++ b/theories/WildCat/Core.v
@@ -1,0 +1,509 @@
+(* -*- mode: coq; mode: visual-line -*-  *)
+
+Require Import Basics.
+
+(** * Wild categories, functors, and transformations *)
+
+(** ** Directed graphs *)
+
+Class IsGraph (A : Type) :=
+{
+  Hom : A -> A -> Type
+}.
+
+Notation "a $-> b" := (Hom a b).
+
+(** ** 0-categorical structures *)
+
+(** A wild (0,1)-category has 1-morphisms and operations on them, but no coherence. *)
+Class Is01Cat (A : Type) := Build_Is01Cat'
+{
+  isgraph_1cat : IsGraph A;
+  Id  : forall (a : A), a $-> a;
+  cat_comp : forall (a b c : A), (b $-> c) -> (a $-> b) -> (a $-> c);
+}.
+
+Global Existing Instance isgraph_1cat.
+Arguments cat_comp {A _ a b c} _ _.
+Notation "g $o f" := (cat_comp g f).
+
+Definition Build_Is01Cat A
+           (Hom' : A -> A -> Type)
+           (Id'  : forall (a : A), Hom' a a)
+           (cat_comp' : forall (a b c : A), Hom' b c -> Hom' a b -> Hom' a c)
+  : Is01Cat A
+  := Build_Is01Cat' A (Build_IsGraph A Hom') Id' cat_comp'.
+
+(** A wild 0-groupoid is a wild (0,1)-category whose morphisms can be reversed.  This is also known as a setoid. *)
+Class Is0Gpd (A : Type) `{Is01Cat A} :=
+  { gpd_rev : forall {a b : A}, (a $-> b) -> (b $-> a) }.
+
+Definition GpdHom {A} `{Is0Gpd A} (a b : A) := a $-> b.
+Notation "a $== b" := (GpdHom a b).
+
+Global Instance reflexive_GpdHom {A} `{Is0Gpd A}
+  : Reflexive GpdHom
+  := fun a => Id a.
+
+Definition gpd_comp {A} `{Is0Gpd A} {a b c : A}
+  : (a $== b) -> (b $== c) -> (a $== c)
+  := fun p q => q $o p.
+Infix "$@" := gpd_comp.
+
+Global Instance transitive_GpdHom {A} `{Is0Gpd A}
+  : Transitive GpdHom
+  := fun a b c f g => f $@ g.
+
+Notation "p ^$" := (gpd_rev p).
+
+Global Instance symmetric_GpdHom {A} `{Is0Gpd A}
+  : Symmetric GpdHom
+  := fun a b f => f^$.
+
+Definition GpdHom_path {A} `{Is0Gpd A} {a b : A} (p : a = b)
+  : a $== b.
+Proof.
+  destruct p; apply Id.
+Defined.
+
+(** A 0-functor acts on morphisms, but satisfies no axioms. *)
+Class Is0Functor {A B : Type} `{IsGraph A} `{IsGraph B} (F : A -> B)
+  := { fmap : forall (a b : A) (f : a $-> b), F a $-> F b }.
+
+Arguments fmap {_ _ _ _} F {_ _ _} f.
+
+(** Products preserve (0,1)-categories. *)
+Global Instance isgraph_prod A B `{IsGraph A} `{IsGraph B}
+  : IsGraph (A * B)
+  := Build_IsGraph (A * B) (fun x y => (fst x $-> fst y) * (snd x $-> snd y)).
+
+Global Instance is01cat_prod A B `{Is01Cat A} `{Is01Cat B}
+  : Is01Cat (A * B).
+Proof.
+  refine (Build_Is01Cat (A * B) (fun x y => (fst x $-> fst y) * (snd x $-> snd y)) _ _).
+  - intros [a b]; exact (Id a, Id b).
+  - intros [a1 b1] [a2 b2] [a3 b3] [f1 g1] [f2 g2]; cbn in *.
+    exact (f1 $o f2 , g1 $o g2).
+Defined.
+
+(** To avoid having to define a separate notion of "two-variable functor", we define two-variable functors in uncurried form.  The following definition applies such a two-variable functor, with a currying built in. *)
+Definition fmap11 {A B C : Type} `{IsGraph A} `{IsGraph B} `{IsGraph C}
+  (F : A -> B -> C) {H2 : Is0Functor (uncurry F)}
+  {a1 a2 : A} {b1 b2 : B} (f1 : a1 $-> a2) (f2 : b1 $-> b2)
+  : F a1 b1 $-> F a2 b2
+  := @fmap _ _ _ _ (uncurry F) H2 (a1, b1) (a2, b2) (f1, f2).
+
+
+(** ** Wild 1-categorical structures *)
+
+(** A wild 1-category (a.k.a. (1,1)-category) has its hom-types enhanced to 0-groupoids, its composition operations to 0-functors, and its composition associative and unital up to these 2-cells. *)
+Class Is1Cat (A : Type) `{Is01Cat A} :=
+{
+  is01cat_hom : forall (a b : A), Is01Cat (a $-> b) ;
+  isgpd_hom : forall (a b : A), Is0Gpd (a $-> b) ;
+  is0functor_comp : forall (a b c : A), Is0Functor (uncurry (@cat_comp A _ a b c)) ;
+  cat_assoc : forall a b c d (f : a $-> b) (g : b $-> c) (h : c $-> d),
+    (h $o g) $o f $== h $o (g $o f);
+  cat_idl : forall a b (f : a $-> b), Id b $o f $== f;
+  cat_idr : forall a b (f : a $-> b), f $o Id a $== f;
+}.
+Global Existing Instance is01cat_hom.
+Global Existing Instance isgpd_hom.
+Global Existing Instance is0functor_comp.
+Arguments cat_assoc {_ _ _ _ _ _ _} f g h.
+Arguments cat_idl {_ _ _ _ _} f.
+Arguments cat_idr {_ _ _ _ _} f.
+
+Definition cat_assoc_opp {A : Type} `{Is1Cat A}
+           {a b c d : A} (f : a $-> b) (g : b $-> c) (h : c $-> d)
+  : h $o (g $o f) $== (h $o g) $o f
+  := (cat_assoc f g h)^$.
+
+Definition Comp2 {A} `{Is1Cat A} {a b c : A}
+           {f g : a $-> b} {h k : b $-> c}
+           (q : h $-> k) (p : f $-> g)
+  : (h $o f $-> k $o g)
+  := fmap11 cat_comp q p.
+
+Infix "$o@" := Comp2.
+
+Definition WhiskerL_Htpy {A} `{Is1Cat A} {a b c : A}
+           {f g : a $-> b} (h : b $-> c) (p : f $== g)
+  : h $o f $== h $o g
+  := (Id h) $o@ p.
+Notation "h $@L p" := (WhiskerL_Htpy h p).
+
+Definition WhiskerR_Htpy {A} `{Is1Cat A} {a b c : A}
+           {f g : b $-> c} (p : f $== g) (h : a $-> b)
+  : f $o h $== g $o h
+  := p $o@ (Id h).
+Notation "p $@R h" := (WhiskerR_Htpy p h).
+
+(** Often, the coherences are actually equalities rather than homotopies. *)
+Class Is1Cat_Strong (A : Type) `{Is01Cat A} := 
+{
+  is01cat_hom_strong : forall (a b : A), Is01Cat (a $-> b) ;
+  isgpd_hom_strong : forall (a b : A), Is0Gpd (a $-> b) ;
+  is0functor_comp_strong : forall (a b c : A), Is0Functor (uncurry (@cat_comp A _ a b c)) ;
+  cat_assoc_strong : forall (a b c d : A)
+    (f : a $-> b) (g : b $-> c) (h : c $-> d),
+    (h $o g) $o f = h $o (g $o f);
+  cat_idl_strong : forall (a b : A) (f : a $-> b), Id b $o f = f;
+  cat_idr_strong : forall (a b : A) (f : a $-> b), f $o Id a = f;
+}.
+
+Arguments cat_assoc_strong {_ _ _ _ _ _ _} f g h.
+Arguments cat_idl_strong {_ _ _ _ _} f.
+Arguments cat_idr_strong {_ _ _ _ _} f.
+
+Definition cat_assoc_opp_strong {A : Type} `{Is1Cat_Strong A}
+           {a b c d : A} (f : a $-> b) (g : b $-> c) (h : c $-> d)
+  : h $o (g $o f) = (h $o g) $o f
+  := (cat_assoc_strong f g h)^.
+
+Global Instance is1cat_is1cat_strong (A : Type) `{Is1Cat_Strong A}
+  : Is1Cat A.
+Proof.
+  srefine (Build_Is1Cat A _ _ _ _ _ _ _).
+  all:intros a b.
+  - apply is01cat_hom_strong.
+  - apply isgpd_hom_strong.
+  - apply is0functor_comp_strong.
+  - intros; apply GpdHom_path, cat_assoc_strong.
+  - intros; apply GpdHom_path, cat_idl_strong.
+  - intros; apply GpdHom_path, cat_idr_strong.
+Defined.
+
+(** Generalizing function extensionality, "Morphism extensionality" states that homwise [GpdHom_path] is an equivalence. *)
+Class HasMorExt (A : Type) `{Is1Cat A} :=
+  { isequiv_Htpy_path : forall a b f g, IsEquiv (@GpdHom_path (a $-> b) _ _ f g) }.
+Global Existing Instance isequiv_Htpy_path.
+
+Definition path_hom {A} `{HasMorExt A} {a b : A} {f g : a $-> b} (p : f $== g) : f = g
+  := GpdHom_path^-1 p.
+
+(** A 1-functor acts on 2-cells (satisfying no axioms) and also preserves composition and identities up to a 2-cell. *)
+Class Is1Functor {A B : Type} `{Is1Cat A} `{Is1Cat B}
+  (* The [!] tells Coq to use typeclass search to find the [IsGraph] parameters of [Is0Functor] instead of assuming additional copies of them. *)
+      (F : A -> B) `{!Is0Functor F} :=
+{
+  fmap2 : forall a b (f g : a $-> b), (f $== g) -> (fmap F f $== fmap F g) ;
+  fmap_id : forall a, fmap F (Id a) $== Id (F a);
+  fmap_comp : forall a b c (f : a $-> b) (g : b $-> c),
+    fmap F (g $o f) $== fmap F g $o fmap F f;
+}.
+
+Arguments fmap2 {A B _ _ _ _} F {_ _ _ _ _ _} p.
+Arguments fmap_id {A B _ _ _ _} F {_ _} a.
+Arguments fmap_comp {A B _ _ _ _} F {_ _ _ _ _} f g.
+
+
+(** ** Natural transformations *)
+
+Definition Transformation {A B : Type} `{IsGraph B} (F : A -> B) (G : A -> B)
+  := forall (a : A), F a $-> G a.
+
+Notation "F $=> G" := (Transformation F G).
+
+(** A 1-natural transformation is natural up to a 2-cell, so its domain must be a 1-category. *)
+Class Is1Natural {A B : Type} `{IsGraph A} `{Is1Cat B}
+      (F : A -> B) `{!Is0Functor F} (G : A -> B) `{!Is0Functor G}
+      (alpha : F $=> G) :=
+{
+  isnat : forall a b (f : a $-> b),
+    alpha b $o fmap F f $== fmap G f $o alpha a;
+}.
+
+Arguments isnat {_ _ _ _ _ _ _ _ _} alpha {alnat _ _} f : rename.
+
+Definition isnat_opp {A B : Type} `{IsGraph A} `{Is1Cat B}
+      {F : A -> B} `{!Is0Functor F} {G : A -> B} `{!Is0Functor G}
+      (alpha : F $=> G) `{!Is1Natural F G alpha}
+      {a b : A} (f : a $-> b)
+  : fmap G f $o alpha a $== alpha b $o fmap F f
+  := (isnat alpha f)^$.
+
+Definition id_transformation {A B : Type} `{Is01Cat B} (F : A -> B)
+  : F $=> F
+  := fun a => Id (F a).
+
+Global Instance is1natural_id {A B : Type} `{IsGraph A} `{Is1Cat B}
+       (F : A -> B) `{!Is0Functor F}
+  : Is1Natural F F (id_transformation F).
+Proof.
+  apply Build_Is1Natural; intros a b f; cbn.
+  refine (cat_idl (fmap F f) $@ (cat_idr (fmap F f))^$).
+Defined.
+
+Definition comp_transformation {A B : Type} `{Is01Cat B}
+           {F G K : A -> B} (gamma : G $=> K) (alpha : F $=> G)
+  : F $=> K
+  := fun a => gamma a $o alpha a.
+
+Global Instance is1natural_comp {A B : Type} `{IsGraph A} `{Is1Cat B}
+       {F G K : A -> B} `{!Is0Functor F} `{!Is0Functor G} `{!Is0Functor K}
+       (gamma : G $=> K) `{!Is1Natural G K gamma}
+       (alpha : F $=> G) `{!Is1Natural F G alpha}
+  : Is1Natural F K (comp_transformation gamma alpha).
+Proof.
+  apply Build_Is1Natural; intros a b f; cbn.
+  refine (cat_assoc _ _ _ $@ _).
+  refine ((gamma b $@L isnat alpha f) $@ _).
+  refine (cat_assoc_opp _ _ _ $@ _).
+  refine ((isnat gamma f) $@R alpha a $@ _).
+  exact (cat_assoc _ _ _).
+Defined.  
+
+(** Modifying a transformation to something pointwise equal preserves naturality. *)
+Definition is1natural_homotopic {A B : Type} `{Is01Cat A} `{Is1Cat B}
+      {F : A -> B} `{!Is0Functor F} {G : A -> B} `{!Is0Functor G}
+      {alpha : F $=> G} (gamma : F $=> G) `{!Is1Natural F G gamma}
+      (p : forall a, alpha a $== gamma a)
+  : Is1Natural F G alpha.
+Proof.
+  refine (Build_Is1Natural _ _ _ _ _ F _ G _ alpha _); intros a b f.
+  refine ((p b $@R fmap F f) $@ _).
+  refine (_ $@ (fmap G f $@L (p a)^$)).
+  apply (isnat gamma).
+Defined.
+
+(** Identity functor *)
+
+Section IdentityFunctor.
+
+  Context {A : Type} `{Is1Cat A}.
+
+  Global Instance is0functor_idmap : Is0Functor idmap.
+  Proof.
+    by apply Build_Is0Functor.
+  Defined.
+
+  Global Instance is1functor_idmap : Is1Functor idmap.
+  Proof.
+    by apply Build_Is1Functor.
+  Defined.
+
+End IdentityFunctor.
+
+(** Constant functor *)
+
+Section ConstantFunctor.
+
+  Context {A B : Type}.
+
+  Global Instance is0coh1functor_const
+    `{IsGraph A} `{Is01Cat B} (x : B)
+    : Is0Functor (fun _ : A => x).
+  Proof.
+    serapply Build_Is0Functor.
+    intros a b f; apply Id.
+  Defined.
+
+  Global Instance is1functor_const
+         `{Is1Cat A} `{Is1Cat B} (x : B)
+    : Is1Functor (fun _ : A => x).
+  Proof.
+    serapply Build_Is1Functor.
+    - intros a b f g p; apply Id.
+    - intro; apply Id.
+    - intros a b c f g. cbn.
+      symmetry.
+      apply cat_idl.
+  Defined.
+
+End ConstantFunctor.
+
+(** Composite functors *)
+
+Section CompositeFunctor.
+
+  Context {A B C : Type} `{Is1Cat A} `{Is1Cat B} `{Is1Cat C}
+          (F : A -> B) `{!Is0Functor F, !Is1Functor F}
+          (G : B -> C) `{!Is0Functor G, !Is1Functor G}.
+
+  Global Instance is0functor_compose : Is0Functor (G o F).
+  Proof.
+    srapply Build_Is0Functor.
+    intros a b f; exact (fmap G (fmap F f)).
+  Defined.
+
+  Global Instance is1functor_compose : Is1Functor (G o F).
+  Proof.
+    srapply Build_Is1Functor.
+    - intros a b f g p; exact (fmap2 G (fmap2 F p)).
+    - intros a; exact (fmap2 G (fmap_id F a) $@ fmap_id G (F a)).
+    - intros a b c f g.
+      refine (fmap2 G (fmap_comp F f g) $@ _).
+      exact (fmap_comp G (fmap F f) (fmap F g)).
+  Defined.
+
+End CompositeFunctor.
+
+(** More products *)
+
+Global Instance is0gpd_prod A B `{Is0Gpd A} `{Is0Gpd B}
+ : Is0Gpd (A * B).
+Proof. 
+  serapply Build_Is0Gpd.
+  intros [x1 x2] [y1 y2] [f1 f2].
+  cbn in *.
+  exact ( (f1^$, f2^$) ).
+Defined.
+
+Global Instance is1cat_prod A B `{Is1Cat A} `{Is1Cat B}
+  : Is1Cat (A * B).
+Proof.
+  serapply (Build_Is1Cat).
+  - intros [x1 x2] [y1 y2].
+    rapply is01cat_prod.
+  - intros [x1 x2] [y1 y2].
+    apply is0gpd_prod.
+    + cbn.
+      apply isgpd_hom.
+    + cbn.
+      apply isgpd_hom.
+  - intros [x1 x2] [y1 y2] [z1 z2].
+    serapply Build_Is0Functor.  
+    intros f g. unfold uncurry.
+    destruct f as [[f11 f12] [f21 f22]].
+    destruct g as [[g11 g12] [g21 g22]]. cbn in *. 
+    intros a. destruct a as [[a11 a12][a21 a22]].
+    exact ( a11 $o@ a21, a12 $o@ a22).
+  - intros [a1 a2] [b1 b2] [c1 c2] [d1 d2] [f1 f2] [g1 g2] [h1 h2].
+    cbn in *. 
+    exact(cat_assoc f1 g1 h1, cat_assoc f2 g2 h2).
+  - intros [a1 a2] [b1 b2] [f1 f2].
+    cbn in *.
+    exact (cat_idl _, cat_idl _).
+  - intros [a1 a2] [b1 b2] [g1 g2].
+    cbn in *.
+    exact (cat_idr _, cat_idr _). 
+Defined. 
+
+(** ** Wild 1-groupoids *)
+
+Class Is1Gpd (A : Type) `{Is1Cat A, !Is0Gpd A} :=
+{ 
+  gpd_issect : forall {a b : A} (f : a $-> b), f^$ $o f $== Id a ;
+  gpd_isretr : forall {a b : A} (f : a $-> b), f $o f^$ $== Id b ;
+}.
+
+(** Wild (2,1)-categories *)
+
+Definition cat_comp_lassoc {A : Type} `{Is1Cat A} (a b c d : A)
+  : (a $-> b) * (b $-> c) * (c $-> d) -> a $-> d.
+Proof.
+  intros [[f g] h].
+  exact ((h $o g) $o f).
+Defined.
+
+Definition cat_comp_rassoc {A : Type} `{Is1Cat A} (a b c d : A)
+  : (a $-> b) * (b $-> c) * (c $-> d) -> a $-> d.
+Proof.
+  intros [[f g] h].
+  exact (h $o (g $o f)).
+Defined.
+
+Global Instance is01cat_cat_assoc_dom {A : Type} `{Is1Cat A}
+       {a b c d : A} : Is01Cat ((a $-> b) * (b $-> c) * (c $-> d)).
+Proof.
+  rapply is01cat_prod.
+Defined.
+
+Global Instance is0functor_cat_comp_lassoc
+       {A : Type} `{Is1Cat A}
+       {a b c d : A} : Is0Functor (cat_comp_lassoc a b c d).
+Proof.
+  apply Build_Is0Functor.
+  intros [[f g] h] [[f' g'] h'] [[al be] ga] ;
+    exact (fmap11 cat_comp (fmap11 cat_comp ga be) al).
+Defined.
+
+Global Instance is0functor_cat_comp_rassoc
+       {A : Type} `{Is1Cat A}
+       {a b c d : A} : Is0Functor (cat_comp_rassoc a b c d).
+Proof.
+  apply Build_Is0Functor.
+  intros [[f g] h] [[f' g'] h'] [[al be] ga] ;
+    exact (fmap11 cat_comp ga (fmap11 cat_comp be al)).
+Defined.
+
+Definition cat_assoc_transformation {A : Type} `{Is1Cat A} {a b c d : A}
+  : (cat_comp_lassoc a b c d) $=> (cat_comp_rassoc a b c d).
+Proof.
+  intros [[f g] h] ; exact (cat_assoc f g h).
+Defined.
+
+Definition cat_comp_idl {A : Type} `{Is1Cat A} (a b : A)
+  : (a $-> b) -> (a $-> b)
+  := fun (f : a $-> b) => Id b $o f.
+
+Global Instance is0functor_cat_comp_idl {A : Type} `{Is1Cat A} (a b : A)
+  : Is0Functor (cat_comp_idl a b).
+Proof.
+  apply Build_Is0Functor.
+  intros f g p; unfold cat_comp_idl; cbn.
+  exact (Id b $@L p).
+Defined.
+
+Definition cat_idl_transformation {A : Type} `{Is1Cat A} {a b : A}
+  : cat_comp_idl a b $=> idmap.
+Proof.
+  intro f ; exact (cat_idl f).
+Defined.
+
+Definition cat_comp_idr {A : Type} `{Is1Cat A} (a b : A)
+  : (a $-> b) -> (a $-> b)
+  := fun (f : a $-> b) => f $o Id a.
+
+Global Instance is0functor_cat_comp_idr {A : Type} `{Is1Cat A} (a b : A)
+  : Is0Functor (cat_comp_idr a b).
+Proof.
+  apply Build_Is0Functor.
+  intros f g p; unfold cat_comp_idr; cbn.
+  exact (p $@R Id a).
+Defined.
+
+Definition cat_idr_transformation {A : Type} `{Is1Cat A} {a b : A}
+  : cat_comp_idr a b $=> idmap.
+Proof.
+  intro f ; exact (cat_idr f).
+Defined.
+
+Class Is21Cat (A : Type) `{Is1Cat A} :=
+{
+  is1cat_hom : forall (a b : A), Is1Cat (a $-> b) ;
+  is1gpd_hom : forall (a b : A), Is1Gpd (a $-> b) ;
+  is1functor_comp : forall (a b c : A),
+      Is1Functor (uncurry (@cat_comp A _ a b c)) ;
+
+  (** *** Associator *)
+  is1natural_cat_assoc : forall (a b c d : A),
+      Is1Natural (cat_comp_lassoc a b c d) (cat_comp_rassoc a b c d)
+                 cat_assoc_transformation ;
+
+  (** *** Unitors *)
+  is1natural_cat_idl : forall (a b : A),
+      Is1Natural (cat_comp_idl a b) idmap
+                 cat_idl_transformation;
+
+  is1natural_cat_idr : forall (a b : A),
+      Is1Natural (cat_comp_idr a b) idmap
+                 cat_idr_transformation;
+
+  (** *** Coherence *)
+  cat_pentagon : forall (a b c d e : A)
+                        (f : a $-> b) (g : b $-> c) (h : c $-> d) (k : d $-> e),
+      (k $@L cat_assoc f g h) $o (cat_assoc f (h $o g) k) $o (cat_assoc g h k $@R f)
+      $== (cat_assoc (g $o f) h k) $o (cat_assoc f g (k $o h)) ;
+
+  cat_tril : forall (a b c : A) (f : a $-> b) (g : b $-> c),
+      (g $@L cat_idl f) $o (cat_assoc f (Id b) g) $== (cat_idr g $@R f)
+}.
+
+Global Existing Instance is1cat_hom.
+Global Existing Instance is1gpd_hom.
+Global Existing Instance is1functor_comp.
+Global Existing Instance is1natural_cat_assoc.
+Global Existing Instance is1natural_cat_idl.
+Global Existing Instance is1natural_cat_idr.

--- a/theories/WildCat/EmptyCat.v
+++ b/theories/WildCat/EmptyCat.v
@@ -1,0 +1,19 @@
+Require Import Basics.
+Require Import WildCat.Core.
+
+(** Empty category *)
+
+Global Instance is01cat_empty : Is01Cat Empty.
+Proof.
+  srapply Build_Is01Cat; intros [].
+Defined.
+
+Global Instance is0gpd_empty : Is0Gpd Empty.
+Proof.
+  constructor; intros [].
+Defined.
+
+Global Instance is1cat_empty : Is1Cat Empty.
+Proof.
+  simple notypeclasses refine (Build_Is1Cat _ _ _ _ _ _ _ _); intros [].
+Defined.

--- a/theories/WildCat/Equiv.v
+++ b/theories/WildCat/Equiv.v
@@ -1,0 +1,288 @@
+(* -*- mode: coq; mode: visual-line -*-  *)
+
+Require Import Basics.
+Require Import WildCat.Core.
+
+(** * Equivalences in wild categories *)
+
+(** We could define equivalences in any wild 2-category as bi-invertible maps, or in a wild 3-category as half-adjoint equivalences.  However, in concrete cases there is often an equivalent definition of equivalences that we want to use instead, and the important property we need is that it's logically equivalent to (quasi-)isomorphism. *)
+
+Class HasEquivs (A : Type) `{Is1Cat A} :=
+{
+  CatEquiv' : A -> A -> Type where "a $<~> b" := (CatEquiv' a b);
+  CatIsEquiv' : forall a b, (a $-> b) -> Type;
+  cate_fun' : forall a b, (a $<~> b) -> (a $-> b);
+  cate_isequiv' : forall a b (f : a $<~> b), CatIsEquiv' a b (cate_fun' a b f);
+  cate_buildequiv' : forall a b (f : a $-> b), CatIsEquiv' a b f -> CatEquiv' a b;
+  cate_buildequiv_fun' : forall a b (f : a $-> b) (fe : CatIsEquiv' a b f),
+      cate_fun' a b (cate_buildequiv' a b f fe) $== f;
+  cate_inv' : forall a b (f : a $-> b), CatIsEquiv' a b f -> (b $-> a);
+  cate_issect' : forall a b (f : a $-> b) (fe : CatIsEquiv' a b f),
+    cate_inv' _ _ f fe $o f $== Id a;
+  cate_isretr' : forall a b (f : a $-> b) (fe : CatIsEquiv' a b f),
+      f $o cate_inv' _ _ f fe $== Id b;
+  catie_adjointify' : forall a b (f : a $-> b) (g : b $-> a)
+    (r : f $o g $== Id b) (s : g $o f $== Id a), CatIsEquiv' a b f;
+}.
+
+(** Since apparently a field of a record can't be the source of a coercion (Coq complains about the uniform inheritance condition, although as officially stated that condition appears to be satisfied), we redefine all the fields of [HasEquivs]. *)
+
+Definition CatEquiv {A} `{HasEquivs A} (a b : A)
+  := @CatEquiv' A _ _ _ a b.
+
+Notation "a $<~> b" := (CatEquiv a b).
+Arguments CatEquiv : simpl never.
+
+Definition cate_fun {A} `{HasEquivs A} {a b : A} (f : a $<~> b)
+  : a $-> b
+  := @cate_fun' A _ _ _ a b f.
+
+Coercion cate_fun : CatEquiv >-> Hom.
+
+(* Being an equivalence should be a typeclass, but we have to redefine it.  (Apparently [Existing Class] doesn't work.) *)
+Class CatIsEquiv {A} `{HasEquivs A} {a b : A} (f : a $-> b)
+  := catisequiv : CatIsEquiv' a b f.
+
+Global Instance cate_isequiv {A} `{HasEquivs A} {a b : A} (f : a $<~> b)
+  : CatIsEquiv f
+  := cate_isequiv' a b f.
+
+Definition Build_CatEquiv {A} `{HasEquivs A} {a b : A}
+           (f : a $-> b) {fe : CatIsEquiv f}
+  : a $<~> b
+  := cate_buildequiv' a b f fe.
+
+Definition cate_buildequiv_fun {A} `{HasEquivs A} {a b : A}
+           (f : a $-> b) {fe : CatIsEquiv f}
+  : cate_fun (Build_CatEquiv f) $== f
+  := cate_buildequiv_fun' a b f fe.
+
+Definition catie_adjointify {A} `{HasEquivs A} {a b : A}
+           (f : a $-> b) (g : b $-> a)
+           (r : f $o g $== Id b) (s : g $o f $== Id a)
+  : CatIsEquiv f
+  := catie_adjointify' a b f g r s.
+
+Definition cate_adjointify {A} `{HasEquivs A} {a b : A}
+           (f : a $-> b) (g : b $-> a)
+           (r : f $o g $== Id b) (s : g $o f $== Id a)
+  : a $<~> b
+  := @Build_CatEquiv _ _ _ _ a b f (catie_adjointify f g r s).
+
+(** This one we define to construct the whole inverse equivalence. *)
+Definition cate_inv {A} `{HasEquivs A} {a b : A} (f : a $-> b) {fe : CatIsEquiv f}
+  : b $<~> a.
+Proof.
+  simple refine (cate_adjointify _ _ _ _).
+  - exact (@cate_inv' A _ _ _ a b f fe).
+  - exact f.
+  - exact (@cate_issect' A _ _ _ a b f fe).
+  - exact (@cate_isretr' A _ _ _ a b f fe).
+Defined.
+
+Notation "f ^-1$" := (cate_inv f).
+
+Definition cate_issect {A} `{HasEquivs A} {a b} (f : a $-> b) {fe : CatIsEquiv f}
+  : f^-1$ $o f $== Id a.
+Proof.
+  refine (_ $@ @cate_issect' A _ _ _ a b f fe).
+  refine (_ $@R f).
+  apply cate_buildequiv_fun'.
+Defined.
+
+Definition cate_isretr {A} `{HasEquivs A} {a b} (f : a $-> b) {fe : CatIsEquiv f}
+  : f $o f^-1$ $== Id b.
+Proof.
+  refine (_ $@ @cate_isretr' A _ _ _ a b f fe).
+  refine (f $@L _).
+  apply cate_buildequiv_fun'.
+Defined.
+
+(** The identity morphism is an equivalence *)
+Global Instance catie_id {A} `{HasEquivs A} (a : A)
+  : CatIsEquiv (Id a)
+  := catie_adjointify (Id a) (Id a) (cat_idl (Id a)) (cat_idl (Id a)).
+
+Definition id_cate {A} `{HasEquivs A} (a : A)
+  : a $<~> a
+  := Build_CatEquiv (Id a).
+
+Global Instance reflexive_cate {A} `{HasEquivs A}
+  : Reflexive (@CatEquiv A _ _ _)
+  := id_cate.
+
+Global Instance symmetric_cate {A} `{HasEquivs A}
+  : Symmetric (@CatEquiv A _ _ _)
+  := fun a b f => cate_inv f.
+
+(** Equivalences can be composed. *)
+Definition compose_cate {A} `{HasEquivs A} {a b c : A}
+  (g : b $<~> c) (f : a $<~> b) : a $<~> c.
+Proof.
+  refine (cate_adjointify (g $o f) (f^-1$ $o g^-1$) _ _).
+  - refine (cat_assoc _ _ _ $@ _).
+    refine ((_ $@L cat_assoc_opp _ _ _) $@ _).
+    refine ((_ $@L (cate_isretr _ $@R _)) $@ _).
+    refine ((_ $@L cat_idl _) $@ _).
+    apply cate_isretr.
+  - refine (cat_assoc _ _ _ $@ _).
+    refine ((_ $@L cat_assoc_opp _ _ _) $@ _).
+    refine ((_ $@L (cate_issect _ $@R _)) $@ _).
+    refine ((_ $@L cat_idl _) $@ _).
+    apply cate_issect.
+Defined.
+
+Notation "g $oE f" := (compose_cate g f).
+
+Definition compose_cate_fun {A} `{HasEquivs A}
+           {a b c : A} (g : b $<~> c) (f : a $<~> b)
+  : cate_fun (g $oE f) $== g $o f.
+Proof.
+  apply cate_buildequiv_fun.
+Defined.
+
+Definition compose_cate_funinv {A} `{HasEquivs A}
+           {a b c : A} (g : b $<~> c) (f : a $<~> b)
+  : g $o f $== cate_fun (g $oE f).
+Proof.
+  apply gpd_rev.
+  apply cate_buildequiv_fun.
+Defined.
+
+Definition id_cate_fun {A} `{HasEquivs A} (a : A) 
+  : cate_fun (id_cate a) $== Id a.
+Proof.
+  apply cate_buildequiv_fun.
+Defined.
+
+Definition compose_cate_assoc {A} `{HasEquivs A}
+           {a b c d : A} (f : a $<~> b) (g : b $<~> c) (h : c $<~> d)
+  : cate_fun ((h $oE g) $oE f) $== cate_fun (h $oE (g $oE f)).
+Proof.
+  refine (compose_cate_fun _ f $@ _ $@ cat_assoc f g h $@ _ $@
+                           compose_cate_funinv h _).
+  - refine (compose_cate_fun h g $@R _).
+  - refine (_ $@L compose_cate_funinv g f).
+Defined.
+
+Definition compose_cate_idl {A} `{HasEquivs A}
+           {a b : A} (f : a $<~> b)
+  : cate_fun (id_cate b $oE f) $== cate_fun f.
+Proof.
+  refine (compose_cate_fun _ f $@ _ $@ cat_idl f).
+  refine (cate_buildequiv_fun _ $@R _).
+Defined.
+
+Definition compose_cate_idr {A} `{HasEquivs A}
+           {a b : A} (f : a $<~> b)
+  : cate_fun (f $oE id_cate a) $== cate_fun f.
+Proof.
+  refine (compose_cate_fun f _ $@ _ $@ cat_idr f).
+  refine (_ $@L cate_buildequiv_fun _).
+Defined.
+
+Global Instance transitive_cate {A} `{HasEquivs A}
+  : Transitive (@CatEquiv A _ _ _)
+  := fun a b c f g => g $oE f.
+
+(** Any sufficiently coherent functor preserves equivalences.  *)
+Global Instance iemap {A B : Type} `{HasEquivs A} `{HasEquivs B}
+       (F : A -> B) `{!Is0Functor F, !Is1Functor F}
+       {a b : A} (f : a $-> b) {fe : CatIsEquiv f}
+  : CatIsEquiv (fmap F f).
+Proof.
+  refine (catie_adjointify (fmap F f) (fmap F f^-1$) _ _).
+  - refine ((fmap_comp F f^-1$ f)^$ $@ fmap2 F (cate_isretr _) $@ fmap_id F _).
+  - refine ((fmap_comp F f f^-1$)^$ $@ fmap2 F (cate_issect _) $@ fmap_id F _).
+Defined.
+
+Definition emap {A B : Type} `{HasEquivs A} `{HasEquivs B}
+           (F : A -> B) `{!Is0Functor F, !Is1Functor F}
+           {a b : A} (f : a $<~> b)
+  : F a $<~> F b
+  := Build_CatEquiv (fmap F f).
+
+(** When we have equivalences, we can define what it means for a category to be univalent. *)
+Definition cat_equiv_path {A : Type} `{HasEquivs A} (a b : A)
+  : (a = b) -> (a $<~> b).
+Proof.
+  intros []; reflexivity.
+Defined.
+
+Class IsUnivalent1Cat (A : Type) `{HasEquivs A}
+  := { isequiv_cat_equiv_path : forall a b, IsEquiv (@cat_equiv_path A _ _ _ a b) }.
+Global Existing Instance isequiv_cat_equiv_path.
+
+Definition cat_path_equiv {A : Type} `{IsUnivalent1Cat A} (a b : A)
+  : (a $<~> b) -> (a = b)
+  := (cat_equiv_path a b)^-1.
+
+(** ** Core of a 1-category *)
+
+Record core (A : Type) := { uncore : A }.
+Arguments uncore {A} c.
+
+Global Instance is01cat_core {A : Type} `{HasEquivs A}
+  : Is01Cat (core A).
+Proof.
+  srapply Build_Is01Cat ; cbv.
+  - intros a b ; exact (uncore a $<~> uncore b).
+  - intros; apply id_cate.
+  - intros a b c ; apply compose_cate.
+Defined.
+
+Global Instance is01cat_core_hom {A : Type} `{HasEquivs A} (a b : core A)
+  : Is01Cat (a $-> b).
+Proof.
+  cbv in a, b.
+  srapply Build_Is01Cat.
+  - intros f g ; exact (cate_fun f $== cate_fun g).
+  - intro f ; apply Id.
+  - intros f g h ; apply cat_comp.
+Defined.
+
+Global Instance is0gpd_core_hom {A : Type} `{HasEquivs A} (a b : core A)
+  : Is0Gpd (a $-> b).
+Proof.
+  cbv in a, b.
+  apply Build_Is0Gpd.
+  intros f g ; cbv.
+  apply gpd_rev.
+Defined.
+
+Global Instance is0functor_cat_comp {A : Type} `{HasEquivs A}
+       (a b c : core A) :
+  Is0Functor (uncurry (@cat_comp (core A) _ a b c)).
+Proof.
+  cbv in a, b, c.
+  apply Build_Is0Functor.
+  - intros [f g] [f' g'] [al be].
+    exact (compose_cate_fun f g
+           $@ (al $o@ be)
+           $@ (compose_cate_fun f' g')^$).
+Defined.
+
+Global Instance is1cat_core {A : Type} `{HasEquivs A}
+  : Is1Cat (core A).
+Proof.
+  rapply Build_Is1Cat.
+  - intros; apply compose_cate_assoc.
+  - intros; apply compose_cate_idl.
+  - intros; apply compose_cate_idr.
+Defined.
+
+Global Instance is0gpd_core {A : Type} `{HasEquivs A}
+  : Is0Gpd (core A).
+Proof.
+  apply Build_Is0Gpd.
+  intros a b f; cbn in *; exact (f^-1$).
+Defined.
+
+Global Instance is1gpd_core {A : Type} `{HasEquivs A}
+  : Is1Gpd (core A).
+Proof.
+  apply Build_Is1Gpd; cbn ; intros a b f;
+    refine (compose_cate_fun _ _ $@ _ $@ (id_cate_fun _)^$).
+  - apply cate_issect.
+  - apply cate_isretr.
+Defined.

--- a/theories/WildCat/FunctorCat.v
+++ b/theories/WildCat/FunctorCat.v
@@ -1,0 +1,137 @@
+(* -*- mode: coq; mode: visual-line -*-  *)
+
+Require Import Basics.
+Require Import WildCat.Core.
+Require Import WildCat.Equiv.
+Require Import WildCat.Induced.
+
+(** * Wild functor categories *)
+
+(** ** Categories of 0-coherent 1-functors *)
+
+Record Fun01 (A B : Type) `{IsGraph A} `{IsGraph B} := {
+  fun01_F : A -> B;
+  fun01_is0functor : Is0Functor fun01_F;
+}.
+
+Coercion fun01_F : Fun01 >-> Funclass.
+Existing Instance fun01_is0functor.
+
+Definition NatTrans {A B : Type} `{IsGraph A} `{Is1Cat B} (F G : A -> B)
+           {ff : Is0Functor F} {fg : Is0Functor G}
+  := { alpha : F $=> G & Is1Natural F G alpha }.
+
+(** Note that even if [A] and [B] are fully coherent oo-categories, the objects of our "functor category" are not fully coherent.  Thus we cannot in general expect this "functor category" to itself be fully coherent.  However, it is at least a 0-coherent 1-category, as long as [B] is a 1-coherent 1-category. *)
+
+Global Instance is0cat_fun01 (A B : Type) `{IsGraph A} `{Is1Cat B} : Is01Cat (Fun01 A B).
+Proof.
+  srapply Build_Is01Cat.
+  - intros [F ?] [G ?].
+    exact (NatTrans F G).
+  - intros [F ?]; cbn.
+    exists (id_transformation F); exact _.
+  - intros [F ?] [G ?] [K ?] [gamma ?] [alpha ?]; cbn in *.
+    exists (comp_transformation gamma alpha); exact _.
+Defined.
+
+(** In fact, in this case it is automatically also a 0-coherent 2-category and a 1-coherent 1-category, with a totally incoherent notion of 2-cell between 1-coherent natural transformations. *)
+
+Global Instance is0coh2cat_fun01 (A B : Type) `{IsGraph A} `{Is1Cat B} : Is1Cat (Fun01 A B).
+Proof.
+  srapply Build_Is1Cat.
+  - intros [F ?] [G ?]; serapply Build_Is01Cat.
+    + intros [alpha ?] [gamma ?].
+      exact (forall a, alpha a $== gamma a).
+    + intros [alpha ?] a; cbn.
+      reflexivity.
+    + intros [alpha ?] [gamma ?] [phi ?] nu mu a.
+      exact (mu a $@ nu a).
+  - intros [F ?] [G ?]; serapply Build_Is0Gpd.
+    intros [alpha ?] [gamma ?] mu a.
+    exact ((mu a)^$).
+  - intros [F ?] [G ?] [K ?].
+    serapply Build_Is0Functor.
+    intros [[alpha ?] [gamma ?]] [[phi ?] [mu ?]] [f g] a.
+    exact (f a $o@ g a).
+  - intros [F ?] [G ?] [K ?] [L ?] [alpha ?] [gamma ?] [phi ?] a; cbn.
+    serapply cat_assoc.
+  - intros [F ?] [G ?] [alpha ?] a; cbn.
+    serapply cat_idl.
+  - intros [F ?] [G ?] [alpha ?] a; cbn.
+    serapply cat_idr.
+Defined.
+
+(** It also inherits a notion of equivalence, namely a natural transformation that is a pointwise equivalence.  Note that this is not a "fully coherent" notion of equivalence, since the functors and transformations are not themselves fully coherent. *)
+
+Definition NatEquiv {A B : Type} `{IsGraph A} `{HasEquivs B}
+           (F G : A -> B) `{!Is0Functor F, !Is0Functor G}
+  := { alpha : forall a, F a $<~> G a & Is1Natural F G (fun a => alpha a) }.
+
+Global Instance hasequivs_fun01 (A B : Type) `{Is01Cat A} `{HasEquivs B}
+  : HasEquivs (Fun01 A B).
+Proof.
+  srapply Build_HasEquivs.
+  1:{ intros [F ?] [G ?]. exact (NatEquiv F G). }
+  1:{ intros [F ?] [G ?] [alpha ?]; cbn in *.
+      exact (forall a, CatIsEquiv (alpha a)). }
+  all:intros [F ?] [G ?] [alpha alnat]; cbn in *.
+  - exists (fun a => alpha a); assumption.
+  - intros a; exact _.
+  - intros ?; srefine (_;_).
+    + intros a; exact (Build_CatEquiv (alpha a)).
+    + cbn. refine (is1natural_homotopic alpha _).
+      intros a; apply cate_buildequiv_fun.
+  - cbn; intros; apply cate_buildequiv_fun.
+  - intros ?; exists (fun a => (alpha a)^-1$).
+    apply Build_Is1Natural; intros a b f.
+    refine ((cat_idr _)^$ $@ _).
+    refine ((_ $@L (cate_isretr (alpha a))^$) $@ _).
+    refine (cat_assoc _ _ _ $@ _).
+    refine ((_ $@L (cat_assoc_opp _ _ _)) $@ _).
+    refine ((_ $@L ((isnat (fun a => alpha a) f)^$ $@R _)) $@ _).
+    refine ((_ $@L (cat_assoc _ _ _)) $@ _).
+    refine (cat_assoc_opp _ _ _ $@ _).
+    refine ((cate_issect (alpha b) $@R _) $@ _).
+    exact (cat_idl _).
+  - intros; apply cate_issect.
+  - intros; apply cate_isretr.
+  - intros [gamma ?] r s a; cbn in *.
+    refine (catie_adjointify (alpha a) (gamma a) (r a) (s a)).
+Defined.
+
+(** ** Categories of 1-coherent 1-functors *)
+
+Record Fun11 (A B : Type) `{Is1Cat A} `{Is1Cat B} :=
+{
+  fun11_fun : A -> B ;
+  is0functor_fun11 : Is0Functor fun11_fun ;
+  is1functor_fun11 : Is1Functor fun11_fun
+}.
+
+Coercion fun11_fun : Fun11 >-> Funclass.
+Global Existing Instance is0functor_fun11.
+Global Existing Instance is1functor_fun11.
+
+Arguments Build_Fun11 {A B _ _ _ _} F _ _ : rename.
+
+Definition fun01_fun11 {A B : Type} `{Is1Cat A} `{Is1Cat B}
+           (F : Fun11 A B)
+  : Fun01 A B.
+Proof.
+  exists F; exact _.
+Defined.
+
+Global Instance is01cat_fun11 {A B : Type} `{Is1Cat A} `{Is1Cat B} : Is01Cat (Fun11 A B).
+Proof.
+  exact (induced_01cat (fun01_fun11)).
+Defined.
+
+Global Instance is1cat_fun11 {A B :Type} `{Is1Cat A} `{Is1Cat B} : Is1Cat (Fun11 A B).
+Proof.
+  exact (induced_1cat (fun01_fun11)).
+Defined.
+
+Global Instance hasequivs_fun11 {A B : Type} `{Is1Cat A} `{HasEquivs B} : HasEquivs (Fun11 A B).
+Proof.
+  exact (induced_hasequivs fun01_fun11).
+Defined.

--- a/theories/WildCat/Induced.v
+++ b/theories/WildCat/Induced.v
@@ -1,0 +1,81 @@
+(* -*- mode: coq; mode: visual-line -*-  *)
+
+Require Import Basics.
+Require Import WildCat.Core.
+Require Import WildCat.Equiv.
+
+(** * Induced wild categories *)
+
+(** A map A -> B of types where B is some type of category induces the same level of structure on A, via taking everything to be defined on the image.
+
+This needs to be separate from Core because of HasEquivs usage.  We don't make these definitions Global Instances because we only want to apply them manually, but we make them Local Instances so that subsequent ones can pick up the previous ones automatically. *)
+
+Section Induced_category.
+  Context {A B : Type} (f : A -> B).
+  
+  Local Instance induced_01cat `{Is01Cat B}: Is01Cat A.
+  Proof.
+    serapply Build_Is01Cat.
+    + intros a1 a2. 
+      exact (f a1 $-> f a2).
+    + intro a. cbn in *. 
+      exact (Id (f a)).
+    + intros a b c; cbn in *; intros g1 g2.
+      exact ( g1 $o g2).
+  Defined.
+
+  (** The structure map along which we induce the category structure becomes a functor with respect to the induced structure *) 
+  Local Instance inducingmap_is0functor `{Is01Cat B} : Is0Functor f.
+  Proof.
+    serapply Build_Is0Functor.
+    intros a b. cbn in *. exact idmap.
+  Defined.
+
+  Local Instance induced_1cat `{Is1Cat B} : Is1Cat A.
+  Proof.
+    serapply Build_Is1Cat.
+    + intros a b. cbn in *. exact _.
+    + intros a b. cbn in *. exact _.
+    + intros a b c. cbn in *. 
+      unfold uncurry. exact _.
+    + intros a b c d; cbn in *. 
+      intros u v w. apply cat_assoc.
+    + intros a b; cbn in *.
+      intros u. apply cat_idl.
+    + intros a b; cbn in *.
+      intros u. apply cat_idr.
+  Defined.
+
+  Local Instance inducingmap_is1functor `{Is1Cat B} : Is1Functor f.
+  Proof.
+    serapply Build_Is1Functor.
+    + intros a b g h. cbn in *. exact idmap.
+    + intros a. cbn in *. exact (Id _).
+    + intros a b c g h. cbn in *. exact (Id _). 
+  Defined.
+
+  Definition induced_hasequivs `{HasEquivs B} : HasEquivs A.
+  Proof.
+    serapply Build_HasEquivs.
+    + intros a b. exact (f a $<~> f b).
+    + intros a b h. apply (CatIsEquiv' (f a) (f b)).
+      exact (fmap f h).
+    + intros a b; cbn in *. 
+      intros g. exact( cate_fun g).
+    + intros a b h; cbn in *. 
+      exact (cate_isequiv' _ _ h ).
+    + intros a b h; cbn in *. 
+      exact ( cate_buildequiv' _ _ h).
+    + intros a b h fe; cbn in *. 
+      exact ( cate_buildequiv_fun' (f a) (f b) h fe) .
+    + intros a b h fe; cbn in *.
+      exact(cate_inv'  _ _ h fe ).
+    + intros a b h fe; cbn in *.
+      exact (cate_issect' _ _ h fe ).
+    + intros a b h fe; cbn in *.
+      exact (cate_isretr' _ _ _ _ ).
+    + intros a b h g m n; cbn in *.  
+      exact ( catie_adjointify' _ _ h g m n  ).
+  Defined.
+
+End Induced_category.

--- a/theories/WildCat/Opposite.v
+++ b/theories/WildCat/Opposite.v
@@ -1,0 +1,179 @@
+(* -*- mode: coq; mode: visual-line -*-  *)
+
+(* Don't import the old WildCat *)
+Require Import Basics.Overture.
+Require Import Basics.PathGroupoids.
+Require Import Basics.Notations.
+Require Import Basics.Contractible.
+Require Import Basics.Equivalences.
+
+Require Import WildCat.Core.
+Require Import WildCat.Equiv.
+
+(** ** Opposite categories *)
+
+Definition op (A : Type) : Type := A.
+Notation "A ^op" := (op A).
+
+(** This stops typeclass search from trying to unfold op. *)
+Typeclasses Opaque op.
+
+Global Instance is01cat_op A `{Is01Cat A} : Is01Cat (A ^op)
+  := Build_Is01Cat A (fun a b => b $-> a) Id (fun a b c g f => f $o g).
+
+Global Instance is1cat_op A `{Is1Cat A} : Is1Cat A^op.
+Proof.
+  srapply Build_Is1Cat; unfold op in *; cbn in *.
+  - intros a b.
+    apply is01cat_hom.
+  - intros a b.
+    apply isgpd_hom.
+  - intros a b c.
+    srapply Build_Is0Functor.
+    intros [f g] [h k] [p q].
+    cbn in *.
+    exact (q $o@ p).
+  - intros a b c d f g h; exact (cat_assoc_opp h g f).
+  - intros a b f; exact (cat_idr f).
+  - intros a b f; exact (cat_idl f).
+ Defined.
+
+Global Instance is1cat_strong_op A `{Is1Cat_Strong A}
+  : Is1Cat_Strong (A ^op).
+Proof.
+  srapply Build_Is1Cat_Strong; unfold op in *; cbn in *.
+  - intros a b c d f g h; exact (cat_assoc_opp_strong h g f).
+  - intros a b f.
+    apply cat_idr_strong.
+  - intros a b f. 
+    apply cat_idl_strong.
+Defined.
+
+(* Opposites are definitionally involutive. You can test this by uncommenting the stuff below. *)
+(*
+Definition test1 A {ac : Is01Cat A} : A = (A^op)^op := 1.
+Definition test2 A {ac : Is01Cat A} : ac = is01cat_op (A^op) := 1.
+Definition test3 A {ac : Is01Cat A} {ac2 : Is1Cat A} : ac2 = is1cat_op (A^op) := 1.
+Definition test4 A {ac : Is01Cat A} {ac2 : Is1Cat A} {ac11 : Is1Cat A} : ac11 = is1coh1cat_op (A^op) := 1.
+*)
+
+(** Opposite groupoids *)
+
+Global Instance is0gpd_op A `{Is0Gpd A} : Is0Gpd (A ^op).
+Proof.
+  srapply Build_Is0Gpd; unfold op in *; cbn in *.
+  intros a b.
+  apply gpd_rev.
+Defined.
+
+Global Instance op0gpd_fun A `{Is0Gpd A} :
+  Is0Functor( (fun x => x) : A^op -> A).
+Proof.
+  srapply Build_Is0Functor; unfold op in *; cbn.
+  intros a b.
+  exact (fun f => f^$).
+Defined.
+
+(** Mike thought co-duals were unnecessary, so I'm commenting this out.
+
+Definition co (A : Type) : Type := A.
+(** I wasn't able to make "A ^co" a notation. *)
+
+(** This stops typeclass search from trying to unfold co. *)
+Typeclasses Opaque co.
+
+Global Instance is01cat_co A `{Is01Cat A} : Is01Cat (co A)
+  := Build_Is01Cat A (fun a b => (a $-> b)^op) Id (fun a b c g f => g $o f).
+
+Global Instance is1cat_co A `{Is1Cat A} : Is1Cat (co A).
+Proof.
+  srapply Build_Is1Cat; unfold co in *; cbn.
+  - intros a b.
+    apply is01cat_op.
+    apply is01cat_hom.
+  - intros a b.
+    apply is0coh1gpd_op.
+    apply isgpd_hom.
+  - intros a b c.
+    srapply Build_Is0Coh1Functor.
+    intros [f g] [h k] [p q].
+    cbn in *.
+    exact (p $o@ q).
+Defined.
+*)
+
+(** Opposite functors *)
+
+Global Instance is0coh1fun_op  A `{Is01Cat A} B `{Is01Cat B}
+       (F : A -> B) `{!Is0Functor F}
+  : Is0Functor (F : A ^op -> B ^op).
+Proof.
+  apply Build_Is0Functor.
+  unfold op.
+  cbn.
+  intros a b.
+  apply fmap.
+  assumption.
+Defined.
+
+Global Instance is0coh2fun_op A B `{Is1Cat A} `{Is1Cat B}
+       (F : A -> B) `{!Is0Functor F, !Is1Functor F}
+  : Is1Functor (F : A^op -> B^op).
+Proof.
+  apply Build_Is1Functor; unfold op in *; cbn in *.
+  - intros a b; apply fmap2; assumption.
+  - intros a; exact (fmap_id F a).
+  - intros a b c f g; exact (fmap_comp F g f).
+Defined.
+
+(** Opposite natural transformations *)
+
+Definition transformation_op {A} {B} `{Is01Cat B}
+           (F : A -> B) (G : A -> B) (alpha : F $=> G)
+  : (@Transformation (A^op) (B^op) (@isgraph_1cat _ (is01cat_op B))
+                     (G : (A^op) -> (B^op)) (F : (A^op) -> (B^op))).
+Proof.
+  unfold op in *.
+  cbn in *.
+  intro a.
+  apply (alpha a).
+Defined.
+
+Global Instance is1nat_op A B `{Is01Cat A} `{Is1Cat B}
+       (F : A -> B) `{!Is0Functor F}
+       (G : A -> B) `{!Is0Functor G}
+       (alpha : F $=> G) `{!Is1Natural F G alpha}
+  : Is1Natural (G : A^op -> B^op) (F : A^op -> B^op) (transformation_op F G alpha).
+Proof.
+  apply Build_Is1Natural.
+  unfold op in *.
+  unfold transformation_op.
+  cbn.
+  intros a b f.
+  apply isnat_opp.
+  assumption.
+Defined.
+
+(** Opposite categories preserve having equivalences. *)
+Global Instance hasequivs_op {A} `{HasEquivs A} : HasEquivs A^op.
+Proof.
+  srapply Build_HasEquivs; intros a b; unfold op in *; cbn.
+  - exact (b $<~> a).
+  - apply CatIsEquiv.
+  - apply cate_fun'.
+  - apply cate_isequiv'.
+  - apply cate_buildequiv'.
+  - apply cate_buildequiv_fun'.
+  - apply cate_inv'.
+  - apply cate_isretr'.
+  - apply cate_issect'.
+  - intros f g s t.
+    exact (catie_adjointify f g t s).
+Defined.
+
+Global Instance isequivs_op {A : Type} `{HasEquivs A}
+       {a b : A} (f : a $-> b) {ief : CatIsEquiv f}
+  : @CatIsEquiv A^op _ _ _ b a f.
+Proof.
+  assumption.
+Defined.

--- a/theories/WildCat/Prod.v
+++ b/theories/WildCat/Prod.v
@@ -1,0 +1,62 @@
+(* -*- mode: coq; mode: visual-line -*-  *)
+
+Require Import Basics.Overture.
+Require Import Basics.PathGroupoids.
+Require Import Basics.Notations.
+Require Import Basics.Contractible.
+Require Import Basics.Equivalences.
+Require Import WildCat.Core.
+Require Import WildCat.Equiv.
+
+(** * More about product categories *)
+
+(** Product categories inherit equivalences *)
+
+Global Instance hasequivs_prod A B `{HasEquivs A} `{HasEquivs B}
+  : HasEquivs (A * B).
+Proof.
+  srefine (Build_HasEquivs (A * B) _ _
+             (fun a b => (fst a $<~> fst b) * (snd a $<~> snd b))
+             _ _ _ _ _ _ _ _ _).
+  1:intros a b f; exact (CatIsEquiv (fst f) * CatIsEquiv (snd f)).
+  all:cbn; intros a b f.
+  - split; [ exact (fst f) | exact (snd f) ].
+  - split; exact _.
+  - intros [fe1 fe2]; split.
+    + exact (Build_CatEquiv (fst f)).
+    + exact (Build_CatEquiv (snd f)).
+  - intros [fe1 fe2]; cbn; split; apply cate_buildequiv_fun.
+  - intros [fe1 fe2]; split; [ exact ((fst f)^-1$) | exact ((snd f)^-1$) ].
+  - intros [fe1 fe2]; split; apply cate_issect.
+  - intros [fe1 fe2]; split; apply cate_isretr.
+  - intros g r s; split.
+    + exact (catie_adjointify (fst f) (fst g) (fst r) (fst s)).
+    + exact (catie_adjointify (snd f) (snd g) (snd r) (snd s)).
+Defined.
+
+Global Instance isequivs_prod A B `{HasEquivs A} `{HasEquivs B}
+       {a1 a2 : A} {b1 b2 : B} {f : a1 $-> a2} {g : b1 $-> b2}
+       {ef : CatIsEquiv f} {eg : CatIsEquiv g}
+  : @CatIsEquiv (A*B) _ _ _ (a1,b1) (a2,b2) (f,g) := (ef,eg).
+
+(** More coherent two-variable functors. *)
+
+Definition fmap22 {A B C : Type} `{Is1Cat A} `{Is1Cat B} `{Is1Cat C}
+  (F : A -> B -> C) `{!Is0Functor (uncurry F), !Is1Functor (uncurry F)}
+  {a1 a2 : A} {b1 b2 : B} (f1 : a1 $-> a2) (f2 : b1 $-> b2) (g1 : a1 $-> a2) (g2 : b1 $-> b2)
+  (alpha : f1 $== g1) (beta : f2 $== g2)
+  : (fmap11 F f1 f2) $== (fmap11 F g1 g2)
+  := @fmap2 _ _ _ _ _ _ (uncurry F) _ _ (a1, b1) (a2, b2) (f1, f2) (g1, g2) (alpha, beta).
+
+Global Instance iemap11 {A B C : Type} `{HasEquivs A} `{HasEquivs B} `{HasEquivs C}
+           (F : A -> B -> C) `{!Is0Functor (uncurry F), !Is1Functor (uncurry F)}
+           {a1 a2 : A} {b1 b2 : B} (f1 : a1 $-> a2) (f2 : b1 $-> b2)
+           {f1e : CatIsEquiv f1} {f2e : CatIsEquiv f2}
+  : CatIsEquiv (fmap11 F f1 f2)
+  := @iemap _ _ _ _ _ _ _ _ (uncurry F) _ _ (a1, b1) (a2, b2) (f1, f2) _.
+
+Definition emap11 {A B C : Type} `{HasEquivs A} `{HasEquivs B} `{HasEquivs C}
+           (F : A -> B -> C) `{!Is0Functor (uncurry F), !Is1Functor (uncurry F)}
+           {a1 a2 : A} {b1 b2 : B} (fe1 : a1 $<~> a2)
+           (fe2 : b1 $<~> b2) : (F a1 b1) $<~> (F a2 b2)
+  := @emap _ _ _ _ _ _ _ _ (uncurry F) _ _ (a1, b1) (a2, b2) (fe1, fe2).

--- a/theories/WildCat/Sum.v
+++ b/theories/WildCat/Sum.v
@@ -1,0 +1,45 @@
+(* -*- mode: coq; mode: visual-line -*-  *)
+
+Require Import Basics.
+Require Import WildCat.Core.
+
+(** ** Sum categories *)
+
+Global Instance is01cat_sum A B `{ Is01Cat A } `{ Is01Cat B}
+  : Is01Cat (A + B).
+Proof.
+  serapply Build_Is01Cat.
+  - intros [a1 | b1] [a2 | b2].
+    + exact (a1 $-> a2).
+    + exact Empty.
+    + exact Empty.
+    + exact (b1 $-> b2).
+  - intros [a | b]; apply Id.
+  - intros [a | b] [a1 | b1] [a2 | b2];
+    try contradiction; apply cat_comp.
+Defined.
+
+(* Note: [try contradiction] deals with empty cases. *)
+Global Instance is1cat_sum A B `{ Is1Cat A } `{ Is1Cat B}
+  : Is1Cat (A + B).
+Proof.
+  serapply Build_Is1Cat.
+  - intros x y.
+    serapply Build_Is01Cat;
+    destruct x as [a1 | b1], y as [a2 | b2];
+    try contradiction; cbn;
+    (apply Hom || apply Id || intros a b c; apply cat_comp).
+  - intros x y; serapply Build_Is0Gpd.
+    destruct x as [a1 | b1], y as [a2 | b2];
+    try contradiction; cbn; intros f g; apply gpd_rev.
+  - intros x y z; serapply Build_Is0Functor.
+    intros [f g] [h i] [j k].
+    destruct x as [a1 | b1], y as [a2 | b2], z as [a3 | b3];
+    try contradiction; exact (j $o@ k).
+  - intros [a1 | b1] [a2 | b2] [a3 | b3] [a4 | b4] f g h;
+    try contradiction; cbn; apply cat_assoc.
+  - intros [a1 | b1] [a2 | b2] f; try contradiction;
+    cbn; apply cat_idl.
+  - intros [a1 | b1] [a2 | b2] f; try contradiction;
+    cbn; apply cat_idr.
+Defined.

--- a/theories/WildCat/Type.v
+++ b/theories/WildCat/Type.v
@@ -1,0 +1,63 @@
+Require Export Basics.
+Require Export WildCat.Core.
+Require Export WildCat.Equiv.
+
+(** ** The category of types *)
+
+Global Instance is01cat_type : Is01Cat Type
+  := Build_Is01Cat Type (fun a b => a -> b)
+                      (fun a => idmap) (fun a b c g f => g o f).
+
+Global Instance is01cat_arrow {A B : Type}: Is01Cat (A $-> B)
+  := Build_Is01Cat _ (fun f g => f == g) (fun f a => idpath)
+                      (fun f g h p q a => q a @ p a).
+
+Global Instance is0gpd_arrow {A B : Type}: Is0Gpd (A $-> B).
+Proof.
+  apply Build_Is0Gpd.
+  intros f g p a ; exact (p a)^.
+Defined.
+
+Global Instance is0functor_comp {A B C : Type}:
+  Is0Functor (uncurry (@cat_comp Type _ A B C)).
+Proof.
+  apply Build_Is0Functor.
+  intros [f g] [f' g'] [p p'] a ;
+    exact (p (g a) @ ap f' (p' a)).
+Defined.
+
+Global Instance is1cat_strong_type : Is1Cat_Strong Type.
+Proof.
+  srapply Build_Is1Cat_Strong; cbn; intros; reflexivity.
+Defined.
+
+Global Instance hasmorext_type `{Funext} : HasMorExt Type.
+Proof.
+  srapply Build_HasMorExt.
+  intros A B f g; cbn in *.
+  refine (isequiv_homotopic (@apD10 A (fun _ => B) f g) _).
+  intros p.
+  destruct p; reflexivity.
+Defined.
+
+Global Instance hasequivs_type : HasEquivs Type.
+Proof.
+  srefine (Build_HasEquivs Type _ _ Equiv (@IsEquiv) _ _ _ _ _ _ _ _); intros A B.
+  all:intros f.
+  - exact f.
+  - exact _.
+  - apply Build_Equiv.
+  - intros; reflexivity.
+  - intros; exact (f^-1).
+  - cbn. intros ? x; apply eissect.
+  - cbn. intros ? x; apply eisretr.
+  - intros g r s; refine (isequiv_adjointify f g r s).
+Defined.
+
+Definition catie_isequiv {A B : Type} {f : A $-> B}
+       `{IsEquiv A B f} : CatIsEquiv f.
+Proof.
+  assumption.
+Defined.
+
+Hint Immediate catie_isequiv : typeclass_instances.

--- a/theories/WildCat/UnitCat.v
+++ b/theories/WildCat/UnitCat.v
@@ -1,0 +1,23 @@
+Require Import Basics.
+Require Import WildCat.Core.
+
+(** Unit category *)
+
+Global Instance is01cat_unit : Is01Cat Unit.
+Proof.
+  srapply Build_Is01Cat.
+  1: intros; exact Unit.
+  all: intros; exact tt.
+Defined.
+
+Global Instance is0gpd_unit : Is0Gpd Unit.
+Proof.
+  constructor; intros; exact tt.
+Defined.
+
+Global Instance is1cat_unit : Is1Cat Unit.
+Proof.
+  simple notypeclasses refine (Build_Is1Cat _ _ _ _ _ _ _ _); try exact _; intros.
+  1:rapply Build_Is0Functor; intros.
+  all:exact tt.
+Defined.

--- a/theories/WildCat/Yoneda.v
+++ b/theories/WildCat/Yoneda.v
@@ -1,0 +1,177 @@
+(* -*- mode: coq; mode: visual-line -*-  *)
+
+Require Export Basics.
+Require Export WildCat.Core.
+Require Export WildCat.Equiv.
+Require Export WildCat.Type.
+Require Export WildCat.Opposite.
+Require Export WildCat.FunctorCat.
+Require Export WildCat.Prod.
+
+(** ** Two-variable hom-functors *)
+
+Global Instance is0functor_hom {A} `{Is01Cat A}
+  : @Is0Functor (A^op * A) Type _ _ (uncurry (@Hom A _)).
+Proof.
+  apply Build_Is0Functor.
+  intros [a1 a2] [b1 b2] [f1 f2] g; cbn in *.
+  exact (f2 $o g $o f1).
+Defined.
+
+(** This requires morphism extensionality! *)
+Global Instance is1functor_hom {A} `{HasMorExt A}
+  : @Is1Functor (A^op * A) Type _ _ _ _ (uncurry (@Hom A _)) _.
+Proof.
+  apply Build_Is1Functor.
+  - intros [a1 a2] [b1 b2] [f1 f2] [g1 g2] [p1 p2] q; cbn in *.
+    apply path_hom.
+    exact ((p2 $@R q) $o@ p1).
+  - intros [a1 a2] f; cbn in *.
+    apply path_hom.
+    exact (cat_idr _ $@ cat_idl f).
+  - intros [a1 a2] [b1 b2] [c1 c2] [f1 f2] [g1 g2] h; cbn in *.
+    apply path_hom.
+    refine (cat_assoc _ _ _ $@ _).
+    refine (cat_assoc _ _ _ $@ _).
+    refine (_ $@ cat_assoc_opp _ _ _).
+    refine (g2 $@L _).
+    refine (_ $@ cat_assoc_opp _ _ _).
+    refine (cat_assoc_opp _ _ _).
+Defined.
+
+(** ** The covariant Yoneda lemma *)
+
+(** This is easier than the contravariant version because it doesn't involve any "op"s. *)
+
+Definition opyon {A : Type} `{Is01Cat A} (a : A) : A -> Type
+  := fun b => (a $-> b).
+
+Global Instance is0coh1functor_opyon {A : Type} `{Is01Cat A} (a : A)
+  : Is0Functor (opyon a).
+Proof.
+  apply Build_Is0Functor.
+  unfold opyon; intros b c f g; cbn in *.
+  exact (f $o g).
+Defined.
+
+Definition opyoneda {A : Type} `{Is01Cat A} (a : A)
+           (F : A -> Type) {ff : Is0Functor F}
+  : F a -> (opyon a $=> F).
+Proof.
+  intros x b f.
+  exact (fmap F f x).
+Defined.
+
+Definition un_opyoneda {A : Type} `{Is01Cat A}
+  (a : A) (F : A -> Type) {ff : Is0Functor F}
+  : (opyon a $=> F) -> F a
+  := fun alpha => alpha a (Id a).
+
+Global Instance is1natural_opyoneda {A : Type} `{Is1Cat A}
+  (a : A) (F : A -> Type) `{!Is0Functor F, !Is1Functor F} (x : F a)
+  : Is1Natural (opyon a) F (opyoneda a F x).
+Proof.
+  apply Build_Is1Natural.
+  unfold opyon, opyoneda; intros b c f g; cbn in *.
+  exact (fmap_comp F g f x).
+Defined.
+
+Definition opyoneda_issect {A : Type} `{Is1Cat A} (a : A)
+           (F : A -> Type) `{!Is0Functor F, !Is1Functor F}
+           (x : F a)
+  : un_opyoneda a F (opyoneda a F x) = x
+  := fmap_id F a x.
+
+(** We assume for the converse that the coherences in [A] are equalities (this is a weak funext-type assumption).  Note that we do not in general recover the witness of 1-naturality.  Indeed, if [A] is fully coherent, then a transformation of the form [yoneda a F x] is always also fully coherently natural, so an incoherent witness of 1-naturality could not be recovered in this way.  *)
+Definition opyoneda_isretr {A : Type} `{Is1Cat_Strong A} (a : A)
+           (F : A -> Type) `{!Is0Functor F, !Is1Functor F}
+           (alpha : opyon a $=> F) {alnat : Is1Natural (opyon a) F alpha}
+           (b : A)
+  : opyoneda a F (un_opyoneda a F alpha) b $== alpha b.
+Proof.
+  unfold opyoneda, un_opyoneda, opyon; intros f.
+  refine ((isnat alpha f (Id a))^ @ _).
+  cbn.
+  apply ap.
+  exact (cat_idr_strong f).
+Defined.
+
+(** Specialization to "full-faithfulness" of the Yoneda embedding.  (In quotes because, again, incoherence means we can't recover the witness of naturality.)  *)
+Definition opyon_cancel {A : Type} `{Is01Cat A} (a b : A)
+  : (opyon a $=> opyon b) -> (b $-> a)
+  := un_opyoneda a (opyon b).
+
+Definition opyon1 {A : Type} `{Is01Cat A} (a : A) : Fun01 A Type.
+Proof.
+  rapply (Build_Fun01 _ _ _ _ (opyon a)).
+Defined.
+
+(** We can also deduce "full-faithfulness" on equivalences. *)
+Definition opyon_equiv {A : Type} `{HasEquivs A} `{!Is1Cat_Strong A}
+           (a b : A)
+  : (opyon1 a $<~> opyon1 b) -> (b $<~> a).
+Proof.
+  intros f.
+  refine (cate_adjointify (f.1 a (Id a)) (f^-1$.1 b (Id b)) _ _) ;
+    apply GpdHom_path; pose proof (f.2); pose proof (f^-1$.2); cbn in *.
+  - refine ((isnat (fun a => (f.1 a)^-1$) (f.1 a (Id a)) (Id b))^ @ _); cbn.
+    refine (_ @ cate_issect (f.1 a) (Id a)); cbn.
+    apply ap.
+    serapply cat_idr_strong.
+  - refine ((isnat f.1 (f^-1$.1 b (Id b)) (Id a))^ @ _); cbn.
+    refine (_ @ cate_isretr (f.1 b) (Id b)); cbn.
+    apply ap.
+    serapply cat_idr_strong.
+Defined.
+
+(** ** The contravariant Yoneda lemma *)
+
+(** We can deduce this from the covariant version with some boilerplate. *)
+
+Definition yon {A : Type} `{Is01Cat A} (a : A) : A^op -> Type
+  := @opyon (A^op) _ a.
+
+Global Instance is0coh1functor_yon {A : Type} `{Is01Cat A} (a : A)
+  : Is0Functor (yon a)
+  := @is0coh1functor_opyon A _ a.
+
+Definition yoneda {A : Type} `{Is01Cat A} (a : A)
+           (F : A^op -> Type) `{!Is0Functor F}
+  : F a -> (yon a $=> F)
+  := @opyoneda (A^op) _ a F _.
+
+Definition un_yoneda {A : Type} `{Is01Cat A} (a : A)
+           (F : A^op -> Type) `{!Is0Functor F}
+  : (yon a $=> F) -> F a
+  := @un_opyoneda (A^op) _ a F _.
+
+Global Instance is1natural_yoneda {A : Type} `{Is1Cat A} (a : A)
+       (F : A^op -> Type) `{!Is0Functor F, !Is1Functor F} (x : F a)
+  : Is1Natural (yon a) F (yoneda a F x)
+  := @is1natural_opyoneda (A^op) _ _ a F _ _ x.
+
+Definition yoneda_issect {A : Type} `{Is1Cat A} (a : A)
+           (F : A^op -> Type) `{!Is0Functor F, !Is1Functor F} (x : F a)
+  : un_yoneda a F (yoneda a F x) = x
+  := @opyoneda_issect (A^op) _ _ a F _ _ x.
+
+Definition yoneda_isretr {A : Type} `{Is1Cat_Strong A} (a : A)
+           (F : A^op -> Type) `{!Is0Functor F}
+           (* Without the hint here, Coq guesses to first project from [Is1Cat_Strong A] and then pass to opposites, whereas what we need is to first pass to opposites and then project. *)
+           `{@Is1Functor _ _ _ (is1cat_is1cat_strong A^op) _ _ F _}
+           (alpha : yon a $=> F) {alnat : Is1Natural (yon a) F alpha}
+           (b : A)
+  : yoneda a F (un_yoneda a F alpha) b $== alpha b
+  := @opyoneda_isretr A^op _ (is1cat_strong_op A) a F _ _ alpha alnat b.
+
+Definition yon_cancel {A : Type} `{Is01Cat A} (a b : A)
+  : (yon a $=> yon b) -> (a $-> b)
+  := un_yoneda a (yon b).
+
+Definition yon1 {A : Type} `{Is01Cat A} (a : A) : Fun01 A^op Type
+  := opyon1 a.
+
+Definition yon_equiv {A : Type} `{HasEquivs A} `{!Is1Cat_Strong A}
+           (a b : A)
+  : (yon1 a $<~> yon1 b) -> (a $<~> b)
+  := (@opyon_equiv A^op _ _ _ _ a b).


### PR DESCRIPTION
This is joint work with @alizter, @emilyriehl, @mpopie, and @tslilc who visited last week.  It's building on the basic approach of #1163, but reorganized and renamed a bit.  In particular:

- We realized that wild categories allow reusing the basic definitions at different dimensions in an enriched style.  This is quite satisfying!
- The terminology is now more coherent, roughly matching the standard higher-categorical notion of (n,r)-category (made wild).
- We got rid of the duplicate data for opposites again; we can consider putting it back, but the issue is that we also want to use this as the basis for a definition of bicategory, potentially even tricategory, etc., and if extra data is hanging around then it would need extra coherence laws.  It also becomes a problem when trying to construct displayed categories without having to explicitly give the redundant data.  So far, we haven't been bothered by the behavior of opposites.

This PR basically gets up to the Yoneda lemma and the definition of Type and pType as wild 1-categories.  We're working on constructing a wild 2-category of wild 1-categories, and hope to get to other stuff like displayed categories, Grothendieck constructions, closed/monoidal categories, and enrichment.

I had hoped that the technology of wild functors could replace the disparate proofs of functoriality in Types/Prod, Types/Sum, etc., but doing that turns out to create universe polymorphism issues (in places like Modalities and PropResizing/Nat that are finicky about universe annotations), since the resulting proofs have different universe parameters.  I'm still not sure whether there is a solution to that.

