### PR TITLE
Undo making various *_morphism definitions into Global Instances

### DIFF
--- a/theories/Algebra/Group.v
+++ b/theories/Algebra/Group.v
@@ -154,6 +154,7 @@ Definition grp_homo_compose {G H K : Group}
 Proof.
   intros f g.
   serapply (Build_GroupHomomorphism (f o g)).
+  serapply compose_sg_morphism.
 Defined.
 
 Definition grp_homo_id {G : Group} : GroupHomomorphism G G.
@@ -246,7 +247,7 @@ Proof.
       1: apply eq.
       rewrite transport_const.
       funext x.
-      exact (preserves_negate (f:=idmap) _). }
+      exact (preserves_negate _). }
   refine (_ oE (issig_GroupIsomorphism G H)^-1).
   refine (_ oE (equiv_functor_sigma' (issig_GroupHomomorphism G H)
     (fun f => 1%equiv))^-1).

--- a/theories/Classes/theory/groups.v
+++ b/theories/Classes/theory/groups.v
@@ -244,7 +244,9 @@ Section compose_mor.
     split; split.
   Defined.
 
-  Global Instance compose_sg_morphism : IsSemiGroupPreserving f -> IsSemiGroupPreserving g ->
+  (* The remaining items in this Section are not made into Global Instances as that
+  causes [serapply Build_GroupHomomorphism] to get stuck in typeclass resolution. *)
+  Instance compose_sg_morphism : IsSemiGroupPreserving f -> IsSemiGroupPreserving g ->
     IsSemiGroupPreserving (g ∘ f).
   Proof.
     red; intros fp gp x y.
@@ -254,7 +256,7 @@ Section compose_mor.
     - apply gp.
   Defined.
 
-  Global Instance compose_monoid_morphism : IsMonoidPreserving f -> IsMonoidPreserving g ->
+  Instance compose_monoid_morphism : IsMonoidPreserving f -> IsMonoidPreserving g ->
     IsMonoidPreserving (g ∘ f).
   Proof.
     intros;split.
@@ -264,7 +266,7 @@ Section compose_mor.
       apply ap,preserves_mon_unit.
   Defined.
 
-  Global Instance invert_sg_morphism
+  Instance invert_sg_morphism
     : forall `{!IsEquiv f}, IsSemiGroupPreserving f ->
       IsSemiGroupPreserving (f^-1).
   Proof.
@@ -279,7 +281,7 @@ Section compose_mor.
     - symmetry; apply eisretr.
   Defined.
 
-  Global Instance invert_monoid_morphism :
+  Instance invert_monoid_morphism :
     forall `{!IsEquiv f}, IsMonoidPreserving f -> IsMonoidPreserving (f^-1).
   Proof.
     intros;split.

--- a/theories/Homotopy/HomotopyGroup.v
+++ b/theories/Homotopy/HomotopyGroup.v
@@ -110,7 +110,7 @@ Proof.
   destruct n.
   + exact (ptr_functor 0).
   + intro f.
-    simple notypeclasses refine (Build_GroupHomomorphism _).
+    serapply Build_GroupHomomorphism.
     { apply Trunc_functor.
       apply iterated_loops_functor.
       assumption. }


### PR DESCRIPTION
Also undid the related changes elsewhere that are no longer needed.

This partially reverts #1185.

In my tests, I had to change both the "invert" results and the "compose" results in order to stop typeclass resolution from spinning, which makes sense if you think about it.

Currently, those results are still left as (non-Global) Instances.  Is that the right thing to do?

