### PR TITLE
More systematic use of equiv_functor variants with identity equivalences

### DIFF
--- a/theories/Algebra/Aut.v
+++ b/theories/Algebra/Aut.v
@@ -22,7 +22,7 @@ Definition equiv_baut_image_unit X
 : BAut X <~> image (Tr (-1)) (unit_name X).
 Proof.
   unfold BAut, image; simpl.
-  refine (equiv_functor_sigma' (equiv_idmap Type) _); intros Z; simpl.
+  apply equiv_functor_sigma_id; intros Z; simpl.
   apply equiv_O_functor; unfold hfiber.
   refine ((equiv_contr_sigma _)^-1 oE _).
   apply equiv_path_inverse.

--- a/theories/Categories/Category/Sigma/Univalent.v
+++ b/theories/Categories/Category/Sigma/Univalent.v
@@ -227,8 +227,8 @@ Section on_both.
   : (Pmor_iso_T (x; xp) (x; xp') 1 1 (left_identity _ _ _ _) (right_identity _ _ _ _))
       <~> Pmor_iso_T' xp xp'.
   Proof.
-    refine (equiv_functor_sigma' (equiv_idmap _) _); intro.
-    refine (equiv_functor_sigma' (equiv_idmap _) _); intro.
+    refine (equiv_functor_sigma_id _); intro.
+    refine (equiv_functor_sigma_id _); intro.
     refine (equiv_functor_sigma' (equiv_iff_hprop _ _) (fun _ => equiv_iff_hprop _ _));
       cbn; intro H';
       first [ apply moveL_transport_V in H'

--- a/theories/Constant.v
+++ b/theories/Constant.v
@@ -20,8 +20,9 @@ Global Instance ishprop_fix_wconst {X : Type} (f : X -> X)
 Proof.
   apply hprop_inhabited_contr; intros [x0 p0].
   refine (contr_equiv' {x:X & f x0 = x} _); unfold FixedBy.
-  refine (equiv_functor_sigma' (equiv_idmap X)
-           (fun x => equiv_concat_l (wconst x x0) x)).
+  apply equiv_functor_sigma_id. intros x.
+  apply equiv_concat_l.
+  apply wconst.
 Defined.
 
 (** It follows that if a type [X] admits a weakly constant endofunction [f], then [FixedBy f] is equivalent to [merely X]. *)

--- a/theories/Extensions.v
+++ b/theories/Extensions.v
@@ -66,8 +66,8 @@ Section Extensions.
               (fun a b c => forall x:A, c (f x) = gd x @ (b x)^)
               g (fun y:B => idpath (g y))).
     refine (contr_equiv' {p:g o f == d & gd == p} _). cbn.
-    refine (equiv_functor_sigma' (equiv_idmap _) _); intros p.
-    refine (equiv_functor_forall' (equiv_idmap _) _); intros x; cbn.
+    refine (equiv_functor_sigma_id _); intros p.
+    refine (equiv_functor_forall_id _); intros x; cbn.
     refine (_ oE equiv_path_inverse _ _).
     symmetry; apply equiv_moveR_1M.
   Defined.

--- a/theories/Fibrations.v
+++ b/theories/Fibrations.v
@@ -15,7 +15,7 @@ Definition equiv_path_hfiber {A B : Type} {f : A -> B} {y : B}
 : { q : x1.1 = x2.1 & x1.2 = ap f q @ x2.2 } <~> (x1 = x2).
 Proof.
   refine (equiv_path_sigma _ _ _ oE _).
-  refine (equiv_functor_sigma' 1 _).
+  apply equiv_functor_sigma_id.
   intros p; simpl.
   refine (_ oE equiv_moveR_Vp _ _ _).
   exact (equiv_concat_l (transport_paths_Fl _ _) _).
@@ -39,7 +39,7 @@ Definition hfiber_ap {A B : Type} {f : A -> B} {x1 x2 : A}
 Proof.
   refine (equiv_path_hfiber (x1;p) (x2;1%path) oE _).
   unfold hfiber; simpl.
-  refine (equiv_functor_sigma' 1 _); intros q.
+  apply equiv_functor_sigma_id; intros q.
   refine (_ oE equiv_path_inverse _ _).
   exact (equiv_concat_r (concat_p1 _)^ _).
 Defined.
@@ -80,19 +80,14 @@ Proof.
   unfold hfiber, functor_hfiber, functor_sigma.
   refine (_ oE (equiv_sigma_assoc _ _)^-1).
   refine (equiv_sigma_assoc _ _ oE _).
-  apply (equiv_functor_sigma' 1); intros a; cbn.
-  refine (_ oE
-         (equiv_functor_sigma'
-            (P := fun r => { s : h a = c & s # ((p a)^ @ ap k r) = q })
-            1 (fun r => equiv_path_sigma _
-                          (h a; (p a)^ @ ap k r) (c; q)))^-1).
-  refine (equiv_functor_sigma'
-            (P := fun r => { s : f a = b & s # (((p a)^)^ @ ap g r) = q^ })
-            1 (fun r => equiv_path_sigma _
-                          (f a; ((p a)^)^ @ ap g r) (b; q^)) oE _).
+  apply equiv_functor_sigma_id; intros a; cbn.
+  refine (_ oE (equiv_functor_sigma_id _)^-1).
+  2:intros; apply equiv_path_sigma.
+  refine (equiv_functor_sigma_id _ oE _).
+  1:intros; apply equiv_path_sigma. cbn.
   refine (equiv_sigma_symm _ oE _).
-  refine (equiv_functor_sigma' 1 _); intros r.
-  refine (equiv_functor_sigma' 1 _); intros s; cbn.
+  apply equiv_functor_sigma_id; intros r.
+  apply equiv_functor_sigma_id; intros s; cbn.
   refine (equiv_concat_l (transport_paths_Fl _ _) _ oE _).
   refine (_ oE (equiv_concat_l (transport_paths_Fl _ _) _)^-1).
   refine ((equiv_ap inverse _ _)^-1 oE _).
@@ -146,30 +141,30 @@ Section UnstableOctahedral.
   Proof.
     unfold hfiber, hfiber_compose_map.
     refine (_ oE (equiv_sigma_assoc _ _)^-1).
-    refine (equiv_functor_sigma' 1 _); intros a; simpl.
-    refine (equiv_compose' (B := {p : g (f a) = g b & {q : f a = b & transport (fun y => g y = g b) q p = 1}}) _ _).
-    - refine (_ oE equiv_sigma_symm _).
+    apply equiv_functor_sigma_id; intros a; simpl.
+    refine (_ oE _); revgoals.
+    - refine (equiv_functor_sigma_id
+                (fun p => (equiv_path_sigma _ _ _)^-1)).
+    - cbn. refine (_ oE equiv_sigma_symm _).
       apply equiv_sigma_contr; intros p.
       destruct p; simpl; exact _.
-    - refine (equiv_functor_sigma' 1
-                (fun p => (equiv_path_sigma _ _ _)^-1)).
   Defined.
 
   Definition hfiber_compose (c : C)
   : hfiber (g o f) c <~> { w : hfiber g c & hfiber f w.1 }.
   Proof.
     unfold hfiber.
-    refine (equiv_sigma_assoc
-              (fun x => g x = c) (fun w => {x : A & f x = w.1}) oE _).
-    refine (equiv_functor_sigma' 1
-             (fun b => equiv_sigma_symm (fun a p => f a = b)) oE _).
+    refine (equiv_sigma_assoc _ _ oE _).
+    refine (equiv_functor_sigma_id _ oE _).
+    1: intros; apply equiv_sigma_symm.
     refine (equiv_sigma_symm _ oE _).
-    refine (equiv_functor_sigma' 1 _); intros a.
-    refine (equiv_functor_sigma' 1
-              (fun b => equiv_sigma_symm0 _ _) oE _); simpl.
+    apply equiv_functor_sigma_id; intros a; cbn.
+    refine (equiv_functor_sigma_id _ oE _).
+    1: intros; apply equiv_sigma_symm0.
     refine ((equiv_sigma_assoc' _ _)^-1 oE _).
     symmetry.
-    exact (equiv_contr_sigma (fun (w:{b:B & f a = b}) => g w.1 = c)).
+    refine (_ oE equiv_contr_sigma _).
+    reflexivity.
   Defined.
 
   Global Instance istruncmap_compose `{!IsTruncMap n g} `{!IsTruncMap n f}
@@ -201,18 +196,14 @@ Definition hfiber_functor_sigma {A B} (P : A -> Type) (Q : B -> Type)
   {w : hfiber f b & hfiber (g w.1) ((w.2)^ # v)}.
 Proof.
   unfold hfiber, functor_sigma.
-  equiv_via ({x : sigT P & {p : f x.1 = b & p # (g x.1 x.2) = v}}).
-  { refine (equiv_functor_sigma' 1
-             (fun x => (equiv_path_sigma Q _ _)^-1)). }
+  refine (_ oE equiv_functor_sigma_id _).
+  2:intros; symmetry; apply equiv_path_sigma.
   refine (_ oE (equiv_sigma_assoc P _)^-1).
-  equiv_via ({a:A & {q:f a = b & {p : P a & q # (g a p) = v}}}).
-  { refine (equiv_functor_sigma' 1 (fun a => _)); simpl.
-    refine (equiv_sigma_symm _). }
-  refine (_ oE (equiv_sigma_assoc' _ _)).
-  refine (equiv_functor_sigma' 1 _);
-    intros [a p]; simpl.
-  refine (equiv_functor_sigma' 1 _);
-    intros u; simpl.
+  refine (_ oE equiv_functor_sigma_id _).
+  2:intros a; cbn; apply equiv_sigma_symm.
+  refine (_ oE equiv_sigma_assoc' _ _).
+  apply equiv_functor_sigma_id; intros [a p]; simpl.
+  apply equiv_functor_sigma_id; intros u; simpl.
   apply equiv_moveL_transport_V.
 Defined.
 

--- a/theories/HIT/FreeIntQuotient.v
+++ b/theories/HIT/FreeIntQuotient.v
@@ -66,7 +66,7 @@ Section FreeIntAction.
                    (Wtil Unit Unit idmap idmap (unit_name R) (unit_name f))
                    (cct tt) (fun r0 : R => (ppt tt r0)^) r).
         symmetry; apply inv_V.
-    - refine (equiv_functor_sigma' 1 _); intros x.
+    - apply equiv_functor_sigma_id; intros x.
       apply equiv_path.
       revert x; refine (S1_ind _ 1 _); cbn.
       rewrite transport_paths_FlFr, concat_p1.

--- a/theories/Homotopy/BlakersMassey.v
+++ b/theories/Homotopy/BlakersMassey.v
@@ -70,14 +70,10 @@ Module GenBlakersMassey (Os : ReflectiveSubuniverses).
                    glue q0 @ (glue q1)^ = r } }
           <~> ap left s = r.
     Proof.
-      refine (_ oE (equiv_sigma_assoc
-                      (fun q0 => transport _ s q0 = q1)
-                      (fun qt => glue qt.1 @ (glue q1)^ = r))).
+      refine (_ oE equiv_sigma_assoc' _ _).
       refine (_ oE equiv_functor_sigma'
                 (Q := fun qt => glue qt.1 @ (glue q1)^ = r)
-                (equiv_functor_sigma'
-                   (Q := fun q0 => q0 = transport _ s^ q1)
-                   equiv_idmap
+                (equiv_functor_sigma_id
                    (fun q0 : Q x0 y =>
                       equiv_moveL_transport_V
                         (fun x => Q x y) s q0 q1))
@@ -199,7 +195,7 @@ Module GenBlakersMassey (Os : ReflectiveSubuniverses).
           refine ((equiv_sigma_pushout _ _ _ _ _)^-1 oE _).
           srefine (equiv_pushout _ _ _ _ _).
           - unfold Ocodeleft2a.
-            srefine ((equiv_functor_sigma' equiv_idmap _) oE _).
+            srefine (equiv_functor_sigma_id _ oE _).
             + intros [y0 [q00 [q10 u]]].
               exact { s  : x0 = x1 &
                     { sq : transport (fun x => Q x y0) s q00 = q10 &
@@ -213,11 +209,11 @@ Module GenBlakersMassey (Os : ReflectiveSubuniverses).
                 refine (equiv_sigma_assoc _ _).
             + cbn.
               refine (equiv_sigma_symm _ oE _).
-              refine (equiv_functor_sigma' equiv_idmap _); intros s.
+              apply equiv_functor_sigma_id; intros s.
               refine (equiv_sigma_assoc _ _ oE _).
-              refine (equiv_functor_sigma' equiv_idmap _ oE _).
+              refine (equiv_functor_sigma_id _ oE _).
               * intros y0.
-                refine (equiv_functor_sigma' equiv_idmap _ oE _).
+                refine (equiv_functor_sigma_id _ oE _).
                 { intros ?.
                   refine (equiv_sigma_symm _). }
                 refine (equiv_sigma_symm _).
@@ -225,18 +221,18 @@ Module GenBlakersMassey (Os : ReflectiveSubuniverses).
                 refine ((equiv_sigma_assoc' _ _)^-1 oE _).
                 refine ((equiv_contr_sigma _)^-1 oE _); cbn.
                 refine (equiv_sigma_assoc _ _ oE _).
-                refine (equiv_functor_sigma' equiv_idmap _); intros q01; cbn.
-                refine (equiv_functor_sigma' equiv_idmap _ oE _).
+                refine (equiv_functor_sigma_id _); intros q01; cbn.
+                refine (equiv_functor_sigma_id _ oE _).
                 { intros ?; apply (equiv_sigma_symm0 _ _). }
                 refine (equiv_sigma_assoc _ _ oE _).
-                refine (equiv_functor_sigma' equiv_idmap _ oE _).
+                refine (equiv_functor_sigma_id _ oE _).
                 { intros q; cbn; apply equiv_sigma_symm. }
                 cbn.
                 refine ((equiv_sigma_assoc' _ _)^-1 oE _).
                 refine ((equiv_contr_sigma _)^-1 oE _); cbn.
                 apply equiv_sigma_symm0.
           - unfold Ocodeleft2b.
-            srefine ((equiv_functor_sigma' equiv_idmap _) oE _).
+            srefine (equiv_functor_sigma_id _ oE _).
             + intros [y0 [q00 [q10 u]]].
               exact { s  : x0 = x1 &
                     (* sq : *) transport (fun x => Q x y0) s q00 = q10 }.
@@ -244,16 +240,16 @@ Module GenBlakersMassey (Os : ReflectiveSubuniverses).
               refine (equiv_path_sigma _ (x0;q00) (x1;q10)).
             + cbn.
               refine (equiv_sigma_symm _ oE _).
-              refine (equiv_functor_sigma' equiv_idmap _); intros s.
+              apply equiv_functor_sigma_id; intros s.
               refine (equiv_sigma_assoc _ _ oE _).
-              refine (equiv_functor_sigma' equiv_idmap _); intros y0.
+              apply equiv_functor_sigma_id; intros y0.
               refine (equiv_sigma_assoc _ _ oE _).
-              refine (equiv_functor_sigma' equiv_idmap _); intros q00.
+              apply equiv_functor_sigma_id; intros q00.
               refine (equiv_sigma_assoc _ _ oE _).
-              refine (equiv_functor_sigma' equiv_idmap _); intros q10.
+              apply equiv_functor_sigma_id; intros q10.
               apply equiv_sigma_symm0.
           - unfold Ocodeleft2c.
-            srefine ((equiv_functor_sigma' equiv_idmap _) oE _).
+            srefine (equiv_functor_sigma_id _ oE _).
             + intros [y0 [q00 [q10 u]]].
               exact { t  : y0 = y1 &
                            transport (Q x1) t q10 = q11 }.
@@ -261,15 +257,15 @@ Module GenBlakersMassey (Os : ReflectiveSubuniverses).
               refine (equiv_path_sigma _ (y0;q10) (y1;q11)).
             + cbn.
               refine (equiv_sigma_assoc _ _ oE _).
-              refine (equiv_functor_sigma' equiv_idmap _ oE _).
+              refine (equiv_functor_sigma_id _ oE _).
               { intros y0; apply equiv_sigma_symm. }
               cbn.
               refine ((equiv_sigma_assoc' _ _)^-1 oE _).
                 refine ((equiv_contr_sigma _)^-1 oE _); cbn.
                 refine (equiv_sigma_assoc _ _ oE _).
-                refine (equiv_functor_sigma' equiv_idmap _); intros q01; cbn.
+                apply equiv_functor_sigma_id; intros q01; cbn.
                 refine (equiv_sigma_assoc _ _ oE _).
-                refine (equiv_functor_sigma' equiv_idmap _ oE _).
+                refine (equiv_functor_sigma_id _ oE _).
                 { intros q; cbn; apply equiv_sigma_symm0. }
                 cbn.
                 refine ((equiv_sigma_assoc' _ _)^-1 oE _).
@@ -297,14 +293,14 @@ Module GenBlakersMassey (Os : ReflectiveSubuniverses).
         Definition Ocodeleft02b : codeleft0 <~> Ocodeleft2b.
         Proof.
           unfold codeleft0, Ocodeleft2b.
-          refine (equiv_functor_sigma' equiv_idmap _); intros s.
-          refine (equiv_functor_sigma' equiv_idmap _); intros y0.
+          apply equiv_functor_sigma_id; intros s.
+          apply equiv_functor_sigma_id; intros y0.
           refine (_ oE equiv_sigma_symm _).
-          refine (equiv_functor_sigma' equiv_idmap _); intros q00.
+          apply equiv_functor_sigma_id; intros q00.
           refine (_ oE equiv_sigma_symm _).
-          refine (equiv_functor_sigma' equiv_idmap _); intros q10.
+          apply equiv_functor_sigma_id; intros q10.
           refine (_ oE equiv_sigma_symm _).
-          refine (equiv_functor_sigma' equiv_idmap _); intros w.
+          apply equiv_functor_sigma_id; intros w.
           refine (_ oE equiv_sigma_symm _).
           refine (equiv_sigma_contr _).
         Defined.
@@ -347,7 +343,7 @@ Now we claim that the left-hand map of this span is also an equivalence.  Rather
         Definition Ocodeleft2a1 : Ocodeleft2a <~> codeleft1.
         Proof.
           unfold Ocodeleft2a, codeleft1.
-          refine (equiv_functor_sigma' equiv_idmap _); intros s; cbn.
+          apply equiv_functor_sigma_id; intros s; cbn.
           (** Here's frobnicate showing up again! *)
           apply frobnicate.
         Defined.
@@ -454,7 +450,7 @@ Now we claim that the left-hand map of this span is also an equivalence.  Rather
         Proof.
           unfold coderight, Ocodeleft2c.
           apply equiv_O_functor.
-          refine (equiv_functor_sigma' equiv_idmap _); intros q01.
+          apply equiv_functor_sigma_id; intros q01.
           apply equiv_moveL_pM.
         Defined.
 

--- a/theories/Idempotents.v
+++ b/theories/Idempotents.v
@@ -121,8 +121,8 @@ Proof.
   contr_sigsig r (fun x:X => idpath (r x)); cbn.
   contr_sigsig s (fun x:A => idpath (s x)); cbn.
   refine (contr_equiv' {K : r o s == idmap & H == K} _).
-  apply (equiv_functor_sigma' (equiv_idmap _)); intros K.
-  apply (equiv_functor_forall' (equiv_idmap _)); intros a; cbn.
+  apply equiv_functor_sigma_id; intros K.
+  apply equiv_functor_forall_id; intros a; cbn.
   apply equiv_concat_lr.
   - refine (concat_p1 _ @ ap_idmap (H a)).
   - symmetry; apply concat_1p.
@@ -735,14 +735,14 @@ Section RetractOfRetracts.
       apply path_forall; intros x; apply split_idem_preidem.
     - simpl; unfold hfiber, Splitting.
       refine (equiv_sigma_assoc _ _ oE _).
-      refine (equiv_functor_sigma' 1 _); intros R; simpl.
+      apply equiv_functor_sigma_id; intros R; simpl.
       refine (_ oE (equiv_path_sigma _ _ _)^-1); simpl.
       refine (equiv_functor_sigma' (equiv_ap10 _ _) _); intros H; simpl.
       destruct f as [f I]; simpl in *.
       destruct H; simpl.
       refine (_ oE (equiv_path_forall _ _)^-1);
         unfold pointwise_paths.
-      refine (equiv_functor_forall' 1 _); intros x; simpl.
+      apply equiv_functor_forall_id; intros x; simpl.
       unfold isidem.
       apply equiv_concat_l.
       refine (concat_p1 _ @ concat_1p _).
@@ -808,10 +808,10 @@ Section CoherentIdempotents.
 
   (** For instance, here is the standard coherent idempotent structure on the identity map. *)
   Global Instance isidem_idmap (X : Type@{i})
-  : @IsIdempotent@{i i j} X idmap
+  : @IsIdempotent@{i i j k} X idmap
     := Build_IsIdempotent idmap (splitting_idmap X).
 
-  Definition idem_idmap (X : Type@{i}) : Idempotent@{i i j} X
+  Definition idem_idmap (X : Type@{i}) : Idempotent@{i i j k} X
   := (idmap ; isidem_idmap X).
 
   (** Note that [Idempotent X], unlike [RetractOf X], lives in the same universe as [X], even if we demand that it contain the identity. *)
@@ -841,17 +841,17 @@ Proof.
                         @ ap s (H (r x))) @ p x = isidem idmap x }.
   - intros [A [r [s H]]]; simpl. apply equiv_idmap.
   - refine (equiv_sigma_assoc _ _ oE _); simpl.
-    refine (equiv_functor_sigma' (equiv_idmap Type) _); intros Y; simpl.
+    apply equiv_functor_sigma_id; intros Y; simpl.
     refine (equiv_sigma_assoc _ _ oE _); simpl.
     refine (_ oE (issig_equiv X Y)^-1).
-    refine (equiv_functor_sigma' 1 _); intros r; simpl.
+    apply equiv_functor_sigma_id; intros r; simpl.
     refine (equiv_sigma_assoc _ _ oE _).
     refine (_ oE (issig_isequiv r)^-1).
-    refine (equiv_functor_sigma' 1 _); intros s; simpl.
+    apply equiv_functor_sigma_id; intros s; simpl.
     unfold Sect.
-    refine (equiv_functor_sigma' 1 _); intros eta; simpl.
-    refine (equiv_functor_sigma' 1 _); intros ep; simpl.
-    refine (equiv_functor_forall' 1 _).
+    apply equiv_functor_sigma_id; intros eta; simpl.
+    apply equiv_functor_sigma_id; intros ep; simpl.
+    apply equiv_functor_forall_id.
     intros x; unfold isidem, ispreidem_idmap; simpl.
     rewrite ap_idmap, !concat_pp_p.
     refine (equiv_moveR_Vp _ _ _ oE _).

--- a/theories/Limits/Pullback.v
+++ b/theories/Limits/Pullback.v
@@ -33,8 +33,8 @@ Definition equiv_pullback_symm {A B C} (f : B -> A) (g : C -> A)
 : Pullback f g <~> Pullback g f.
 Proof.
   refine (_ oE equiv_sigma_symm (fun b c => f b = g c)).
-  refine (equiv_functor_sigma' 1 _); intros c.
-  refine (equiv_functor_sigma' 1 _); intros b.
+  apply equiv_functor_sigma_id; intros c.
+  apply equiv_functor_sigma_id; intros b.
   apply equiv_path_inverse.
 Defined.
 
@@ -93,12 +93,9 @@ Proof.
   unfold hfiber, Pullback.
   refine (_ oE (equiv_sigma_assoc _ _)^-1).
   simpl.
-  refine (_ oE (@equiv_functor_sigma'
-                 B (fun b' => {_ : {c:C & f b' = g c} & b' = b})
-                 B (fun b' => {_ : b' = b & {c:C & f b' = g c}})
-                 1
-                 (fun b' => equiv_sigma_symm0 {c:C & f b' = g c} (b' = b)))).
-  refine (_ oE (equiv_sigma_assoc' _ _)).
+  refine (_ oE equiv_functor_sigma_id _).
+  2:intros; apply equiv_sigma_symm0.
+  refine (_ oE equiv_sigma_assoc' _ _).
   refine (_ oE equiv_contr_sigma _).
   exact (equiv_functor_sigma_id (fun c => equiv_path_inverse _ _)).
 Defined.
@@ -117,14 +114,11 @@ Definition hfiber_pullback_along' {A B C} (g : C -> A) (f : B -> A) (c:C)
 Proof.
   unfold hfiber, Pullback.
   refine (_ oE (equiv_sigma_assoc _ _)^-1).
-  refine (equiv_functor_sigma' 1 _); intros b.
+  apply equiv_functor_sigma_id; intros b.
   refine (_ oE (equiv_sigma_assoc _ _)^-1).
   simpl.
-  refine (_ oE (@equiv_functor_sigma'
-                 C (fun c' => {_ : f b = g c' & c' = c})
-                 C (fun c' => {_ : c' = c & f b = g c'})
-                 1
-                 (fun c' => equiv_sigma_symm0 (f b = g c') (c' = c)))).
+  refine (_ oE equiv_functor_sigma_id _).
+  2:intros; apply equiv_sigma_symm0.
   refine (_ oE equiv_sigma_assoc' _ _).
   refine (_ oE equiv_contr_sigma _).
   apply equiv_idmap.
@@ -150,21 +144,19 @@ Section Functor_Pullback.
   Proof.
     destruct z as [b2 [c2 e2]].
     refine (_ oE hfiber_functor_sigma _ _ _ _ _ _).
-    refine (equiv_functor_sigma' 1 _).
+    apply equiv_functor_sigma_id.
     intros [b1 e1]; simpl.
-    refine (_ oE (equiv_transport (fun x => hfiber (functor_sigma l _) x) _ _
-                                 (transport_sigma' e1^ (c2; e2)))).
+    refine (_ oE (equiv_transport _ _ _ (transport_sigma' e1^ (c2; e2)))).
     refine (_ oE hfiber_functor_sigma _ _ _ _ _ _); simpl.
-    refine (equiv_functor_sigma' 1 _).
+    apply equiv_functor_sigma_id.
     intros [c1 e3]; simpl.
-    refine (_ oE (equiv_transport (hfiber (fun e0 => (p b1 @ ap h e0) @ (q c1)^)) _ _
-                                 (ap (fun e => e3^ # e) (transport_paths_Fl e1^ e2)))).
-    refine (_ oE (equiv_transport (hfiber (fun e0 => (p b1 @ ap h e0) @ (q c1)^)) _ _
-                                 (transport_paths_Fr e3^ _))).
+    refine (_ oE (equiv_transport _ _ _
+                   (ap (fun e => e3^ # e) (transport_paths_Fl e1^ e2)))).
+    refine (_ oE (equiv_transport _ _ _ (transport_paths_Fr e3^ _))).
     unfold functor_hfiber; simpl.
     refine (equiv_concat_l (transport_sigma' e2 _) _ oE _); simpl.
     refine (equiv_path_sigma _ _ _ oE _); simpl.
-    refine (equiv_functor_sigma' 1 _); intros e0; simpl.
+    apply equiv_functor_sigma_id; intros e0; simpl.
     refine (equiv_concat_l (transport_paths_Fl e0 _) _ oE _).
     refine (equiv_concat_l (whiskerL (ap h e0)^ (transport_paths_r e2 _)) _ oE _).
     refine (equiv_moveR_Vp _ _ _ oE _).
@@ -212,17 +204,17 @@ Section PullbackSigma.
   Proof.
     refine (_ oE (equiv_sigma_assoc _ _)^-1).
     refine (equiv_sigma_assoc _ _ oE _).
-    apply (equiv_functor_sigma' equiv_idmap); intro y.
+    apply equiv_functor_sigma_id; intro y.
     refine (_ oE (equiv_sigma_assoc _ _)^-1).
-    refine (equiv_functor_sigma' equiv_idmap _ oE _).
+    refine (equiv_functor_sigma_id _ oE _).
     1: intro; apply equiv_sigma_assoc.
     refine (equiv_sigma_symm _ oE _).
-    refine (equiv_functor_sigma' equiv_idmap _); intro z.
+    refine (equiv_functor_sigma_id _); intro z.
     refine (_ oE _).
-    { refine (equiv_functor_sigma' equiv_idmap _); intro b.
-      refine (equiv_functor_sigma' equiv_idmap _); intro c.
+    { refine (equiv_functor_sigma_id _); intro b.
+      refine (equiv_functor_sigma_id _); intro c.
       apply equiv_path_sigma. }
-    refine (equiv_functor_sigma' equiv_idmap _ oE _).
+    refine (equiv_functor_sigma_id _ oE _).
     1: intro b; cbn; apply equiv_sigma_symm.
     cbn; apply equiv_sigma_symm.
   Defined.

--- a/theories/Modalities/Lex.v
+++ b/theories/Modalities/Lex.v
@@ -76,7 +76,7 @@ Module Lex_Modalities_Theory (Os : Modalities).
   Proof.
     apply isconnected_sigma; [ exact _ | intros a ].
     refine (isconnected_equiv O (hfiber g (f a))
-                              (equiv_functor_sigma' (equiv_idmap _)
+                              (equiv_functor_sigma_id
                               (fun b => equiv_path_inverse _ _))
                               _).
   Defined.
@@ -319,7 +319,7 @@ Module Lex_Reflective_Subuniverses
       refine (_ oE Build_Equiv _ _
                 (O_functor_hfiber O (@pr1 A B) (g x)) _).
       unfold hfiber.
-      refine (equiv_functor_sigma' 1 _). intros y; cbn.
+      apply equiv_functor_sigma_id. intros y; cbn.
       refine (_ oE (equiv_moveR_equiv_V _ _)).
       apply equiv_concat_l.
       apply moveL_equiv_V.

--- a/theories/Modalities/Modality.v
+++ b/theories/Modalities/Modality.v
@@ -628,7 +628,7 @@ Section ModalFact.
     simple refine (Build_PathFactorization fact fact' _ _ _ _).
     - refine (_ oE equiv_fibration_replacement (factor2 fact)).
       refine ((equiv_fibration_replacement (factor2 fact'))^-1 oE _).
-      refine (equiv_functor_sigma' 1 _); intros b; simpl.
+      apply equiv_functor_sigma_id; intros b; simpl.
       apply equiv_O_factor_hfibers.
     - intros a; exact (pr1_path (equiv_O_factor_hfibers_beta f fact fact' a)).
     - intros x.

--- a/theories/Pointed/Loops.v
+++ b/theories/Pointed/Loops.v
@@ -143,28 +143,33 @@ Proof.
   induction n as [|n IHn]; [ assumption | apply loops_2functor, IHn ].
 Defined.
 
+(** The fiber of [loops_functor f] is equivalent to a fiber of [ap f]. *)
+Definition hfiber_loops_functor {A B : pType} (f : A ->* B) (p : loops B)
+  : {q : loops A & ap f q = (point_eq f @ p) @ (point_eq f)^}
+    <~> hfiber (loops_functor f) p.
+Proof.
+  apply equiv_functor_sigma_id; intros q.
+  refine (equiv_moveR_Vp _ _ _ oE _).
+  apply equiv_moveR_pM.
+Defined.
+
 (** The loop space functor decreases the truncation level by one.  *)
 Global Instance istrunc_loops_functor {n} (A B : pType) (f : A ->* B)
   `{IsTruncMap n.+1 _ _ f} : IsTruncMap n (loops_functor f).
 Proof.
-  intro p.
-  refine (trunc_equiv' _ (equiv_functor_sigma' 1
-    (fun q => equiv_moveR_Vp _ _ _))).
-  refine (trunc_equiv' _ (equiv_functor_sigma' 1
-    (fun q => equiv_moveR_pM _ _ _))).
+  intro p. apply (trunc_equiv' _ (hfiber_loops_functor f p)).
 Defined.
 
 (** And likewise the connectedness.  *)
-(* Note: We give the definition explicitly since it was slow before. *)
 Global Instance isconnected_loops_functor `{Univalence} {n : trunc_index}
   (A B : pType) (f : A ->* B) `{IsConnMap n.+1 _ _ f}
-  : IsConnMap n (loops_functor f)
-  := fun (p : loops B) =>
-    isconnected_equiv' n _
-      (equiv_functor_sigma' 1 (fun q => equiv_moveR_Vp _ p _))
-      (isconnected_equiv' n _
-        (equiv_functor_sigma' 1 (fun q => equiv_moveR_pM _ _ _))
-        (isconnected_equiv' n _ (hfiber_ap _)^-1 (isconnected_paths _ _))).
+  : IsConnMap n (loops_functor f).
+Proof.
+  intros p; eapply isconnected_equiv'.
+  - refine (hfiber_loops_functor f p oE _).
+    symmetry; apply hfiber_ap.
+  - exact _.
+Defined.
 
 (** It follows that loop spaces "commute with images". *)
 Definition equiv_loops_image `{Univalence} n {A B : pType} (f : A ->* B)

--- a/theories/Pointed/pEquiv.v
+++ b/theories/Pointed/pEquiv.v
@@ -71,13 +71,11 @@ Definition issig_pequiv' (A B : pType)
 Proof.
   transitivity { f : A ->* B & IsEquiv f }.
   2: issig.
-  refine ((equiv_functor_sigma' (P := fun f => IsEquiv f.1)
-    (issig_pmap A B) (fun f => equiv_idmap _)) oE _).
-  refine (_ oE (equiv_functor_sigma' (Q := fun f => f.1 (point A) = point B)
-    (issig_equiv A B)^-1 (fun f => equiv_idmap _))).
+  refine (equiv_functor_sigma_pb (issig_pmap A B) oE _).
+  refine (_ oE (equiv_functor_sigma_pb (issig_equiv A B))^-1).
   refine (_ oE (equiv_sigma_assoc _ _)^-1).
   refine (equiv_sigma_assoc _ _ oE _).
-  refine (equiv_functor_sigma' 1 _).
+  apply equiv_functor_sigma_id.
   intro; cbn; apply equiv_sigma_symm0.
 Defined.
 

--- a/theories/Pointed/pMap.v
+++ b/theories/Pointed/pMap.v
@@ -16,7 +16,7 @@ Proof.
   intros [f feq]; cbn.
   contr_sigsig f (fun a:A => idpath (f a)); cbn.
   refine (contr_equiv' {feq' : f (point A) = point B & feq = feq'} _).
-  refine (equiv_functor_sigma' (equiv_idmap _) _); intros p.
+  apply equiv_functor_sigma_id; intros p.
   refine (equiv_path_inverse _ _ oE _).
   apply equiv_concat_r. symmetry; apply concat_1p.
 Defined.

--- a/theories/Pointed/pSusp.v
+++ b/theories/Pointed/pSusp.v
@@ -100,36 +100,23 @@ Module Book_Loop_Susp_Adjunction.
   : (psusp A ->* B) <~> (A ->* loops B).
   Proof.
     refine (_ oE (issig_pmap (psusp A) B)^-1).
-    refine (_ oE (equiv_functor_sigma'
+    refine (_ oE (equiv_functor_sigma_pb
                  (Q := fun NSm => fst NSm.1 = point B)
-                 (equiv_Susp_rec A B)
-                 (fun f => 1%equiv))).
+                 (equiv_Susp_rec A B))).
     refine (_ oE (equiv_sigma_assoc _ _)^-1); simpl.
-    refine (_ oE
-              (equiv_functor_sigma'
-                 (Q := fun a => {_ : fst a = point B & A -> fst a = snd a })
-                 (equiv_idmap (B * B))
-                 (fun NS => equiv_sigma_symm0
-                              (A -> fst NS = snd NS)
-                              (fst NS = point B)))).
+    refine (_ oE equiv_functor_sigma_id _).
+    2:intros; apply equiv_sigma_symm0.
     refine (_ oE (equiv_sigma_prod _)^-1); simpl.
-    refine (_ oE
-              (equiv_functor_sigma'
-                 (Q := fun b => {_ : b = point B & { p : B & A -> b = p}})
-                 1
-                 (fun b => equiv_sigma_symm (A := B) (B := b = point B)
-                             (fun p _ => A -> b = p)))).
+    refine (_ oE equiv_functor_sigma_id _).
+    2:intros; apply equiv_sigma_symm.
     refine (_ oE equiv_sigma_assoc' _ _).
     refine (_ oE equiv_contr_sigma _); simpl.
     refine (_ oE (equiv_sigma_contr
                    (A := {p : B & A -> point B = p})
                    (fun pm => { q : point B = pm.1 & pm.2 (point A) = q }))^-1).
     refine (_ oE (equiv_sigma_assoc _ _)^-1); simpl.
-    refine (_ oE
-              (equiv_functor_sigma'
-                 (Q := fun b => {q : point B = b & {p : A -> point B = b & p (point A) = q}})
-                 1
-                 (fun b => equiv_sigma_symm (fun p q => p (point A) = q)))).
+    refine (_ oE equiv_functor_sigma_id _).
+    2:intros; apply equiv_sigma_symm.
     refine (_ oE equiv_sigma_assoc' _ _).
     refine (_ oE equiv_contr_sigma _); simpl.
     refine (issig_pmap A (loops B)).

--- a/theories/PropResizing/Nat.v
+++ b/theories/PropResizing/Nat.v
@@ -888,16 +888,9 @@ Section AssumeStuff.
           + destruct (zero_neq_succ n (H0)).
           + cbn. apply ap.
             apply path_sigma_hprop; reflexivity. }
-        { srefine ((equiv_functor_forall_pf
-                      (Q := fun mh =>
-                              (equiv_N_segment_succ_maps n)
-                                (f, xsn) (succ_seg (succ n) mh)
-                              = xs ((equiv_N_segment_succ_maps n)
-                                      (f, xsn)
-                                      ((equiv_N_segment (succ n))^-1
-                                         (inl mh))))
-                   (equiv_N_segment_lt_succ n)) oE _).
-          srefine ((equiv_functor_forall_pf (equiv_N_segment n)) oE _).
+        { srefine ((equiv_functor_forall_pb
+                     (equiv_N_segment_lt_succ n)^-1)^-1 oE _).
+          srefine ((equiv_functor_forall_pb (equiv_N_segment n)^-1)^-1 oE _).
           srefine (equiv_sum_ind _ oE _).
           apply equiv_functor_prod'.
           - apply equiv_functor_forall_id; intros [m H].
@@ -920,8 +913,7 @@ Section AssumeStuff.
               * cbn. apply ap, path_sigma_hprop; reflexivity.
           - refine ((equiv_contr_forall _)^-1 oE _).
             apply equiv_concat_lr.
-            + cbv [equiv_fun equiv_inv equiv_isequiv equiv_N_segment_succ_maps equiv_N_segment_lt_succ equiv_N_segment equiv_adjointify isequiv_adjointify equiv_compose' equiv_compose equiv_precompose' equiv_functor_sigma_id equiv_N_segment_succ equiv_sum_ind equiv_functor_prod_l equiv_functor_sum_r equiv_functor_sigma' equiv_functor_sum equiv_functor_sum' equiv_functor_sigma equiv_functor_prod equiv_functor_prod' equiv_idmap isequiv_idmap equiv_unit_rec isequiv_functor_sigma equiv_iff_hprop equiv_iff_hprop_uncurried eisretr inverse transport succ_seg];
-                cbn.
+            + cbn.
               match goal with
               | [ |- context[match ?L with | inl _ => inr tt | inr Hs => inl (?k; Hs) end] ] => generalize L
               end.

--- a/theories/Spaces/BAut.v
+++ b/theories/Spaces/BAut.v
@@ -122,18 +122,13 @@ Proof.
   unfold WeaklyConstant.
   (** Now we peel away a bunch of contractible types. *)
   refine (equiv_sigT_coind _ _ oE _).
-  refine (equiv_functor_sigma'
-           (P := fun k : forall xy, P xy.1 => forall Z p q, k (Z;p) = k (Z;q))
-           (equiv_sigT_ind
-              (fun Zp => P Zp.1))^-1 (fun k => equiv_idmap _) oE _).
-  refine (equiv_functor_sigma'
-            (equiv_idmap (forall Zp : {Z:Type & Z=X}, P Zp.1))
-            (fun k => (equiv_sigT_ind
-                         (fun Zp => forall q, k Zp = k (Zp.1;q)))^-1) oE _).
-  refine (equiv_functor_sigma'
-           (equiv_idmap (forall Zp : {Z:Type & Z=X}, P Zp.1))
-           (fun k => (equiv_contr_forall
-                        (fun Zp => forall q, k Zp = k (Zp.1;q)))^-1) oE _); simpl.
+  srefine ((equiv_functor_sigma_pb _) oE _).
+  2: symmetry; apply equiv_sigT_ind'.
+  refine (equiv_functor_sigma_id _ oE _).
+  1:{ intros; symmetry; etransitivity.
+      - apply equiv_sigT_ind'.
+      - serapply equiv_contr_forall. }
+  cbn.
   refine (equiv_functor_sigma'
             (P := fun (e : P X) => forall q:X=X, transport P q^ e = e)
             ((equiv_contr_forall
@@ -145,7 +140,7 @@ Proof.
     refine (transport_compose P pr1 (path_contr (X;1) (X;g)) f @ _).
     apply transport2.
     refine (ap_pr1_path_contr_basedpaths' _ _ @ concat_1p g^). }
-  refine (equiv_functor_sigma' 1 _); intros e.
+  refine (equiv_functor_sigma_id _); intros e.
   refine (equiv_functor_forall' (equiv_path_universe X X)^-1 _).
   intros g; simpl.
   refine (equiv_moveR_transport_V _ _ _ _ oE _).
@@ -160,14 +155,12 @@ Definition center_baut `{Univalence} X `{IsHSet X}
 : { f : X <~> X & forall g:X<~>X, g o f == f o g }
   <~> (forall Z:BAut X, Z = Z).
 Proof.
-  refine (equiv_functor_forall'
-            (P := fun Z => Z.1 = Z.1)
-            1
+  refine (equiv_functor_forall_id
             (fun Z => equiv_path_sigma_hprop Z Z) oE _).
   refine (baut_ind_hset X (fun Z => Z = Z) oE _).
   simpl.
   refine (equiv_functor_sigma' (equiv_path_universe X X) _); intros f.
-  refine (equiv_functor_forall' 1 _); intros g; simpl.
+  apply equiv_functor_forall_id; intros g; simpl.
   refine (_ oE equiv_path_arrow _ _).
   refine (_ oE equiv_path_equiv (g oE f) (f oE g)).
   revert g. equiv_intro (equiv_path X X) g.
@@ -209,9 +202,7 @@ Section Center2BAut.
   : { f : forall x:X, x=x & forall (g:X<~>X) (x:X), ap g (f x) = f (g x) }
       <~> (forall Z:BAut X, (idpath Z) = (idpath Z)).
   Proof.
-    refine ((equiv_functor_forall'
-               (P := fun Z => idpath Z.1 = idpath Z.1)
-               1
+    refine ((equiv_functor_forall_id
                (fun Z => (equiv_concat_lr _ _)
                            oE (equiv_ap (equiv_path_sigma_hprop Z Z) 1%path 1%path))) oE _).
     { symmetry; apply path_sigma_hprop_1. }
@@ -224,7 +215,7 @@ Section Center2BAut.
       - symmetry; apply path_universe_1.
       - apply path_universe_1. }
     intros f.
-    refine (equiv_functor_forall' 1 _); intros g.
+    apply equiv_functor_forall_id; intros g.
     refine (_ oE equiv_path3_universe _ _).
     refine (dpath_paths2 (path_universe g) _ _ oE _).
     cbn.

--- a/theories/Spaces/BAut/Bool/IncoherentIdempotent.v
+++ b/theories/Spaces/BAut/Bool/IncoherentIdempotent.v
@@ -15,9 +15,10 @@ Section IncoherentQuasiIdempotent.
   : IsQuasiIdempotent (preidem_idmap (BAut (BAut Bool)))
     := negb_center2_baut_baut_bool.
 
-  Let s := retract_sect (splitting_preidem_retractof_qidem (preidem_idmap (BAut (BAut Bool)))).
-  Let r := retract_retr (splitting_preidem_retractof_qidem (preidem_idmap (BAut (BAut Bool)))).
-  Let issect := retract_issect (splitting_preidem_retractof_qidem (preidem_idmap (BAut (BAut Bool)))) : r o s == idmap.
+  Let ret := splitting_preidem_retractof_qidem (preidem_idmap (BAut (BAut Bool))).
+  Let s := retract_sect ret.
+  Let r := retract_retr ret.
+  Let issect := retract_issect ret : r o s == idmap.
 
   (** Since the space of splittings of the identity pre-idempotent is contractible, nontriviality of this 2-central element implies that not every quasi-idempotence witness of the identity is recoverable from its own splitting. *)
   Definition splitting_preidem_notequiv_qidem_baut_baut_bool

--- a/theories/Spaces/Finite.v
+++ b/theories/Spaces/Finite.v
@@ -704,7 +704,7 @@ Proof.
   apply finite_choice in g.
   strip_truncations.
   unfold finplus.
-  refine (fcard_equiv' (equiv_functor_sigma' (equiv_idmap X) g)).
+  refine (fcard_equiv' (equiv_functor_sigma_id g)).
 Defined.
 
 (** The sum of a finite constant family is the product by its cardinality. *)
@@ -895,7 +895,7 @@ Section DecidableQuotients.
     apply ap, path_arrow; intros z; revert z.
     refine (Quotient_ind_hprop _ _ _); intros x; simpl.
     apply fcard_equiv'; unfold hfiber.
-    refine (equiv_functor_sigma' 1 _); intros y; simpl.
+    refine (equiv_functor_sigma_id _); intros y; simpl.
     symmetry.
     refine (path_quotient R y x oE _).
     apply equiv_iff_hprop; apply symmetry.

--- a/theories/Types/Equiv.v
+++ b/theories/Types/Equiv.v
@@ -18,10 +18,10 @@ Section AssumeFunext.
     (* We will show that if [IsEquiv] is inhabited, then it is contractible, because it is equivalent to a sigma of a pointed path-space over a pointed path-space, both of which are contractible. *)
     refine (contr_equiv' { g : B -> A & g = f^-1 } _).
     equiv_via ({ g:B->A & { r:g=f^-1 & { s:g=f^-1 & r=s }}}); apply equiv_inverse.
-    1:exact (equiv_functor_sigma' 1 (fun _ => equiv_sigma_contr _ )).
+    1:exact (equiv_functor_sigma_id (fun _ => equiv_sigma_contr _ )).
     (* First we apply [issig], peel off the first component, and convert to pointwise paths. *)
     refine (_ oE (issig_isequiv f)^-1).
-    refine (equiv_functor_sigma' (equiv_idmap (B -> A)) _); intros g; simpl.
+    refine (equiv_functor_sigma_id _); intros g; simpl.
     equiv_via ({ r : g == f^-1 & { s : g == f^-1 & r == s }}).
     (* Now the idea is that if [f] is an equivalence, then [g f == 1] and [f g == 1] are both equivalent to [g == f^-1]. *)
     { refine (equiv_functor_sigma'

--- a/theories/Types/Forall.v
+++ b/theories/Types/Forall.v
@@ -241,14 +241,6 @@ Definition equiv_functor_forall_pb {A B : Type} {P : A -> Type}
   : (forall a, P a) <~> (forall b, P (f b))
   := equiv_functor_forall' (Q := P o f) f (fun b => equiv_idmap).
 
-Definition equiv_functor_forall_pf {A B : Type} {Q : B -> Type}
-  (f : B <~> A)
-  : (forall a, (Q (f^-1 a))) <~> (forall b, Q b).
-Proof.
-  srefine (equiv_functor_forall' (P := Q o f^-1) f _).
-  intros b; exact (equiv_transport Q _ _ (eissect f b)).
-Defined.
-
 (** There is another way to make forall functorial that acts on on equivalences only. *)
 
 Definition equiv_functor_forall_covariant

--- a/theories/Types/Sigma.v
+++ b/theories/Types/Sigma.v
@@ -453,6 +453,11 @@ Definition equiv_functor_sigma_id `{P : A -> Type} `{Q : A -> Type}
 : sigT P <~> sigT Q
   := equiv_functor_sigma' 1 g.
 
+Definition equiv_functor_sigma_pb {A B : Type} {Q : B -> Type}
+           (f : A <~> B)
+: sigT (Q o f) <~> sigT Q
+  := equiv_functor_sigma f (fun a => 1%equiv).
+
 (** Lemma 3.11.9(i): Summing up a contractible family of types does nothing. *)
 
 Global Instance isequiv_pr1_contr {A} {P : A -> Type}
@@ -567,6 +572,12 @@ Definition equiv_sigT_ind `{P : A -> Type}
            (Q : sigT P -> Type)
 : (forall (x:A) (y:P x), Q (x;y)) <~> (forall xy, Q xy)
   := Build_Equiv _ _ (sigT_ind Q) _.
+
+(** And a curried version *)
+Definition equiv_sigT_ind' `{P : A -> Type}
+           (Q : forall a, P a -> Type)
+: (forall (x:A) (y:P x), Q x y) <~> (forall xy, Q xy.1 xy.2)
+  := equiv_sigT_ind (fun xy => Q xy.1 xy.2).
 
 (** *** The negative universal property. *)
 

--- a/theories/Types/Sum.v
+++ b/theories/Types/Sum.v
@@ -119,7 +119,7 @@ Global Instance ishprop_hfiber_inl {A B : Type} (z : A + B)
 Proof.
   destruct z as [a|b]; unfold hfiber.
   - refine (trunc_equiv' _
-              (equiv_functor_sigma' 1
+              (equiv_functor_sigma_id
                  (fun x => equiv_path_sum (inl x) (inl a)))).
   - refine (trunc_equiv _
               (fun xp => inl_ne_inr (xp.1) b xp.2)^-1).
@@ -130,7 +130,7 @@ Global Instance decidable_hfiber_inl {A B : Type} (z : A + B)
 Proof.
   destruct z as [a|b]; unfold hfiber.
   - refine (decidable_equiv' _
-              (equiv_functor_sigma' 1
+              (equiv_functor_sigma_id
                  (fun x => equiv_path_sum (inl x) (inl a))) _).
   - refine (decidable_equiv _
               (fun xp => inl_ne_inr (xp.1) b xp.2)^-1 _).
@@ -143,7 +143,7 @@ Proof.
   - refine (trunc_equiv _
               (fun xp => inr_ne_inl (xp.1) a xp.2)^-1).
   - refine (trunc_equiv' _
-              (equiv_functor_sigma' 1
+              (equiv_functor_sigma_id
                  (fun x => equiv_path_sum (inr x) (inr b)))).
 Defined.
 
@@ -154,7 +154,7 @@ Proof.
   - refine (decidable_equiv _
               (fun xp => inr_ne_inl (xp.1) a xp.2)^-1 _).
   - refine (decidable_equiv' _
-              (equiv_functor_sigma' 1
+              (equiv_functor_sigma_id
                  (fun x => equiv_path_sum (inr x) (inr b))) _).
 Defined.
 


### PR DESCRIPTION
`equiv_functor_sigma_id` and its friends, used appropriately, can eliminate a lot more explicit type family arguments.