### PR TITLE
Make center of contr_basedequiv compute

### DIFF
--- a/theories/Types/Universe.v
+++ b/theories/Types/Universe.v
@@ -481,17 +481,18 @@ Definition equiv_induction'_comp (P : forall U V, U <~> V -> Type)
 Global Instance contr_basedequiv {X : Type}
 : Contr {Y : Type & X <~> Y}.
 Proof.
-  refine (trunc_equiv' {Y : Type & X = Y}
-           (equiv_functor_sigma' (equiv_idmap Type)
-             (fun Y => equiv_equiv_path X Y))).
+  exists (X; equiv_idmap).
+  intros [Y f]; revert Y f.
+  exact (equiv_induction _ idpath).
 Defined.
 
 Global Instance contr_basedequiv' {X : Type}
 : Contr {Y : Type & Y <~> X}.
 Proof.
-  refine (trunc_equiv' {Y : Type & Y = X}
-           (equiv_functor_sigma' (equiv_idmap Type)
-             (fun Y => equiv_equiv_path Y X))).
+  serapply Build_Contr.
+  - exact (X; equiv_idmap).
+  - intros [Y f]; revert Y X f.
+    refine (equiv_induction' _ (fun T => idpath)).
 Defined.
 
 (** ** Truncations *)

--- a/theories/Types/Universe.v
+++ b/theories/Types/Universe.v
@@ -454,7 +454,7 @@ Theorem equiv_induction {U : Type} (P : forall V, U <~> V -> Type) :
 Proof.
   intros H0 V.
   apply (equiv_ind (equiv_path U V)).
-  exact (paths_ind U (fun Y p => P Y (equiv_path U Y p)) H0 V).
+  intro p; induction p; exact H0.
 Defined.
 
 Definition equiv_induction_comp {U : Type} (P : forall V, U <~> V -> Type)
@@ -468,7 +468,7 @@ Theorem equiv_induction' (P : forall U V, U <~> V -> Type) :
 Proof.
   intros H0 U V w.
   apply (equiv_ind (equiv_path U V)).
-  exact (paths_ind' (fun X Y p => P X Y (equiv_path X Y p)) H0 U V).
+  intro p; induction p; apply H0.
 Defined.
 
 Definition equiv_induction'_comp (P : forall U V, U <~> V -> Type)
@@ -480,8 +480,8 @@ Theorem equiv_induction_inv {U : Type} (P : forall V, V <~> U -> Type) :
   (P U (equiv_idmap U)) -> (forall V (w : V <~> U), P V w).
 Proof.
   intros H0 V.
-  apply (equiv_ind ((equiv_equiv_path V U) oE equiv_path_inverse _ _)).
-  exact (paths_ind U (fun Y p => P Y (equiv_path Y U p^)) H0 V).
+  apply (equiv_ind (equiv_path V U)).
+  intro p; induction p; apply H0.
 Defined.
 
 Definition equiv_induction_inv_comp {U : Type} (P : forall V, V <~> U -> Type)

--- a/theories/Types/Universe.v
+++ b/theories/Types/Universe.v
@@ -452,7 +452,7 @@ Definition transport_path_universe_pV `{Funext}
 Theorem equiv_induction {U : Type} (P : forall V, U <~> V -> Type) :
   (P U (equiv_idmap U)) -> (forall V (w : U <~> V), P V w).
 Proof.
-  intros H0 V w.
+  intros H0 V.
   apply (equiv_ind (equiv_path U V)).
   exact (paths_ind U (fun Y p => P Y (equiv_path U Y p)) H0 V).
 Defined.
@@ -476,6 +476,19 @@ Definition equiv_induction'_comp (P : forall U V, U <~> V -> Type)
   : equiv_induction' P didmap U U (equiv_idmap U) = didmap U
   := (equiv_ind_comp (P U U) _ 1).
 
+Theorem equiv_induction_inv {U : Type} (P : forall V, V <~> U -> Type) :
+  (P U (equiv_idmap U)) -> (forall V (w : V <~> U), P V w).
+Proof.
+  intros H0 V.
+  apply (equiv_ind ((equiv_equiv_path V U) oE equiv_path_inverse _ _)).
+  exact (paths_ind U (fun Y p => P Y (equiv_path Y U p^)) H0 V).
+Defined.
+
+Definition equiv_induction_inv_comp {U : Type} (P : forall V, V <~> U -> Type)
+  (didmap : P U (equiv_idmap U))
+  : equiv_induction_inv P didmap U (equiv_idmap U) = didmap
+  := (equiv_ind_comp (P U) _ 1).
+
 (** ** Based equivalence types *)
 
 Global Instance contr_basedequiv {X : Type}
@@ -489,10 +502,11 @@ Defined.
 Global Instance contr_basedequiv' {X : Type}
 : Contr {Y : Type & Y <~> X}.
 Proof.
+  (* The next line is used so that Coq can figure out the type of (X; equiv_idmap). *)
   serapply Build_Contr.
   - exact (X; equiv_idmap).
-  - intros [Y f]; revert Y X f.
-    refine (equiv_induction' _ (fun T => idpath)).
+  - intros [Y f]; revert Y f.
+    refine (equiv_induction_inv _ idpath).
 Defined.
 
 (** ** Truncations *)


### PR DESCRIPTION
For some reason, with the current proofs of `contr_basedequiv` and `contr_basedequiv'`, the following cause Coq to spin:

```
Compute (center {Y : Type & nat <~> Y}).
Compute (center {Y : Type & Y <~> nat}).
Compute (@center {Y : Type & nat <~> Y} (@contr_basedequiv nat)).
Compute (@center {Y : Type & Y <~> nat} (@contr_basedequiv' nat)).
```

So I replaced their proofs with proofs that give explicit centers.