### PR TITLE
remove global compose and invers for semigrop and monoid morphisms

### DIFF
--- a/theories/Algebra/Group.v
+++ b/theories/Algebra/Group.v
@@ -152,6 +152,7 @@ Defined.
 Definition grp_homo_compose {G H K : Group}
   : GroupHomomorphism H K -> GroupHomomorphism G H -> GroupHomomorphism G K.
 Proof.
+  pose @compose_sg_morphism.
   intros f g.
   serapply (Build_GroupHomomorphism (f o g)).
 Defined.

--- a/theories/Algebra/Group.v
+++ b/theories/Algebra/Group.v
@@ -152,7 +152,6 @@ Defined.
 Definition grp_homo_compose {G H K : Group}
   : GroupHomomorphism H K -> GroupHomomorphism G H -> GroupHomomorphism G K.
 Proof.
-  pose @compose_sg_morphism.
   intros f g.
   serapply (Build_GroupHomomorphism (f o g)).
 Defined.

--- a/theories/Classes/theory/groups.v
+++ b/theories/Classes/theory/groups.v
@@ -244,7 +244,8 @@ Section compose_mor.
     split; split.
   Defined.
 
-  Global Instance compose_sg_morphism : IsSemiGroupPreserving f -> IsSemiGroupPreserving g ->
+  (** Making these global instances causes typeclass loops. *)
+  Local Instance compose_sg_morphism : IsSemiGroupPreserving f -> IsSemiGroupPreserving g ->
     IsSemiGroupPreserving (g ∘ f).
   Proof.
     red; intros fp gp x y.
@@ -254,7 +255,7 @@ Section compose_mor.
     - apply gp.
   Defined.
 
-  Global Instance compose_monoid_morphism : IsMonoidPreserving f -> IsMonoidPreserving g ->
+  Local Instance compose_monoid_morphism : IsMonoidPreserving f -> IsMonoidPreserving g ->
     IsMonoidPreserving (g ∘ f).
   Proof.
     intros;split.
@@ -264,7 +265,7 @@ Section compose_mor.
       apply ap,preserves_mon_unit.
   Defined.
 
-  Global Instance invert_sg_morphism
+  Local Instance invert_sg_morphism
     : forall `{!IsEquiv f}, IsSemiGroupPreserving f ->
       IsSemiGroupPreserving (f^-1).
   Proof.
@@ -279,7 +280,7 @@ Section compose_mor.
     - symmetry; apply eisretr.
   Defined.
 
-  Global Instance invert_monoid_morphism :
+  Local Instance invert_monoid_morphism :
     forall `{!IsEquiv f}, IsMonoidPreserving f -> IsMonoidPreserving (f^-1).
   Proof.
     intros;split.

--- a/theories/Classes/theory/groups.v
+++ b/theories/Classes/theory/groups.v
@@ -244,7 +244,7 @@ Section compose_mor.
     split; split.
   Defined.
 
-  (** Making these global instances causes typeclass loops. *)
+  (** Making these global instances causes typeclass loops.  Instead they are declared below as [Hint Extern]s that apply only when the goal has the specified form. *)
   Local Instance compose_sg_morphism : IsSemiGroupPreserving f -> IsSemiGroupPreserving g ->
     IsSemiGroupPreserving (g ∘ f).
   Proof.
@@ -296,6 +296,11 @@ End compose_mor.
 Hint Extern 4 (IsSemiGroupPreserving (_ ∘ _)) =>
   class_apply @compose_sg_morphism : typeclass_instances.
 Hint Extern 4 (IsMonoidPreserving (_ ∘ _)) =>
+  class_apply @compose_monoid_morphism : typeclass_instances.
+
+Hint Extern 4 (IsSemiGroupPreserving (_ o _)) =>
+  class_apply @compose_sg_morphism : typeclass_instances.
+Hint Extern 4 (IsMonoidPreserving (_ o _)) =>
   class_apply @compose_monoid_morphism : typeclass_instances.
 
 Hint Extern 4 (IsSemiGroupPreserving (_^-1)) =>

--- a/theories/Homotopy/HomotopyGroup.v
+++ b/theories/Homotopy/HomotopyGroup.v
@@ -110,7 +110,7 @@ Proof.
   destruct n.
   + exact (ptr_functor 0).
   + intro f.
-    simple notypeclasses refine (Build_GroupHomomorphism _).
+    serapply Build_GroupHomomorphism.
     { apply Trunc_functor.
       apply iterated_loops_functor.
       assumption. }


### PR DESCRIPTION
These cause typeclass loops in many other places in the spectral sequences development where there is more algebra, so I think it's better not to have them as instances.  In `grp_homo_compose` it was enough to pose `compose_sg_morphism` as a hint.  (I don't understand why `grp_iso_inverse` still works without any such hint.)