### PR TITLE
Trunc index inc

### DIFF
--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -547,45 +547,12 @@ Notation "n .+4" := (n.+1.+3)%nat   : nat_scope.
 Notation "n .+5" := (n.+1.+4)%trunc : trunc_scope.
 Notation "n .+5" := (n.+1.+4)%nat   : nat_scope.
 Local Open Scope trunc_scope.
-Fixpoint nat_to_trunc_index (n : nat) : trunc_index
-  := match n with
-       | 0%nat => minus_two.+2
-       | S n' => (nat_to_trunc_index n').+1
-     end.
 
-Coercion nat_to_trunc_index : nat >-> trunc_index.
-
-Definition int_to_trunc_index (v : Decimal.int) : option trunc_index
-  := match v with
-     | Decimal.Pos d => Some (nat_to_trunc_index (Nat.of_uint d))
-     | Decimal.Neg d => match Nat.of_uint d with
-                        | 2%nat => Some minus_two
-                        | 1%nat => Some (minus_two.+1)
-                        | 0%nat => Some (minus_two.+2)
-                        | _ => None
-                        end
-     end.
-
-Fixpoint trunc_index_to_little_uint n acc :=
-  match n with
-  | minus_two => acc
-  | minus_two.+1 => acc
-  | minus_two.+2 => acc
-  | trunc_S n => trunc_index_to_little_uint n (Decimal.Little.succ acc)
-  end.
-
-Definition trunc_index_to_int n :=
-  match n with
-  | minus_two => Decimal.Neg (Nat.to_uint 2)
-  | minus_two.+1 => Decimal.Neg (Nat.to_uint 1)
-  | n => Decimal.Pos (Decimal.rev (trunc_index_to_little_uint n Decimal.zero))
-  end.
-
-Numeral Notation trunc_index int_to_trunc_index trunc_index_to_int : trunc_scope (warning after 5000).
+(** Further notation for truncation levels is introducted in Trunc.v. *)
 
 Fixpoint IsTrunc_internal (n : trunc_index) (A : Type) : Type :=
   match n with
-    | -2 => Contr_internal A
+    | minus_two => Contr_internal A
     | n'.+1 => forall (x y : A), IsTrunc_internal n' (x = y)
   end.
 
@@ -594,7 +561,7 @@ Arguments IsTrunc_internal n A : simpl nomatch.
 Class IsTrunc (n : trunc_index) (A : Type) : Type :=
   Trunc_is_trunc : IsTrunc_internal n A.
 
-(** We use the priciple that we should always be doing typeclass resolution on truncation of non-equality types.  We try to change the hypotheses and goals so that they never mention something like [IsTrunc n (_ = _)] and instead say [IsTrunc (S n) _].  If you're evil enough that some of your paths [a = b] are n-truncated, but others are not, then you'll have to either reason manually or add some (local) hints with higher priority than the hint below, or generalize your equality type so that it's not a path anymore. *)
+(** We use the principle that we should always be doing typeclass resolution on truncation of non-equality types.  We try to change the hypotheses and goals so that they never mention something like [IsTrunc n (_ = _)] and instead say [IsTrunc (S n) _].  If you're evil enough that some of your paths [a = b] are n-truncated, but others are not, then you'll have to either reason manually or add some (local) hints with higher priority than the hint below, or generalize your equality type so that it's not a path anymore. *)
 
 Typeclasses Opaque IsTrunc. (* don't auto-unfold [IsTrunc] in typeclass search *)
 
@@ -625,9 +592,9 @@ progress match goal with
              => change (forall (a : A) (b : B a) (c : C a b) (d : D a b c), IsTrunc n.+1 (T a b c d)) in H; cbv beta in H
          end : core.
 
-Notation Contr := (IsTrunc (-2)).
-Notation IsHProp := (IsTrunc (-1)).
-Notation IsHSet := (IsTrunc 0).
+Notation Contr := (IsTrunc (minus_two)).
+Notation IsHProp := (IsTrunc (minus_two.+1)).
+Notation IsHSet := (IsTrunc minus_two.+2).
 
 Hint Extern 0 => progress change Contr_internal with Contr in * : typeclass_instances.
 

--- a/theories/Basics/Trunc.v
+++ b/theories/Basics/Trunc.v
@@ -10,11 +10,11 @@ Generalizable Variables A B m n f.
 Open Scope trunc_scope.
 
 (* Increase a truncation index by a natural number. *)
-Definition trunc_index_inc (k : trunc_index)
-  : nat -> trunc_index
-  := fix inner (n : nat) : trunc_index := match n with
+Fixpoint trunc_index_inc (k : trunc_index) (n : nat)
+  : trunc_index
+  := match n with
       | O => k
-      | S m => (inner m).+1
+      | S m => (trunc_index_inc k m).+1
     end.
 
 (* This is a variation that inserts the successor operations in

--- a/theories/Categories/GroupoidCategory/Dual.v
+++ b/theories/Categories/GroupoidCategory/Dual.v
@@ -1,6 +1,7 @@
 (** * Propositional self-duality of groupoid categories *)
 Require Import Category.Core GroupoidCategory.Core Category.Paths Category.Dual.
 Require Import HoTT.Types HoTT.UnivalenceImpliesFunext.
+Require Import Basics.Trunc.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Pointed/Loops.v
+++ b/theories/Pointed/Loops.v
@@ -171,6 +171,18 @@ Proof.
   - exact _.
 Defined.
 
+Definition isconnected_iterated_loops_functor `{Univalence}
+  (k : nat) (A B : pType) (f : A ->* B)
+  : forall n : trunc_index, IsConnMap (trunc_index_inc' n k) f
+                       -> IsConnMap n (iterated_loops_functor k f).
+Proof.
+  induction k; intros n C.
+  - exact C.
+  - apply isconnected_loops_functor.
+    apply IHk.
+    exact C.
+Defined.
+
 (** It follows that loop spaces "commute with images". *)
 Definition equiv_loops_image `{Univalence} n {A B : pType} (f : A ->* B)
   : loops (Build_pType (image n.+1 f) (factor1 (image n.+1 f) (point A)))

--- a/theories/Pointed/Loops.v
+++ b/theories/Pointed/Loops.v
@@ -322,7 +322,7 @@ Defined.
 
 (* Loops neutralise sigmas when truncated *)
 Lemma loops_psigma_trunc (n : nat) : forall (Aa : pType)
-  (Pp : pFam Aa) (istrunc_Pp : IsTrunc_pFam (nat_to_trunc_index_2 n) Pp),
+  (Pp : pFam Aa) (istrunc_Pp : IsTrunc_pFam (trunc_index_inc minus_two n) Pp),
   iterated_loops n (psigma Pp)
   <~>* iterated_loops n Aa.
 Proof.

--- a/theories/Pointed/pTrunc.v
+++ b/theories/Pointed/pTrunc.v
@@ -88,19 +88,16 @@ Defined.
 
 Definition ptr_iterated_loops `{Univalence} (n : trunc_index)
   (k : nat) (A : pType)
-  : pTr n (iterated_loops k A) <~>* iterated_loops k (pTr (n +2+ k).-2 A).
+  : pTr n (iterated_loops k A) <~>* iterated_loops k (pTr (trunc_index_inc' n k) A).
 Proof.
   revert A n.
   induction k.
   { intros A n; cbn.
-    rewrite 2 (trunc_index_add_succ n).
-    rewrite trunc_index_add_minus_two.
     reflexivity. }
   intros A n.
   cbn; etransitivity.
   1: apply ptr_loops.
   apply pequiv_loops_functor.
-  rewrite trunc_index_add_succ.
   apply IHk.
 Defined.
 

--- a/theories/Spectra/Spectrum.v
+++ b/theories/Spectra/Spectrum.v
@@ -39,7 +39,7 @@ Existing Instance to_is_spectrum.
 
 Definition strunc `{Univalence} (k : trunc_index) (E : Spectrum) : Spectrum.
 Proof.
-  simple refine (Build_Spectrum (Build_Prespectrum (fun n => pTr (trunc_index_inc n k) (E n)) _) _).
+  simple refine (Build_Spectrum (Build_Prespectrum (fun n => pTr (trunc_index_inc k n) (E n)) _) _).
   - intros n.
     exact ((ptr_loops _ (E n.+1)) o*E (ptr_pequiv _ (equiv_glue E n))).
   - intros n. unfold glue.


### PR DESCRIPTION
1st commit:

Trunc.v: rewrite trunc_index_inc so `trunc_index_inc minus_two.+2 n` definitionally agrees with `nat_to_trunc_index n`.

Trunc.v: add `trunc_index_inc'` which inserts the successors in a different order.

Loops.v: Replace only use of `nat_to_trunc_index_2` with `trunc_index_inc`.

pTrunc.v: Use `trunc_index_inc'` instead of `+2+` to eliminate rewrites in `ptr_iterated_loops`.

Spectrum.v: use new argument order for `trunc_index_inc`.

2nd commit:

Loops.v: Add `isconnected_iterated_loops_functor`, using `trunc_index_inc'`.
