### PR TITLE
Some more cubical stuff

### DIFF
--- a/theories/Cubical/DPathCube.v
+++ b/theories/Cubical/DPathCube.v
@@ -198,3 +198,83 @@ Section DPathCubeConst.
   Defined.
 
 End DPathCubeConst.
+
+(** Dependent Kan fillers *)
+
+Section Kan.
+Context {A} {x000 x010 x100 x110 x001 x011 x101 x111 : A}
+  {p0i0 : x000 = x010} {p1i0 : x100 = x110} {pi00 : x000 = x100}
+  {pi10 : x010 = x110} {p0i1 : x001 = x011} {p1i1 : x101 = x111}
+  {pi01 : x001 = x101} {pi11 : x011 = x111} {p00i : x000 = x001}
+  {p01i : x010 = x011} {p10i : x100 = x101} {p11i : x110 = x111}
+  {s1ii : PathSquare p1i0 p1i1 p10i p11i} {s0ii : PathSquare p0i0 p0i1 p00i p01i}
+  {sii0 : PathSquare p0i0 p1i0 pi00 pi10} {sii1 : PathSquare p0i1 p1i1 pi01 pi11}
+  {si0i : PathSquare p00i p10i pi00 pi01} {si1i : PathSquare p01i p11i pi10 pi11}
+  (c : PathCube s0ii s1ii sii0 sii1 si0i si1i)
+  {P : A -> Type} {y000 y010 y100 y110 y001 y011 y101 y111}
+  {q0i0 : DPath P p0i0 y000 y010} {q1i0 : DPath P p1i0 y100 y110} {qi00 : DPath P pi00 y000 y100}
+  {qi10 : DPath P pi10 y010 y110} {q0i1 : DPath P p0i1 y001 y011} {q1i1 : DPath P p1i1 y101 y111}
+  {qi01 : DPath P pi01 y001 y101} {qi11 : DPath P pi11 y011 y111} {q00i : DPath P p00i y000 y001}
+  {q01i : DPath P p01i y010 y011} {q10i : DPath P p10i y100 y101} {q11i : DPath P p11i y110 y111}.
+
+Definition dc_fill_left
+  (t1ii : DPathSquare P s1ii q1i0 q1i1 q10i q11i)
+  (tii0 : DPathSquare P sii0 q0i0 q1i0 qi00 qi10) (tii1 : DPathSquare P sii1 q0i1 q1i1 qi01 qi11)
+  (ti0i : DPathSquare P si0i q00i q10i qi00 qi01) (ti1i : DPathSquare P si1i q01i q11i qi10 qi11)
+  : {t0ii : DPathSquare P s0ii q0i0 q0i1 q00i q01i & DPathCube P c t0ii t1ii tii0 tii1 ti0i ti1i}.
+Proof.
+  destruct c.
+  apply cu_fill_left.
+Defined.
+
+Definition dc_fill_right
+  (t0ii : DPathSquare P s0ii q0i0 q0i1 q00i q01i)
+  (tii0 : DPathSquare P sii0 q0i0 q1i0 qi00 qi10) (tii1 : DPathSquare P sii1 q0i1 q1i1 qi01 qi11)
+  (ti0i : DPathSquare P si0i q00i q10i qi00 qi01) (ti1i : DPathSquare P si1i q01i q11i qi10 qi11)
+  : {t1ii : DPathSquare P s1ii q1i0 q1i1 q10i q11i & DPathCube P c t0ii t1ii tii0 tii1 ti0i ti1i}.
+Proof.
+  destruct c.
+  apply cu_fill_right.
+Defined.
+
+Definition dc_fill_top
+  (t0ii : DPathSquare P s0ii q0i0 q0i1 q00i q01i) (t1ii : DPathSquare P s1ii q1i0 q1i1 q10i q11i)
+                                                  (tii1 : DPathSquare P sii1 q0i1 q1i1 qi01 qi11)
+  (ti0i : DPathSquare P si0i q00i q10i qi00 qi01) (ti1i : DPathSquare P si1i q01i q11i qi10 qi11)
+  : {tii0 : DPathSquare P sii0 q0i0 q1i0 qi00 qi10 & DPathCube P c t0ii t1ii tii0 tii1 ti0i ti1i}.
+Proof.
+  destruct c.
+  apply cu_fill_top.
+Defined.
+
+Definition dc_fill_bottom
+  (t0ii : DPathSquare P s0ii q0i0 q0i1 q00i q01i) (t1ii : DPathSquare P s1ii q1i0 q1i1 q10i q11i)
+  (tii0 : DPathSquare P sii0 q0i0 q1i0 qi00 qi10)
+  (ti0i : DPathSquare P si0i q00i q10i qi00 qi01) (ti1i : DPathSquare P si1i q01i q11i qi10 qi11)
+  : {tii1 : DPathSquare P sii1 q0i1 q1i1 qi01 qi11 & DPathCube P c t0ii t1ii tii0 tii1 ti0i ti1i}.
+Proof.
+  destruct c.
+  apply cu_fill_bottom.
+Defined.
+
+Definition dc_fill_front
+  (t0ii : DPathSquare P s0ii q0i0 q0i1 q00i q01i) (t1ii : DPathSquare P s1ii q1i0 q1i1 q10i q11i)
+  (tii0 : DPathSquare P sii0 q0i0 q1i0 qi00 qi10) (tii1 : DPathSquare P sii1 q0i1 q1i1 qi01 qi11)
+                                                  (ti1i : DPathSquare P si1i q01i q11i qi10 qi11)
+  : {ti0i : DPathSquare P si0i q00i q10i qi00 qi01 & DPathCube P c t0ii t1ii tii0 tii1 ti0i ti1i}.
+Proof.
+  destruct c.
+  apply cu_fill_front.
+Defined.
+
+Definition dc_fill_back
+  (t0ii : DPathSquare P s0ii q0i0 q0i1 q00i q01i) (t1ii : DPathSquare P s1ii q1i0 q1i1 q10i q11i)
+  (tii0 : DPathSquare P sii0 q0i0 q1i0 qi00 qi10) (tii1 : DPathSquare P sii1 q0i1 q1i1 qi01 qi11)
+  (ti0i : DPathSquare P si0i q00i q10i qi00 qi01)
+  : {ti1i : DPathSquare P si1i q01i q11i qi10 qi11 & DPathCube P c t0ii t1ii tii0 tii1 ti0i ti1i}.
+Proof.
+  destruct c.
+  apply cu_fill_back.
+Defined.
+
+End Kan.

--- a/theories/Cubical/DPathSquare.v
+++ b/theories/Cubical/DPathSquare.v
@@ -48,6 +48,23 @@ Section DPathSquareConstructors.
 
 End DPathSquareConstructors.
 
+(* DPathSquares can be given by 2-dimensional DPaths *)
+Definition equiv_ds_dpath {A} (P : A -> Type) {a00 a10 a01 a11 : A}
+  {px0 : a00 = a10} {px1 : a01 = a11}
+  {p0x : a00 = a01} {p1x : a10 = a11}
+  (s : px0 @ p1x = p0x @ px1) {b00 b10 b01 b11}
+  {qx0 : DPath P px0 b00 b10} {qx1 : DPath P px1 b01 b11}
+  {q0x : DPath P p0x b00 b01} {q1x : DPath P p1x b10 b11}
+  : DPath (fun p => DPath P p b00 b11) s (qx0 @D q1x) (q0x @D qx1)
+    <~> DPathSquare P (sq_path s) qx0 qx1 q0x q1x.
+Proof.
+  set (s' := sq_path s).
+  rewrite <- (eissect sq_path s : sq_path^-1 s' = s).
+  clearbody s'; clear s.
+  destruct s'; cbn.
+  apply equiv_sq_path.
+Defined.
+
 (* We have an apD for DPathSquares *)
 Definition ds_apD {A} {B : A -> Type} (f : forall a, B a) {a00 a10 a01 a11 : A}
   {px0 : a00 = a10} {px1 : a01 = a11} {p0x p1x} (s : PathSquare px0 px1 p0x p1x)
@@ -134,3 +151,53 @@ Proof.
   cbn in *.
   exact _.
 Defined.
+
+(** A DPath in a path-type is naturally a DPathSquare.  *)
+
+Definition equiv_sq_dp_D {A : Type} {B : A -> Type} (f g : forall a : A, B a)
+  {x1 x2 : A} (p : x1 = x2) (q1 : f x1 = g x1) (q2 : f x2 = g x2)
+  : DPathSquare B (sq_refl_h p) (dp_apD f p) (dp_apD g p) q1 q2
+    <~> DPath (fun x : A => f x = g x) p q1 q2.
+Proof.
+  destruct p. cbn.
+  exact (equiv_sq_1G^-1%equiv).
+Defined.
+
+(** Dependent Kan operations *)
+
+Section Kan.
+
+  Context {A : Type} {P : A -> Type} {a00 a10 a01 a11 : A}
+          {px0 : a00 = a10} {px1 : a01 = a11} {p0x p1x}
+          (s : PathSquare px0 px1 p0x p1x)
+          {b00 : P a00} {b10 : P a10} {b01 : P a01} {b11 : P a11}.
+
+  Definition ds_fill_l (qx1 : DPath P px1 b01 b11)
+             (q0x : DPath P p0x b00 b01) (q1x : DPath P p1x b10 b11)
+    : {qx0 : DPath P px0 b00 b10 & DPathSquare P s qx0 qx1 q0x q1x}.
+  Proof.
+    destruct s; apply sq_fill_l.
+  Defined.
+
+  Definition ds_fill_r (qx0 : DPath P px0 b00 b10)
+             (q0x : DPath P p0x b00 b01) (q1x : DPath P p1x b10 b11)
+    : {qx1 : DPath P px1 b01 b11 & DPathSquare P s qx0 qx1 q0x q1x}.
+  Proof.
+    destruct s; apply sq_fill_r.
+  Defined.
+
+  Definition ds_fill_t (qx0 : DPath P px0 b00 b10)
+             (qx1 : DPath P px1 b01 b11) (q1x : DPath P p1x b10 b11)
+    : {q0x : DPath P p0x b00 b01 & DPathSquare P s qx0 qx1 q0x q1x}.
+  Proof.
+    destruct s; apply sq_fill_t.
+  Defined.
+
+  Definition ds_fill_b (qx0 : DPath P px0 b00 b10)
+             (qx1 : DPath P px1 b01 b11) (q0x : DPath P p0x b00 b01)
+    : {q1x : DPath P p1x b10 b11 & DPathSquare P s qx0 qx1 q0x q1x}.
+  Proof.
+    destruct s; apply sq_fill_b.
+  Defined.
+
+End Kan.

--- a/theories/Cubical/PathCube.v
+++ b/theories/Cubical/PathCube.v
@@ -517,13 +517,12 @@ Arguments cu_flip_lr {_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _}.
 
 (* PathCube Kan fillers ~ Every open crate has a lid *)
 
-
 Definition cu_fill_left {A} {x000 x010 x100 x110 x001 x011 x101 x111 : A}
   {p0i0 : x000 = x010} {p1i0 : x100 = x110} {pi00 : x000 = x100}
   {pi10 : x010 = x110} {p0i1 : x001 = x011} {p1i1 : x101 = x111}
   {pi01 : x001 = x101} {pi11 : x011 = x111} {p00i : x000 = x001}
   {p01i : x010 = x011} {p10i : x100 = x101} {p11i : x110 = x111}
-                                      (s1ii : PathSquare p1i0 p1i1 p10i p11i)
+                                          (s1ii : PathSquare p1i0 p1i1 p10i p11i)
   (sii0 : PathSquare p0i0 p1i0 pi00 pi10) (sii1 : PathSquare p0i1 p1i1 pi01 pi11)
   (si0i : PathSquare p00i p10i pi00 pi01) (si1i : PathSquare p01i p11i pi10 pi11)
   : {s0ii : PathSquare p0i0 p0i1 p00i p01i & PathCube s0ii s1ii sii0 sii1 si0i si1i}.
@@ -565,7 +564,7 @@ Definition cu_fill_top {A} {x000 x010 x100 x110 x001 x011 x101 x111 : A}
   {pi01 : x001 = x101} {pi11 : x011 = x111} {p00i : x000 = x001}
   {p01i : x010 = x011} {p10i : x100 = x101} {p11i : x110 = x111}
   (s0ii : PathSquare p0i0 p0i1 p00i p01i) (s1ii : PathSquare p1i0 p1i1 p10i p11i)
-                                      (sii1 : PathSquare p0i1 p1i1 pi01 pi11)
+                                          (sii1 : PathSquare p0i1 p1i1 pi01 pi11)
   (si0i : PathSquare p00i p10i pi00 pi01) (si1i : PathSquare p01i p11i pi10 pi11)
   : {sii0 : PathSquare p0i0 p1i0 pi00 pi10 & PathCube s0ii s1ii sii0 sii1 si0i si1i}.
 Proof.
@@ -600,7 +599,7 @@ Definition cu_fill_front {A} {x000 x010 x100 x110 x001 x011 x101 x111 : A}
   {p01i : x010 = x011} {p10i : x100 = x101} {p11i : x110 = x111}
   (s0ii : PathSquare p0i0 p0i1 p00i p01i) (s1ii : PathSquare p1i0 p1i1 p10i p11i)
   (sii0 : PathSquare p0i0 p1i0 pi00 pi10) (sii1 : PathSquare p0i1 p1i1 pi01 pi11)
-                                      (si1i : PathSquare p01i p11i pi10 pi11)
+                                          (si1i : PathSquare p01i p11i pi10 pi11)
   : {si0i : PathSquare p00i p10i pi00 pi01 & PathCube s0ii s1ii sii0 sii1 si0i si1i}.
 Proof.
   refine (_;_).


### PR DESCRIPTION
In addition to some fairly simple stuff and cosmetic changes, this:

- Defines the dependent Kan operations for `DPathSquare` and `DPathCube`
- Changes the proof of `sq_path` to one that was easier for me to reason about, enabling me to prove a dependent version `equiv_ds_dpath`
- Reverses the direction of `dp_compose` to match other lemmas like `ap_compose` in which the composition is in the domain.
