### PR TITLE
Redefine IsTrunc as an instance of AccRSU in Overture

### DIFF
--- a/contrib/HoTTBook.v
+++ b/contrib/HoTTBook.v
@@ -1536,6 +1536,7 @@ Proof.
     + refine (H' a b).
     + apply H.
   - intros H' a b.
+    change (IsHProp (a = b)).
     eapply trunc_equiv.
     + apply (H' a b).
     + apply (@isequiv_inverse _ _ _ (H _ _)).

--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -716,7 +716,7 @@ Lemma Book_3_11 `{Univalence} : ~ (forall A, Trunc (-1) A -> A).
   {
     intros A.
     apply Book_3_4_solution_1.
-    apply Trunc_is_trunc.
+    exact _.
   }
 
   (** There are no fixpoints of the fix-point free autoequivalence of 2 (called

--- a/theories/Algebra/Group.v
+++ b/theories/Algebra/Group.v
@@ -101,7 +101,8 @@ Defined.
 Global Instance ishset_grouphomomorphism {F : Funext} {G H : Group}
   : IsHSet (GroupHomomorphism G H).
 Proof.
-  intros f g; apply (trunc_equiv' _ equiv_path_grouphomomorphism).
+  intros f g. change (IsHProp (f = g)).
+  apply (trunc_equiv' _ equiv_path_grouphomomorphism).
 Defined.
 
 (** * Some basic properties of group homomorphisms *)

--- a/theories/Basics/Trunc.v
+++ b/theories/Basics/Trunc.v
@@ -250,7 +250,7 @@ Definition trunc_equiv A {B} (f : A -> B)
   : IsTrunc n B.
 Proof.
   generalize dependent B; generalize dependent A.
-  simple_induction n n IH; simpl; intros A ? B f ?.
+  simple_induction n n IH; simpl; intros A H B f ?.
   - exact (contr_equiv _ f).
   - intros x y.
     exact (IH (f^-1 x = f^-1 y) (H (f^-1 x) (f^-1 y))
@@ -307,7 +307,7 @@ Lemma contr_inhabited_hprop (A : Type) `{H : IsHProp A} (x : A)
 Proof.
   exists x.
   intro y.
-  apply center, H.
+  apply center; rapply H.
 Defined.
 
 (** If inhabitation implies contractibility, then we have an h-proposition.  We probably won't often have a hypothesis of the form [A -> Contr A], so we make sure we give priority to other instances. *)

--- a/theories/Categories/Category/Univalent.v
+++ b/theories/Categories/Category/Univalent.v
@@ -20,6 +20,7 @@ Notation isotoid C s d := (@equiv_inv _ _ (@idtoiso C s d) _).
 Global Instance trunc_category `{IsCategory C} : IsTrunc 1 C | 10000.
 Proof.
   intros ? ?.
+  change (IsHSet (x = y)).
   eapply trunc_equiv';
   [ symmetry;
     esplit;

--- a/theories/Categories/ExponentialLaws/Tactics.v
+++ b/theories/Categories/ExponentialLaws/Tactics.v
@@ -11,7 +11,7 @@ Ltac exp_laws_misc_t' :=
   match goal with
     | _ => reflexivity
     | _ => progress intros
-    | _ => progress simpl in *
+    | _ => progress cbn in *
     | _ => apply (@path_forall _); intro
     | _ => rewrite !identity_of
     | _ => progress autorewrite with morphism
@@ -62,17 +62,17 @@ Ltac exp_laws_handle_transport' :=
       => rewrite (fun a b => @transport_compose _ _ a b (fun y' => f (g (y' x)) z) (@object_of C D))
     | _ => progress transport_path_forall_hammer
     | [ |- context[components_of (transport ?P ?p ?z)] ]
-      => simpl rewrite (@ap_transport _ P _ _ _ p (fun _ => components_of) z)
+      => cbn; rewrite (@ap_transport _ P _ _ _ p (fun _ => components_of) z)
     | [ |- context[object_of (transport ?P ?p ?z)] ]
-      => simpl rewrite (@ap_transport _ P _ _ _ p (fun _ => object_of) z)
+      => cbn; rewrite (@ap_transport _ P _ _ _ p (fun _ => object_of) z)
     | [ |- context[morphism_of (transport ?P ?p ?z)] ]
-      => simpl rewrite (@ap_transport _ P _ _ _ p (fun _ => morphism_of) z)
+      => cbn; rewrite (@ap_transport _ P _ _ _ p (fun _ => morphism_of) z)
     | [ |- context[fst (transport ?P ?p ?z)] ]
-      => simpl rewrite (@ap_transport _ P _ _ _ p (fun _ => fst) z)
+      => cbn; rewrite (@ap_transport _ P _ _ _ p (fun _ => fst) z)
     | [ |- context[snd (transport ?P ?p ?z)] ]
-      => simpl rewrite (@ap_transport _ P _ _ _ p (fun _ => snd) z)
+      => cbn; rewrite (@ap_transport _ P _ _ _ p (fun _ => snd) z)
     | [ |- context[pr1 (transport ?P ?p ?z)] ]
-      => simpl rewrite (@ap_transport _ P _ _ _ p (fun _ => pr1) z)
+      => cbn; rewrite (@ap_transport _ P _ _ _ p (fun _ => pr1) z)
   end.
 
 Ltac exp_laws_t' :=

--- a/theories/Categories/NatCategory.v
+++ b/theories/Categories/NatCategory.v
@@ -29,6 +29,7 @@ Module Export Core.
     induction n; [ typeclasses eauto |].
     induction n; [ typeclasses eauto |].
     intros [x|x] [y|y];
+      change (In (SepRSU ContrRSU)) with (IsHProp);
       typeclasses eauto.
   Qed.
 

--- a/theories/Classes/implementations/binary_naturals.v
+++ b/theories/Classes/implementations/binary_naturals.v
@@ -326,7 +326,7 @@ Section naturals.
     - split; try intros m n; try apply nat_full.
       + split; try intros m n; try apply nat_full.
         * split; try intros m n; try apply nat_full.
-          -- apply _.
+          -- change (IsHProp (m = n)); exact _.
           -- apply cotransitive.
           -- split; intros E.
              ++ assert (X : unary m = unary n) by by apply tight_apart.

--- a/theories/Extensions.v
+++ b/theories/Extensions.v
@@ -9,32 +9,11 @@ Require Import HoTT.Tactics.
 Local Open Scope nat_scope.
 Local Open Scope path_scope.
 
-(** Given [C : B -> Type] and [f : A -> B], an extension of [g : forall a, C (f a)] along [f] is a section [h : forall b, C b] such that [h (f a) = g a] for all [a:A].  This is equivalently the existence of fillers for commutative squares, restricted to the case where the bottom of the square is the identity; type-theoretically, this approach is sometimes more convenient.  In this file we study the type of such extensions.  One of its crucial properties is that a path between extensions is equivalently an extension in a fibration of paths.
-
-This turns out to be useful for several reasons.  For instance, by iterating it, we can to formulate universal properties without needing [Funext].  It also gives us a way to "quantify" a universal property by the connectedness of the type of extensions. *)
-
 Section Extensions.
 
+  (** ** Facts about [ExtensionAlong] *)
+
   (* TODO: consider naming for [ExtensionAlong] and subsequent lemmas.  As a name for the type itself, [Extension] or [ExtensionAlong] seems great; but resultant lemma names such as [path_extension] (following existing naming conventions) are rather misleading. *)
-
-  (** This elimination rule (and others) can be seen as saying that, given a fibration over the codomain and a section of it over the domain, there is some *extension* of this to a section over the whole codomain.  It can also be considered as an equivalent form of an [hfiber] of precomposition-with-[f] that replaces paths by pointwise paths, thereby avoiding [Funext]. *)
-
-  Definition ExtensionAlong {A B : Type} (f : A -> B)
-             (P : B -> Type) (d : forall x:A, P (f x))
-    := { s : forall y:B, P y & forall x:A, s (f x) = d x }.
-  (** [ExtensionAlong] takes 5 universe parameters:
-      - the size of A
-      - the size of B
-      - the size of P
-      - >= max(B,P)
-      - >= max(A,P).
-    The following [Check] verifies that this is in fact the case. *)
-  (** We would like to say [Check], but because of bug #4517, https://coq.inria.fr/bugs/show_bug.cgi?id=4517, we can't. *)
-  Definition check_ExtensionAlong@{a b p m n} : True@{Set}.
-  Proof.
-    Check ExtensionAlong@{a b p m n}.
-  Abort.
-  (** If necessary, we could coalesce the latter two with a universe annotation, but that would make the definition harder to read. *)
 
   (** It's occasionally useful to be able to modify those max universes. *)
   Definition lift_extensionalong@{a b p m1 n1 m2 n2} {A : Type@{a}} {B : Type@{b}} (f : A -> B)
@@ -89,30 +68,7 @@ Section Extensions.
     exact _.
   Defined.
 
-  (** Here is the iterated version. *)
-
-  Fixpoint ExtendableAlong@{i j k l}
-           (n : nat) {A : Type@{i}} {B : Type@{j}}
-           (f : A -> B) (C : B -> Type@{k}) : Type@{l}
-    := match n with
-         | 0 => Unit
-         | S n => (forall (g : forall a, C (f a)),
-                     ExtensionAlong@{i j k l l} f C g) *
-                  forall (h k : forall b, C b),
-                    ExtendableAlong n f (fun b => h b = k b)
-       end.
-  (** [ExtendableAlong] takes 4 universe parameters:
-      - size of A
-      - size of B
-      - size of C
-      - size of result (>= A,B,C) *)
-  (** We would like to say [Check], but because of bug #4517, https://coq.inria.fr/bugs/show_bug.cgi?id=4517, we can't. *)
-  Definition check_ExtendableAlong@{a b c r} : True@{Set}.
-  Proof.
-    Check ExtendableAlong@{a b c r}.
-  Abort.
-
-  Global Arguments ExtendableAlong n%nat_scope {A B}%type_scope (f C)%function_scope.
+  (** ** Facts about [ExtendableAlong] *)
 
   (** We can modify the universes, as with [ExtensionAlong]. *)
   Definition lift_extendablealong@{i j k l1 l2}
@@ -319,20 +275,7 @@ Section Extensions.
       apply IHn, ext.
   Defined.
 
-  (** And the oo-version. *)
-
-  Definition ooExtendableAlong@{i j k l}
-             {A : Type@{i}} {B : Type@{j}}
-             (f : A -> B) (C : B -> Type@{k}) : Type@{l}
-    := forall n : nat, ExtendableAlong@{i j k l} n f C.
-  (** Universe parameters are the same as for [ExtendableAlong]. *)
-  (** We would like to say [Check], but because of bug #4517, https://coq.inria.fr/bugs/show_bug.cgi?id=4517, we can't. *)
-  Definition check_ooExtendableAlong@{a b c r} : True@{Set}.
-  Proof.
-    Check ooExtendableAlong@{a b c r}.
-  Abort.
-
-  Global Arguments ooExtendableAlong {A B}%type_scope (f C)%function_scope.
+  (** ** Facts about [ooExtendableAlong] *)
 
   (** Universe modification. *)
   Definition lift_ooextendablealong@{i j k l1 l2}

--- a/theories/HIT/Circle.v
+++ b/theories/HIT/Circle.v
@@ -196,6 +196,7 @@ Proof.
   intros x y.
   assert (p := merely_path_is0connected S1 base x).
   assert (q := merely_path_is0connected S1 base y).
+  change (IsHSet (x = y)).
   strip_truncations.
   destruct p, q.
   refine (trunc_equiv' (n := 0) Int equiv_loopS1_int^-1).
@@ -231,5 +232,3 @@ Proof.
   apply dp_apD_path_transport.
   exact (S1_ind_beta_loop _ _ _).
 Defined.
-
-

--- a/theories/HSet.v
+++ b/theories/HSet.v
@@ -20,7 +20,7 @@ Defined.
 
 Definition hset_axiomK {A} `{axiomK A} : IsHSet A.
 Proof.
-  intros x y H.
+  intros x y.
   apply @hprop_allpath.
   intros p q.
   by induction p.

--- a/theories/Homotopy/Suspension.v
+++ b/theories/Homotopy/Suspension.v
@@ -532,7 +532,7 @@ Proof.
   apply isconnected_from_elim.
   intros C H' f. exists (f North).
   assert ({ p0 : f North = f South & forall x:X, ap f (merid x) = p0 })
-    as [p0 allpath_p0] by (apply (isconnected_elim n); apply H').
+    as [p0 allpath_p0] by (apply (isconnected_elim n); rapply H').
   apply (Susp_ind (fun a => f a = f North) 1 p0^).
   intros x.
   apply (concat (transport_paths_Fl _ _)).

--- a/theories/NullHomotopy.v
+++ b/theories/NullHomotopy.v
@@ -19,7 +19,7 @@ Lemma istrunc_nullhomotopy {n : trunc_index}
 Proof.
   apply @trunc_sigma; auto.
   intros y. apply (@trunc_forall _).
-  intros x. apply trunc_succ.
+  intros x. serapply trunc_succ.
 Defined.
 
 End NullHomotopy.

--- a/theories/Pointed/Loops.v
+++ b/theories/Pointed/Loops.v
@@ -371,7 +371,7 @@ Proof.
   intro tr_loops.
   intros x y p.
   destruct p.
-  apply tr_loops.
+  rapply tr_loops.
 Defined.
 
 (* This is slightly different to 7.2.9 in that we ommit n = -1, which is

--- a/theories/Spaces/BAut.v
+++ b/theories/Spaces/BAut.v
@@ -44,6 +44,7 @@ Global Instance trunc_baut `{Univalence} {n X} `{IsTrunc n.+1 X}
 : IsTrunc n.+2 (BAut X).
 Proof.
   intros [Z p] [W q].
+  change (IsTrunc n.+1 ((Z;p) = (W;q) :> {Y:Type & merely (Y = X) })).
   strip_truncations.
   refine (@trunc_equiv' _ _ (path_baut _ _) n.+1 _); simpl.
   symmetry in q; destruct q.

--- a/theories/Spaces/BAut/Rigid.v
+++ b/theories/Spaces/BAut/Rigid.v
@@ -28,7 +28,7 @@ Global Instance contr_baut_rigid `{Univalence} {A : Type} `{IsRigid A}
   : Contr (BAut A).
 Proof.
   refine (contr_trunc_conn (Tr 0)).
-  intros Z W; baut_reduce.
+  intros Z W; change (IsHProp (Z = W)); baut_reduce.
   refine (trunc_equiv (A <~> A)
                       (path_baut (point (BAut A)) (point (BAut A)))).
 Defined.

--- a/theories/Types/Sum.v
+++ b/theories/Types/Sum.v
@@ -882,7 +882,7 @@ Global Instance trunc_sum n' (n := n'.+2)
          `{IsTrunc n A, IsTrunc n B}
 : IsTrunc n (A + B) | 100.
 Proof.
-  intros a b.
+  intros a b. change (IsTrunc n'.+1 (a = b)).
   eapply trunc_equiv';
     [ exact (equiv_path_sum _ _) | ].
   destruct a, b; simpl in *;


### PR DESCRIPTION
This is an experiment in the direction of #1209.  At first I tried @jdchristensen's suggestion of defining an `AccRSU` to be a family of formally suspended functions, but I couldn't find a way of doing it that didn't require a lot more changes to the library.  So I went back to my idea of making `AccRSU` an inductive type, which has the advantage that `IsTrunc n` can be a notation for `In (Tr n)` and yet `IsTrunc n.+1 A` can still be definitionally equal to `forall (x y:A), IsTrunc n (x = y)`, and similarly `IsTrunc (-2)` can be definitionally equal to the usual definition of `Contr` (which for us is actually `Contr_internal`).

I haven't touched the `Modalities` code yet; this is just an experiment in the feasibility of defining `IsTrunc` in `Overture` in terms of `AccRSU`.  It's surprising how much of the library compiles without a problem with this change.  However, there are a few places where weird things happen; I'm hoping maybe someone with better Ltac/typeclass-fu can help.

The main issue seems to be whether `Tr : trunc_index -> AccRSU` should be set to `simpl never` or to `simpl nomatch`.  Setting it to `simpl never` seems in principle like a better option to me, since we don't want `IsTrunc n.+1` to get simplified to `In (SepRSU (Tr n))` (as then instances for `IsTrunc` wouldn't match it any more, plus the reader who knows about truncations but not about RSUs would get confused).  And indeed, without `simpl never` we do get problems like that.  But setting it to `simpl never` produces other behavior that I don't understand.

Take a look at the proof of `trunc_sum` on line 885 of `Types/Sum.v`.  It's a bit confusing because `n` is defined to equal `n'.+2` (I don't know why it was written this way), but you can just do a `subst n` at the beginning.  Now the goal is `IsTrunc n'.+2 (A+B)`, which is definitionally equal to `forall (x y:A+B), IsTrunc n'.+1 (x=y)`, so we'd hope that the first line `intros a b` would change the goal to `IsTrunc n'.+1 (a=b)`.  And indeed this is what happens... but only if `Tr` is set to `simpl nomatch`!  If `Tr` is set to `simpl never`, then `intros x y` instead changes the goal to

```
 In
    (SepRSU
       ((fix Tr (n : trunc_index) : AccRSU :=
           match n with
           | -2 => ContrRSU
           | m.+1 => SepRSU (Tr m)
           end) n')) (a = b)
```

There are two confusing things about this, for me.  The first one is that I didn't expect `simpl never/nomatch` to affect the behavior of `intros`!  However, looking at the Coq reference manual I see that `intro` uses the the tactic `hnf` to reduce the goal to a forall, and while the manual doesn't mention that `simpl never/nomatch` might affect `hnf` (they are only mentioned in the subsequent section that describes `cbn` and `simpl`), it seems reasonable that they might.

The second and more confusing thing is that `simpl never` is causing _more_ simplification to occur than `simpl nomatch`!  A bit of experimentation suggests that this happens with `hnf` and `simpl`, but not `cbn`.  Under `simpl nomatch`, `hnf` reduces this goal correctly to `forall x y : A + B, IsTrunc n'.+1 (x = y)`, while `simpl` and `cbn` both reduce it correctly to `  forall (x y : A + B) (x0 y0 : x = y), IsTrunc n' (x0 = y0)`.  And under `simpl never`, `cbn` correctly leaves it untouched, but `hnf` and `simpl` both produce a nasty-looking `fix/match` term.

Can anyone explain what is happening?  Is this just more weird behavior of the old `simpl` algorithm (which perhaps `hnf` is using a variant of)?  More importantly, is there a way to make this work without the `change` statements?
