### PR TITLE
The universal property of suspension, without funext

### DIFF
--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -101,6 +101,10 @@ Section IsEquivHomotopic.
 
 End IsEquivHomotopic.
 
+Definition isequiv_homotopic' {A B : Type} (f : A <~> B) {g : A -> B} (h : f == g)
+  : IsEquiv g
+  := isequiv_homotopic f h.
+
 (** Transporting is an equivalence. *)
 Section EquivTransport.
 

--- a/theories/Colimits/Pushout.v
+++ b/theories/Colimits/Pushout.v
@@ -151,6 +151,24 @@ Definition pushout_sym {A B C} {f : A -> B} {g : A -> C}
   : Pushout f g <~> Pushout g f :=
 equiv_adjointify pushout_sym_map pushout_sym_map sect_pushout_sym_map sect_pushout_sym_map.
 
+(** ** Functoriality *)
+
+Definition functor_pushout
+           {A B C} (f : A -> B) (g : A -> C)
+           {A' B' C'} (f' : A' -> B') (g' : A' -> C')
+           (h : A -> A') (k : B -> B') (l : C -> C')
+           (p : k o f == f' o h) (q : l o g == g' o h)
+  : Pushout f g -> Pushout f' g'.
+Proof.
+  unfold Pushout; serapply functor_coeq.
+  - exact h.
+  - exact (functor_sum k l).
+  - intros a; cbn.
+    apply ap, p.
+  - intros a; cbn.
+    apply ap, q.
+Defined.
+
 (** ** Equivalences *)
 
 (** Pushouts preserve equivalences. *)
@@ -182,6 +200,32 @@ Section EquivPushout.
   Defined.
 
 End EquivPushout.
+
+(** ** Contractibility *)
+
+(** The pushout of a span of contractible types is contractible *)
+
+Global Instance contr_pushout {A B C : Type} `{Contr A, Contr B, Contr C}
+       (f : A -> B) (g : A -> C)
+  : Contr (Pushout f g).
+Proof.
+  exists (pushl (center B)).
+  serapply Pushout_ind.
+  - intros b; apply ap, path_contr.
+  - intros c.
+    refine (_ @ pglue (center A) @ _).
+    + apply ap, path_contr.
+    + apply ap, path_contr.
+  - intros a.
+    rewrite transport_paths_r.
+    assert (p := path_contr (center A) a).
+    destruct p.
+    refine ((concat_p1 _)^ @ _).
+    apply whiskerL.
+    change 1 with (ap (@pushr A B C f g) (idpath (g (center A)))).
+    apply (ap (ap pushr)).
+    apply path_contr.
+Defined.
 
 (** ** Sigmas *)
 

--- a/theories/Cubical/DPath.v
+++ b/theories/Cubical/DPath.v
@@ -82,6 +82,13 @@ Proof.
   by destruct p.
 Defined.
 
+(* which corresponds to ordinary apD *)
+Definition dp_path_transport_apD {A P} (f : forall a, P a) {a0 a1 : A} (p : a0 = a1)
+  : dp_path_transport (apD f p) = dp_apD f p.
+Proof.
+  by destruct p.
+Defined.
+
 (* A DPath over a constant family is just a path *)
 Definition dp_const {A C} {a0 a1 : A} {p : a0 = a1} {x y}
   : (x = y) -> DPath (fun _ => C) p x y.
@@ -94,6 +101,10 @@ Global Instance isequiv_dp_const {A C} {a0 a1 : A} {p : a0 = a1} {x y}
 Proof.
   destruct p; exact _.
 Defined.
+
+Definition equiv_dp_const {A C} {a0 a1 : A} {p : a0 = a1} {x y}
+  : (x = y) <~> DPath (fun _ => C) p x y
+  := Build_Equiv _ _ dp_const _.
 
 (* dp_apD of a non-dependent map is just a constant DPath *)
 Definition dp_apD_const {A B} (f : A -> B) {a0 a1 : A}

--- a/theories/Cubical/DPathSquare.v
+++ b/theories/Cubical/DPathSquare.v
@@ -1,4 +1,5 @@
 Require Import Basics.
+Require Import Types.
 Require Import Cubical.DPath.
 Require Import Cubical.PathSquare.
 
@@ -124,8 +125,8 @@ Proof.
 Defined.
 
 (* dp_apD fits into a natural square *)
-Definition dp_apD_nat {A} {P : A -> Type} (f g : forall x, P x) {x y : A}
-  (p : x = y) (q : f == g)
+Definition dp_apD_nat {A} {P : A -> Type} {f g : forall x, P x} {x y : A}
+  (q : f == g) (p : x = y)
   : DPathSquare P (sq_refl_h _) (dp_apD f p) (dp_apD g p) (q x) (q y).
 Proof.
   destruct p.
@@ -201,3 +202,22 @@ Section Kan.
   Defined.
 
 End Kan.
+
+(** Another equivalent formulation of a dependent square over reflexivity *)
+Definition equiv_ds_transport_dpath {A} {a0 a1 : A} {p : a0 = a1}
+           {P : A -> Type} {b00 b10 b01 b11}
+           (qx0 : DPath P p b00 b10) (qx1 : DPath P p b01 b11)
+           (q0x : b00 = b01) (q1x : b10 = b11)
+  : DPathSquare P (sq_refl_h p) qx0 qx1 q0x q1x
+    <~> transport (fun y => DPath P p y b11) q0x
+          (transport (fun y => DPath P p b00 y) q1x
+                     qx0) = qx1.
+Proof.
+  destruct p; cbn.
+  refine (_ oE equiv_sq_path^-1).
+  refine (equiv_concat_l _ _ oE _).
+  { apply transport_paths_l. }
+  refine (equiv_moveR_Vp _ _ _ oE _).
+  refine (equiv_concat_l _ _).
+  apply transport_paths_r.
+Defined.

--- a/theories/Extensions.v
+++ b/theories/Extensions.v
@@ -383,6 +383,12 @@ Section Extensions.
   : ooExtendableAlong f C -> ooExtendableAlong f D
     := fun ppp n => extendable_postcompose n C D f g (ppp n).
 
+  Definition ooextendable_postcompose'
+             {A B : Type} (C D : B -> Type) (f : A -> B)
+             (g : forall b, C b <~> D b)
+  : ooExtendableAlong f C -> ooExtendableAlong f D
+    := fun ppp n => extendable_postcompose' n C D f g (ppp n).
+
   Definition ooextendable_compose
              {A B C : Type} (P : C -> Type) (f : A -> B) (g : B -> C)
   : ooExtendableAlong g P -> ooExtendableAlong f (fun b => P (g b)) -> ooExtendableAlong (g o f) P

--- a/theories/Homotopy/Suspension.v
+++ b/theories/Homotopy/Suspension.v
@@ -136,6 +136,22 @@ Proof.
   apply ap, inverse. refine (Susp_ind_beta_merid _ _ _ _ _).
 Defined.
 
+Definition Susp_eta_homot_dp {X : Type} {P : Susp X -> Type} (f : forall y, P y)
+  : f == Susp_ind_dp P (f North) (f South) (fun x => dp_apD f (merid x)).
+Proof.
+  unfold pointwise_paths. refine (Susp_ind_dp _ 1 1 _).
+  intros x.
+  apply dp_paths_FlFr_D.
+  cbn.
+  refine (concat_pp_p _ _ _ @ _).
+  apply moveR_Vp.
+  refine (concat_1p _ @ _ @ (concat_p1 _)^).
+  apply (equiv_inj dp_path_transport).
+  refine (dp_path_transport_apD _ _ @ _). 
+  refine (_ @ (dp_path_transport_apD f (merid x))^).
+  serapply Susp_ind_dp_beta_merid.
+Defined.
+
 Definition Susp_rec_eta_homot {X Y : Type} (f : Susp X -> Y)
 : f == Susp_rec (f North) (f South) (fun x => ap f (merid x)).
 Proof.
@@ -156,13 +172,29 @@ Definition Susp_rec_eta `{Funext} {X Y : Type} (f : Susp X -> Y)
   : f = Susp_rec (f North) (f South) (fun x => ap f (merid x))
 := path_forall _ _ (Susp_rec_eta_homot f).
 
+(** ** Functoriality *)
+
+Definition functor_susp {X Y : Type} (f : X -> Y)
+  : Susp X -> Susp Y.
+Proof.
+  serapply Susp_rec.
+  - exact North.
+  - exact South.
+  - intros x; exact (merid (f x)).
+Defined.
+
+Definition ap_functor_susp_merid {X Y : Type} (f : X -> Y) (x : X)
+  : ap (functor_susp f) (merid x) = merid (f x).
+Proof.
+  serapply Susp_rec_beta_merid.
+Defined.
+
 (** ** Universal property *)
 
 Definition equiv_Susp_rec `{Funext} (X Y : Type)
 : (Susp X -> Y) <~> { NS : Y * Y & X -> fst NS = snd NS }.
 Proof.
-  simple refine (Build_Equiv (Susp X -> Y)
-                     { NS : Y * Y & X -> fst NS = snd NS } _ _).
+  unshelve econstructor.
   { intros f.
     exists (f North , f South).
     intros x. exact (ap f (merid x)). }
@@ -203,7 +235,15 @@ Proof.
     apply (concatR (concat_p1 _)), whiskerL. apply ap_const.
 Defined.
 
-(* ** Connectedness of the suspension *)
+(** ** Contractibility of the suspension *)
+
+Global Instance contr_susp (A : Type) `{Contr A}
+  : Contr (Susp A).
+Proof.
+  unfold Susp; exact _.
+Defined.
+
+(** ** Connectedness of the suspension *)
 
 Global Instance isconnected_susp {n : trunc_index} {X : Type}
   `{H : IsConnected n X} : IsConnected n.+1 (Susp X).

--- a/theories/Homotopy/Suspension.v
+++ b/theories/Homotopy/Suspension.v
@@ -2,9 +2,11 @@
 Require Import Basics.
 Require Import Types.
 Require Import Cubical.
+Require Import WildCat.
 Require Import Colimits.Pushout.
 Require Import NullHomotopy.
 Require Import Truncations.
+Require Import Extensions.
 Import TrM.
 
 (** * The suspension of a type *)
@@ -209,6 +211,285 @@ Proof.
     unfold Susp_rec; apply ap.
     apply path_forall; intros x.
     apply apD_const.
+Defined.
+
+(** Using wild 0-groupoids, the universal property can be proven without funext.  A simple equivalence of 0-groupoids between [Susp X -> Y] and [{ NS : Y * Y & X -> fst NS = snd NS }] would not carry all the higher-dimensional information, but if we generalize it to dependent functions, then it does suffice. *)
+Section UnivProp.
+  Context (X : Type) (P : Susp X -> Type).
+
+  (** Here is the domain of the equivalence: sections of [P] over [Susp X]. *)
+  Definition Susp_ind_type := forall z:Susp X, P z.
+
+  Local Instance is01cat_Susp_ind_type : Is01Cat Susp_ind_type.
+  Proof. apply is01cat_forall; intros; apply is01cat_paths. Defined.
+
+  Local Instance is0gpd_Susp_ind_type : Is0Gpd Susp_ind_type.
+  Proof. apply is0gpd_forall; intros; apply is0gpd_paths. Defined.
+
+  (** The codomain is a sigma-groupoid of this family, consisting of input data for [Susp_ind]. *)
+  Definition Susp_ind_data' (NS : P North * P South)
+    := forall x:X, DPath P (merid x) (fst NS) (snd NS).
+
+  Local Instance is01cat_Susp_ind_data' NS : Is01Cat (Susp_ind_data' NS).
+  Proof. apply is01cat_forall; intros; apply is01cat_paths. Defined.
+
+  Local Instance is0gpd_Susp_ind_data' NS : Is0Gpd (Susp_ind_data' NS).
+  Proof. apply is0gpd_forall; intros; apply is0gpd_paths. Defined.
+
+  (** Here is the codomain itself. *)
+  Definition Susp_ind_data := sig Susp_ind_data'.
+
+  Local Instance is01cat_Susp_ind_data : Is01Cat Susp_ind_data.
+  Proof. rapply is01cat_sigma. Defined.
+
+  Local Instance is0gpd_Susp_ind_data : Is0Gpd Susp_ind_data.
+  Proof. rapply is0gpd_sigma. Defined.
+
+  (** Here is the functor. *)
+  Definition Susp_ind_inv : Susp_ind_type -> Susp_ind_data.
+  Proof.
+    intros f.
+    exists (f North,f South).
+    intros x.
+    exact (dp_apD f (merid x)).
+  Defined.
+
+  Local Instance is0functor_susp_ind_inv : Is0Functor Susp_ind_inv.
+  Proof.
+    constructor; unfold Susp_ind_type; cbn.
+    intros f g p.
+    unshelve econstructor.
+    - apply path_prod; apply p.
+    - intros x.
+      rewrite transport_path_prod, !transport_forall_constant; cbn.
+      apply equiv_ds_transport_dpath.
+      exact (dp_apD_nat p (merid x)).
+  Defined.
+
+  (** And now we can prove that it's an equivalence. *)
+  Definition equiv0gpd_Susp_ind_inv : IsEquiv0Gpd Susp_ind_inv.
+  Proof.
+    constructor.
+    - intros [[n s] g].
+      exists (Susp_ind_dp P n s g); cbn.
+      exists idpath.
+      intros x; cbn.
+      apply Susp_ind_dp_beta_merid.
+    - intros f g [p q]; cbn in *.
+      serapply Susp_ind_dp; cbn.
+      1:exact (ap fst p).
+      1:exact (ap snd p).
+      intros x; specialize (q x).
+      apply equiv_sq_dp_D.
+      apply equiv_ds_transport_dpath.
+      rewrite transport_forall_constant in q.
+      rewrite <- (eta_path_prod p) in q.
+      rewrite transport_path_prod in q.
+      exact q.
+  Defined.
+
+End UnivProp.
+
+(** The full non-funext version of the universal property should be formulated with respect to a notion of "wild hom-oo-groupoid", which we don't currently have.  However, we can deduce statements about full higher universal properties that we do have, for instance the statement that a type is local for [functor_susp f] -- expressed in terms of [ooExtendableAlong] -- if and only if all its identity types are local for [f].  (We will use this in [Modalities.Localization] for separated subuniverses.)  To prove this, we again generalize it to the case of dependent types, starting with naturality of the above 0-dimensional universal property. *)
+
+Section UnivPropNat.
+  (** We will show that [Susp_ind_inv] for [X] and [Y] commute with precomposition with [f] and [functor_susp f]. *)
+  Context {X Y : Type} (f : X -> Y) (P : Susp Y -> Type).
+
+  (** We recall all those instances from the previous section. *)
+  Local Existing Instances is01cat_Susp_ind_type is0gpd_Susp_ind_type is01cat_Susp_ind_data' is0gpd_Susp_ind_data' is01cat_Susp_ind_data is0gpd_Susp_ind_data.
+
+  (** Here is an intermediate family of groupoids that we have to use, since precomposition with [f] doesn't land in quite the right place. *)
+  Definition Susp_ind_data'' (NS : P North * P South)
+    := forall x:X, DPath P (merid (f x)) (fst NS) (snd NS).
+
+  Local Instance is01cat_Susp_ind_data'' NS : Is01Cat (Susp_ind_data'' NS).
+  Proof. apply is01cat_forall; intros; apply is01cat_paths. Defined.
+
+  Local Instance is0gpd_Susp_ind_data'' NS : Is0Gpd (Susp_ind_data'' NS).
+  Proof. apply is0gpd_forall; intros; apply is0gpd_paths. Defined.
+
+  (** We decompose "precomposition with [f]" into a functor_sigma of two fiberwise functors.  Here is the first. *)
+  Definition functor_Susp_ind_data'' (NS : P North * P South)
+    : Susp_ind_data' Y P NS -> Susp_ind_data'' NS
+    := fun g x => g (f x).
+
+  Local Instance is0functor_functor_Susp_ind_data'' NS
+    : Is0Functor (functor_Susp_ind_data'' NS).
+  Proof.
+    constructor.
+    intros g h p a.
+    exact (p (f a)).
+  Defined.
+
+  (** And here is the second.  This one is actually a fiberwise equivalence of types at each [x]. *)
+  Definition equiv_Susp_ind_data' (NS : P North * P South) (x : X)
+    : DPath P (merid (f x)) (fst NS) (snd NS)
+      <~> DPath (P o functor_susp f) (merid x) (fst NS) (snd NS).
+  Proof.
+    etransitivity.
+    - apply (equiv_transport (fun p => DPath P p (fst NS) (snd NS))).
+      symmetry; apply ap_functor_susp_merid.
+    - symmetry. 
+      apply (dp_compose (functor_susp f) P (merid x)).
+  Defined.
+
+  Definition functor_Susp_ind_data' (NS : P North * P South)
+    : Susp_ind_data'' NS -> Susp_ind_data' X (P o functor_susp f) NS.
+  Proof.
+    serapply (functor_forall idmap); intros x.
+    apply equiv_Susp_ind_data'.
+  Defined.
+
+  Local Instance is0functor_functor_Susp_ind_data' NS
+    : Is0Functor (functor_Susp_ind_data' NS).
+  Proof.
+    constructor.
+    intros g h q x.
+    cbn; apply ap, ap.
+    exact (q x).
+  Defined.
+
+  (** And therefore a fiberwise equivalence of 0-groupoids. *)
+  Local Instance isequiv0gpd_functor_Susp_ind_data' NS
+    : IsEquiv0Gpd (functor_Susp_ind_data' NS).
+  Proof.
+    constructor.
+    - intros g.
+      unshelve econstructor.
+      + intros x.
+        apply ((equiv_Susp_ind_data' NS x)^-1).
+        exact (g x).
+      + intros x.
+        apply eisretr.
+    - intros g h p x.
+      apply (equiv_inj (equiv_Susp_ind_data' NS x)).
+      exact (p x).
+  Defined.
+
+  (** Now we put them together. *)
+  Definition functor_Susp_ind_data
+    : Susp_ind_data Y P -> Susp_ind_data X (P o functor_susp f)
+    := fun NSg => (NSg.1 ; (functor_Susp_ind_data' NSg.1 o
+                             (functor_Susp_ind_data'' NSg.1)) NSg.2).
+
+  Local Instance is0functor_functor_Susp_ind_data
+    : Is0Functor functor_Susp_ind_data.
+  Proof.
+    refine (is0functor_sigma _ _
+           (fun NS => functor_Susp_ind_data' NS o functor_Susp_ind_data'' NS)).
+  Defined.
+
+  (** Here is the "precomposition with [functor_susp f]" functor. *)
+  Definition functor_Susp_ind_type
+    : Susp_ind_type Y P -> Susp_ind_type X (P o functor_susp f)
+    := fun g => g o functor_susp f.
+
+  Local Instance is0functor_functor_Susp_ind_type
+    : Is0Functor functor_Susp_ind_type.
+  Proof.
+    constructor.
+    intros g h p a.
+    exact (p (functor_susp f a)).
+  Defined.
+
+  (** And here is the desired naturality square. *)
+  Definition Susp_ind_inv_nat
+    : (Susp_ind_inv X (P o functor_susp f)) o functor_Susp_ind_type
+      $=> functor_Susp_ind_data o (Susp_ind_inv Y P).
+  Proof.
+    intros g; exists idpath; intros x.
+    change (dp_apD (fun x0 : Susp X => g (functor_susp f x0)) (merid x) =
+            (functor_Susp_ind_data (Susp_ind_inv Y P g)).2 x).
+    refine (dp_apD_compose (functor_susp f) P (merid x) g @ _).
+    cbn; apply ap.
+    apply (moveL_transport_V (fun p => DPath P p (g North) (g South))).
+    exact (apD (dp_apD g) (ap_functor_susp_merid f x)).
+  Defined.
+
+  (** From this we can deduce a equivalence between extendability, which is definitionally equal to split essential surjectivity of a functor between forall 0-groupoids. *)
+  Definition extension_iff_functor_susp
+    : (forall g, ExtensionAlong (functor_susp f) P g)
+      <-> (forall NS g, ExtensionAlong f (fun x => DPath P (merid x) (fst NS) (snd NS)) g).
+  Proof.
+    (** The proof is by chaining logical equivalences. *)
+    transitivity (SplEssSurj functor_Susp_ind_type).
+    { reflexivity. }
+    etransitivity.
+    { refine (isesssurj_iff_commsq Susp_ind_inv_nat); try exact _.
+      all:apply equiv0gpd_Susp_ind_inv. }
+    etransitivity.
+    { refine (isesssurj_iff_sigma _ _ 
+                (fun NS => functor_Susp_ind_data' NS o functor_Susp_ind_data'' NS)). }
+    apply iff_functor_forall; intros [N S]; cbn.
+    etransitivity.
+    { apply iffL_isesssurj; exact _. }
+    reflexivity.
+  Defined.
+
+  (** We have to close the section now because we have to generalize [extension_iff_functor_susp] over [P]. *)
+
+End UnivPropNat.
+
+(** Now we can iterate, deducing [n]-extendability. *)
+Definition extendable_iff_functor_susp
+           {X Y : Type} (f : X -> Y) (P : Susp Y -> Type) (n : nat)
+  : (ExtendableAlong n (functor_susp f) P)
+    <-> (forall NS, ExtendableAlong n f (fun x => DPath P (merid x) (fst NS) (snd NS))).
+Proof.
+  revert P. induction n as [|n IHn]; intros P; [ split; intros; exact tt | ].
+  (** It would be nice to be able to do this proof by chaining logcal equivalences too, especially since the two parts seem very similar.  But I haven't managed to make that work. *)
+  split.
+  - intros [e1 en] [N S]; split.
+    + apply extension_iff_functor_susp.
+      exact e1.
+    + cbn; intros h k.
+      pose (h' := Susp_ind_dp P N S h).
+      pose (k' := Susp_ind_dp P N S k).
+      specialize (en h' k').
+      assert (IH := fst (IHn _) en (1,1)); clear IHn en.
+      cbn in IH.
+      refine (extendable_postcompose' n _ _ f _ IH); clear IH.
+      intros y.
+      etransitivity.
+      1:symmetry; apply equiv_sq_dp_D.
+      etransitivity.
+      1:apply equiv_ds_transport_dpath.
+      subst h' k'; cbn.
+      apply equiv_concat_lr.
+      * symmetry. exact (Susp_ind_dp_beta_merid P N S h y).
+      * exact (Susp_ind_dp_beta_merid P N S k y).
+  - intros e; split.
+    + apply extension_iff_functor_susp.
+      intros NS; exact (fst (e NS)).
+    + intros h k.
+      apply (IHn _).
+      intros [p q].
+      specialize (e (h North, k South)).
+      cbn in *; apply snd in e.
+      refine (extendable_postcompose' n _ _ f _ (e _ _)); intros y.
+      etransitivity.
+      2:apply equiv_sq_dp_D.
+      etransitivity.
+      2:symmetry;apply equiv_ds_transport_dpath.
+      etransitivity.
+      2:apply (equiv_moveR_transport_p (fun y0 : P North => DPath P (merid y) y0 (k South))).
+      reflexivity.
+Defined.
+
+(** As usual, deducing oo-extendability is trivial. *)
+Definition ooextendable_iff_functor_susp
+           {X Y : Type} (f : X -> Y) (P : Susp Y -> Type)
+  : (ooExtendableAlong (functor_susp f) P)
+    <-> (forall NS, ooExtendableAlong f (fun x => DPath P (merid x) (fst NS) (snd NS))).
+Proof.
+  split; intros e.
+  - intros NS n.
+    apply extendable_iff_functor_susp.
+    exact (e n).
+  - intros n.
+    apply extendable_iff_functor_susp.
+    intros NS; exact (e NS n).
 Defined.
 
 (** ** Nullhomotopies of maps out of suspensions *)

--- a/theories/Pointed/pSusp.v
+++ b/theories/Pointed/pSusp.v
@@ -32,10 +32,9 @@ Definition psusp (X : pType) : pType
 
 (** ** Suspension Functor *)
 
-(* Definition of suspension functor *)
+(* Definition of pointed suspension functor *)
 Definition psusp_functor {X Y : pType} (f : X ->* Y) : psusp X ->* psusp Y
-  := Build_pMap (psusp X) (psusp Y)
-    (Susp_rec North South (fun x => merid (f x))) 1.
+  := Build_pMap (psusp X) (psusp Y) (functor_susp f) 1.
 
 (* Suspension functor preserves composition *)
 Definition psusp_functor_compose {X Y Z : pType} (g : Y ->* Z) (f : X ->* Y)

--- a/theories/Spaces/Torus/TorusEquivCircles.v
+++ b/theories/Spaces/Torus/TorusEquivCircles.v
@@ -64,15 +64,15 @@ Section TorusEquivCircle.
     refine (_;_;_).
     unfold sq_ap2.
     (* 1. Unfusing ap *)
-    refine (cu_concat_lr (cu_ds (dp_apD_nat _ _ _
-      (fun y => ap_compose _ (fun f => f y) _))) _
+    refine (cu_concat_lr (cu_ds (dp_apD_nat
+      (fun y => ap_compose _ (fun f => f y) _) _)) _
       (sji0:=?[X1]) (sji1:=?X1) (sj0i:=?[Y1]) (sj1i:=?Y1) (pj11:=1)).
     (* 2. Reducing c2t' on loop *)
-    refine (cu_concat_lr (cu_ds (dp_apD_nat _ _ _
-      (fun x => ap_apply_l _ _ @ apD10 (ap _(S1_rec_beta_loop _ _ _)) x))) _
+    refine (cu_concat_lr (cu_ds (dp_apD_nat
+      (fun x => ap_apply_l _ _ @ apD10 (ap _(S1_rec_beta_loop _ _ _)) x) _)) _
       (sji0:=?[X2]) (sji1:=?X2) (sj0i:=?[Y2]) (sj1i:=?Y2) (pj11:=1)).
     (* 3. Reducing ap10 on function extensionality *)
-    refine (cu_concat_lr (cu_ds (dp_apD_nat _ _ _ (ap10_path_forall _ _ _))) _
+    refine (cu_concat_lr (cu_ds (dp_apD_nat (ap10_path_forall _ _ _) _)) _
       (sji0:=?[X3]) (sji1:=?X3) (sj0i:=?[Y3]) (sj1i:=?Y3) (pj11:=1)).
     (* 4. Reducing S1_ind_dp on loop *)
     refine (cu_concat_lr (cu_G11 (ap _ (S1_ind_dp_beta_loop _ _ _))) _

--- a/theories/Types/Forall.v
+++ b/theories/Types/Forall.v
@@ -285,6 +285,18 @@ Proof.
   symmetry; apply transport_pp.
 Qed.
 
+(** ** Functoriality on logical equivalences *)
+
+(** At least over a fixed base *)
+Definition iff_functor_forall {A : Type} {P Q : A -> Type}
+           (f : forall a, P a <-> Q a)
+  : (forall a, P a) <-> (forall a, Q a).
+Proof.
+  split.
+  - intros g a; exact (fst (f a) (g a)).
+  - intros h a; exact (snd (f a) (h a)).
+Defined.
+
 (** ** Two variable versions for function extensionality. *)
 
 Definition equiv_path_forall11 {A : Type} {B : A -> Type} {P : forall a : A, B a -> Type} (f g : forall a b, P a b)

--- a/theories/Types/Prod.v
+++ b/theories/Types/Prod.v
@@ -260,6 +260,12 @@ Definition equiv_functor_prod_r {A A' B : Type} (f : A <~> A')
   : A * B <~> A' * B
   := f *E 1.
 
+(** ** Logical equivalences *)
+
+Definition iff_functor_prod {A A' B B' : Type} (f : A <-> A') (g : B <-> B')
+  : A * B <-> A' * B'
+  := (functor_prod (fst f) (fst g) , functor_prod (snd f) (snd g)).
+
 (** ** Symmetry *)
 
 (** This is a special property of [prod], of course, not an instance of a general family of facts about types. *)

--- a/theories/WildCat/Forall.v
+++ b/theories/WildCat/Forall.v
@@ -19,6 +19,15 @@ Proof.
   + intros x y z f g a; exact (f a $o g a).
 Defined.
 
+Global Instance is0gpd_forall (A : Type) (B : A -> Type)
+  (* Apparently when there's a [forall] there, Coq can't automatically add the [Is01Cat] instance from the [Is0Gpd] instance. *)
+  `{forall a, Is01Cat (B a)} `{forall a, Is0Gpd (B a)}
+  : Is0Gpd (forall a, B a).
+Proof.
+  constructor.
+  intros f g p a; exact ((p a)^$).
+Defined.
+
 Global Instance is1cat_forall (A : Type) (B : A -> Type)
   {c1 : forall a, Is01Cat (B a)} {c2 : forall a, Is1Cat (B a)}
   : Is1Cat (forall a, B a).


### PR DESCRIPTION
On top of #1205; see last 3 commits only (or wait to review until that's merged).

It's perhaps a bit of a stretch to say that this is an application of wild categories, when it's only using wild 0-groupoids that are just setoids, but I think the wild-category-theoretic perspective is helpful.

I need this right now just for separated localizations, but I expect it may be useful in Pointed too, e.g. using the `pForall` in the wildcat branch.