### PR TITLE
Replace eqp_issig_contr tactic with a lemma

### DIFF
--- a/theories/Algebra/Group.v
+++ b/theories/Algebra/Group.v
@@ -233,7 +233,7 @@ Definition equiv_path_group {U : Univalence} {G H : Group}
 Proof.
   refine (equiv_compose'
     (B := sig (fun f : G <~> H => IsMonoidPreserving f)) _ _).
-  { eqp_issig_contr issig_group.
+  { revert G H; apply (eqp_issig_contr issig_group).
     + intros [G [? [? [? ?]]]].
       exists 1%equiv.
       exact _.

--- a/theories/Algebra/Group.v
+++ b/theories/Algebra/Group.v
@@ -233,7 +233,7 @@ Definition equiv_path_group {U : Univalence} {G H : Group}
 Proof.
   refine (equiv_compose'
     (B := sig (fun f : G <~> H => IsMonoidPreserving f)) _ _).
-  { revert G H; apply (eqp_issig_contr issig_group).
+  { revert G H; apply (equiv_path_issig_contr issig_group).
     + intros [G [? [? [? ?]]]].
       exists 1%equiv.
       exact _.

--- a/theories/Factorization.v
+++ b/theories/Factorization.v
@@ -66,7 +66,7 @@ Section Factorization.
     : PathFactorization fact fact' <~> fact = fact'.
   Proof.
     refine (_ oE (issig_PathFactorization fact fact')^-1).
-    revert fact fact'; apply (eqp_issig_contr issig_Factorization).
+    revert fact fact'; apply (equiv_path_issig_contr issig_Factorization).
     { intros [I [f1 [f2 [ff [oc1 oc2]]]]].
       exists (equiv_idmap I); cbn.
       exists (fun x:A => 1%path); cbn.

--- a/theories/Factorization.v
+++ b/theories/Factorization.v
@@ -66,7 +66,7 @@ Section Factorization.
     : PathFactorization fact fact' <~> fact = fact'.
   Proof.
     refine (_ oE (issig_PathFactorization fact fact')^-1).
-    eqp_issig_contr issig_Factorization.
+    revert fact fact'; apply (eqp_issig_contr issig_Factorization).
     { intros [I [f1 [f2 [ff [oc1 oc2]]]]].
       exists (equiv_idmap I); cbn.
       exists (fun x:A => 1%path); cbn.

--- a/theories/Idempotents.v
+++ b/theories/Idempotents.v
@@ -108,7 +108,7 @@ Definition equiv_path_retractof `{ua : Univalence} {X : Type}
            (R' R : RetractOf X)
   : PathRetractOf X R' R <~> R' = R.
 Proof.
-  eqp_issig_contr (issig_retractof X).
+  revert R' R; apply (eqp_issig_contr (issig_retractof X)).
   { intros [A [r [s H]]]; cbn.
     exists equiv_idmap.
     exists (fun x => 1%path).

--- a/theories/Idempotents.v
+++ b/theories/Idempotents.v
@@ -108,7 +108,7 @@ Definition equiv_path_retractof `{ua : Univalence} {X : Type}
            (R' R : RetractOf X)
   : PathRetractOf X R' R <~> R' = R.
 Proof.
-  revert R' R; apply (eqp_issig_contr (issig_retractof X)).
+  revert R' R; apply (equiv_path_issig_contr (issig_retractof X)).
   { intros [A [r [s H]]]; cbn.
     exists equiv_idmap.
     exists (fun x => 1%path).

--- a/theories/PathAny.v
+++ b/theories/PathAny.v
@@ -17,22 +17,27 @@ Proof.
   refine (@isequiv_contr_contr {x:A & a=x} {x:A & P a x} _ _ _).
 Defined.
 
-(** This tactic applies the above equivalence and combines it with an [issig] lemma for [A].  (If the type family [P] is also a record, then the user has to apply its [issig] manually.) *)
-Ltac eqp_issig_contr e :=
-  match goal with
-  | [ |- ?X <~> ?x = ?y ] => revert x y
-  | _ => idtac
-  end;
-  let x := fresh in
-  let y := fresh in
-  equiv_intro e x;
-  equiv_intro e y;
-  refine ((equiv_ap' e^-1 _ _)^-1 oE _);
-  revert x y;
-  match goal with
-    [ |- forall x y, @?P x y <~> ?eq ] =>
-    refine (equiv_path_from_contr P _ _)
-  end.
+(** Another useful result when trying to characterize the path type of [A] when given an equivalence [e : B <~> A], such as an [issig] lemma for [A]. *)
+Definition equiv_path_along_equiv {A B : Type} (P : A -> A -> Type)
+           (e : B <~> A)
+           (K : forall b0 b1 : B, P (e b0) (e b1) <~> b0 = b1)
+  : forall a0 a1 : A, P a0 a1 <~> a0 = a1.
+Proof.
+  equiv_intros e b0 b1.
+  refine (_ oE K b0 b1).
+  apply equiv_ap'.
+Defined.
+
+(** This simply combines the two previous results, a common idiom. *)
+Definition eqp_issig_contr {A B : Type} {P : A -> A -> Type}
+           (e : B <~> A)
+           (Prefl : forall b, P (e b) (e b))
+           (cp : forall b1, Contr {b2 : B & P (e b1) (e b2)})
+  : forall a0 a1 : A, P a0 a1 <~> a0 = a1.
+Proof.
+  apply (equiv_path_along_equiv _ e).
+  apply equiv_path_from_contr; assumption.
+Defined.
 
 (** After [eqp_issig_contr], we are left showing the contractibility of a sigma-type whose base and fibers are large nested sigma-types of the same depth.  Moreover, we expect that the types appearing in those two large nested sigma-types "pair up" to form contractible based "path-types".  The following lemma "peels off" the first such pair, whose contractibility can often be found with typeclass search.  The remaining contractibility goal is then simplified by substituting the center of contraction of that first based "path-type", or more precisely a *specific* center that may or may not be the one given by the contractibility instance; the latter freedom sometimes makes things faster and simpler. *)
 Definition contr_sigma_sigma (A : Type) (B : A -> Type)

--- a/theories/PathAny.v
+++ b/theories/PathAny.v
@@ -17,8 +17,8 @@ Proof.
   refine (@isequiv_contr_contr {x:A & a=x} {x:A & P a x} _ _ _).
 Defined.
 
-(** Another useful result when trying to characterize the path type of [A] when given an equivalence [e : B <~> A], such as an [issig] lemma for [A]. *)
-Definition equiv_path_along_equiv {A B : Type} (P : A -> A -> Type)
+(** This is another result for characterizing the path type of [A] when given an equivalence [e : B <~> A], such as an [issig] lemma for [A]. It can help Coq to deduce the type family [P] if [revert] is used to move [a0] and [a1] into the goal, if needed. *)
+Definition equiv_path_along_equiv {A B : Type} {P : A -> A -> Type}
            (e : B <~> A)
            (K : forall b0 b1 : B, P (e b0) (e b1) <~> b0 = b1)
   : forall a0 a1 : A, P a0 a1 <~> a0 = a1.
@@ -28,18 +28,18 @@ Proof.
   apply equiv_ap'.
 Defined.
 
-(** This simply combines the two previous results, a common idiom. *)
-Definition eqp_issig_contr {A B : Type} {P : A -> A -> Type}
+(** This simply combines the two previous results, a common idiom. Again, it can help Coq to deduce the type family [P] if [revert] is used to move [a0] and [a1] into the goal, if needed. *)
+Definition equiv_path_issig_contr {A B : Type} {P : A -> A -> Type}
            (e : B <~> A)
            (Prefl : forall b, P (e b) (e b))
            (cp : forall b1, Contr {b2 : B & P (e b1) (e b2)})
   : forall a0 a1 : A, P a0 a1 <~> a0 = a1.
 Proof.
-  apply (equiv_path_along_equiv _ e).
+  apply (equiv_path_along_equiv e).
   apply equiv_path_from_contr; assumption.
 Defined.
 
-(** After [eqp_issig_contr], we are left showing the contractibility of a sigma-type whose base and fibers are large nested sigma-types of the same depth.  Moreover, we expect that the types appearing in those two large nested sigma-types "pair up" to form contractible based "path-types".  The following lemma "peels off" the first such pair, whose contractibility can often be found with typeclass search.  The remaining contractibility goal is then simplified by substituting the center of contraction of that first based "path-type", or more precisely a *specific* center that may or may not be the one given by the contractibility instance; the latter freedom sometimes makes things faster and simpler. *)
+(** After [equiv_path_issig_contr], we are left showing the contractibility of a sigma-type whose base and fibers are large nested sigma-types of the same depth.  Moreover, we expect that the types appearing in those two large nested sigma-types "pair up" to form contractible based "path-types".  The following lemma "peels off" the first such pair, whose contractibility can often be found with typeclass search.  The remaining contractibility goal is then simplified by substituting the center of contraction of that first based "path-type", or more precisely a *specific* center that may or may not be the one given by the contractibility instance; the latter freedom sometimes makes things faster and simpler. *)
 Definition contr_sigma_sigma (A : Type) (B : A -> Type)
            (C : A -> Type) (D : forall a, B a -> C a -> Type)
            {cac : Contr {x:A & C x} }

--- a/theories/Pointed/pMap.v
+++ b/theories/Pointed/pMap.v
@@ -9,7 +9,7 @@ Definition equiv_path_pmap `{Funext} {A B : pType} (f g : A ->* B)
   : (f ==* g) <~> (f = g).
 Proof.
   refine (_ oE (issig_phomotopy f g)^-1).
-  eqp_issig_contr (issig_pmap A B).
+  revert f g; apply (eqp_issig_contr (issig_pmap A B)).
   { intros [f feq]; cbn.
     exists (fun a => 1%path).
     apply concat_1p. }

--- a/theories/Pointed/pMap.v
+++ b/theories/Pointed/pMap.v
@@ -9,7 +9,7 @@ Definition equiv_path_pmap `{Funext} {A B : pType} (f g : A ->* B)
   : (f ==* g) <~> (f = g).
 Proof.
   refine (_ oE (issig_phomotopy f g)^-1).
-  revert f g; apply (eqp_issig_contr (issig_pmap A B)).
+  revert f g; apply (equiv_path_issig_contr (issig_pmap A B)).
   { intros [f feq]; cbn.
     exists (fun a => 1%path).
     apply concat_1p. }


### PR DESCRIPTION
The `eqp_issig_contr` tactic for characterizing identity types can be replaced by a lemma.  The advantages of this are that the type of the lemma provides clear documentation for what it can do, and the lemma only needs to be proved once, instead of each time the tactic is used.  I also split out part of the functionality into another lemma which might be of independent use.  All the uses of the old tactic have been converted to the new lemma, just by adding a `revert` and an `apply`.