### PR TITLE
Add equiv_path_forall2 and define path_forall2 using it

### DIFF
--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -674,13 +674,6 @@ Definition path_forall `{Funext} {A : Type} {P : A -> Type} (f g : forall x : A,
 
 Global Arguments path_forall {_ A%type_scope P} (f g)%function_scope _.
 
-Definition path_forall2 `{Funext} {A B : Type} {P : A -> B -> Type} (f g : forall x y, P x y) :
-  (forall x y, f x y = g x y) -> f = g
-  :=
-  (fun E => path_forall f g (fun x => path_forall (f x) (g x) (E x))).
-
-Global Arguments path_forall2 {_} {A B}%type_scope {P} (f g)%function_scope _.
-
 (** *** Tactics *)
 
 (** We declare some more [Hint Resolve] hints, now in the "hint database" [path_hints].  In general various hints (resolve, rewrite, unfold hints) can be grouped into "databases". This is necessary as sometimes different kinds of hints cannot be mixed, for example because they would cause a combinatorial explosion or rewriting cycles.

--- a/theories/Types/Forall.v
+++ b/theories/Types/Forall.v
@@ -285,6 +285,24 @@ Proof.
   symmetry; apply transport_pp.
 Qed.
 
+(** ** Two variable versions for function extensionality. *)
+
+Definition equiv_path_forall2 {A B : Type} {P : A -> B -> Type} (f g : forall x y, P x y)
+  : (forall (a : A) (b : B), f a b = g a b) <~> f = g
+  := (equiv_path_forall f g) oE (equiv_functor_forall_id (fun a => equiv_path_forall (f a) (g a))).
+
+Definition path_forall2 {A B : Type} {P : A -> B -> Type} (f g : forall x y, P x y)
+  : (forall x y, f x y = g x y) -> f = g
+  := equiv_path_forall2 f g.
+
+Global Instance isequiv_path_forall2 `{P : A -> B -> Type} (f g : forall x y, P x y)
+  : IsEquiv (path_forall2 f g) | 0
+  := _.
+
+Global Arguments equiv_path_forall2 {A B}%type_scope {P} (f g)%function_scope.
+
+Global Arguments path_forall2 {A B}%type_scope {P} (f g)%function_scope.
+
 (** ** Truncatedness: any dependent product of n-types is an n-type *)
 
 Global Instance contr_forall `{P : A -> Type} `{forall a, Contr (P a)}

--- a/theories/Types/Forall.v
+++ b/theories/Types/Forall.v
@@ -301,7 +301,7 @@ Global Instance isequiv_path_forall2 `{P : A -> B -> Type} (f g : forall x y, P 
 
 Global Arguments equiv_path_forall2 {A B}%type_scope {P} (f g)%function_scope.
 
-Global Arguments path_forall2 {A B}%type_scope {P} (f g)%function_scope.
+Global Arguments path_forall2 {A B}%type_scope {P} (f g)%function_scope _.
 
 (** ** Truncatedness: any dependent product of n-types is an n-type *)
 

--- a/theories/Types/Forall.v
+++ b/theories/Types/Forall.v
@@ -287,21 +287,21 @@ Qed.
 
 (** ** Two variable versions for function extensionality. *)
 
-Definition equiv_path_forall2 {A B : Type} {P : A -> B -> Type} (f g : forall x y, P x y)
+Definition equiv_path_forall11 {A B : Type} {P : A -> B -> Type} (f g : forall x y, P x y)
   : (forall (a : A) (b : B), f a b = g a b) <~> f = g
   := (equiv_path_forall f g) oE (equiv_functor_forall_id (fun a => equiv_path_forall (f a) (g a))).
 
-Definition path_forall2 {A B : Type} {P : A -> B -> Type} (f g : forall x y, P x y)
+Definition path_forall11 {A B : Type} {P : A -> B -> Type} (f g : forall x y, P x y)
   : (forall x y, f x y = g x y) -> f = g
-  := equiv_path_forall2 f g.
+  := equiv_path_forall11 f g.
 
-Global Instance isequiv_path_forall2 `{P : A -> B -> Type} (f g : forall x y, P x y)
-  : IsEquiv (path_forall2 f g) | 0
+Global Instance isequiv_path_forall11 `{P : A -> B -> Type} (f g : forall x y, P x y)
+  : IsEquiv (path_forall11 f g) | 0
   := _.
 
-Global Arguments equiv_path_forall2 {A B}%type_scope {P} (f g)%function_scope.
+Global Arguments equiv_path_forall11 {A B}%type_scope {P} (f g)%function_scope.
 
-Global Arguments path_forall2 {A B}%type_scope {P} (f g)%function_scope _.
+Global Arguments path_forall11 {A B}%type_scope {P} (f g)%function_scope _.
 
 (** ** Truncatedness: any dependent product of n-types is an n-type *)
 

--- a/theories/Types/Forall.v
+++ b/theories/Types/Forall.v
@@ -287,15 +287,15 @@ Qed.
 
 (** ** Two variable versions for function extensionality. *)
 
-Definition equiv_path_forall11 {A B : Type} {P : A -> B -> Type} (f g : forall x y, P x y)
-  : (forall (a : A) (b : B), f a b = g a b) <~> f = g
+Definition equiv_path_forall11 {A : Type} {B : A -> Type} {P : forall a : A, B a -> Type} (f g : forall a b, P a b)
+  : (forall (a : A) (b : B a), f a b = g a b) <~> f = g
   := (equiv_path_forall f g) oE (equiv_functor_forall_id (fun a => equiv_path_forall (f a) (g a))).
 
-Definition path_forall11 {A B : Type} {P : A -> B -> Type} (f g : forall x y, P x y)
+Definition path_forall11 {A : Type} {B : A -> Type} {P : forall a : A, B a -> Type} (f g : forall a b, P a b)
   : (forall x y, f x y = g x y) -> f = g
   := equiv_path_forall11 f g.
 
-Global Instance isequiv_path_forall11 `{P : A -> B -> Type} (f g : forall x y, P x y)
+Global Instance isequiv_path_forall11 {A : Type} {B : A -> Type} `{P : forall a : A, B a -> Type} (f g : forall a b, P a b)
   : IsEquiv (path_forall11 f g) | 0
   := _.
 


### PR DESCRIPTION
I needed `equiv_path_forall2`, and it seemed slightly easier to define this directly and then define `path_forall2` using it compared to showing that the existing definition of `path_forall2` is an equivalence.  As a result, `path_forall2` moves from Overture to Forall.

If this is a problem, I can do it the other way.  `path_forall2` isn't used anywhere in the library, but others might use it.

Another question:  I had to remove `{_}` and `_` from the `Global Arguments path_forall2` line.  Not sure why they were there.  The `{_}` was probably for `Funext` which is now in the context.  Not sure about the trailing `_`.  `_ _` would make more sense.