### PR TITLE
Make equiv_sigma_assoc and contr_basedpaths easier to use

### DIFF
--- a/theories/Basics/Contractible.v
+++ b/theories/Basics/Contractible.v
@@ -45,6 +45,10 @@ Proof.
   intros [y p]; apply path_basedpaths.
 Defined.
 
+(* Sometimes we end up with a sigma of a one-sided path type that's not eta-expanded, which Coq doesn't seem able to match with the previous instance. *)
+Global Instance contr_basedpaths_etashort {X : Type} (x : X) : Contr (sigT (@paths X x)) | 100
+  := contr_basedpaths x.
+
 Definition path_basedpaths' {X : Type} {x y : X} (p : y = x)
 : (x;1) = (y;p) :> {z:X & z=x}.
 Proof.

--- a/theories/DProp.v
+++ b/theories/DProp.v
@@ -87,7 +87,7 @@ Proof.
   destruct P as [P hP dP]. destruct Q as [Q hQ dQ].
   refine (((equiv_ap' issig_dprop^-1 _ _)^-1)
             oE _); cbn.
-  refine ((equiv_ap' (equiv_sigma_assoc _ (fun Xp => Decidable Xp.1))^-1
+  refine ((equiv_ap' (equiv_sigma_assoc' _ _)^-1
                      ((P;hP);dP) ((Q;hQ);dQ))
             oE _).
   refine (equiv_path_sigma_hprop _ _ oE _); cbn.

--- a/theories/EquivalenceVarieties.v
+++ b/theories/EquivalenceVarieties.v
@@ -134,7 +134,7 @@ Local Definition equiv_fcontr_isequiv' `(f : A -> B)
   : (forall b:B, Contr {a : A & f a = b}) <~> IsEquiv f.
 Proof.
   (* First we get rid of those pesky records. *)
-  refine (_ oE (equiv_functor_forall idmap
+  refine (_ oE (equiv_functor_forall_id 
     (fun b => (issig_contr {a : A & f a = b})^-1))).
   refine (issig_isequiv f oE _).
   (* Now we can really get to work.
@@ -145,12 +145,9 @@ Proof.
       (equiv_sigT_coind _ _)
       (fun fg => equiv_idmap (forall x y,
         (equiv_sigT_coind _ (fun b a => f a = b) fg x = y))))^-1).
-  refine (_ oE (equiv_sigma_assoc
-    (fun g => forall x, f (g x) = x)
-    (fun gh => forall x y,
-      (fun b => (gh.1 b; gh.2 b)) x = y))^-1).
-  refine (equiv_functor_sigma' 1 _). intros g.
-  refine (equiv_functor_sigma' 1 _). intros r. simpl.
+  refine (_ oE (equiv_sigma_assoc _ _)^-1).
+  refine (equiv_functor_sigma_id _). intros g.
+  refine (equiv_functor_sigma_id _). intros r. simpl.
   (* Now we use the fact that Paulin-Mohring J is an equivalence. *)
   refine (_ oE (@equiv_functor_forall' _ _
     (fun x => forall a (y : f a = x),

--- a/theories/Fibrations.v
+++ b/theories/Fibrations.v
@@ -167,7 +167,7 @@ Section UnstableOctahedral.
     refine (equiv_functor_sigma' 1 _); intros a.
     refine (equiv_functor_sigma' 1
               (fun b => equiv_sigma_symm0 _ _) oE _); simpl.
-    refine ((equiv_sigma_assoc (fun b => f a = b) (fun w => g w.1 = c))^-1 oE _).
+    refine ((equiv_sigma_assoc' _ _)^-1 oE _).
     symmetry.
     exact (equiv_contr_sigma (fun (w:{b:B & f a = b}) => g w.1 = c)).
   Defined.
@@ -208,8 +208,7 @@ Proof.
   equiv_via ({a:A & {q:f a = b & {p : P a & q # (g a p) = v}}}).
   { refine (equiv_functor_sigma' 1 (fun a => _)); simpl.
     refine (equiv_sigma_symm _). }
-  refine (_ oE (equiv_sigma_assoc (fun a => f a = b)
-                 (fun w => {p : P w.1 & w.2 # (g w.1 p) = v}))).
+  refine (_ oE (equiv_sigma_assoc' _ _)).
   refine (equiv_functor_sigma' 1 _);
     intros [a p]; simpl.
   refine (equiv_functor_sigma' 1 _);

--- a/theories/FunextVarieties.v
+++ b/theories/FunextVarieties.v
@@ -80,6 +80,7 @@ Section Homotopies.
   (** Use priority 1, so we don't override [Contr Unit]. *)
   Global Instance contr_basedhtpy : Contr {g : forall x, B x & f == g } | 1.
   Proof.
+    unfold WeakFunext in wf.    (* Allow typeclass inference to find it *)
     exists (f;idhtpy). intros [g h].
     (* The trick is to show that the type [{g : forall x, B x & f == g }] is a retract of [forall x, {y : B x & f x = y}], which is contractible due to J and weak funext.  Here are the retraction and its section. *)
     pose (r := fun k => existT (fun g => f == g)
@@ -87,8 +88,7 @@ Section Homotopies.
     pose (s := fun (g : forall x, B x) (h : f == g) x => (g x ; h x)).
     (* Because of judgemental eta-conversion, the retraction is actually definitional, so we can just replace the goal. *)
     change (r (fun x => (f x ; idpath (f x))) = r (s g h)).
-    apply ap; refine (@path_contr _ _ _ _).
-    apply wf. intros x; exact (contr_basedpaths (f x)).
+    apply ap; serapply path_contr.
   Defined.
 
   (** This enables us to prove that pointwise homotopies have the same elimination rule as the identity type. *)

--- a/theories/Homotopy/BlakersMassey.v
+++ b/theories/Homotopy/BlakersMassey.v
@@ -222,11 +222,7 @@ Module GenBlakersMassey (Os : ReflectiveSubuniverses).
                   refine (equiv_sigma_symm _). }
                 refine (equiv_sigma_symm _).
               * cbn.
-                refine ((equiv_sigma_assoc (fun y => y = y1) (fun yt =>
-                         {b : {q00 : Q x0 yt.1 &
-                              {q10 : Q x1 yt.1 & glue q00 @ (glue q10)^ = r} } &
-                         {_ : transport (fun x => Q x yt.1) s b.1 = b.2.1 &
-                              transport (Q x1) yt.2 (b.2).1 = q11}}))^-1 oE _).
+                refine ((equiv_sigma_assoc' _ _)^-1 oE _).
                 refine ((equiv_contr_sigma _)^-1 oE _); cbn.
                 refine (equiv_sigma_assoc _ _ oE _).
                 refine (equiv_functor_sigma' equiv_idmap _); intros q01; cbn.
@@ -236,9 +232,7 @@ Module GenBlakersMassey (Os : ReflectiveSubuniverses).
                 refine (equiv_functor_sigma' equiv_idmap _ oE _).
                 { intros q; cbn; apply equiv_sigma_symm. }
                 cbn.
-                refine ((equiv_sigma_assoc (fun q => q = q11) (fun qt =>
-                   {_ : glue q01 @ (glue qt.1)^ = r &
-                        transport (fun x => Q x y1) s q01 = qt.1}))^-1 oE _).
+                refine ((equiv_sigma_assoc' _ _)^-1 oE _).
                 refine ((equiv_contr_sigma _)^-1 oE _); cbn.
                 apply equiv_sigma_symm0.
           - unfold Ocodeleft2b.
@@ -270,11 +264,7 @@ Module GenBlakersMassey (Os : ReflectiveSubuniverses).
               refine (equiv_functor_sigma' equiv_idmap _ oE _).
               { intros y0; apply equiv_sigma_symm. }
               cbn.
-              refine ((equiv_sigma_assoc (fun y => y = y1) (fun yt =>
-                        {b : {q00 : Q x0 yt.1 &
-                             {q10 : Q x1 yt.1 &
-                             glue q00 @ (glue q10)^ = r}}
-                             & transport (Q x1) yt.2 (b.2).1 = q11}))^-1 oE _).
+              refine ((equiv_sigma_assoc' _ _)^-1 oE _).
                 refine ((equiv_contr_sigma _)^-1 oE _); cbn.
                 refine (equiv_sigma_assoc _ _ oE _).
                 refine (equiv_functor_sigma' equiv_idmap _); intros q01; cbn.
@@ -282,8 +272,7 @@ Module GenBlakersMassey (Os : ReflectiveSubuniverses).
                 refine (equiv_functor_sigma' equiv_idmap _ oE _).
                 { intros q; cbn; apply equiv_sigma_symm0. }
                 cbn.
-                refine ((equiv_sigma_assoc (fun q => q = q11)
-                          (fun qt => glue q01 @ (glue qt.1)^ = r))^-1 oE _).
+                refine ((equiv_sigma_assoc' _ _)^-1 oE _).
                 refine ((equiv_contr_sigma _)^-1 oE _); cbn.
                 apply equiv_idmap.
           - intros [s [q01 [w u]]]; reflexivity.

--- a/theories/Idempotents.v
+++ b/theories/Idempotents.v
@@ -701,14 +701,11 @@ Section RetractOfRetracts.
     - refine ((hfiber_fibration f
                   (fun g => { I : IsPreIdempotent g & @IsQuasiIdempotent _ g I }))^-1 oE _).
       unfold hfiber.
-      refine (equiv_functor_sigma'
-                (equiv_sigma_assoc IsPreIdempotent
-                                   (fun fi => @IsQuasiIdempotent _ fi.1 fi.2))^-1
-                (fun a => _)); simpl.
+      refine (equiv_functor_sigma' (equiv_sigma_assoc _ _)^-1 (fun a => _)); simpl.
       destruct a as [[g I] J]; unfold quasiidempotent_pr1; simpl.
       apply equiv_idmap.
     - simpl.  unfold hfiber, Splitting.
-      refine (equiv_functor_sigma' (equiv_idmap (RetractOf X)) _);
+      refine (equiv_functor_sigma_id _);
         intros R; simpl.
       apply equiv_ap10.
   Defined.

--- a/theories/Limits/Pullback.v
+++ b/theories/Limits/Pullback.v
@@ -91,18 +91,16 @@ Definition hfiber_pullback_along {A B C} (f : B -> A) (g : C -> A) (b:B)
 : hfiber (f ^* g) b <~> hfiber g (f b).
 Proof.
   unfold hfiber, Pullback.
-  refine (_ oE (equiv_sigma_assoc (fun b' => {c : C & f b' = g c})
-                                 (fun x => (f^* g) x = b))^-1).
+  refine (_ oE (equiv_sigma_assoc _ _)^-1).
   simpl.
   refine (_ oE (@equiv_functor_sigma'
                  B (fun b' => {_ : {c:C & f b' = g c} & b' = b})
                  B (fun b' => {_ : b' = b & {c:C & f b' = g c}})
                  1
                  (fun b' => equiv_sigma_symm0 {c:C & f b' = g c} (b' = b)))).
-  refine (_ oE (equiv_sigma_assoc (fun b' => b' = b)
-                                 (fun b'p => {c:C & f b'p.1 = g c}))).
+  refine (_ oE (equiv_sigma_assoc' _ _)).
   refine (_ oE equiv_contr_sigma _).
-  exact (equiv_functor_sigma' 1 (fun c => equiv_path_inverse _ _)).
+  exact (equiv_functor_sigma_id (fun c => equiv_path_inverse _ _)).
 Defined.
 
 (** And the dual sort of pullback *)
@@ -118,19 +116,16 @@ Definition hfiber_pullback_along' {A B C} (g : C -> A) (f : B -> A) (c:C)
 : hfiber (g ^*' f) c <~> hfiber f (g c).
 Proof.
   unfold hfiber, Pullback.
-  refine (_ oE (equiv_sigma_assoc (fun b' => {c : C & f b' = g c})
-                                 (fun x => (g^*' f) x = c))^-1).
+  refine (_ oE (equiv_sigma_assoc _ _)^-1).
   refine (equiv_functor_sigma' 1 _); intros b.
-  refine (_ oE (equiv_sigma_assoc (fun c' => f b = g c')
-                                 (fun x => (g^*' f) (b;x) = c))^-1).
+  refine (_ oE (equiv_sigma_assoc _ _)^-1).
   simpl.
   refine (_ oE (@equiv_functor_sigma'
                  C (fun c' => {_ : f b = g c' & c' = c})
                  C (fun c' => {_ : c' = c & f b = g c'})
                  1
                  (fun c' => equiv_sigma_symm0 (f b = g c') (c' = c)))).
-  refine (_ oE (equiv_sigma_assoc (fun c' => c' = c)
-                                 (fun c'p => f b = g c'p.1))).
+  refine (_ oE equiv_sigma_assoc' _ _).
   refine (_ oE equiv_contr_sigma _).
   apply equiv_idmap.
 Defined.

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -906,14 +906,13 @@ Section Reflective_Subuniverse.
       refine (_ oE (equiv_sigma_assoc _ _)^-1%equiv); cbn.
       refine (_ oE equiv_functor_sigma_id _).
       2:intros; apply equiv_sigma_symm.
-      refine (_ oE (equiv_sigma_assoc
-                      _ (fun aq => {b : B aq.1 & aq.2 # (h z,k z) = (b,b)}))).
+      refine (_ oE (equiv_sigma_assoc' _ _)). 
       refine (_ oE equiv_contr_sigma _); cbn.
       refine (_ oE equiv_functor_sigma_id _).
       2:{ intros; symmetry; etransitivity; revgoals.
           - apply equiv_path_prod.
           - apply equiv_sigma_prod0. }
-      refine (_ oE equiv_sigma_assoc _ (fun bp => k z = bp.1)).
+      refine (_ oE equiv_sigma_assoc' _ _).
       refine (_ oE equiv_contr_sigma _); cbn.
       apply equiv_path_inverse.
     Defined.

--- a/theories/Pointed/pFiber.v
+++ b/theories/Pointed/pFiber.v
@@ -30,7 +30,7 @@ Proof.
                    (P := fun a => {_ : f a = point B & a = point A})
                    (Q := fun a => {_ : a = point A & f a = point B })
                    1 (fun a => equiv_sigma_symm0 _ _))).
-    refine (_ oE equiv_sigma_assoc _ (fun a => f a.1 = point B)).
+    refine (_ oE equiv_sigma_assoc' _ _).
     refine (_ oE equiv_contr_sigma _); simpl.
     apply equiv_concat_l.
     symmetry; apply point_eq.

--- a/theories/Pointed/pSusp.v
+++ b/theories/Pointed/pSusp.v
@@ -119,9 +119,7 @@ Module Book_Loop_Susp_Adjunction.
                  1
                  (fun b => equiv_sigma_symm (A := B) (B := b = point B)
                              (fun p _ => A -> b = p)))).
-    refine (_ oE
-              (equiv_sigma_assoc (fun b => b = point B)
-                                 (fun bq => {p:B & A -> bq.1 = p}))).
+    refine (_ oE equiv_sigma_assoc' _ _).
     refine (_ oE equiv_contr_sigma _); simpl.
     refine (_ oE (equiv_sigma_contr
                    (A := {p : B & A -> point B = p})
@@ -132,10 +130,7 @@ Module Book_Loop_Susp_Adjunction.
                  (Q := fun b => {q : point B = b & {p : A -> point B = b & p (point A) = q}})
                  1
                  (fun b => equiv_sigma_symm (fun p q => p (point A) = q)))).
-    refine (_ oE
-              (equiv_sigma_assoc
-                 (fun b => point B = b)
-                 (fun bq => {p : A -> point B = bq.1 & p (point A) = bq.2}))).
+    refine (_ oE equiv_sigma_assoc' _ _).
     refine (_ oE equiv_contr_sigma _); simpl.
     refine (issig_pmap A (loops B)).
   Defined.

--- a/theories/Types/Sigma.v
+++ b/theories/Types/Sigma.v
@@ -499,6 +499,18 @@ Definition equiv_sigma_assoc `(P : A -> Type) (Q : {a : A & P a} -> Type)
           (fun _ => 1)
           (fun _ => 1)).
 
+Definition equiv_sigma_assoc' `(P : A -> Type) (Q : forall a : A, P a -> Type)
+: {a : A & {p : P a & Q a p}} <~> {ap : sigT P & Q ap.1 ap.2}
+  := @Build_Equiv
+       _ _ _
+       (@Build_IsEquiv
+          {a : A & {p : P a & Q a p}} {ap : sigT P & Q ap.1 ap.2}
+          (fun apq => ((apq.1; apq.2.1); apq.2.2))
+          (fun apq => (apq.1.1; (apq.1.2; apq.2)))
+          (fun _ => 1)
+          (fun _ => 1)
+          (fun _ => 1)).
+
 Definition equiv_sigma_prod `(Q : (A * B) -> Type)
 : {a : A & {b : B & Q (a,b)}} <~> sigT Q
   := @Build_Equiv

--- a/theories/UnivalenceVarieties.v
+++ b/theories/UnivalenceVarieties.v
@@ -34,13 +34,12 @@ Theorem WeakUnivalence_implies_Univalence :
 Proof.
   intros [etop H] A.
   apply isequiv_from_functor_sigma.
-  refine (@isequiv_contr_contr _ {B:Type & A <~> B} (contr_basedpaths A) _ _).
-  refine (contr_retracttype
-            (Build_RetractOf _ {B:Type & A <~> B}
+  serapply isequiv_contr_contr.
+  serapply (contr_retracttype
+            (Build_RetractOf _ _
                              (fun Be => (Be.1 ; equiv_path A Be.1 Be.2))
                              (fun Bf => (Bf.1 ; etop A Bf.1 Bf.2))
-                             _)
-            (contr_basedpaths A)).
+                             _)).
   intros [B f].
   refine (path_sigma' (fun B => A <~> B) 1 (H A B f)).
 Defined.
@@ -70,8 +69,7 @@ Proof.
     refine (unit vwu A @ _ @ (unit vwu B)^).
     refine (_ @ flip vwu A B (fun a b => f a = b) @ _).
     - apply ap, path_arrow; intros a.
-      symmetry; apply (contract vwu).
-      apply contr_basedpaths.
+      symmetry; rapply (contract vwu).
     - apply ap, path_arrow; intros b.
       apply (contract vwu), fcontr_isequiv; exact _. }
   { intros A B f.
@@ -81,15 +79,9 @@ Proof.
     rewrite !(unit_comp vwu).
     rewrite <- !transport_compose.
     rewrite (transport_sigma' (C := fun P (a0:A) => P a0)); cbn.
-    assert (p : (transport (fun x : A -> Type0 => x a)
-                   (path_arrow (fun _ : A => Unit)
-                      (fun a0 : A => {b : B & f a0 = b})
-                      (fun a0 : A =>
-                         (contract vwu {b : B & f a0 = b}
-                           (contr_basedpaths (f a0)))^)) tt)
-                = (f a ; 1))
-      by apply path_contr.
-    rewrite p; clear p.
+    refine (ap _ _ @ _).
+    1:{ apply ap, ap.
+        exact (path_contr _ (f a ; 1)). }
     rewrite (flip_comp vwu).
     rewrite transport_sigma'; cbn.
     apply ap, path_contr. }


### PR DESCRIPTION
I finally realized that the reason Coq is often unable to guess the type family `Q` in `equiv_sigma_assoc` is that its domain is a sigma-type.  Defining a variant `equiv_sigma_assoc'` in which `Q` is instead a curried function of two (dependent) variables seems to remove the need to ever give it explicit arguments.  (Indeed, I'm tempted to make `P` and `Q` globally implicit arguments to both of them, but I didn't go that far yet.)

I also realized that the reason Coq is sometimes unable to find `contr_basedpaths` by typeclass inference is that it's looking at an eta-short form `sig (@paths A x)` which it's unable to unify with `{y:A & x = y}` since the latter is a notation for the eta-long form `sig (fun y => @paths A x y)`.  (I believe that when Coq displays `{y:_ & x = y}` it means it has the eta-short form `sig (@paths A x)`, although I don't know exactly why.)   Defining an eta-short variant seems to allow typeclass inference to find it all the time.
