### PR TITLE
More wild category stuff

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -52,6 +52,7 @@ theories/WildCat/EmptyCat.v
 theories/WildCat/Prod.v
 theories/WildCat/Equiv.v
 theories/WildCat/Sum.v
+theories/WildCat/Forall.v
 theories/WildCat/Opposite.v
 theories/WildCat/Type.v
 theories/WildCat/Induced.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -57,6 +57,8 @@ theories/WildCat/Type.v
 theories/WildCat/Induced.v
 theories/WildCat/FunctorCat.v
 theories/WildCat/Yoneda.v
+theories/WildCat/TwoOneCat.v
+theories/WildCat/NatTrans.v
 
 #
 #   Types

--- a/theories/Algebra/Group.v
+++ b/theories/Algebra/Group.v
@@ -363,6 +363,62 @@ Proof.
   1,2: apply grp_homo_op.
 Defined.
 
+(** Group forms a 01Cat *)
+Global Instance is01cat_Group : Is01Cat Group :=
+  (Build_Is01Cat Group GroupHomomorphism (@grp_homo_id) (@grp_homo_compose)).
+
+Global Instance is01cat_GroupHomomorphism {A B : Group} : Is01Cat (A $-> B) :=
+  induced_01cat (@grp_homo_map A B).
+
+Global Instance is0gpd_GroupHomomorphism {A B : Group}: Is0Gpd (A $-> B) := 
+  induced_0gpd (@grp_homo_map A B).
+
+Global Instance is0functor_postcomp_GroupHomomorphism
+       {A B C : Group} (h : B $-> C)
+  : Is0Functor (@cat_postcomp Group _ A B C h).
+Proof.
+  apply Build_Is0Functor.
+  intros [f ?] [g ?] p a ; exact (ap h (p a)).
+Defined.
+
+Global Instance is0functor_precomp_GroupHomomorphism
+       {A B C : Group} (h : A $-> B)
+  : Is0Functor (@cat_precomp Group _ A B C h).
+Proof.
+  apply Build_Is0Functor.
+  intros [f ?] [g ?] p a ; exact (p (h a)).
+Defined.
+
+(** Group forms a 1Cat *)
+Global Instance is1cat_group : Is1Cat Group.
+Proof.
+  srapply Build_Is1Cat; cbn; intros; reflexivity.
+Defined.
+
+Instance hasmorext_group `{Funext} : HasMorExt Group.
+Proof.
+  srapply Build_HasMorExt.
+  intros A B f g; cbn in *.
+  simple notypeclasses refine (isequiv_homotopic ((equiv_path_grouphomomorphism)^-1) _). 
+  1,3: exact _.
+(*   1: exact _. *)
+  1: apply equiv_isequiv.
+  intros []. reflexivity. 
+Defined.
+
+Global Instance hasequivs_group : HasEquivs Group.
+Proof.
+  srefine (Build_HasEquivs Group _ _ GroupIsomorphism (fun G H f => IsEquiv f) _ _ _ _ _ _ _ _); intros A B f.
+  - exact f.
+  - cbn. exact _.
+  - apply Build_GroupIsomorphism.
+  - intro fe. reflexivity.
+  - intro fe. exact (grp_iso_inverse (Build_GroupIsomorphism _ _ f fe)).
+  - cbn. intros ? x; apply eissect.
+  - cbn. intros ? x; apply eisretr.
+  - intros g r s; refine (isequiv_adjointify f g r s).
+Defined.
+
 
 (** TODO: If #1140 gets resolved, include this: *)
 (* Module GroupUtf8.

--- a/theories/Algebra/Group.v
+++ b/theories/Algebra/Group.v
@@ -3,6 +3,7 @@ Require Import PathAny.
 Require Export Classes.interfaces.abstract_algebra.
 Require Export Classes.theory.groups.
 Require Import Pointed.Core.
+Require Import WildCat.
 Require Basics.Utf8.
 
 Generalizable Variables G H A B C f g.

--- a/theories/Pointed/pType.v
+++ b/theories/Pointed/pType.v
@@ -28,12 +28,13 @@ Defined.
 
 Global Instance is1cat_ptype : Is1Cat pType.
 Proof.
-  simple refine (Build_Is1Cat _ _ _ _ _ _ _ _); try exact _.
-  - intros A B C; rapply Build_Is0Functor.
-    intros [f1 f2] [g1 g2] [p q]; cbn.
-    transitivity (f1 o* g2).
-    + apply pmap_postwhisker; assumption.
-    + apply pmap_prewhisker; assumption.
+  econstructor.
+  - intros A B C h; rapply Build_Is0Functor.
+    intros f g p; cbn.
+    apply pmap_postwhisker; assumption.
+  - intros A B C h; rapply Build_Is0Functor.
+    intros f g p; cbn.
+    apply pmap_prewhisker; assumption.
   - intros ? ? ? ? f g h; exact (pmap_compose_assoc h g f).
   - intros ? ? f; exact (pmap_postcompose_idmap f).
   - intros ? ? f; exact (pmap_precompose_idmap f).

--- a/theories/WildCat.v
+++ b/theories/WildCat.v
@@ -1,11 +1,17 @@
+(* Basic theory *)
 Require Export WildCat.Core.
 Require Export WildCat.Equiv.
-Require Export WildCat.UnitCat.
-Require Export WildCat.EmptyCat.
+Require Export WildCat.Square.
 Require Export WildCat.Opposite.
-Require Export WildCat.Type.
 Require Export WildCat.Induced.
 Require Export WildCat.FunctorCat.
+Require Export WildCat.NatTrans.
 Require Export WildCat.Yoneda.
+(* Examples *)
+Require Export WildCat.Type.
+Require Export WildCat.UnitCat.
+Require Export WildCat.EmptyCat.
 Require Export WildCat.Prod.
 Require Export WildCat.Sum.
+(* Higher categories *)
+Require Export WildCat.TwoOneCat.

--- a/theories/WildCat.v
+++ b/theories/WildCat.v
@@ -1,7 +1,6 @@
 (* Basic theory *)
 Require Export WildCat.Core.
 Require Export WildCat.Equiv.
-Require Export WildCat.Square.
 Require Export WildCat.Opposite.
 Require Export WildCat.Induced.
 Require Export WildCat.FunctorCat.
@@ -13,5 +12,6 @@ Require Export WildCat.UnitCat.
 Require Export WildCat.EmptyCat.
 Require Export WildCat.Prod.
 Require Export WildCat.Sum.
+Require Export WildCat.Forall.
 (* Higher categories *)
 Require Export WildCat.TwoOneCat.

--- a/theories/WildCat/EmptyCat.v
+++ b/theories/WildCat/EmptyCat.v
@@ -15,5 +15,5 @@ Defined.
 
 Global Instance is1cat_empty : Is1Cat Empty.
 Proof.
-  simple notypeclasses refine (Build_Is1Cat _ _ _ _ _ _ _ _); intros [].
+  simple notypeclasses refine (Build_Is1Cat _ _ _ _ _ _ _ _ _); intros [].
 Defined.

--- a/theories/WildCat/Equiv.v
+++ b/theories/WildCat/Equiv.v
@@ -234,7 +234,6 @@ Defined.
 Global Instance is01cat_core_hom {A : Type} `{HasEquivs A} (a b : core A)
   : Is01Cat (a $-> b).
 Proof.
-  cbv in a, b.
   srapply Build_Is01Cat.
   - intros f g ; exact (cate_fun f $== cate_fun g).
   - intro f ; apply Id.
@@ -244,22 +243,31 @@ Defined.
 Global Instance is0gpd_core_hom {A : Type} `{HasEquivs A} (a b : core A)
   : Is0Gpd (a $-> b).
 Proof.
-  cbv in a, b.
   apply Build_Is0Gpd.
   intros f g ; cbv.
   apply gpd_rev.
 Defined.
 
-Global Instance is0functor_cat_comp {A : Type} `{HasEquivs A}
-       (a b c : core A) :
-  Is0Functor (uncurry (@cat_comp (core A) _ a b c)).
+Global Instance is0functor_core_postcomp {A : Type} `{HasEquivs A}
+       (a b c : core A) (h : b $-> c) :
+  Is0Functor (cat_postcomp a h).
 Proof.
-  cbv in a, b, c.
   apply Build_Is0Functor.
-  - intros [f g] [f' g'] [al be].
-    exact (compose_cate_fun f g
-           $@ (al $o@ be)
-           $@ (compose_cate_fun f' g')^$).
+  intros f g al; cbn in h.
+  exact (compose_cate_fun h f
+           $@ (h $@L al)
+           $@ (compose_cate_fun h g)^$).
+Defined.
+
+Global Instance is0functor_core_precomp {A : Type} `{HasEquivs A}
+       (a b c : core A) (h : a $-> b) :
+  Is0Functor (cat_precomp c h).
+Proof.
+  apply Build_Is0Functor.
+  intros f g al; cbn in h.
+  exact (compose_cate_fun f h
+           $@ (al $@R h)
+           $@ (compose_cate_fun g h)^$).
 Defined.
 
 Global Instance is1cat_core {A : Type} `{HasEquivs A}

--- a/theories/WildCat/Forall.v
+++ b/theories/WildCat/Forall.v
@@ -1,0 +1,42 @@
+(* -*- mode: coq; mode: visual-line -*-  *)
+
+Require Import Basics.Overture.
+Require Import Basics.PathGroupoids.
+Require Import Basics.Notations.
+Require Import Basics.Contractible.
+Require Import Basics.Equivalences.
+Require Import WildCat.Core.
+
+(** ** Indexed product of categories *)
+
+Global Instance is01cat_forall (A : Type) (B : A -> Type)
+  {c : forall a, Is01Cat (B a)}
+  : Is01Cat (forall a, B a).
+Proof.
+  serapply Build_Is01Cat.
+  + intros x y; exact (forall (a : A), x a $-> y a).
+  + intros x a; exact (Id (x a)).
+  + intros x y z f g a; exact (f a $o g a).
+Defined.
+
+Global Instance is1cat_forall (A : Type) (B : A -> Type)
+  {c1 : forall a, Is01Cat (B a)} {c2 : forall a, Is1Cat (B a)}
+  : Is1Cat (forall a, B a).
+Proof.
+  serapply Build_Is1Cat.
+  + intros x y; serapply Build_Is01Cat.
+    - intros f g; exact (forall a, f a $== g a).
+    - intros f a; apply Id.
+    - intros f g h q p a; exact (p a $@ q a).
+  + intros x y; serapply Build_Is0Gpd.
+    intros f g p a; exact (gpd_rev (p a)).
+  + intros x y z h; serapply Build_Is0Functor.
+    intros f g p a.
+    exact (h a $@L p a).
+  + intros x y z h; serapply Build_Is0Functor.
+    intros f g p a.
+    exact (p a $@R h a).
+  + intros w x y z f g h a; apply cat_assoc.
+  + intros x y f a; apply cat_idl.
+  + intros x y f a; apply cat_idr.
+Defined.

--- a/theories/WildCat/FunctorCat.v
+++ b/theories/WildCat/FunctorCat.v
@@ -49,10 +49,14 @@ Proof.
   - intros [F ?] [G ?]; serapply Build_Is0Gpd.
     intros [alpha ?] [gamma ?] mu a.
     exact ((mu a)^$).
-  - intros [F ?] [G ?] [K ?].
+  - intros [F ?] [G ?] [K ?] [alpha ?].
     serapply Build_Is0Functor.
-    intros [[alpha ?] [gamma ?]] [[phi ?] [mu ?]] [f g] a.
-    exact (f a $o@ g a).
+    intros [phi ?] [mu ?] f a.
+    exact (alpha a $@L f a).
+  - intros [F ?] [G ?] [K ?] [alpha ?].
+    serapply Build_Is0Functor.
+    intros [phi ?] [mu ?] f a.
+    exact (f a $@R alpha a).
   - intros [F ?] [G ?] [K ?] [L ?] [alpha ?] [gamma ?] [phi ?] a; cbn.
     serapply cat_assoc.
   - intros [F ?] [G ?] [alpha ?] a; cbn.

--- a/theories/WildCat/FunctorCat.v
+++ b/theories/WildCat/FunctorCat.v
@@ -4,6 +4,7 @@ Require Import Basics.
 Require Import WildCat.Core.
 Require Import WildCat.Equiv.
 Require Import WildCat.Induced.
+Require Import WildCat.NatTrans.
 
 (** * Wild functor categories *)
 

--- a/theories/WildCat/Induced.v
+++ b/theories/WildCat/Induced.v
@@ -36,8 +36,9 @@ Section Induced_category.
     serapply Build_Is1Cat.
     + intros a b. cbn in *. exact _.
     + intros a b. cbn in *. exact _.
-    + intros a b c. cbn in *. 
-      unfold uncurry. exact _.
+    + intros a b c. cbn in *. exact _.
+    + intros a b c h.
+      exact (is0functor_precomp (f a) (f b) (f c) h).
     + intros a b c d; cbn in *. 
       intros u v w. apply cat_assoc.
     + intros a b; cbn in *.

--- a/theories/WildCat/Induced.v
+++ b/theories/WildCat/Induced.v
@@ -24,6 +24,12 @@ Section Induced_category.
       exact ( g1 $o g2).
   Defined.
 
+  Local Instance induced_0gpd `{Is0Gpd B} : Is0Gpd A.
+  Proof.
+    rapply Build_Is0Gpd.
+    intros a b g; cbn in *; exact (g^$).
+  Defined.
+
   (** The structure map along which we induce the category structure becomes a functor with respect to the induced structure *) 
   Local Instance inducingmap_is0functor `{Is01Cat B} : Is0Functor f.
   Proof.
@@ -55,6 +61,11 @@ Section Induced_category.
     + intros a b c g h. cbn in *. exact (Id _). 
   Defined.
 
+  Instance induced_hasmorext `{HasMorExt B} : HasMorExt A.
+  Proof.
+    constructor. intros. apply H1.
+  Defined.
+
   Definition induced_hasequivs `{HasEquivs B} : HasEquivs A.
   Proof.
     serapply Build_HasEquivs.
@@ -69,12 +80,12 @@ Section Induced_category.
       exact ( cate_buildequiv' _ _ h).
     + intros a b h fe; cbn in *. 
       exact ( cate_buildequiv_fun' (f a) (f b) h fe) .
-    + intros a b h fe; cbn in *.
-      exact(cate_inv'  _ _ h fe ).
-    + intros a b h fe; cbn in *.
-      exact (cate_issect' _ _ h fe ).
-    + intros a b h fe; cbn in *.
-      exact (cate_isretr' _ _ _ _ ).
+    + intros a b h; cbn in *.
+      exact(cate_inv'  _ _ h ).
+    + intros a b h; cbn in *.
+      exact (cate_issect' _ _ h ).
+    + intros a b h; cbn in *.
+      exact (cate_isretr' _ _ _ ).
     + intros a b h g m n; cbn in *.  
       exact ( catie_adjointify' _ _ h g m n  ).
   Defined.

--- a/theories/WildCat/NatTrans.v
+++ b/theories/WildCat/NatTrans.v
@@ -1,0 +1,68 @@
+Require Import Basics.
+Require Import WildCat.Core.
+Require Import WildCat.Square.
+
+(** ** Natural transformations *)
+
+Definition Transformation {A B : Type} `{IsGraph B} (F : A -> B) (G : A -> B)
+  := forall (a : A), F a $-> G a.
+
+Notation "F $=> G" := (Transformation F G).
+
+(** A 1-natural transformation is natural up to a 2-cell, so its domain must be a 1-category. *)
+Class Is1Natural {A B : Type} `{IsGraph A} `{Is1Cat B}
+      (F : A -> B) `{!Is0Functor F} (G : A -> B) `{!Is0Functor G}
+      (alpha : F $=> G) :=
+{
+  isnat : forall a a' (f : a $-> a'),
+    Square (fmap F f) (fmap G f) (alpha a) (alpha a');
+}.
+
+Arguments isnat {_ _ _ _ _ _ _ _ _} alpha {alnat _ _} f : rename.
+
+(** The transposed natural square *)
+Definition isnat_tr {A B : Type} `{IsGraph A} `{Is1Cat B}
+      {F : A -> B} `{!Is0Functor F} {G : A -> B} `{!Is0Functor G}
+      (alpha : F $=> G) `{!Is1Natural F G alpha}
+      {a a' : A} (f : a $-> a')
+  : Square (alpha a) (alpha a') (fmap F f) (fmap G f)
+  := (isnat alpha f)^$.
+
+Definition id_transformation {A B : Type} `{Is01Cat B} (F : A -> B)
+  : F $=> F
+  := fun a => Id (F a).
+
+Global Instance is1natural_id {A B : Type} `{IsGraph A} `{Is1Cat B}
+       (F : A -> B) `{!Is0Functor F}
+  : Is1Natural F F (id_transformation F).
+Proof.
+  apply Build_Is1Natural; intros a b f; cbn. exact vrfl.
+Defined.
+
+Definition comp_transformation {A B : Type} `{Is01Cat B}
+           {F G K : A -> B} (gamma : G $=> K) (alpha : F $=> G)
+  : F $=> K
+  := fun a => gamma a $o alpha a.
+
+Global Instance is1natural_comp {A B : Type} `{IsGraph A} `{Is1Cat B}
+       {F G K : A -> B} `{!Is0Functor F} `{!Is0Functor G} `{!Is0Functor K}
+       (gamma : G $=> K) `{!Is1Natural G K gamma}
+       (alpha : F $=> G) `{!Is1Natural F G alpha}
+  : Is1Natural F K (comp_transformation gamma alpha).
+Proof.
+  apply Build_Is1Natural; intros a b f; cbn.
+  exact (isnat alpha f $@v isnat gamma f).
+Defined.
+
+(** Modifying a transformation to something pointwise equal preserves naturality. *)
+Definition is1natural_homotopic {A B : Type} `{Is01Cat A} `{Is1Cat B}
+      {F : A -> B} `{!Is0Functor F} {G : A -> B} `{!Is0Functor G}
+      {alpha : F $=> G} (gamma : F $=> G) `{!Is1Natural F G gamma}
+      (p : forall a, alpha a $== gamma a)
+  : Is1Natural F G alpha.
+Proof.
+  constructor; intros a b f.
+  refine (_ $@hL _ $@hR p b).
+  1: exact (p a). 
+  exact (isnat gamma f).
+Defined.

--- a/theories/WildCat/Opposite.v
+++ b/theories/WildCat/Opposite.v
@@ -9,6 +9,7 @@ Require Import Basics.Equivalences.
 
 Require Import WildCat.Core.
 Require Import WildCat.Equiv.
+Require Import WildCat.NatTrans.
 
 (** ** Opposite categories *)
 
@@ -155,7 +156,7 @@ Proof.
   unfold transformation_op.
   cbn.
   intros a b f.
-  apply isnat_opp.
+  apply isnat_tr.
   assumption.
 Defined.
 

--- a/theories/WildCat/Opposite.v
+++ b/theories/WildCat/Opposite.v
@@ -28,11 +28,16 @@ Proof.
     apply is01cat_hom.
   - intros a b.
     apply isgpd_hom.
-  - intros a b c.
+  - intros a b c h.
     srapply Build_Is0Functor.
-    intros [f g] [h k] [p q].
+    intros f g p.
     cbn in *.
-    exact (q $o@ p).
+    exact (p $@R h).
+  - intros a b c h.
+    srapply Build_Is0Functor.
+    intros f g p.
+    cbn in *.
+    exact (h $@L p).
   - intros a b c d f g h; exact (cat_assoc_opp h g f).
   - intros a b f; exact (cat_idr f).
   - intros a b f; exact (cat_idl f).

--- a/theories/WildCat/Prod.v
+++ b/theories/WildCat/Prod.v
@@ -8,7 +8,72 @@ Require Import Basics.Equivalences.
 Require Import WildCat.Core.
 Require Import WildCat.Equiv.
 
-(** * More about product categories *)
+(** * Product categories *)
+
+(** Products preserve (0,1)-categories. *)
+Global Instance isgraph_prod A B `{IsGraph A} `{IsGraph B}
+  : IsGraph (A * B)
+  := Build_IsGraph (A * B) (fun x y => (fst x $-> fst y) * (snd x $-> snd y)).
+
+Global Instance is01cat_prod A B `{Is01Cat A} `{Is01Cat B}
+  : Is01Cat (A * B).
+Proof.
+  refine (Build_Is01Cat (A * B) (fun x y => (fst x $-> fst y) * (snd x $-> snd y)) _ _).
+  - intros [a b]; exact (Id a, Id b).
+  - intros [a1 b1] [a2 b2] [a3 b3] [f1 g1] [f2 g2]; cbn in *.
+    exact (f1 $o f2 , g1 $o g2).
+Defined.
+
+(** To avoid having to define a separate notion of "two-variable functor", we define two-variable functors in uncurried form.  The following definition applies such a two-variable functor, with a currying built in. *)
+Definition fmap11 {A B C : Type} `{IsGraph A} `{IsGraph B} `{IsGraph C}
+  (F : A -> B -> C) {H2 : Is0Functor (uncurry F)}
+  {a1 a2 : A} {b1 b2 : B} (f1 : a1 $-> a2) (f2 : b1 $-> b2)
+  : F a1 b1 $-> F a2 b2
+  := @fmap _ _ _ _ (uncurry F) H2 (a1, b1) (a2, b2) (f1, f2).
+
+
+Global Instance is0gpd_prod A B `{Is0Gpd A} `{Is0Gpd B}
+ : Is0Gpd (A * B).
+Proof. 
+  serapply Build_Is0Gpd.
+  intros [x1 x2] [y1 y2] [f1 f2].
+  cbn in *.
+  exact ( (f1^$, f2^$) ).
+Defined.
+
+Global Instance is1cat_prod A B `{Is1Cat A} `{Is1Cat B}
+  : Is1Cat (A * B).
+Proof.
+  serapply (Build_Is1Cat).
+  - intros [x1 x2] [y1 y2].
+    rapply is01cat_prod.
+  - intros [x1 x2] [y1 y2].
+    apply is0gpd_prod.
+    + cbn.
+      apply isgpd_hom.
+    + cbn.
+      apply isgpd_hom.
+  - intros [x1 x2] [y1 y2] [z1 z2] [h1 h2].
+    serapply Build_Is0Functor.  
+    intros [f1 f2] [g1 g2] [p1 p2]; cbn in *. 
+    exact ( h1 $@L p1 , h2 $@L p2 ).
+  - intros [x1 x2] [y1 y2] [z1 z2] [h1 h2].
+    serapply Build_Is0Functor.  
+    intros [f1 f2] [g1 g2] [p1 p2]; cbn in *. 
+    exact ( p1 $@R h1 , p2 $@R h2 ).
+  - intros [a1 a2] [b1 b2] [c1 c2] [d1 d2] [f1 f2] [g1 g2] [h1 h2].
+    cbn in *. 
+    exact(cat_assoc f1 g1 h1, cat_assoc f2 g2 h2).
+  - intros [a1 a2] [b1 b2] [f1 f2].
+    cbn in *.
+    exact (cat_idl _, cat_idl _).
+  - intros [a1 a2] [b1 b2] [g1 g2].
+    cbn in *.
+    exact (cat_idr _, cat_idr _). 
+Defined. 
+
+
+
 
 (** Product categories inherit equivalences *)
 

--- a/theories/WildCat/Sum.v
+++ b/theories/WildCat/Sum.v
@@ -32,10 +32,14 @@ Proof.
   - intros x y; serapply Build_Is0Gpd.
     destruct x as [a1 | b1], y as [a2 | b2];
     try contradiction; cbn; intros f g; apply gpd_rev.
-  - intros x y z; serapply Build_Is0Functor.
-    intros [f g] [h i] [j k].
+  - intros x y z h; serapply Build_Is0Functor.
+    intros f g p.
     destruct x as [a1 | b1], y as [a2 | b2], z as [a3 | b3];
-    try contradiction; exact (j $o@ k).
+    try contradiction; cbn in *; change (f $== g) in p; exact (h $@L p).
+  - intros x y z h; serapply Build_Is0Functor.
+    intros f g p.
+    destruct x as [a1 | b1], y as [a2 | b2], z as [a3 | b3];
+    try contradiction; cbn in *; change (f $== g) in p; exact (p $@R h).
   - intros [a1 | b1] [a2 | b2] [a3 | b3] [a4 | b4] f g h;
     try contradiction; cbn; apply cat_assoc.
   - intros [a1 | b1] [a2 | b2] f; try contradiction;

--- a/theories/WildCat/TwoOneCat.v
+++ b/theories/WildCat/TwoOneCat.v
@@ -1,0 +1,130 @@
+Require Import Basics.
+Require Import WildCat.Core.
+Require Import WildCat.Square.
+Require Import WildCat.Prod.
+Require Import WildCat.NatTrans.
+
+(** * Wild (2,1)-categories *)
+
+Definition cat_comp_lassoc {A : Type} `{Is1Cat A} (a b c d : A)
+  : (a $-> b) * (b $-> c) * (c $-> d) -> a $-> d.
+Proof.
+  intros [[f g] h].
+  exact ((h $o g) $o f).
+Defined.
+
+Definition cat_comp_rassoc {A : Type} `{Is1Cat A} (a b c d : A)
+  : (a $-> b) * (b $-> c) * (c $-> d) -> a $-> d.
+Proof.
+  intros [[f g] h].
+  exact (h $o (g $o f)).
+Defined.
+
+Global Instance is01cat_cat_assoc_dom {A : Type} `{Is1Cat A}
+       {a b c d : A} : Is01Cat ((a $-> b) * (b $-> c) * (c $-> d)).
+Proof.
+  rapply is01cat_prod.
+Defined.
+
+Global Instance is0functor_cat_comp_lassoc
+       {A : Type} `{Is1Cat A}
+       {a b c d : A} : Is0Functor (cat_comp_lassoc a b c d).
+Proof.
+  apply Build_Is0Functor.
+  intros [[f g] h] [[f' g'] h'] [[al be] ga] ;
+    exact (fmap11 cat_comp (fmap11 cat_comp ga be) al).
+Defined.
+
+Global Instance is0functor_cat_comp_rassoc
+       {A : Type} `{Is1Cat A}
+       {a b c d : A} : Is0Functor (cat_comp_rassoc a b c d).
+Proof.
+  apply Build_Is0Functor.
+  intros [[f g] h] [[f' g'] h'] [[al be] ga] ;
+    exact (fmap11 cat_comp ga (fmap11 cat_comp be al)).
+Defined.
+
+
+Definition cat_comp_idl {A : Type} `{Is1Cat A} (a b : A)
+  : (a $-> b) -> (a $-> b)
+  := fun (f : a $-> b) => Id b $o f.
+
+Global Instance is0functor_cat_comp_idl {A : Type} `{Is1Cat A} (a b : A)
+  : Is0Functor (cat_comp_idl a b).
+Proof.
+  apply Build_Is0Functor.
+  intros f g p; unfold cat_comp_idl; cbn.
+  exact (Id b $@L p).
+Defined.
+
+
+
+Definition cat_comp_idr {A : Type} `{Is1Cat A} (a b : A)
+  : (a $-> b) -> (a $-> b)
+  := fun (f : a $-> b) => f $o Id a.
+
+Global Instance is0functor_cat_comp_idr {A : Type} `{Is1Cat A} (a b : A)
+  : Is0Functor (cat_comp_idr a b).
+Proof.
+  apply Build_Is0Functor.
+  intros f g p; unfold cat_comp_idr; cbn.
+  exact (p $@R Id a).
+Defined.
+
+
+Definition cat_assoc_transformation {A : Type} `{Is1Cat A} {a b c d : A}
+  : (cat_comp_lassoc a b c d) $=> (cat_comp_rassoc a b c d).
+Proof.
+  intros [[f g] h] ; exact (cat_assoc f g h).
+Defined.
+
+Definition cat_idl_transformation {A : Type} `{Is1Cat A} {a b : A}
+  : cat_comp_idl a b $=> idmap.
+Proof.
+  intro f ; exact (cat_idl f).
+Defined.
+
+
+Definition cat_idr_transformation {A : Type} `{Is1Cat A} {a b : A}
+  : cat_comp_idr a b $=> idmap.
+Proof.
+  intro f ; exact (cat_idr f).
+Defined.
+
+Class Is21Cat (A : Type) `{Is1Cat A} :=
+{
+  is1cat_hom : forall (a b : A), Is1Cat (a $-> b) ;
+  is1gpd_hom : forall (a b : A), Is1Gpd (a $-> b) ;
+  is1functor_comp : forall (a b c : A),
+      Is1Functor (uncurry (@cat_comp A _ a b c)) ;
+
+  (** *** Associator *)
+  is1natural_cat_assoc : forall (a b c d : A),
+      Is1Natural (cat_comp_lassoc a b c d) (cat_comp_rassoc a b c d)
+                 cat_assoc_transformation ;
+
+  (** *** Unitors *)
+  is1natural_cat_idl : forall (a b : A),
+      Is1Natural (cat_comp_idl a b) idmap
+                 cat_idl_transformation;
+
+  is1natural_cat_idr : forall (a b : A),
+      Is1Natural (cat_comp_idr a b) idmap
+                 cat_idr_transformation;
+
+  (** *** Coherence *)
+  cat_pentagon : forall (a b c d e : A)
+                        (f : a $-> b) (g : b $-> c) (h : c $-> d) (k : d $-> e),
+      (k $@L cat_assoc f g h) $o (cat_assoc f (h $o g) k) $o (cat_assoc g h k $@R f)
+      $== (cat_assoc (g $o f) h k) $o (cat_assoc f g (k $o h)) ;
+
+  cat_tril : forall (a b c : A) (f : a $-> b) (g : b $-> c),
+      (g $@L cat_idl f) $o (cat_assoc f (Id b) g) $== (cat_idr g $@R f)
+}.
+
+Global Existing Instance is1cat_hom.
+Global Existing Instance is1gpd_hom.
+Global Existing Instance is1functor_comp.
+Global Existing Instance is1natural_cat_assoc.
+Global Existing Instance is1natural_cat_idl.
+Global Existing Instance is1natural_cat_idr.

--- a/theories/WildCat/TwoOneCat.v
+++ b/theories/WildCat/TwoOneCat.v
@@ -1,6 +1,5 @@
 Require Import Basics.
 Require Import WildCat.Core.
-Require Import WildCat.Square.
 Require Import WildCat.Prod.
 Require Import WildCat.NatTrans.
 

--- a/theories/WildCat/Type.v
+++ b/theories/WildCat/Type.v
@@ -18,12 +18,18 @@ Proof.
   intros f g p a ; exact (p a)^.
 Defined.
 
-Global Instance is0functor_comp {A B C : Type}:
-  Is0Functor (uncurry (@cat_comp Type _ A B C)).
+Global Instance is0functor_type_postcomp {A B C : Type} (h : B $-> C):
+  Is0Functor (cat_postcomp A h).
 Proof.
   apply Build_Is0Functor.
-  intros [f g] [f' g'] [p p'] a ;
-    exact (p (g a) @ ap f' (p' a)).
+  intros f g p a; exact (ap h (p a)).
+Defined.
+
+Global Instance is0functor_type_precomp {A B C : Type} (h : A $-> B):
+  Is0Functor (cat_precomp C h).
+Proof.
+  apply Build_Is0Functor.
+  intros f g p a; exact (p (h a)).
 Defined.
 
 Global Instance is1cat_strong_type : Is1Cat_Strong Type.

--- a/theories/WildCat/UnitCat.v
+++ b/theories/WildCat/UnitCat.v
@@ -17,7 +17,7 @@ Defined.
 
 Global Instance is1cat_unit : Is1Cat Unit.
 Proof.
-  simple notypeclasses refine (Build_Is1Cat _ _ _ _ _ _ _ _); try exact _; intros.
-  1:rapply Build_Is0Functor; intros.
-  all:exact tt.
+  econstructor.
+  1,2:econstructor.
+  all:intros; exact tt.
 Defined.

--- a/theories/WildCat/Yoneda.v
+++ b/theories/WildCat/Yoneda.v
@@ -6,6 +6,7 @@ Require Export WildCat.Equiv.
 Require Export WildCat.Type.
 Require Export WildCat.Opposite.
 Require Export WildCat.FunctorCat.
+Require Export WildCat.NatTrans.
 Require Export WildCat.Prod.
 
 (** ** Two-variable hom-functors *)

--- a/theories/WildCat/Yoneda.v
+++ b/theories/WildCat/Yoneda.v
@@ -25,7 +25,7 @@ Proof.
   apply Build_Is1Functor.
   - intros [a1 a2] [b1 b2] [f1 f2] [g1 g2] [p1 p2] q; cbn in *.
     apply path_hom.
-    exact ((p2 $@R q) $o@ p1).
+    exact (((p2 $@R q) $@R _) $@ (_ $@L p1)).
   - intros [a1 a2] f; cbn in *.
     apply path_hom.
     exact (cat_idr _ $@ cat_idl f).


### PR DESCRIPTION
Some more stuff from the wildcat branch that I think we can merge into master:

- Switch to whiskering as a basic operation
- Groups form a category
- Initial and terminal objects
- indexed product of categories (`forall` of categories over types)
- Separate `NatTrans` and `TwoOneCat` into their own files

I did not merge `WildCat/Square` for now, which required changing the natural transformation proofs back to using ordinary 2-cells.
