### PR TITLE
Avoid rewrites in *_morphism proofs; make into Global Instances

### DIFF
--- a/theories/Algebra/Group.v
+++ b/theories/Algebra/Group.v
@@ -153,11 +153,7 @@ Definition grp_homo_compose {G H K : Group}
   : GroupHomomorphism H K -> GroupHomomorphism G H -> GroupHomomorphism G K.
 Proof.
   intros f g.
-  serapply Build_GroupHomomorphism.
-  1: exact (f o g).
-  intros x y.
-  refine (ap f (grp_homo_op g _ _) @ _).
-  apply grp_homo_op.
+  serapply (Build_GroupHomomorphism (f o g)).
 Defined.
 
 Definition grp_homo_id {G : Group} : GroupHomomorphism G G.
@@ -181,14 +177,8 @@ Definition grp_iso_inverse {G H : Group}
 Proof.
   intros [f e].
   serapply Build_GroupIsomorphism.
-  { serapply Build_GroupHomomorphism.
-    1: exact f^-1.
-    unfold IsSemiGroupPreserving.
-    intros x y.
-    apply (ap f)^-1.
-    rewrite grp_homo_op.
-    by rewrite !eisretr. }
-  exact _.
+  - serapply (Build_GroupHomomorphism f^-1).
+  - exact _.
 Defined.
 
 (* We can build an isomorphism from an operation preserving equivalence. *)
@@ -256,7 +246,7 @@ Proof.
       1: apply eq.
       rewrite transport_const.
       funext x.
-      exact (preserves_negate x). }
+      exact (preserves_negate (f:=idmap) _). }
   refine (_ oE (issig_GroupIsomorphism G H)^-1).
   refine (_ oE (equiv_functor_sigma' (issig_GroupHomomorphism G H)
     (fun f => 1%equiv))^-1).

--- a/theories/Classes/theory/groups.v
+++ b/theories/Classes/theory/groups.v
@@ -226,16 +226,6 @@ Section from_another_ab_group.
 
 End from_another_ab_group.
 
-Instance id_sg_morphism `{IsSemiGroup A} : IsSemiGroupPreserving (@id A).
-Proof.
-  red. split.
-Qed.
-
-Instance id_monoid_morphism `{IsMonoid A} : IsMonoidPreserving (@id A).
-Proof.
-split;split.
-Qed.
-
 Section compose_mor.
 
   Context
@@ -244,16 +234,27 @@ Section compose_mor.
     `{SgOp C} `{MonUnit C}
     (f : A -> B) (g : B -> C).
 
-  Instance compose_sg_morphism : IsSemiGroupPreserving f -> IsSemiGroupPreserving g ->
+  Global Instance id_sg_morphism : IsSemiGroupPreserving (@id A).
+  Proof.
+    split.
+  Defined.
+
+  Global Instance id_monoid_morphism : IsMonoidPreserving (@id A).
+  Proof.
+    split; split.
+  Defined.
+
+  Global Instance compose_sg_morphism : IsSemiGroupPreserving f -> IsSemiGroupPreserving g ->
     IsSemiGroupPreserving (g ∘ f).
   Proof.
-    red;intros.
+    red; intros fp gp x y.
     unfold Compose.
-    rewrite (preserves_sg_op x y).
-    apply preserves_sg_op.
-  Qed.
+    refine ((ap g _) @ _).
+    - apply fp.
+    - apply gp.
+  Defined.
 
-  Instance compose_monoid_morphism : IsMonoidPreserving f -> IsMonoidPreserving g ->
+  Global Instance compose_monoid_morphism : IsMonoidPreserving f -> IsMonoidPreserving g ->
     IsMonoidPreserving (g ∘ f).
   Proof.
     intros;split.
@@ -261,28 +262,33 @@ Section compose_mor.
     - red;unfold Compose.
       etransitivity;[|apply preserves_mon_unit].
       apply ap,preserves_mon_unit.
-  Qed.
+  Defined.
 
-  Instance invert_sg_morphism
+  Global Instance invert_sg_morphism
     : forall `{!IsEquiv f}, IsSemiGroupPreserving f ->
       IsSemiGroupPreserving (f^-1).
   Proof.
-    red;intros.
+    red; intros E fp x y.
     apply (Paths.equiv_inj f).
-    rewrite (preserves_sg_op (f:=f)).
-    rewrite !eisretr.
-    reflexivity.
-  Qed.
+    refine (_ @ _ @ _ @ _)^.
+    - apply fp.
+    (* We could use [apply ap2; apply eisretr] here, but it is convenient
+       to have things in terms of ap. *)
+    - refine (ap (fun z => z * _) _); apply eisretr.
+    - refine (ap (fun z => _ * z) _); apply eisretr.
+    - symmetry; apply eisretr.
+  Defined.
 
-  Instance invert_monoid_morphism :
+  Global Instance invert_monoid_morphism :
     forall `{!IsEquiv f}, IsMonoidPreserving f -> IsMonoidPreserving (f^-1).
   Proof.
     intros;split.
     - apply _.
     - apply (Paths.equiv_inj f).
-      rewrite eisretr.
-      rewrite (preserves_mon_unit (f:=f)). reflexivity.
-  Qed.
+      refine (_ @ _).
+      + apply eisretr.
+      + symmetry; apply preserves_mon_unit.
+  Defined.
 
 End compose_mor.
 

--- a/theories/Homotopy/HomotopyGroup.v
+++ b/theories/Homotopy/HomotopyGroup.v
@@ -110,7 +110,7 @@ Proof.
   destruct n.
   + exact (ptr_functor 0).
   + intro f.
-    serapply Build_GroupHomomorphism.
+    simple notypeclasses refine (Build_GroupHomomorphism _).
     { apply Trunc_functor.
       apply iterated_loops_functor.
       assumption. }


### PR DESCRIPTION
For work in progress, I need to reason about these proofs, so avoid rewrites.

Also, some of these results were reproved elsewhere, so make them into Global Instances.  This sometimes causes `serapply BuildGroupHomomorphism` to spin, so you need to either add `notypeclasses` or provide the map.
