### PR TITLE
Change equiv_path_from_contr to work with based path types

### DIFF
--- a/contrib/HoTTBook.v
+++ b/contrib/HoTTBook.v
@@ -44,7 +44,7 @@
    1. Compile the latest version of the HoTT Book to update the LaTeX
       labels. Do not forget to pull in changes from HoTT/HoTT.
 
-   2. Run `etc/Book.py` as described by `etc/Book.py` if you run it with `-h`.
+   2. Run `cat ../book/*.aux | etc/Book.py contrib/HoTTBook.v`.
       If it complains, fix things.
 
    3. Add contents to new entries.
@@ -766,9 +766,7 @@ Definition Book_4_9_5 := @HoTT.FunextVarieties.WeakFunext_implies_Funext.
 (* ================================================== thm:identity-systems *)
 (** Theorem 5.8.2 *)
 
-(** This is just the implication (iv) => (iii). *)
-
-Definition Book_5_8_2 := @HoTT.PathAny.equiv_path_from_contr.
+Definition Book_5_8_2_iv_implies_iii := @HoTT.PathAny.equiv_path_from_contr.
 
 (* ================================================== thm:ML-identity-systems *)
 (** Theorem 5.8.4 *)

--- a/contrib/HoTTBook.v
+++ b/contrib/HoTTBook.v
@@ -44,8 +44,8 @@
    1. Compile the latest version of the HoTT Book to update the LaTeX
       labels. Do not forget to pull in changes from HoTT/HoTT.
 
-   2. Run `etc/Book.py` as described by `etc/Book.py` if you run it without
-      arguments. If it complains, fix things.
+   2. Run `etc/Book.py` as described by `etc/Book.py` if you run it with `-h`.
+      If it complains, fix things.
 
    3. Add contents to new entries.
 
@@ -766,7 +766,9 @@ Definition Book_4_9_5 := @HoTT.FunextVarieties.WeakFunext_implies_Funext.
 (* ================================================== thm:identity-systems *)
 (** Theorem 5.8.2 *)
 
+(** This is just the implication (iv) => (iii). *)
 
+Definition Book_5_8_2 := @HoTT.PathAny.equiv_path_from_contr.
 
 (* ================================================== thm:ML-identity-systems *)
 (** Theorem 5.8.4 *)
@@ -1429,18 +1431,15 @@ Definition Book_7_6_2 := @HoTT.Fibrations.equiv_istruncmap_ap.
 
 Definition Book_8_8_1 := @HoTT.Homotopy.WhiteheadsPrinciple.isequiv_issurj_tr0_isequiv_ap.
 
-
 (* ================================================== thm:whitehead1 *)
 (** Corollary 8.8.2 *)
 
 Definition Book_8_8_2 := @HoTT.Homotopy.WhiteheadsPrinciple.isequiv_isbij_tr0_isequiv_loops.
 
-
 (* ================================================== thm:whiteheadn *)
 (** Theorem 8.8.3 *)
 
 Definition Book_8_8_3 := @HoTT.Homotopy.WhiteheadsPrinciple.whiteheads_principle.
-
 
 (* ================================================== thm:whitehead-contr *)
 (** Corollary 8.8.4 *)
@@ -1449,6 +1448,11 @@ Definition Book_8_8_3 := @HoTT.Homotopy.WhiteheadsPrinciple.whiteheads_principle
 
 (* ================================================== thm:pik-conn *)
 (** Corollary 8.8.5 *)
+
+
+
+(* ================================================== lem:encode-decode-loop *)
+(** Lemma 8.9.1 *)
 
 
 

--- a/theories/Extensions.v
+++ b/theories/Extensions.v
@@ -54,15 +54,12 @@ Section Extensions.
                     (fun x => pr2 ext x @ (pr2 ext' x)^))
     <~> ext = ext'.
   Proof.
-    revert ext ext'.
-    refine (equiv_path_from_contr
-              (fun (ext ext' : ExtensionAlong f P d) => (ExtensionAlong
-                                  f (fun y => pr1 ext y = pr1 ext' y)
-                                  (fun x => pr2 ext x @ (pr2 ext' x)^))) _ _).
-    { intros [g gd]; unfold ExtensionAlong; cbn.
+    revert ext'.
+    serapply equiv_path_from_contr.
+    { unfold ExtensionAlong; cbn.
       exists (fun y => 1%path).
       intros x; symmetry; apply concat_pV. }
-    intros [g gd]; unfold ExtensionAlong; cbn.
+    destruct ext as [g gd]; unfold ExtensionAlong; cbn.
     refine (contr_sigma_sigma
               (forall y:B, P y) (fun s => forall x:A, s (f x) = d x)
               (fun a => g == a)

--- a/theories/PathAny.v
+++ b/theories/PathAny.v
@@ -2,8 +2,7 @@ Require Import HoTT.Basics HoTT.Types Fibrations FunextVarieties.
 
 (** A nice method for proving characterizations of path-types of nested sigma-types, due to Rijke. *)
 
-(** To show that the based path-type of [A] is equivalent to some specified family [P], it suffices to show that [P] is reflexive and its total space is contractible. This is part of Theorem 5.8.2,
-namely (iv) implies (iii). *)
+(** To show that the based path-type of [A] is equivalent to some specified family [P], it suffices to show that [P] is reflexive and its total space is contractible. This is part of Theorem 5.8.2, namely (iv) implies (iii). *)
 Definition equiv_path_from_contr {A : Type} (a : A) (P : A -> Type)
            (Prefl : P a)
            (cp : Contr {y:A & P y} )

--- a/theories/PathAny.v
+++ b/theories/PathAny.v
@@ -2,19 +2,20 @@ Require Import HoTT.Basics HoTT.Types Fibrations FunextVarieties.
 
 (** A nice method for proving characterizations of path-types of nested sigma-types, due to Rijke. *)
 
-(** To show that the path-type of [A] is equivalent to some specified family [P], it suffices to show that [P] is reflexive and its "based path-spaces" are contractible. *)
-Definition equiv_path_from_contr {A : Type} (P : A -> A -> Type)
-           (Prefl : forall x, P x x)
-           (cp : forall x, Contr {y:A & P x y} )
-           (a b : A)
-  : P a b <~> a = b.
+(** To show that the based path-type of [A] is equivalent to some specified family [P], it suffices to show that [P] is reflexive and its total space is contractible. This is part of Theorem 5.8.2,
+namely (iv) implies (iii). *)
+Definition equiv_path_from_contr {A : Type} (a : A) (P : A -> Type)
+           (Prefl : P a)
+           (cp : Contr {y:A & P y} )
+           (b : A)
+  : P b <~> a = b.
 Proof.
   apply equiv_inverse.
   srefine (Build_Equiv _ _ _ _).
   { intros []; apply Prefl. }
   revert b; apply isequiv_from_functor_sigma.
   (* For some reason, typeclass search can't find the Contr instances unless we give the types explicitly. *)
-  refine (@isequiv_contr_contr {x:A & a=x} {x:A & P a x} _ _ _).
+  refine (@isequiv_contr_contr {x:A & a=x} {x:A & P x} _ _ _).
 Defined.
 
 (** This is another result for characterizing the path type of [A] when given an equivalence [e : B <~> A], such as an [issig] lemma for [A]. It can help Coq to deduce the type family [P] if [revert] is used to move [a0] and [a1] into the goal, if needed. *)
@@ -36,7 +37,9 @@ Definition equiv_path_issig_contr {A B : Type} {P : A -> A -> Type}
   : forall a0 a1 : A, P a0 a1 <~> a0 = a1.
 Proof.
   apply (equiv_path_along_equiv e).
-  apply equiv_path_from_contr; assumption.
+  intro a0.
+  serapply equiv_path_from_contr.
+  apply Prefl.
 Defined.
 
 (** After [equiv_path_issig_contr], we are left showing the contractibility of a sigma-type whose base and fibers are large nested sigma-types of the same depth.  Moreover, we expect that the types appearing in those two large nested sigma-types "pair up" to form contractible based "path-types".  The following lemma "peels off" the first such pair, whose contractibility can often be found with typeclass search.  The remaining contractibility goal is then simplified by substituting the center of contraction of that first based "path-type", or more precisely a *specific* center that may or may not be the one given by the contractibility instance; the latter freedom sometimes makes things faster and simpler. *)


### PR DESCRIPTION
Update Extensions.v to work with this, which simplifies the proof there.

Also note that this is part of Theorem 5.8.2 in HoTTBook.v

The based version specializes to the previous unbased version, but there are situations where the based version can be used directly and the unbased version can't.