### PR TITLE
Global Set Loose Hint Behavior "Strict"

### DIFF
--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -24,6 +24,7 @@
 *)
 
 Require Import HoTT Coq.Init.Peano.
+Require Import UnivalenceImpliesFunext.
 
 Local Open Scope path_scope.
 

--- a/theories/Algebra/AbelianGroup.v
+++ b/theories/Algebra/AbelianGroup.v
@@ -1,5 +1,4 @@
-Require Import Basics.
-Require Import Types.
+Require Import HoTT.Basics HoTT.Types UnivalenceImpliesFunext.
 Require Import Truncations.
 Require Import HIT.Coeq.
 Require Import Algebra.Group.

--- a/theories/Algebra/Group.v
+++ b/theories/Algebra/Group.v
@@ -1,5 +1,4 @@
-Require Import Basics.
-Require Import Types.
+Require Import HoTT.Basics HoTT.Types UnivalenceImpliesFunext.
 Require Import PathAny.
 Require Export Classes.interfaces.abstract_algebra.
 Require Export Classes.theory.groups.

--- a/theories/Algebra/QuotientGroup.v
+++ b/theories/Algebra/QuotientGroup.v
@@ -1,5 +1,4 @@
-Require Import Basics.
-Require Import Types.
+Require Import HoTT.Basics HoTT.Types UnivalenceImpliesFunext.
 Require Import Algebra.Group.
 Require Import Algebra.Subgroup.
 Require Import Algebra.Congruence.

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -27,6 +27,9 @@ Global Set Default Goal Selector "!".
 (** Currently Coq doesn't print equivalences correctly (8.6). This fixes that. See https://github.com/HoTT/HoTT/issues/1000 *)
 Global Set Printing Primitive Projection Parameters.
 
+(** This tells Coq that when we [Require] a module without [Import]ing it, typeclass instances defined in that module should also not be imported.  In other words, the only effect of [Require] without [Import] is to make qualified names available. *)
+Global Set Loose Hint Behavior "Strict".
+
 (** Apply using the same opacity information as typeclass proof search. *)
 Ltac class_apply c := autoapply c with typeclass_instances.
 

--- a/theories/BoundedSearch.v
+++ b/theories/BoundedSearch.v
@@ -1,5 +1,5 @@
 Require Import Coq.Init.Peano.
-Require Import HoTT.Basics HoTT.Truncations HoTT.HProp HoTT.Types.Arrow HoTT.Types.Forall HoTT.Types.Sigma HoTT.Spaces.Nat HoTT.DProp.
+Require Import HoTT.Basics HoTT.Truncations HoTT.HProp HoTT.Types HoTT.Spaces.Nat HoTT.DProp.
 
 Section bounded_search.
 

--- a/theories/Categories/Category/Sigma/OnObjects.v
+++ b/theories/Categories/Category/Sigma/OnObjects.v
@@ -1,5 +1,5 @@
 (** * ∑-categories on objects - a generalization of subcategories *)
-Require Import Types.Unit.
+Require Import HoTT.Basics HoTT.Types.
 Require Import Category.Core Functor.Core Category.Sigma.Core.
 Require Functor.Composition.Core Functor.Identity.
 Require Import Functor.Paths.

--- a/theories/Categories/Category/Sigma/Univalent.v
+++ b/theories/Categories/Category/Sigma/Univalent.v
@@ -2,7 +2,7 @@
 Require Import Category.Core Category.Morphisms.
 Require Import Category.Univalent.
 Require Import Category.Sigma.Core Category.Sigma.OnObjects Category.Sigma.OnMorphisms.
-Require Import HoTT.Types.Sigma HoTT.Basics.Equivalences HoTT.Basics.Trunc HoTT.Basics.PathGroupoids HoTT.Tactics.
+Require Import HoTT.Types HoTT.Basics HoTT.Tactics.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Categories/Category/Univalent.v
+++ b/theories/Categories/Category/Univalent.v
@@ -1,6 +1,6 @@
 (** * Definition of a univalent/saturated precategory, or just "category" *)
 Require Import Category.Core Category.Morphisms.
-Require Import HoTT.Tactics Trunc.
+Require Import HoTT.Basics HoTT.Types HoTT.Tactics Trunc.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Categories/CategoryOfSections/Core.v
+++ b/theories/Categories/CategoryOfSections/Core.v
@@ -4,7 +4,7 @@ Require Import Category.Strict.
 Require Import Functor.Identity NaturalTransformation.Identity.
 Require Import NaturalTransformation.Paths NaturalTransformation.Composition.Core.
 Require Import Functor.Paths.
-Require Import Trunc Types.Sigma.
+Require Import Trunc HoTT.Basics HoTT.Types.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Categories/ChainCategory.v
+++ b/theories/Categories/ChainCategory.v
@@ -2,7 +2,7 @@
 Require Import Category.Core Category.Subcategory.Full.
 Require Import Category.Sigma.Univalent.
 Require Import Category.Morphisms Category.Univalent Category.Strict.
-Require Import HoTT.Basics.Trunc HoTT.DProp HoTT.TruncType HoTT.Spaces.Nat.
+Require Import HoTT.Basics HoTT.Types HoTT.DProp HoTT.TruncType HoTT.Spaces.Nat.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Categories/Comma/Core.v
+++ b/theories/Categories/Comma/Core.v
@@ -3,7 +3,7 @@ Require Import Category.Core Functor.Core.
 Require Import InitialTerminalCategory.Core InitialTerminalCategory.Functors.
 Require Functor.Identity.
 Require Import Category.Strict.
-Require Import Types.Paths Types.Sigma Trunc HoTT.Tactics HProp.
+Require Import HoTT.Basics HoTT.Types Trunc HoTT.Tactics HProp.
 Import Functor.Identity.FunctorIdentityNotations.
 
 Set Universe Polymorphism.

--- a/theories/Categories/DiscreteCategory.v
+++ b/theories/Categories/DiscreteCategory.v
@@ -1,5 +1,5 @@
 (** * Discrete category *)
-Require Import Category.Core GroupoidCategory.Core.
+Require Import HoTT.Basics Category.Core GroupoidCategory.Core.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Categories/ExponentialLaws/Law0.v
+++ b/theories/Categories/ExponentialLaws/Law0.v
@@ -1,6 +1,7 @@
 (** * Exponential laws about the initial category *)
 Require Import Category.Core Functor.Core FunctorCategory.Core Functor.Identity Functor.Composition.Core.
 Require Import InitialTerminalCategory.Core InitialTerminalCategory.Functors InitialTerminalCategory.NaturalTransformations.
+Require Import HoTT.Basics HoTT.Types.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Categories/ExponentialLaws/Law1/Functors.v
+++ b/theories/Categories/ExponentialLaws/Law1/Functors.v
@@ -1,6 +1,7 @@
 (** * Functors involving functor categories involving the terminal category *)
 Require Import Category.Core Functor.Core FunctorCategory.Core Functor.Identity NaturalTransformation.Core NaturalTransformation.Paths Functor.Composition.Core.
 Require Import InitialTerminalCategory.Core InitialTerminalCategory.Functors InitialTerminalCategory.NaturalTransformations.
+Require Import HoTT.Basics HoTT.Types.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Categories/ExponentialLaws/Law1/Law.v
+++ b/theories/Categories/ExponentialLaws/Law1/Law.v
@@ -1,7 +1,7 @@
 (** * Exponential laws about the terminal category *)
 Require Import Category.Core Functor.Core FunctorCategory.Core Functor.Identity NaturalTransformation.Core Functor.Paths NaturalTransformation.Paths ExponentialLaws.Law1.Functors Functor.Composition.Core.
 Require Import InitialTerminalCategory.Core.
-Require Import HoTT.Tactics ExponentialLaws.Tactics.
+Require Import HoTT.Basics HoTT.Types HoTT.Tactics ExponentialLaws.Tactics.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Categories/ExponentialLaws/Law1/Law.v
+++ b/theories/Categories/ExponentialLaws/Law1/Law.v
@@ -1,7 +1,7 @@
 (** * Exponential laws about the terminal category *)
 Require Import Category.Core Functor.Core FunctorCategory.Core Functor.Identity NaturalTransformation.Core Functor.Paths NaturalTransformation.Paths ExponentialLaws.Law1.Functors Functor.Composition.Core.
 Require Import InitialTerminalCategory.Core.
-Require Import HoTT.Basics HoTT.Types HoTT.Tactics ExponentialLaws.Tactics.
+Require Import Basics.Trunc HoTT.Tactics ExponentialLaws.Tactics.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Categories/Functor/Paths.v
+++ b/theories/Categories/Functor/Paths.v
@@ -1,6 +1,6 @@
 (** * Classification of path spaces of functors *)
 Require Import Category.Core Functor.Core.
-Require Import HProp HoTT.Tactics Equivalences Basics.PathGroupoids Types.Sigma Trunc Types.Paths.
+Require Import HoTT.Basics HoTT.Types HoTT.Tactics Equivalences HProp.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Categories/FunctorCategory/Core.v
+++ b/theories/Categories/FunctorCategory/Core.v
@@ -1,7 +1,8 @@
 (** * Functor category [D → C] (also [Cᴰ] and [[D, C]]) *)
 Require Import Category.Core Category.Strict Functor.Core NaturalTransformation.Core Functor.Paths.
+Require Import HoTT.Basics HoTT.Types.
 (** These must come last, so that [identity], [compose], etc., refer to natural transformations. *)
-Require Import NaturalTransformation.Composition.Core NaturalTransformation.Identity NaturalTransformation.Composition.Laws.
+Require Import NaturalTransformation.Composition.Core NaturalTransformation.Identity NaturalTransformation.Composition.Laws NaturalTransformation.Paths. 
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Categories/FundamentalPreGroupoidCategory.v
+++ b/theories/Categories/FundamentalPreGroupoidCategory.v
@@ -1,6 +1,7 @@
 (** * Fundamental Pregroupoids *)
 Require Import Category.Core Category.Morphisms.
 Require Import HoTT.Truncations PathGroupoids.
+Require Import HoTT.Basics HoTT.Types.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Categories/Grothendieck/PseudofunctorToCat.v
+++ b/theories/Categories/Grothendieck/PseudofunctorToCat.v
@@ -1,11 +1,12 @@
 (** * Grothendieck Construction of a pseudofunctor to Cat *)
+Require Import FunctorCategory.Morphisms.
 Require Import Category.Core Functor.Core NaturalTransformation.Core.
 Require Import Pseudofunctor.Core Pseudofunctor.RewriteLaws.
 Require Import Category.Morphisms NaturalTransformation.Isomorphisms Cat.Morphisms.
 Require Import Functor.Composition.Core Functor.Composition.Laws.
 Require Import Functor.Identity.
 Require Import FunctorCategory.Core.
-Require Import HoTT.Basics HoTT.Types HoTT.Tactics PathGroupoids.
+Require Import Basics Types HoTT.Tactics PathGroupoids.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Categories/Grothendieck/PseudofunctorToCat.v
+++ b/theories/Categories/Grothendieck/PseudofunctorToCat.v
@@ -5,7 +5,7 @@ Require Import Category.Morphisms NaturalTransformation.Isomorphisms Cat.Morphis
 Require Import Functor.Composition.Core Functor.Composition.Laws.
 Require Import Functor.Identity.
 Require Import FunctorCategory.Core.
-Require Import Types.Sigma HoTT.Tactics PathGroupoids.
+Require Import HoTT.Basics HoTT.Types HoTT.Tactics PathGroupoids.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Categories/Grothendieck/ToSet/Morphisms.v
+++ b/theories/Categories/Grothendieck/ToSet/Morphisms.v
@@ -3,7 +3,7 @@ Require Import Category.Core Functor.Core.
 Require Import Category.Morphisms.
 Require Import SetCategory.Core.
 Require Import Grothendieck.ToSet.Core.
-Require Import HoTT.Basics.Equivalences HoTT.Types.Sigma.
+Require Import HoTT.Basics HoTT.Types.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Categories/GroupoidCategory/Dual.v
+++ b/theories/Categories/GroupoidCategory/Dual.v
@@ -1,6 +1,6 @@
 (** * Propositional self-duality of groupoid categories *)
 Require Import Category.Core GroupoidCategory.Core Category.Paths Category.Dual.
-Require Import HoTT.Types.Universe HoTT.UnivalenceImpliesFunext.
+Require Import HoTT.Types HoTT.UnivalenceImpliesFunext.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Categories/HomotopyPreCategory.v
+++ b/theories/Categories/HomotopyPreCategory.v
@@ -1,6 +1,6 @@
 (** * Homotopy PreCategory of Types *)
 Require Import Category.Core Category.Morphisms.
-Require Import HoTT.Truncations HSet.
+Require Import HoTT.Basics HoTT.Truncations HSet.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Categories/InitialTerminalCategory/Core.v
+++ b/theories/Categories/InitialTerminalCategory/Core.v
@@ -1,4 +1,5 @@
 (** * Initial and terminal category definitions *)
+Require Import HoTT.Basics HoTT.Types.
 Require Import Category.Core.
 Require Import NatCategory Contractible.
 

--- a/theories/Categories/InitialTerminalCategory/Functors.v
+++ b/theories/Categories/InitialTerminalCategory/Functors.v
@@ -2,6 +2,7 @@
 Require Import Category.Core Functor.Core Functor.Paths.
 Require Import InitialTerminalCategory.Core.
 Require Import NatCategory Contractible.
+Require Import HoTT.Basics HoTT.Types.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Categories/NaturalTransformation/Paths.v
+++ b/theories/Categories/NaturalTransformation/Paths.v
@@ -1,6 +1,6 @@
 (** * Classify the path space of natural transformations *)
 Require Import Category.Core Functor.Core NaturalTransformation.Core.
-Require Import Equivalences Types.Sigma Trunc.
+Require Import Equivalences HoTT.Types Trunc.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Categories/ProductLaws.v
+++ b/theories/Categories/ProductLaws.v
@@ -1,7 +1,7 @@
 (** * Laws about product categories *)
 Require Import Category.Core Functor.Core InitialTerminalCategory.Core InitialTerminalCategory.Functors Category.Prod Functor.Prod Functor.Composition.Core Functor.Identity Functor.Prod.Universal Functor.Composition.Laws Functor.Prod.Universal.
 Require Import Functor.Paths.
-Require Import Types.Prod Types.Forall HoTT.Tactics.
+Require Import HoTT.Basics HoTT.Types HoTT.Tactics.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Categories/Pseudofunctor/Identity.v
+++ b/theories/Categories/Pseudofunctor/Identity.v
@@ -4,6 +4,7 @@ Require Import NaturalTransformation.Isomorphisms.
 Require Import NaturalTransformation.Paths.
 Require Import Cat.Core.
 Require Import Pseudofunctor.Core.
+Require Import HoTT.Basics HoTT.Types.
 
 (** Bring things into scope. *)
 Import NaturalTransformation.Identity.

--- a/theories/Categories/Pseudofunctor/Identity.v
+++ b/theories/Categories/Pseudofunctor/Identity.v
@@ -1,10 +1,10 @@
 (** * Identity pseudofunctor *)
+Require Import FunctorCategory.Morphisms.
 Require Import Category.Core Functor.Core NaturalTransformation.Core.
 Require Import NaturalTransformation.Isomorphisms.
 Require Import NaturalTransformation.Paths.
 Require Import Cat.Core.
 Require Import Pseudofunctor.Core.
-Require Import HoTT.Basics HoTT.Types.
 
 (** Bring things into scope. *)
 Import NaturalTransformation.Identity.

--- a/theories/Categories/SemiSimplicialSets.v
+++ b/theories/Categories/SemiSimplicialSets.v
@@ -1,4 +1,5 @@
 (** * The category of semisimplicial sets *)
+Require Import Types.
 Require Import Category.Core Functor.Core.
 Require Import Category.Morphisms.
 Require Import Category.Dual FunctorCategory.Core.

--- a/theories/Categories/SetCategory/Core.v
+++ b/theories/Categories/SetCategory/Core.v
@@ -1,6 +1,6 @@
 (** * PreCategories [set_cat] and [prop_cat] *)
 Require Import Category.Core Category.Strict.
-Require Import HoTT.Basics.Trunc HProp HSet Types.Universe UnivalenceImpliesFunext TruncType.
+Require Import HoTT.Basics HoTT.Types HProp HSet UnivalenceImpliesFunext TruncType.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Categories/SetCategory/Morphisms.v
+++ b/theories/Categories/SetCategory/Morphisms.v
@@ -3,7 +3,7 @@ Require Import Category.Core Functor.Core NaturalTransformation.Core.
 Require Import Category.Morphisms NaturalTransformation.Paths.
 Require Import Category.Univalent.
 Require Import SetCategory.Core.
-Require Import Basics.Trunc Types.Sigma HProp HSet Types.Universe Equivalences HoTT.Misc UnivalenceImpliesFunext TruncType.
+Require Import HoTT.Basics HoTT.Types HProp HSet Equivalences UnivalenceImpliesFunext TruncType.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Categories/SimplicialSets.v
+++ b/theories/Categories/SimplicialSets.v
@@ -1,5 +1,6 @@
 (** * The simplex category Δ, and the precategory of simplicial sets, [Δᵒᵖ → set] *)
-Require Import Category.Core Functor.Core.
+Require Import Basics Types Spaces.Nat.
+Require Import Category.Core Functor.Core Functor.Paths.
 Require Import SetCategory.Core.
 Require Import ChainCategory FunctorCategory.Core.
 Require Import Category.Dual.

--- a/theories/Categories/Structure/Core.v
+++ b/theories/Categories/Structure/Core.v
@@ -1,6 +1,6 @@
 (** * Notions of Structure *)
 Require Import Category.Core.
-Require Import HProp HSet Types.Sigma Trunc.
+Require Import HoTT.Basics HoTT.Types HProp HSet Trunc.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Classes/categories/ua_category.v
+++ b/theories/Classes/categories/ua_category.v
@@ -1,6 +1,7 @@
 Require Import
-  HoTT.Basics.Equivalences
-  HoTT.Types.Universe
+  HoTT.Basics
+  HoTT.Types
+  HoTT.UnivalenceImpliesFunext
   HoTT.Categories.Category.Core
   HoTT.Categories.Category.Univalent
   HoTT.Classes.theory.ua_isomorphic.

--- a/theories/Classes/implementations/natpair_integers.v
+++ b/theories/Classes/implementations/natpair_integers.v
@@ -14,6 +14,7 @@ Require Import
   HoTT.Classes.interfaces.naturals
   HoTT.Classes.interfaces.integers
   HoTT.Classes.theory.rings
+  HoTT.Classes.theory.apartness
   HoTT.Classes.orders.sum
   HoTT.Classes.orders.rings
   HoTT.Classes.tactics.ring_tac
@@ -22,7 +23,7 @@ Require Import
 
 Generalizable Variables B.
 
-Local Set Loose Hint Behavior "Lax".
+Import ring_quote.Quoting.Instances.
 Local Set Universe Minimization ToSet.
 
 Module NatPair.

--- a/theories/Classes/implementations/natpair_integers.v
+++ b/theories/Classes/implementations/natpair_integers.v
@@ -8,11 +8,13 @@ Require Import HoTT.HIT.quotient
   HoTT.Types.Sum
   HoTT.TruncType.
 Require Import
+  HoTT.Classes.implementations.peano_naturals
   HoTT.Classes.interfaces.abstract_algebra
   HoTT.Classes.interfaces.orders
   HoTT.Classes.interfaces.naturals
   HoTT.Classes.interfaces.integers
   HoTT.Classes.theory.rings
+  HoTT.Classes.orders.sum
   HoTT.Classes.orders.rings
   HoTT.Classes.tactics.ring_tac
   HoTT.Classes.interfaces.naturals
@@ -20,6 +22,7 @@ Require Import
 
 Generalizable Variables B.
 
+Local Set Loose Hint Behavior "Lax".
 Local Set Universe Minimization ToSet.
 
 Module NatPair.

--- a/theories/Classes/implementations/natpair_integers.v
+++ b/theories/Classes/implementations/natpair_integers.v
@@ -14,6 +14,7 @@ Require Import
   HoTT.Classes.interfaces.naturals
   HoTT.Classes.interfaces.integers
   HoTT.Classes.theory.rings
+  HoTT.Classes.theory.groups
   HoTT.Classes.theory.apartness
   HoTT.Classes.orders.sum
   HoTT.Classes.orders.rings
@@ -300,6 +301,8 @@ Arguments Tapart {_ _ _} _ _.
 Arguments to_ring N {_} B {_ _ _ _ _ _} / _.
 
 End PairT.
+
+Import PairT.
 
 Section contents.
 Universe UN UNalt.

--- a/theories/Classes/implementations/natpair_integers.v
+++ b/theories/Classes/implementations/natpair_integers.v
@@ -1118,4 +1118,38 @@ Global Instance Z_zero_product@{} : ZeroProduct Z
 
 End contents.
 
+Module Instances.
+  Global Existing Instance T_set.
+  Global Existing Instance inject.
+  Global Existing Instance Tle_hprop.
+  Global Existing Instance Tlt_hprop.
+  Global Existing Instance Tapart_hprop.
+  Global Existing Instance Z_of_pair.
+  Global Existing Instance Z_of_N.
+  Global Existing Instance R_dec.
+  Global Existing Instance Z0.
+  Global Existing Instance Z1.
+  Global Existing Instance Z_plus.
+  Global Existing Instance Z_mult.
+  Global Existing Instance Z_negate.
+  Global Existing Instance Z_of_N_injective.
+  Global Existing Instance Zle.
+  Global Existing Instance ishprop_Zle.
+  Global Existing Instance Zle_cast_embedding.
+  Global Existing Instance Z_order.
+  Global Existing Instance Zle_dec.
+  Global Existing Instance Zlt.
+  Global Existing Instance ishprop_Zlt.
+  Global Existing Instance Z_strict_srorder.
+  Global Existing Instance Zlt_dec.
+  Global Existing Instance Zapart.
+  Global Existing Instance ishprop_Zapart.
+  Global Existing Instance Z_trivial_apart.
+  Global Existing Instance Z_to_ring.
+  Global Existing Instance Z_integers.
+  Global Existing Instance Z_abs.
+  Global Existing Instance Z_zero_product.
+  Global Existing Instance Z_of_N_morphism.
+End Instances.
+
 End NatPair.

--- a/theories/Classes/implementations/natpair_integers.v
+++ b/theories/Classes/implementations/natpair_integers.v
@@ -1117,37 +1117,8 @@ Global Instance Z_zero_product@{} : ZeroProduct Z
 End contents.
 
 Module Instances.
-  Global Existing Instance T_set.
-  Global Existing Instance inject.
-  Global Existing Instance Tle_hprop.
-  Global Existing Instance Tlt_hprop.
-  Global Existing Instance Tapart_hprop.
-  Global Existing Instance Z_of_pair.
-  Global Existing Instance Z_of_N.
-  Global Existing Instance R_dec.
-  Global Existing Instance Z0.
-  Global Existing Instance Z1.
-  Global Existing Instance Z_plus.
-  Global Existing Instance Z_mult.
-  Global Existing Instance Z_negate.
-  Global Existing Instance Z_of_N_injective.
-  Global Existing Instance Zle.
-  Global Existing Instance ishprop_Zle.
-  Global Existing Instance Zle_cast_embedding.
-  Global Existing Instance Z_order.
-  Global Existing Instance Zle_dec.
-  Global Existing Instance Zlt.
-  Global Existing Instance ishprop_Zlt.
-  Global Existing Instance Z_strict_srorder.
-  Global Existing Instance Zlt_dec.
-  Global Existing Instance Zapart.
-  Global Existing Instance ishprop_Zapart.
-  Global Existing Instance Z_trivial_apart.
-  Global Existing Instance Z_to_ring.
-  Global Existing Instance Z_integers.
-  Global Existing Instance Z_abs.
-  Global Existing Instance Z_zero_product.
-  Global Existing Instance Z_of_N_morphism.
+  Global Existing Instances
+    T_set inject Tle_hprop Tlt_hprop Tapart_hprop Z_of_pair Z_of_N R_dec Z0 Z1 Z_plus Z_mult Z_negate Z_of_N_injective Zle ishprop_Zle Zle_cast_embedding Z_order Zle_dec Zlt ishprop_Zlt Z_strict_srorder Zlt_dec Zapart ishprop_Zapart Z_trivial_apart Z_to_ring Z_integers Z_abs Z_zero_product Z_of_N_morphism.
 End Instances.
 
 End NatPair.

--- a/theories/Classes/implementations/natpair_integers.v
+++ b/theories/Classes/implementations/natpair_integers.v
@@ -29,7 +29,7 @@ Local Set Universe Minimization ToSet.
 
 Module NatPair.
 
-Module PairT.
+Module Import PairT.
 
 Record T (N : Type) := C { pos : N ; neg : N }.
 Arguments C {N} _ _.
@@ -301,8 +301,6 @@ Arguments Tapart {_ _ _} _ _.
 Arguments to_ring N {_} B {_ _ _ _ _ _} / _.
 
 End PairT.
-
-Import PairT.
 
 Section contents.
 Universe UN UNalt.

--- a/theories/Classes/interfaces/abstract_algebra.v
+++ b/theories/Classes/interfaces/abstract_algebra.v
@@ -1,6 +1,6 @@
 Require Coq.Init.Peano.
-Require Export
-  HoTT.Classes.interfaces.canonical_names.
+Require Export HoTT.Classes.interfaces.canonical_names.
+Require Import HProp.
 
 Generalizable Variables A B f g x y.
 

--- a/theories/Classes/interfaces/ua_algebra.v
+++ b/theories/Classes/interfaces/ua_algebra.v
@@ -2,18 +2,13 @@
 
 Require Export
   Coq.Unicode.Utf8
-  HoTT.Basics.Overture
-  HoTT.Basics.Trunc
+  HoTT.Basics
   HoTT.Classes.implementations.ne_list
   HoTT.Classes.implementations.family_prod.
 
 Require Import
-  HoTT.Basics.Equivalences
-  HoTT.Types.Sigma
-  HoTT.Types.Arrow
-  HoTT.Types.Forall
-  HoTT.Types.Universe
-  HoTT.HSet
+  HoTT.Types
+  HoTT.HSet HoTT.HProp
   HoTT.Classes.implementations.list.
 
 Import ne_list.notations.

--- a/theories/Classes/orders/integers.v
+++ b/theories/Classes/orders/integers.v
@@ -3,6 +3,7 @@ Require
   HoTT.Classes.theory.integers
   HoTT.Classes.theory.int_abs.
 Require Import
+  HoTT.Classes.implementations.peano_naturals
   HoTT.Classes.interfaces.abstract_algebra
   HoTT.Classes.interfaces.integers
   HoTT.Classes.interfaces.naturals
@@ -10,10 +11,12 @@ Require Import
   HoTT.Classes.interfaces.orders
   HoTT.Classes.implementations.natpair_integers
   HoTT.Classes.orders.rings
-  HoTT.Classes.theory.rings.
+  HoTT.Classes.theory.rings
+  HoTT.Classes.theory.integers.
 Require Export
   HoTT.Classes.orders.nat_int.
 
+Import NatPair.Instances.
 Generalizable Variables N Z R f.
 
 Section integers.

--- a/theories/Classes/orders/integers.v
+++ b/theories/Classes/orders/integers.v
@@ -14,6 +14,7 @@ Require Import
 Require Export
   HoTT.Classes.orders.nat_int.
 
+Local Set Loose Hint Behavior "Lax".
 Generalizable Variables N Z R f.
 
 Section integers.

--- a/theories/Classes/orders/integers.v
+++ b/theories/Classes/orders/integers.v
@@ -14,7 +14,6 @@ Require Import
 Require Export
   HoTT.Classes.orders.nat_int.
 
-Local Set Loose Hint Behavior "Lax".
 Generalizable Variables N Z R f.
 
 Section integers.

--- a/theories/Classes/orders/naturals.v
+++ b/theories/Classes/orders/naturals.v
@@ -1,9 +1,10 @@
 Require Import
   HoTT.Types.Universe
   HoTT.Types.Sigma.
-Require
+Require Import
   HoTT.Classes.theory.naturals.
 Require Import
+  HoTT.Classes.theory.apartness
   HoTT.Classes.interfaces.abstract_algebra
   HoTT.Classes.interfaces.naturals
   HoTT.Classes.interfaces.orders

--- a/theories/Classes/orders/rings.v
+++ b/theories/Classes/orders/rings.v
@@ -1,6 +1,7 @@
 Require Import
   HoTT.Classes.interfaces.abstract_algebra
   HoTT.Classes.interfaces.orders
+  HoTT.Classes.theory.groups
   HoTT.Classes.theory.rings.
 Require Export
   HoTT.Classes.orders.semirings.

--- a/theories/Classes/orders/semirings.v
+++ b/theories/Classes/orders/semirings.v
@@ -1,5 +1,6 @@
 Require Import HoTT.Basics.Decidable.
 Require Import
+  HoTT.Classes.theory.apartness
   HoTT.Classes.interfaces.abstract_algebra
   HoTT.Classes.interfaces.orders
   HoTT.Classes.theory.rings.

--- a/theories/Classes/orders/sum.v
+++ b/theories/Classes/orders/sum.v
@@ -1,5 +1,6 @@
 Require Import
   HoTT.Classes.interfaces.canonical_names
+  HoTT.Classes.interfaces.abstract_algebra
   HoTT.Classes.interfaces.orders.
 
 Generalizable Variables A B.

--- a/theories/Classes/tactics/ring_quote.v
+++ b/theories/Classes/tactics/ring_quote.v
@@ -78,17 +78,17 @@ Section Lookup.
 
   Context (x:R) {A B:Type0 } (va : Vars A) (vb : Vars B).
 
-  Global Instance lookup_l `{!Lookup x va} : Lookup x (merge va vb).
+  Local Instance lookup_l `{!Lookup x va} : Lookup x (merge va vb).
   Proof.
   exists (inl (lookup x va)). apply lookup_correct.
   Defined.
 
-  Global Instance lookup_r `{!Lookup x vb} : Lookup x (merge va vb).
+  Local Instance lookup_r `{!Lookup x vb} : Lookup x (merge va vb).
   Proof.
   exists (inr (lookup x vb)). apply lookup_correct.
   Defined.
 
-  Global Instance lookup_single : Lookup x (singleton x).
+  Local Instance lookup_single : Lookup x (singleton x).
   Proof.
   exists tt. reflexivity.
   Defined.
@@ -130,13 +130,13 @@ Section Quote.
   intros [?|?];auto.
   Defined.
 
-  Global Instance quote_zero (V:Type0) (v: Vars V): Quote v 0 noVars.
+  Local Instance quote_zero (V:Type0) (v: Vars V): Quote v 0 noVars.
   Proof.
   exists Zero.
   reflexivity.
   Defined.
 
-  Global Instance quote_one (V:Type0) (v: Vars V): Quote v 1 noVars.
+  Local Instance quote_one (V:Type0) (v: Vars V): Quote v 1 noVars.
   Proof.
   exists One.
   reflexivity.
@@ -157,7 +157,7 @@ Section Quote.
   - intros [[?|?]|?];reflexivity.
   Qed.
 
-  Global Instance quote_plus (V:Type0) (v: Vars V) n
+  Local Instance quote_plus (V:Type0) (v: Vars V) n
   (V':Type0) (v': Vars V') m (V'':Type0) (v'': Vars V'')
   `{!Quote v n v'} `{!Quote (merge v v') m v''}: Quote v (n + m) (merge v' v'').
   Proof.
@@ -179,7 +179,7 @@ Section Quote.
   - intros [[?|?]|?];reflexivity.
   Qed.
 
-  Global Instance quote_mult (V:Type0) (v: Vars V) n
+  Local Instance quote_mult (V:Type0) (v: Vars V) n
     (V':Type0) (v': Vars V') m (V'':Type0) (v'': Vars V'')
     `{!Quote v n v'} `{!Quote (merge v v') m v''}
     : Quote v (n * m) (merge v' v'').
@@ -194,7 +194,7 @@ Section Quote.
   simpl. apply ap,eval_quote.
   Qed.
 
-  Global Instance quote_neg (V:Type0) (v : Vars V) n (V':Type0) (v' : Vars V')
+  Local Instance quote_neg (V:Type0) (v : Vars V) n (V':Type0) (v' : Vars V')
     `{!Quote v n v'}
     : Quote v (almost_negate n) v'.
   Proof.
@@ -202,14 +202,14 @@ Section Quote.
   apply quote_neg_ok.
   Defined.
 
-  Global Instance quote_old_var (V:Type0) (v: Vars V) x {i: Lookup x v}
+  Local Instance quote_old_var (V:Type0) (v: Vars V) x {i: Lookup x v}
     : Quote v x noVars | 8.
   Proof.
   exists (Var (inl (lookup x v))).
   apply lookup_correct.
   Defined.
 
-  Global Instance quote_new_var (V:Type0) (v: Vars V) x
+  Local Instance quote_new_var (V:Type0) (v: Vars V) x
     : Quote v x (singleton x) | 9.
   Proof.
   exists (Var (inr tt)).
@@ -248,7 +248,7 @@ path_via (eval (merge v (merge v' v'')) (expr_map sum_aux (quote n)));
   intros [[?|?]|?];reflexivity.
 Qed.
 
-Global Instance eq_quote (V:Type0) (v: Vars V) n
+Local Instance eq_quote (V:Type0) (v: Vars V) n
   (V':Type0) (v': Vars V') m (V'':Type0) (v'': Vars V'')
   `{!Quote v n v'} `{!Quote (merge v v') m v''}
   : EqQuote (merge v v') n m v''.
@@ -281,5 +281,11 @@ intros [[]|?]. reflexivity.
 Qed.
 
 End contents.
+
+Module Export Instances.
+  Global Existing Instances lookup_l lookup_r lookup_single quote_zero quote_one quote_plus quote_mult quote_neg eq_quote.
+  Global Existing Instance quote_old_var | 8.
+  Global Existing Instance quote_new_var | 9.
+End Instances.
 
 End Quoting.

--- a/theories/Classes/tactics/ring_tac.v
+++ b/theories/Classes/tactics/ring_tac.v
@@ -12,6 +12,8 @@ Require Import
 
 Generalizable Variables A B C R V f l n m Vlt.
 
+Import Quoting.Instances.
+
 Section content.
 Context `{DecidablePaths C}.
 

--- a/theories/Classes/tests/ring_tac.v
+++ b/theories/Classes/tests/ring_tac.v
@@ -1,6 +1,7 @@
 Require Import
   HoTT.Classes.interfaces.abstract_algebra
   HoTT.Classes.implementations.peano_naturals
+  HoTT.Classes.orders.sum
   HoTT.Classes.tactics.ring_tac
   HoTT.Classes.tactics.ring_quote.
 

--- a/theories/Classes/tests/ring_tac.v
+++ b/theories/Classes/tests/ring_tac.v
@@ -1,10 +1,11 @@
 Require Import
   HoTT.Classes.interfaces.abstract_algebra
   HoTT.Classes.implementations.peano_naturals
-  HoTT.Classes.tactics.ring_tac.
+  HoTT.Classes.tactics.ring_tac
+  HoTT.Classes.tactics.ring_quote.
 
+Import Quoting.Instances.
 Generalizable Variables R.
-Local Set Loose Hint Behavior "Lax".
 
 Lemma test1 `{IsSemiRing R}
   : forall x y : R, x + (y * x) = x * (y + 1).

--- a/theories/Classes/tests/ring_tac.v
+++ b/theories/Classes/tests/ring_tac.v
@@ -4,6 +4,7 @@ Require Import
   HoTT.Classes.tactics.ring_tac.
 
 Generalizable Variables R.
+Local Set Loose Hint Behavior "Lax".
 
 Lemma test1 `{IsSemiRing R}
   : forall x y : R, x + (y * x) = x * (y + 1).

--- a/theories/Classes/tests/ring_tac.v
+++ b/theories/Classes/tests/ring_tac.v
@@ -1,5 +1,6 @@
 Require Import
   HoTT.Classes.interfaces.abstract_algebra
+  HoTT.Classes.implementations.peano_naturals
   HoTT.Classes.tactics.ring_tac.
 
 Generalizable Variables R.

--- a/theories/Classes/theory/int_abs.v
+++ b/theories/Classes/theory/int_abs.v
@@ -8,6 +8,7 @@ Require Import
   HoTT.Classes.theory.rings
   HoTT.Classes.orders.rings.
 
+Local Set Loose Hint Behavior "Lax".
 Generalizable Variables N Z Zle Zlt R f.
 
 Section contents.

--- a/theories/Classes/theory/int_abs.v
+++ b/theories/Classes/theory/int_abs.v
@@ -6,6 +6,7 @@ Require Import
   HoTT.Classes.orders.nat_int
   HoTT.Classes.theory.integers
   HoTT.Classes.theory.rings
+  HoTT.Classes.theory.groups
   HoTT.Classes.orders.rings.
 
 Generalizable Variables N Z Zle Zlt R f.

--- a/theories/Classes/theory/int_abs.v
+++ b/theories/Classes/theory/int_abs.v
@@ -8,7 +8,6 @@ Require Import
   HoTT.Classes.theory.rings
   HoTT.Classes.orders.rings.
 
-Local Set Loose Hint Behavior "Lax".
 Generalizable Variables N Z Zle Zlt R f.
 
 Section contents.

--- a/theories/Classes/theory/integers.v
+++ b/theories/Classes/theory/integers.v
@@ -5,14 +5,17 @@ Require Import
 Require
  HoTT.Classes.theory.nat_distance.
 Require Import
+ HoTT.Classes.implementations.peano_naturals
  HoTT.Classes.interfaces.naturals
  HoTT.Classes.interfaces.abstract_algebra
  HoTT.Classes.interfaces.orders
  HoTT.Classes.implementations.natpair_integers
+ HoTT.Classes.theory.rings
  HoTT.Classes.isomorphisms.rings.
 Require Export
  HoTT.Classes.interfaces.integers.
 
+Import NatPair.Instances.
 Generalizable Variables N Z R f.
 
 Lemma to_ring_unique `{Integers Z} `{IsRing R} (f: Z -> R)
@@ -141,6 +144,8 @@ Qed.
 
 Global Instance int_dec : DecidablePaths Z | 10.
 Proof.
+Set Typeclasses Debug.
+Set Loose Hint Behavior "Lax".
 apply decidablepaths_equiv with (NatPair.Z nat)
   (integers_to_ring (NatPair.Z nat) Z);apply _.
 Qed.

--- a/theories/Classes/theory/integers.v
+++ b/theories/Classes/theory/integers.v
@@ -13,7 +13,6 @@ Require Import
 Require Export
  HoTT.Classes.interfaces.integers.
 
-Local Set Loose Hint Behavior "Lax".
 Generalizable Variables N Z R f.
 
 Lemma to_ring_unique `{Integers Z} `{IsRing R} (f: Z -> R)

--- a/theories/Classes/theory/integers.v
+++ b/theories/Classes/theory/integers.v
@@ -2,9 +2,8 @@
 Require Import
   HoTT.Types.Universe
   HoTT.Basics.Decidable.
-Require
- HoTT.Classes.theory.nat_distance.
 Require Import
+ HoTT.Classes.theory.nat_distance
  HoTT.Classes.implementations.peano_naturals
  HoTT.Classes.interfaces.naturals
  HoTT.Classes.interfaces.abstract_algebra

--- a/theories/Classes/theory/integers.v
+++ b/theories/Classes/theory/integers.v
@@ -13,6 +13,7 @@ Require Import
 Require Export
  HoTT.Classes.interfaces.integers.
 
+Local Set Loose Hint Behavior "Lax".
 Generalizable Variables N Z R f.
 
 Lemma to_ring_unique `{Integers Z} `{IsRing R} (f: Z -> R)

--- a/theories/Classes/theory/integers.v
+++ b/theories/Classes/theory/integers.v
@@ -144,8 +144,6 @@ Qed.
 
 Global Instance int_dec : DecidablePaths Z | 10.
 Proof.
-Set Typeclasses Debug.
-Set Loose Hint Behavior "Lax".
 apply decidablepaths_equiv with (NatPair.Z nat)
   (integers_to_ring (NatPair.Z nat) Z);apply _.
 Qed.

--- a/theories/Classes/theory/nat_distance.v
+++ b/theories/Classes/theory/nat_distance.v
@@ -1,12 +1,14 @@
 Require Import HoTT.Types.Universe.
-Require
+Require Import
   HoTT.Classes.orders.naturals
   HoTT.Classes.implementations.peano_naturals.
 Require Import
   HoTT.Classes.interfaces.abstract_algebra
   HoTT.Classes.interfaces.naturals
   HoTT.Classes.interfaces.orders
+  HoTT.Classes.theory.naturals
   HoTT.Classes.theory.additional_operations.
+
 
 Generalizable Variables N.
 

--- a/theories/Classes/theory/premetric.v
+++ b/theories/Classes/theory/premetric.v
@@ -18,6 +18,7 @@ Require Import
 
 Generalizable Variables A B.
 
+Local Set Loose Hint Behavior "Lax".
 Local Set Universe Minimization ToSet.
 
 

--- a/theories/Classes/theory/premetric.v
+++ b/theories/Classes/theory/premetric.v
@@ -6,16 +6,23 @@ Require Import
   HoTT.Classes.interfaces.naturals
   HoTT.Classes.interfaces.rationals
   HoTT.Classes.interfaces.orders
+  HoTT.Classes.implementations.peano_naturals
   HoTT.Classes.implementations.natpair_integers
   HoTT.Classes.theory.rings
+  HoTT.Classes.theory.groups
   HoTT.Classes.theory.integers
   HoTT.Classes.theory.dec_fields
   HoTT.Classes.orders.dec_fields
+  HoTT.Classes.orders.sum
   HoTT.Classes.theory.rationals
   HoTT.Classes.orders.lattices
   HoTT.Classes.theory.additional_operations
-  HoTT.Classes.implementations.assume_rationals.
+  HoTT.Classes.implementations.assume_rationals
+  HoTT.Classes.tactics.ring_quote
+  HoTT.Classes.tactics.ring_tac.
 
+Import NatPair.Instances.
+Import Quoting.Instances.
 Generalizable Variables A B.
 
 Local Set Universe Minimization ToSet.
@@ -231,7 +238,8 @@ split.
   apply (merely_destruct E1);intros [d1 [d1' [E3 E4]]].
   apply (merely_destruct E2);intros [d2 [d2' [E5 E6]]].
   apply tr;exists (d1+d2),(d1'+d2'). split.
-  + rewrite E3,E5. abstract (apply pos_eq; ring_tac.ring_with_nat).
+  + rewrite E3,E5.
+   abstract (apply pos_eq; ring_tac.ring_with_nat).
   + intros x. apply triangular with (g x);trivial.
 - intros e f g. split.
   + apply (Trunc_ind _). intros [d [d' [E1 E2]]].

--- a/theories/Classes/theory/premetric.v
+++ b/theories/Classes/theory/premetric.v
@@ -18,7 +18,6 @@ Require Import
 
 Generalizable Variables A B.
 
-Local Set Loose Hint Behavior "Lax".
 Local Set Universe Minimization ToSet.
 
 

--- a/theories/Classes/theory/rationals.v
+++ b/theories/Classes/theory/rationals.v
@@ -14,7 +14,7 @@ Require Import
   HoTT.Classes.implementations.natpair_integers
   HoTT.Classes.theory.additional_operations.
 
-
+Local Set Loose Hint Behavior "Lax".
 Local Set Universe Minimization ToSet.
 
 Section contents.

--- a/theories/Classes/theory/rationals.v
+++ b/theories/Classes/theory/rationals.v
@@ -1,19 +1,26 @@
 Require Import
   HoTT.Types.Universe
   HoTT.Basics.Decidable
+  HoTT.Classes.implementations.peano_naturals
+  HoTT.Classes.implementations.natpair_integers
   HoTT.Classes.interfaces.abstract_algebra
   HoTT.Classes.interfaces.naturals
   HoTT.Classes.interfaces.integers
   HoTT.Classes.interfaces.rationals
   HoTT.Classes.interfaces.orders
   HoTT.Classes.theory.rings
+  HoTT.Classes.theory.groups
   HoTT.Classes.theory.integers
   HoTT.Classes.theory.dec_fields
+  HoTT.Classes.orders.sum
   HoTT.Classes.orders.dec_fields
   HoTT.Classes.orders.lattices
-  HoTT.Classes.implementations.natpair_integers
-  HoTT.Classes.theory.additional_operations.
+  HoTT.Classes.theory.additional_operations
+  HoTT.Classes.tactics.ring_quote
+  HoTT.Classes.tactics.ring_tac.
 
+Import Quoting.Instances.
+Import NatPair.Instances.
 Local Set Universe Minimization ToSet.
 
 Section contents.
@@ -289,7 +296,8 @@ Lemma Qabs_nonneg@{} : forall q : Q, 0 <= abs q.
 Proof.
 intros q;destruct (total_abs_either q) as [E|E];destruct E as [E1 E2];rewrite E2.
 - trivial.
-- apply flip_nonneg_negate. rewrite involutive;trivial.
+- apply flip_nonneg_negate.
+ rewrite involutive;trivial.
 Qed.
 
 Lemma Qabs_nonpos_0@{} : forall q : Q, abs q <= 0 -> q = 0.

--- a/theories/Classes/theory/rationals.v
+++ b/theories/Classes/theory/rationals.v
@@ -14,7 +14,6 @@ Require Import
   HoTT.Classes.implementations.natpair_integers
   HoTT.Classes.theory.additional_operations.
 
-Local Set Loose Hint Behavior "Lax".
 Local Set Universe Minimization ToSet.
 
 Section contents.

--- a/theories/Classes/theory/rings.v
+++ b/theories/Classes/theory/rings.v
@@ -1,4 +1,4 @@
-Require
+Require Import
   HoTT.Classes.theory.groups
   HoTT.Classes.theory.apartness.
 Require Import

--- a/theories/Classes/theory/ua_first_isomorphism.v
+++ b/theories/Classes/theory/ua_first_isomorphism.v
@@ -9,6 +9,7 @@ Require Import
   HoTT.Types.Universe
   HoTT.HSet
   HoTT.HIT.quotient
+  HoTT.UnivalenceImpliesFunext
   HoTT.Classes.interfaces.canonical_names
   HoTT.Classes.theory.ua_isomorphic
   HoTT.Classes.theory.ua_subalgebra

--- a/theories/Classes/theory/ua_homomorphism.v
+++ b/theories/Classes/theory/ua_homomorphism.v
@@ -6,16 +6,13 @@
 Require Export HoTT.Classes.interfaces.ua_setalgebra.
 
 Require Import
-  HoTT.Basics.Equivalences
-  HoTT.Basics.PathGroupoids
-  HoTT.Types.Forall
-  HoTT.Types.Arrow
-  HoTT.Types.Universe
-  HoTT.Types.Sigma
+  HoTT.Basics
+  HoTT.Types
   HoTT.Fibrations
   HoTT.HProp
   HoTT.HSet
-  HoTT.Tactics.
+  HoTT.Tactics
+  UnivalenceImpliesFunext.
 
 Import algebra_notations ne_list.notations.
 

--- a/theories/Classes/theory/ua_isomorphic.v
+++ b/theories/Classes/theory/ua_isomorphic.v
@@ -4,12 +4,10 @@
 Require Export HoTT.Classes.theory.ua_homomorphism.
 
 Require Import
-  HoTT.Basics.Overture
-  HoTT.Basics.Trunc
-  HoTT.Basics.Equivalences
-  HoTT.Types.Forall
-  HoTT.Types.Sigma
-  HoTT.Types.Universe
+  HoTT.Basics
+  HoTT.Types
+  HoTT.UnivalenceImpliesFunext
+  HoTT.HProp
   HoTT.Tactics.
 
 (** Two algebras [A B : Algebra σ] are isomorphic if there is an

--- a/theories/Classes/theory/ua_quotient_algebra.v
+++ b/theories/Classes/theory/ua_quotient_algebra.v
@@ -1,12 +1,13 @@
 Require Export HoTT.Classes.interfaces.ua_congruence.
 
 Require Import
-  HoTT.Basics.Equivalences
-  HoTT.Types.Sigma
-  HoTT.Types.Universe
+  HoTT.Basics
+  HoTT.Types
+  HoTT.HProp
   HoTT.HSet
   HoTT.HIT.quotient
   HoTT.Truncations
+  HoTT.UnivalenceImpliesFunext
   HoTT.Classes.implementations.list
   HoTT.Classes.theory.ua_homomorphism.
 

--- a/theories/Classes/theory/ua_quotient_algebra.v
+++ b/theories/Classes/theory/ua_quotient_algebra.v
@@ -9,6 +9,7 @@ Require Import
   HoTT.Truncations
   HoTT.UnivalenceImpliesFunext
   HoTT.Classes.implementations.list
+  HoTT.Classes.interfaces.canonical_names
   HoTT.Classes.theory.ua_homomorphism.
 
 Import algebra_notations ne_list.notations.

--- a/theories/Classes/theory/ua_second_isomorphism.v
+++ b/theories/Classes/theory/ua_second_isomorphism.v
@@ -5,6 +5,7 @@ Require Import
   HoTT.Types.Universe
   HoTT.HSet
   HoTT.HIT.quotient
+  HoTT.UnivalenceImpliesFunext
   HoTT.Classes.interfaces.canonical_names
   HoTT.Classes.theory.ua_isomorphic
   HoTT.Classes.theory.ua_subalgebra

--- a/theories/Classes/theory/ua_subalgebra.v
+++ b/theories/Classes/theory/ua_subalgebra.v
@@ -1,10 +1,9 @@
 Require Import
-  HoTT.Basics.Equivalences
+  HoTT.Basics
   HoTT.TruncType
   HoTT.HProp
-  HoTT.Types.Universe
-  HoTT.Types.Sigma
-  HoTT.Types.Forall
+  HoTT.Types
+  HoTT.UnivalenceImpliesFunext
   HoTT.Classes.theory.ua_homomorphism.
 
 Import algebra_notations ne_list.notations.

--- a/theories/Classes/theory/ua_third_isomorphism.v
+++ b/theories/Classes/theory/ua_third_isomorphism.v
@@ -3,6 +3,7 @@
 Require Import
   HoTT.Types.Universe
   HoTT.HIT.quotient
+  HoTT.UnivalenceImpliesFunext
   HoTT.Classes.interfaces.canonical_names
   HoTT.Classes.theory.ua_quotient_algebra
   HoTT.Classes.theory.ua_isomorphic

--- a/theories/Colimits/Colimit_Pushout_Flattening.v
+++ b/theories/Colimits/Colimit_Pushout_Flattening.v
@@ -8,6 +8,7 @@ Require Import Diagrams.Cocone.
 Require Import Colimits.Colimit.
 Require Import Colimits.Colimit_Pushout.
 Require Import Colimits.Colimit_Flattening.
+Require Import UnivalenceImpliesFunext.
 
 (** * Pushout case *)
 

--- a/theories/Constant.v
+++ b/theories/Constant.v
@@ -1,5 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 Require Import HoTT.Basics HoTT.Types.
+Require Import HProp FunextVarieties.
 Require Import Extensions Factorization Modalities.Modality.
 Require Import HoTT.Truncations.
 Import TrM.

--- a/theories/DProp.v
+++ b/theories/DProp.v
@@ -5,6 +5,7 @@
 Require Import HoTT.Basics HoTT.Types.
 Require Import TruncType HProp UnivalenceImpliesFunext.
 Require Import HoTT.Truncations.
+Import TrM.
 
 Local Open Scope path_scope.
 

--- a/theories/Extensions.v
+++ b/theories/Extensions.v
@@ -3,7 +3,7 @@
 (** * Extensions and extendible maps *)
 
 Require Import HoTT.Basics HoTT.Types.
-Require Import HProp EquivalenceVarieties PathAny.
+Require Import HProp FunextVarieties EquivalenceVarieties PathAny.
 Require Import HoTT.Tactics.
 
 Local Open Scope nat_scope.

--- a/theories/Factorization.v
+++ b/theories/Factorization.v
@@ -3,7 +3,7 @@
 (** * Factorizations and factorization systems. *)
 
 Require Import HoTT.Basics HoTT.Types.
-Require Import HProp UnivalenceImpliesFunext Extensions PathAny.
+Require Import HProp FunextVarieties UnivalenceImpliesFunext Extensions PathAny.
 Require Import HoTT.Tactics.
 Local Open Scope path_scope.
 

--- a/theories/Fibrations.v
+++ b/theories/Fibrations.v
@@ -1,8 +1,7 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 (** * Basic facts about fibrations *)
 
-Require Import HoTT.Basics Types.Sigma Types.Paths.
-Require Import EquivalenceVarieties.
+Require Import HoTT.Basics HoTT.Types HProp EquivalenceVarieties.
 
 Local Open Scope equiv_scope.
 Local Open Scope path_scope.

--- a/theories/HIT/Circle.v
+++ b/theories/HIT/Circle.v
@@ -2,8 +2,7 @@
 
 (** * Theorems about the circle [S1]. *)
 
-Require Import HoTT.Basics.
-Require Import Types.Paths Types.Forall Types.Arrow Types.Universe Types.Empty Types.Unit.
+Require Import HoTT.Basics HoTT.Types HProp.
 Require Import HSet UnivalenceImpliesFunext.
 Require Import Spaces.Pos.
 Require Import Spaces.Int.

--- a/theories/HIT/FreeIntQuotient.v
+++ b/theories/HIT/FreeIntQuotient.v
@@ -1,5 +1,5 @@
 (* -*- mode: coq; mode: visual-line -*- *)
-Require Import HoTT.Basics HoTT.Types.
+Require Import HoTT.Basics HoTT.Types UnivalenceImpliesFunext.
 Require Import TruncType HProp HSet.
 Require Import Spaces.Int.
 Require Import HIT.Coeq HIT.Circle HIT.Flattening Truncations.

--- a/theories/HIT/V.v
+++ b/theories/HIT/V.v
@@ -2,8 +2,7 @@
 
 (** * The cumulative hierarchy [V]. *)
 
-Require Import HoTT.Basics HoTT.Basics.Notations HoTT.Basics.Utf8.
-Require Import Types.Unit Types.Bool Types.Universe Types.Sigma Types.Arrow Types.Forall.
+Require Import HoTT.Basics HoTT.Basics.Utf8 HoTT.Types.
 Require Import HProp HSet UnivalenceImpliesFunext TruncType.
 Require Import Colimits.SpanPushout.
 Require Import HoTT.Truncations Colimits.Quotient.

--- a/theories/HIT/quotient.v
+++ b/theories/HIT/quotient.v
@@ -1,6 +1,5 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
-Require Import HoTT.Basics.
-Require Import Types.Universe Types.Arrow Types.Sigma.
+Require Import HoTT.Basics HoTT.Types.
 Require Import HSet HProp UnivalenceImpliesFunext TruncType.
 Require Import HIT.epi Truncations.
 

--- a/theories/HIT/surjective_factor.v
+++ b/theories/HIT/surjective_factor.v
@@ -1,6 +1,5 @@
 Require Import
-        HoTT.Types.Arrow
-        HoTT.Types.Universe
+        HoTT.Types
         HoTT.Basics
         HoTT.Truncations
         HoTT.HIT.unique_choice.

--- a/theories/Homotopy/BlakersMassey.v
+++ b/theories/Homotopy/BlakersMassey.v
@@ -1,5 +1,4 @@
-Require Import Basics.
-Require Import Types.
+Require Import HoTT.Basics HoTT.Types HProp UnivalenceImpliesFunext.
 Require Import Colimits.Pushout.
 Require Import Colimits.SpanPushout.
 Require Import Homotopy.Join.

--- a/theories/Homotopy/ClassifyingSpace.v
+++ b/theories/Homotopy/ClassifyingSpace.v
@@ -7,6 +7,7 @@ Require Import Algebra.AbelianGroup.
 Require Import Homotopy.HSpace.
 Require Import TruncType.
 Require Import Truncations.
+Require Import UnivalenceImpliesFunext.
 Import TrM.
 
 Local Open Scope pointed_scope.

--- a/theories/Homotopy/EMSpace.v
+++ b/theories/Homotopy/EMSpace.v
@@ -9,6 +9,7 @@ Require Import Homotopy.Suspension.
 Require Import Homotopy.ClassifyingSpace.
 Require Import Homotopy.HSpace.
 Require Import TruncType.
+Require Import UnivalenceImpliesFunext.
 Import TrM.
 
 (* Formalisation of Eilenberg-MacLane spaces *)

--- a/theories/Homotopy/HSpace.v
+++ b/theories/Homotopy/HSpace.v
@@ -1,6 +1,6 @@
 Require Import Basics.
 Require Import Types.
-Require Import Truncations.
+Require Import Truncations UnivalenceImpliesFunext.
 Require Export Classes.interfaces.abstract_algebra.
 Import TrM.
 

--- a/theories/Homotopy/WhiteheadsPrinciple.v
+++ b/theories/Homotopy/WhiteheadsPrinciple.v
@@ -2,7 +2,7 @@ Require Import Basics.
 Require Import Types.
 Require Import Pointed.
 Require Import Fibrations.
-Require Import EquivalenceVarieties.
+Require Import EquivalenceVarieties UnivalenceImpliesFunext.
 Require Import Algebra.Group.
 Require Import Homotopy.HomotopyGroup.
 Require Import Truncations.

--- a/theories/Idempotents.v
+++ b/theories/Idempotents.v
@@ -3,6 +3,7 @@ Require Import HoTT.Basics HoTT.Types.
 Require Import Fibrations FunextVarieties UnivalenceImpliesFunext EquivalenceVarieties Constant.
 Require Import HoTT.Truncations.
 Require Import PathAny.
+Import TrM.
 
 Local Open Scope nat_scope.
 Local Open Scope path_scope.

--- a/theories/Modalities/Accessible.v
+++ b/theories/Modalities/Accessible.v
@@ -154,6 +154,7 @@ Module Accessible_Modalities_Theory
 
   Export Os Acc.
   Module Export Os_Theory := Modalities_Theory Os.
+  Import Acc.Os_Theory.
 
   (** Unsurprisingly, the generators are connected. *)
   Global Instance isconnected_acc_gen O i : IsConnected O (acc_gen O i).

--- a/theories/Modalities/Fracture.v
+++ b/theories/Modalities/Fracture.v
@@ -1,5 +1,5 @@
 (* -*- mode: coq; mode: visual-line -*- *)
-Require Import HoTT.Basics HoTT.Types.
+Require Import HoTT.Basics HoTT.Types UnivalenceImpliesFunext.
 Require Import Fibrations Extensions Pullback NullHomotopy.
 Require Import Modality Lex Open Closed Nullification.
 Require Import HoTT.Tactics.

--- a/theories/Modalities/Lex.v
+++ b/theories/Modalities/Lex.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 Require Import HoTT.Basics HoTT.Types.
-Require Import EquivalenceVarieties Fibrations Extensions Pullback NullHomotopy Factorization.
+Require Import EquivalenceVarieties Fibrations Extensions Pullback NullHomotopy Factorization UnivalenceImpliesFunext.
 Require Import Modality Accessible.
 Require Import HoTT.Tactics.
 
@@ -368,20 +368,15 @@ Module Accessible_Lex_Modalities_Theory
 
   A more serious issue is that there are some declarations that function up to a syntactic equality that is stricter than judgmental conversion.  For instance, [Inductive] and [Record] definitions, like modules, always create a new object not convertible to any previously existing one.  There are no [Inductive] or [Record] definitions in [Modalities_Theory], but there are [Class] declarations, and these function similarly.  In particular, typeclass search is unable to use [Instance]s defined in [Acc_Theory] to instantiate typeclasses from [Modalities_Theory] (such as [IsConnected]) needed by functions in [Lex_Theory], and vice versa.
 
-  Fortunately, all the typeclasses defined in [Modalities_Theory] are *singleton* or *definitional* classes (defined with `:= unique_field` rather than `{ field1 ; field2 ; ... }`), which means that they do not actually introduce a new record wrapper.  Thus, the [Instance]s from [Acc_Theory] can in fact be typechecked to *belong* to the typeclasses needed by [Lex_Theory], and hence can be supplied explicitly.
-
-  We can also do this once and for all by defining [Instance]s translating automatically between the two typeclasses, although unfortunately we probably can't declare such instances in both directions at once for fear of infinite loops.  Fortunately, there is not a lot in [Acc_Theory], so this direction seems likely to be the most useful. *)
-
-  Global Instance isconnected_acc_to_lex {O : Modality} {A : Type}
-         {H : Acc_Theory.Os_Theory.RSU.IsConnected O A}
-            : Lex_Theory.Os_Theory.RSU.IsConnected O A
-         := H.
+  Fortunately, all the typeclasses defined in [Modalities_Theory] are *singleton* or *definitional* classes (defined with `:= unique_field` rather than `{ field1 ; field2 ; ... }`), which means that they do not actually introduce a new record wrapper.  Thus, the [Instance]s from [Acc_Theory] can in fact be typechecked to *belong* to the typeclasses needed by [Lex_Theory], and hence can be supplied (or [assert]ed) explicitly. *)
 
   (** Probably the most important thing about an accessible lex modality is that the universe of modal types is again modal.  Here by "the universe" we mean a universe large enough to contain the generating family; this is why we need accessibility. *)
   Global Instance inO_typeO `{Univalence} (O : Modality) `{Lex O}
   : In O (Type_ O).
   Proof.
     apply (snd (inO_iff_isnull O _)); intros i n; simpl in *.
+    assert (Lex_Theory.Os_Theory.RSU.IsConnected O (acc_gen O i))
+      by exact (isconnected_acc_gen O i).
     destruct n; [ exact tt | split ].
     - intros P.
       (** The case [n=0] is basically just one of the above characterizations of lex-ness. *)

--- a/theories/Modalities/Topological.v
+++ b/theories/Modalities/Topological.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*- *)
-Require Import HoTT.Basics HoTT.Types.
-Require Import EquivalenceVarieties Extensions.
+Require Import HoTT.Basics HoTT.Types HProp UnivalenceImpliesFunext.
+Require Import EquivalenceVarieties FunextVarieties Extensions.
 Require Import HoTT.Truncations.
 Require Import Modality Accessible Lex Nullification.
 

--- a/theories/ObjectClassifier.v
+++ b/theories/ObjectClassifier.v
@@ -2,8 +2,7 @@
 This equivalence is close to the existence of an object classifier.
 *)
 
-Require Import HoTT.Basics.
-Require Import Types.Universe Types.Sigma Types.Arrow.
+Require Import HoTT.Basics HoTT.Types.
 Require Import Fibrations HProp EquivalenceVarieties UnivalenceImpliesFunext Pullback.
 
 Local Open Scope path_scope.

--- a/theories/Pointed/Loops.v
+++ b/theories/Pointed/Loops.v
@@ -1,13 +1,7 @@
-Require Import Basics.
-Require Import Types.
-Require Import HSet.
-Require Import Fibrations.
-Require Import Factorization.
-Require Import HoTT.Truncations.
-Require Import Pointed.Core.
-Require Import Pointed.pMap.
-Require Import Pointed.pEquiv.
-Require Import Pointed.pHomotopy.
+Require Import HoTT.Basics HoTT.Types.
+Require Import HSet Fibrations Factorization HoTT.Truncations HProp.
+Require Import UnivalenceImpliesFunext.
+Require Import Pointed.Core Pointed.pMap Pointed.pEquiv Pointed.pHomotopy.
 
 Import TrM.
 

--- a/theories/Pointed/pMap.v
+++ b/theories/Pointed/pMap.v
@@ -1,4 +1,4 @@
-Require Import Basics Types PathAny.
+Require Import Basics Types PathAny FunextVarieties.
 Require Import Pointed.Core.
 Require Import Pointed.pHomotopy.
 

--- a/theories/Spaces/BAut.v
+++ b/theories/Spaces/BAut.v
@@ -1,5 +1,5 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
-Require Import HoTT.Basics HoTT.Types.
+Require Import HoTT.Basics HoTT.Types HProp.
 Require Import Constant Factorization UnivalenceImpliesFunext.
 Require Import Modalities.Modality HoTT.Truncations.
 Require Export Algebra.ooGroup Algebra.Aut.

--- a/theories/Spaces/BAut/Cantor.v
+++ b/theories/Spaces/BAut/Cantor.v
@@ -1,5 +1,5 @@
 (* -*- mode: coq; mode: visual-line -*- *)
-Require Import HoTT.Basics HoTT.Types.
+Require Import HoTT.Basics HoTT.Types UnivalenceImpliesFunext.
 Require Import Idempotents.
 Require Import HoTT.Truncations Spaces.BAut Spaces.Cantor.
 

--- a/theories/Spaces/Card.v
+++ b/theories/Spaces/Card.v
@@ -1,6 +1,7 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 (** Representation of cardinals, see Chapter 10 of the HoTT book. *)
 Require Import HoTT.Basics HoTT.Types HoTT.HSet HoTT.TruncType.
+Require Import UnivalenceImpliesFunext.
 Require Import HoTT.Classes.interfaces.abstract_algebra.
 Require Import HoTT.Truncations.
 

--- a/theories/Spaces/No/Addition.v
+++ b/theories/Spaces/No/Addition.v
@@ -1,5 +1,5 @@
 (* -*- mode: coq; mode: visual-line -*- *)
-Require Import HoTT.Basics HoTT.Types.
+Require Import HoTT.Basics HoTT.Types UnivalenceImpliesFunext.
 Require Import HoTT.Spaces.No.Core HoTT.Spaces.No.Negation.
 
 Local Open Scope path_scope.

--- a/theories/Spaces/Torus/TorusHomotopy.v
+++ b/theories/Spaces/Torus/TorusHomotopy.v
@@ -9,6 +9,7 @@ Require Import Spaces.Int.
 Require Import HIT.Circle.
 Require Import Truncations.
 Require Import Homotopy.HomotopyGroup.
+Require Import UnivalenceImpliesFunext.
 Import TrM.
 
 Require Import Torus.

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -1,7 +1,7 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 
 Require Import Basics Types.
-Require Import TruncType HProp.
+Require Import TruncType HProp UnivalenceImpliesFunext.
 Require Import Modalities.Modality Modalities.Identity.
 
 (** * Truncations of types, in all dimensions. *)

--- a/theories/Types/Sum.v
+++ b/theories/Types/Sum.v
@@ -2,7 +2,7 @@
 (** * Theorems about disjoint unions *)
 
 Require Import HoTT.Basics.
-Require Import Types.Empty Types.Prod Types.Sigma.
+Require Import Types.Empty Types.Unit Types.Prod Types.Sigma.
 (** The following are only required for the equivalence between [sum] and a sigma type *)
 Require Import Types.Bool Types.Forall.
 


### PR DESCRIPTION
This [new flag](https://coq.inria.fr/refman/proof-engine/tactics.html#coq:opt.loose-hint-behavior) prevents typeclass instances from "leaking" out of un-imported modules and through transitivity of imported files.  I think this is the correct behavior: only instances from imported modules should be visible.  (It also fixes a problem in at least one place that the import of `Modalities.Identity` in `Truncations.Core` kills typeclass search.)

It turns out that we were (probably unknowingly) relying on this (mis)feature in a lot of places, so I had to change a lot of files.  And there are some that I still couldn't figure out how to fix.  Currently the following files are still giving errors with `make -k`:

- [x] `Categories/Pseudofunctor/Identity`
- [x] `Categories/Grothendieck/PseudofunctorToCat`
- [x] `Categories/SimplicialSets`
- [x] `Categories/ExponentialLaws/Law1/Law`
- [x] `Classes/tactics/ring_tac`
- [x] `Classes/tests/ring_tac11`
- [x] `Classes/implementations/natpair_integers`
- [x] `Classes/orders/sum`
- [x] `Classes/theory/ua_quotient_algebra`
- [x] `Classes/theory/rings`

I don't understand enough about the Categories and Classes libraries to fix these easily; can someone else look at it please?  I've checked "Allow edits from maintainers" on this draft PR so anyone who wants to work on fixing these files can just push to my branch.  Of course, once the files are fixed, there may be other files that depend on them that will also have their own errors; feel free to use the "task list" above to track the files that need work.
