### PR TITLE
Experimenting with proving equiv_O_coeq using the Yoneda lemma

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -57,6 +57,7 @@ theories/WildCat/Sigma.v
 theories/WildCat/Opposite.v
 theories/WildCat/Paths.v
 theories/WildCat/Type.v
+theories/WildCat/CatCat.v
 theories/WildCat/Induced.v
 theories/WildCat/EquivGpd.v
 theories/WildCat/FunctorCat.v

--- a/theories/Extensions.v
+++ b/theories/Extensions.v
@@ -340,6 +340,12 @@ Section Extensions.
   : ooExtendableAlong f C -> IsEquiv (fun g => g oD f)
     := fun ps => isequiv_extendable 0 (fst (ps 1%nat), snd (ps 2)).
 
+  Definition equiv_ooextendable `{Funext}
+             {A B : Type} (C : B -> Type) (f : A -> B)
+             (ext : ooExtendableAlong f C)
+    : (forall b, C b) <~> (forall a, C (f a))
+    := Build_Equiv _ _ _ (isequiv_ooextendable C f ext).
+
   Definition equiv_ooextendable_pathsplit `{Funext}
              {A B : Type} (C : B -> Type) (f : A -> B)
   : ooExtendableAlong f C <~>

--- a/theories/HIT/Coeq.v
+++ b/theories/HIT/Coeq.v
@@ -52,7 +52,7 @@ Defined.
 
 Definition Coeq_unrec {B A} (f g : B -> A) {P}
            (h : Coeq f g -> P)
-  : {h : A -> P & h o f == h o g}.
+  : {k : A -> P & k o f == k o g}.
 Proof.
   exists (h o coeq).
   intros b. exact (ap h (cglue b)).

--- a/theories/HIT/Coeq.v
+++ b/theories/HIT/Coeq.v
@@ -48,6 +48,37 @@ Proof.
   refine (Coeq_ind_beta_cglue (fun _ => P) _ _ _).
 Defined.
 
+(** ** Universal property *)
+
+Definition Coeq_unrec {B A} (f g : B -> A) {P}
+           (h : Coeq f g -> P)
+  : {h : A -> P & h o f == h o g}.
+Proof.
+  exists (h o coeq).
+  intros b. exact (ap h (cglue b)).
+Defined.
+
+Definition isequiv_Coeq_rec `{Funext} {B A} (f g : B -> A) P
+  : IsEquiv (fun p : {h : A -> P & h o f == h o g} => Coeq_rec P p.1 p.2).
+Proof.
+  srapply (isequiv_adjointify _ (Coeq_unrec f g)).
+  - intros h.
+    apply path_arrow.
+    srapply Coeq_ind; intros b.
+    1:reflexivity.
+    cbn.
+    abstract (rewrite transport_paths_FlFr, concat_p1, Coeq_rec_beta_cglue, concat_Vp; reflexivity).
+  - intros [h q]; srapply path_sigma'.
+    + reflexivity.
+    + cbn.
+      rapply path_forall; intros b.
+      apply Coeq_rec_beta_cglue.
+Defined.
+
+Definition equiv_Coeq_rec `{Funext} {B A} (f g : B -> A) P
+  : {h : A -> P & h o f == h o g} <~> (Coeq f g -> P)
+  := Build_Equiv _ _ _ (isequiv_Coeq_rec f g P).
+
 (** ** Functoriality *)
 
 Definition functor_coeq {B A f g B' A' f' g'}

--- a/theories/WildCat.v
+++ b/theories/WildCat.v
@@ -16,5 +16,6 @@ Require Export WildCat.Prod.
 Require Export WildCat.Sum.
 Require Export WildCat.Forall.
 Require Export WildCat.Sigma.
+Require Export WildCat.CatCat.
 (* Higher categories *)
 Require Export WildCat.TwoOneCat.

--- a/theories/WildCat/CatCat.v
+++ b/theories/WildCat/CatCat.v
@@ -1,0 +1,87 @@
+(* -*- mode: coq; mode: visual-line -*-  *)
+
+Require Import Basics.Overture.
+Require Import Basics.PathGroupoids.
+Require Import Basics.Notations.
+Require Import Basics.Contractible.
+Require Import Basics.Equivalences.
+Require Import WildCat.Core.
+Require Import WildCat.FunctorCat.
+Require Import WildCat.Equiv.
+Require Import WildCat.Induced.
+
+(** * Wild categories of wild categories *)
+
+(** ** The wild category of wild (0,1)-categories *)
+
+(** The category of wild (0,1)-categories is simplest, but minimally coherent. *)
+Record WildCat01 :=
+{
+  cat01_carrier : Type;
+  cat01_is01cat : Is01Cat cat01_carrier;
+}.
+
+(* note for morgan: this allows us to consider WildCats as types. *)
+Coercion cat01_carrier : WildCat01 >-> Sortclass.
+
+Global Existing Instance cat01_is01cat.
+
+Global Instance is01cat_wildcat01 : Is01Cat WildCat01.
+Proof.
+  srapply Build_Is01Cat.
+  + intros A B; exact (Fun01 A B).
+  + intros C. cbn in *.
+    exists idmap; exact _.
+  + intros A B C [G g] [F f].
+    exists (G o F); exact _.
+Defined.
+
+(** In fact [WildCat01] is probably a (wild) 1-category and even a (1,2)-category, but we haven't shown that or even defined the latter. *)
+
+(** ** The wild category of wild 1-categories *)
+
+(** This should form a wild 2-category. *) 
+
+Record WildCat :=
+{
+  cat_carrier : Type;
+  cat_isgraph : IsGraph cat_carrier;
+  cat_is01cat : Is01Cat cat_carrier;
+  cat_is1cat : Is1Cat cat_carrier
+}.
+
+(* note for morgan: this allows us to consider WildCats as types. *)
+Coercion cat_carrier : WildCat >-> Sortclass. 
+
+Global Existing Instance cat_isgraph.
+Global Existing Instance cat_is01cat.
+Global Existing Instance cat_is1cat.
+
+(** The proofs below are almost identical to those showing that WildCat01 is a (0,1)-category, but we use [Fun11] instead of [Fun01]. *)
+Global Instance is01cat_wildcat : Is01Cat WildCat.
+Proof.
+  srapply Build_Is01Cat.
+  + intros A B; exact (Fun11 A B).
+  + intro A; rapply (Build_Fun11 idmap).
+  + intros C D E [F ? ?] [G ? ?]; cbn in *.
+    srapply (Build_Fun11 (F o G)).
+Defined.
+
+(** Now we show WildCat is a 2-category, with a 1-category structure on Fun02 given by natural transformations. *) 
+
+Global Instance is1cat_wildcat : Is1Cat WildCat.
+(** Proof.
+  srapply Build_Is1Coh1Cat.
+  + intros A B C D f g h.
+  exact (Fun1 A B).
+  + intros C. cbn in *.
+  unfold Fun1. 
+  exists (idmap). srapply Build_Is0Coh1Functor. intros a b. cbn.
+  exact (idmap).
+  + intros A B C; cbn in *; unfold Fun1.
+  intros [G g] [F f]. 
+  exists ( G o F). 
+  srapply Build_Is0Coh1Functor.
+  intros u v h. cbn in *.  exact (fmap G ( fmap F h)).
+  Defined. *)
+Admitted. 

--- a/theories/WildCat/CatCat.v
+++ b/theories/WildCat/CatCat.v
@@ -21,7 +21,7 @@ Record WildCat01 :=
   cat01_is01cat : Is01Cat cat01_carrier;
 }.
 
-(* note for morgan: this allows us to consider WildCats as types. *)
+(* This allows us to consider WildCats as types. *)
 Coercion cat01_carrier : WildCat01 >-> Sortclass.
 
 Global Existing Instance cat01_is01cat.

--- a/theories/WildCat/CatCat.v
+++ b/theories/WildCat/CatCat.v
@@ -50,7 +50,7 @@ Record WildCat :=
   cat_is1cat : Is1Cat cat_carrier
 }.
 
-(* note for morgan: this allows us to consider WildCats as types. *)
+(* This allows us to consider WildCats as types. *)
 Coercion cat_carrier : WildCat >-> Sortclass. 
 
 Global Existing Instance cat_isgraph.

--- a/theories/WildCat/FunctorCat.v
+++ b/theories/WildCat/FunctorCat.v
@@ -24,7 +24,7 @@ Definition NatTrans {A B : Type} `{IsGraph A} `{Is1Cat B} (F G : A -> B)
 
 (** Note that even if [A] and [B] are fully coherent oo-categories, the objects of our "functor category" are not fully coherent.  Thus we cannot in general expect this "functor category" to itself be fully coherent.  However, it is at least a 0-coherent 1-category, as long as [B] is a 1-coherent 1-category. *)
 
-Global Instance is0cat_fun01 (A B : Type) `{IsGraph A} `{Is1Cat B} : Is01Cat (Fun01 A B).
+Global Instance is01cat_fun01 (A B : Type) `{IsGraph A} `{Is1Cat B} : Is01Cat (Fun01 A B).
 Proof.
   srapply Build_Is01Cat.
   - intros [F ?] [G ?].
@@ -34,6 +34,12 @@ Proof.
   - intros [F ?] [G ?] [K ?] [gamma ?] [alpha ?]; cbn in *.
     exists (comp_transformation gamma alpha); exact _.
 Defined.
+
+Definition fun01_inducingmap
+           {A B : Type} (f : A -> B) `{Is01Cat B}
+           (Acat := induced_01cat f)
+  : Fun01 A B
+  := Build_Fun01 A B _ _ f (inducingmap_is0functor f).
 
 (** In fact, in this case it is automatically also a 0-coherent 2-category and a 1-coherent 1-category, with a totally incoherent notion of 2-cell between 1-coherent natural transformations. *)
 

--- a/theories/WildCat/Induced.v
+++ b/theories/WildCat/Induced.v
@@ -53,6 +53,24 @@ Section Induced_category.
       intros u. apply cat_idr.
   Defined.
 
+  Local Instance induced_1cat_strong `{Is1Cat_Strong B} : Is1Cat_Strong A.
+  Proof.
+    snrapply Build_Is1Cat_Strong.
+    + intros a b. cbn in *. exact _.
+    + intros a b. cbn in *.
+      exact (@isgpd_hom _ _ (is1cat_is1cat_strong B) _ _).
+    + intros a b c g. cbn in *.
+      exact (is0functor_postcomp (f a) (f b) (f c) g).
+    + intros a b c h.
+      exact (is0functor_precomp (f a) (f b) (f c) h).
+    + intros a b c d; cbn in *. 
+      intros u v w. apply cat_assoc_strong.
+    + intros a b; cbn in *.
+      intros u. apply cat_idl_strong.
+    + intros a b; cbn in *.
+      intros u. apply cat_idr_strong.
+  Defined.
+
   Local Instance inducingmap_is1functor `{Is1Cat B} : Is1Functor f.
   Proof.
     srapply Build_Is1Functor.


### PR DESCRIPTION
One of my hopes for the wild categories library was to allow more conceptual category-theoretic proofs of things like "reflections into subuniverses preserve colimits because they are left adjoints", by "chaining natural equivalences" and the Yoneda lemma.  Since the slowness of the current proof that reflectors preserve coequalizers was mentioned in #1243, I thought I would see whether we have enough wild category stuff to do that proof this way.

We did, almost.  I had to port the category-of-categories over from the wildcat branch, prove the universal property of coequalizers (did we really not have that yet?), and mess around a bit with the inclusion functor from the category of modal types into the category of all types -- in a cleaner development probably most of the `{...}`s in the proof would be separated out as lemmas.  But it works.

Advantages of this approach:

- More conceptual; easier to write and read.
- Faster.  It's hard to compare apples to apples, because I had to add other extra stuff to the library here, and also comment out some stuff in ReflectiveSubuniverse that doesn't work any more (see below), but a rough estimate told me that the compile time of ReflectiveSubuniverse is at least halved (!).

Disadvantages of this approach:

- With the version of the yoneda lemma in the current wild categories library, it requires funext.  But it would probably be possible to prove a yoneda lemma for functors taking values in wild groupoids rather than types.
- The resulting equivalence has worse computational behavior.  The computation lemmas `equiv_O_coeq_to_O` and `inverse_equiv_O_coeq_to_O` that used to have one-line proofs are no longer so easy.  I just commented them out (and the ones about pushouts derived from them) for now, so I don't know how hard they are now.
