### PR TITLE
Path-groupoids and sigma-types as wild categories

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -53,6 +53,7 @@ theories/WildCat/Prod.v
 theories/WildCat/Equiv.v
 theories/WildCat/Sum.v
 theories/WildCat/Forall.v
+theories/WildCat/Sigma.v
 theories/WildCat/Opposite.v
 theories/WildCat/Paths.v
 theories/WildCat/Type.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -54,6 +54,7 @@ theories/WildCat/Equiv.v
 theories/WildCat/Sum.v
 theories/WildCat/Forall.v
 theories/WildCat/Opposite.v
+theories/WildCat/Paths.v
 theories/WildCat/Type.v
 theories/WildCat/Induced.v
 theories/WildCat/FunctorCat.v

--- a/theories/WildCat.v
+++ b/theories/WildCat.v
@@ -8,6 +8,7 @@ Require Export WildCat.NatTrans.
 Require Export WildCat.Yoneda.
 (* Examples *)
 Require Export WildCat.Type.
+Require Export WildCat.Paths.
 Require Export WildCat.UnitCat.
 Require Export WildCat.EmptyCat.
 Require Export WildCat.Prod.

--- a/theories/WildCat.v
+++ b/theories/WildCat.v
@@ -14,5 +14,6 @@ Require Export WildCat.EmptyCat.
 Require Export WildCat.Prod.
 Require Export WildCat.Sum.
 Require Export WildCat.Forall.
+Require Export WildCat.Sigma.
 (* Higher categories *)
 Require Export WildCat.TwoOneCat.

--- a/theories/WildCat/Paths.v
+++ b/theories/WildCat/Paths.v
@@ -1,0 +1,19 @@
+Require Export Basics.
+Require Export WildCat.Core.
+
+(** * Path groupoids as wild categories *)
+
+(** Not global instances for now *)
+Local Instance is01cat_paths (A : Type) : Is01Cat A.
+Proof.
+  unshelve econstructor.
+  - constructor; intros x y; exact (x = y).
+  - intros a; reflexivity.
+  - intros a b c q p; exact (p @ q).
+Defined.
+
+Local Instance is0gpd_paths (A : Type) : Is0Gpd A.
+Proof.
+  constructor.
+  intros x y p; exact (p^).
+Defined.

--- a/theories/WildCat/Sigma.v
+++ b/theories/WildCat/Sigma.v
@@ -1,0 +1,43 @@
+(* -*- mode: coq; mode: visual-line -*-  *)
+
+Require Import Basics.
+Require Import WildCat.Core.
+
+(** ** Indexed sum of categories *)
+
+Global Instance is01cat_sigma (A : Type) (B : A -> Type)
+  {c : forall a, Is01Cat (B a)}
+  : Is01Cat (sig B).
+Proof.
+  serapply Build_Is01Cat.
+  + intros [x u] [y v].
+    exact {p : x = y & p # u $-> v}.
+  + intros [x u].
+    exists idpath. exact (Id u).
+  + intros [x u] [y v] [z w] [q g] [p f].
+    exists (p @ q).
+    destruct p, q; cbn in *. 
+    exact (g $o f).
+Defined.
+
+Global Instance is0gpd_sigma (A : Type) (B : A -> Type)
+  `{forall a, Is01Cat (B a)} `{forall a, Is0Gpd (B a)}
+  : Is0Gpd (sig B).
+Proof.
+  constructor.
+  intros [x u] [y v] [p f].
+  exists (p^).
+  destruct p; cbn in *.
+  exact (f^$).
+Defined.
+
+Global Instance is0functor_sigma {A : Type} (B C : A -> Type)
+       {bc : forall a, Is01Cat (B a)} {cc : forall a, Is01Cat (C a)}
+       (F : forall a, B a -> C a) {ff : forall a, Is0Functor (F a)}
+  : Is0Functor (fun (x:sig B) => (x.1 ; F x.1 x.2)).
+Proof.
+  constructor; intros [a1 b1] [a2 b2] [p f]; cbn.
+  exists p.
+  destruct p; cbn in *.
+  exact (fmap (F a1) f).
+Defined.


### PR DESCRIPTION
I thought we had path-groupoids already, but I couldn't find them.  Maybe we just talked about it but didn't do it?

I know @mpopie worked on sigma-types during the wild categories week, but I think maybe it never got committed?  (And perhaps was discarded as eventually becoming an instance of displayed categories.)  I needed just the basic facts about them for an upcoming PR, and I think the definitions have changed, so I figured it was easier to reprove them.