### PR TITLE
Import IsGraph-as-a-parameter from wildcat branch

### DIFF
--- a/theories/Algebra/Group.v
+++ b/theories/Algebra/Group.v
@@ -365,10 +365,10 @@ Proof.
 Defined.
 
 (** The wild cat of Groups *)
-Global Instance isgraph_Group : IsGraph Group
+Global Instance isgraph_group : IsGraph Group
   := Build_IsGraph Group GroupHomomorphism.
 
-Global Instance is01cat_Group : Is01Cat Group :=
+Global Instance is01cat_group : Is01Cat Group :=
   (Build_Is01Cat Group _ (@grp_homo_id) (@grp_homo_compose)).
 
 Global Instance isgraph_grouphomomorphism {A B : Group} : IsGraph (A $-> B)

--- a/theories/Algebra/Group.v
+++ b/theories/Algebra/Group.v
@@ -364,27 +364,32 @@ Proof.
   1,2: apply grp_homo_op.
 Defined.
 
-(** Group forms a 01Cat *)
+(** The wild cat of Groups *)
+Global Instance isgraph_Group : IsGraph Group
+  := Build_IsGraph Group GroupHomomorphism.
+
 Global Instance is01cat_Group : Is01Cat Group :=
-  (Build_Is01Cat Group GroupHomomorphism (@grp_homo_id) (@grp_homo_compose)).
+  (Build_Is01Cat Group _ (@grp_homo_id) (@grp_homo_compose)).
 
-Global Instance is01cat_GroupHomomorphism {A B : Group} : Is01Cat (A $-> B) :=
-  induced_01cat (@grp_homo_map A B).
+Global Instance isgraph_grouphomomorphism {A B : Group} : IsGraph (A $-> B)
+  := induced_graph (@grp_homo_map A B).
 
-Global Instance is0gpd_GroupHomomorphism {A B : Group}: Is0Gpd (A $-> B) := 
-  induced_0gpd (@grp_homo_map A B).
+Global Instance is01cat_grouphomomorphism {A B : Group} : Is01Cat (A $-> B)
+  := induced_01cat (@grp_homo_map A B).
 
-Global Instance is0functor_postcomp_GroupHomomorphism
-       {A B C : Group} (h : B $-> C)
-  : Is0Functor (@cat_postcomp Group _ A B C h).
+Global Instance is0gpd_grouphomomorphism {A B : Group}: Is0Gpd (A $-> B)
+  := induced_0gpd (@grp_homo_map A B).
+
+Global Instance is0functor_postcomp_grouphomomorphism {A B C : Group} (h : B $-> C)
+  : Is0Functor (@cat_postcomp Group _ _ A B C h).
 Proof.
   apply Build_Is0Functor.
   intros [f ?] [g ?] p a ; exact (ap h (p a)).
 Defined.
 
-Global Instance is0functor_precomp_GroupHomomorphism
+Global Instance is0functor_precomp_grouphomomorphism
        {A B C : Group} (h : A $-> B)
-  : Is0Functor (@cat_precomp Group _ A B C h).
+  : Is0Functor (@cat_precomp Group _ _ A B C h).
 Proof.
   apply Build_Is0Functor.
   intros [f ?] [g ?] p a ; exact (p (h a)).
@@ -393,7 +398,7 @@ Defined.
 (** Group forms a 1Cat *)
 Global Instance is1cat_group : Is1Cat Group.
 Proof.
-  srapply Build_Is1Cat; cbn; intros; reflexivity.
+  by rapply Build_Is1Cat.
 Defined.
 
 Instance hasmorext_group `{Funext} : HasMorExt Group.
@@ -408,24 +413,16 @@ Defined.
 
 Global Instance hasequivs_group : HasEquivs Group.
 Proof.
-  srefine (Build_HasEquivs Group _ _ GroupIsomorphism (fun G H f => IsEquiv f) _ _ _ _ _ _ _ _); intros A B f.
-  - exact f.
-  - cbn. exact _.
-  - apply Build_GroupIsomorphism.
-  - intro fe. reflexivity.
-  - intro fe. exact (grp_iso_inverse (Build_GroupIsomorphism _ _ f fe)).
-  - cbn. intros ? x; apply eissect.
-  - cbn. intros ? x; apply eisretr.
-  - intros g r s; refine (isequiv_adjointify f g r s).
+  unshelve econstructor.
+  + exact GroupIsomorphism.
+  + exact (fun G H f => IsEquiv f).
+  + intros G H f; exact f.
+  + exact Build_GroupIsomorphism.
+  + intros G H; exact grp_iso_inverse.
+  + cbn; exact _.
+  + reflexivity.
+  + intros ????; apply eissect.
+  + intros ????; apply eisretr.
+  + intros G H f g p q.
+    exact (isequiv_adjointify f g p q).
 Defined.
-
-
-(** TODO: If #1140 gets resolved, include this: *)
-(* Module GroupUtf8.
-
-  Import Basics.Utf8.
-  Infix "≅" := GroupIsomorphism.
-  Infix "×" := group_prod.
-
-End GroupUtf8.
- *)

--- a/theories/Basics/Notations.v
+++ b/theories/Basics/Notations.v
@@ -9,6 +9,7 @@ Reserved Infix "<~=~>" (at level 70, no associativity).
 Reserved Infix "==*" (at level 70, no associativity).
 Reserved Infix "<~>*" (at level 85).
 Reserved Infix "->*" (at level 99).
+Reserved Infix "->**" (at level 99).
 Reserved Infix "=n" (at level 70, no associativity).
 Reserved Infix "o*" (at level 40).
 Reserved Infix "oL" (at level 40, left associativity).
@@ -40,8 +41,8 @@ Reserved Notation "f ^-1" (at level 3, format "f '^-1'").
 Reserved Notation "f ^-1*" (at level 3, format "f '^-1*'").
 Reserved Notation "f ^-1$" (at level 3, format "f '^-1$'").
 Reserved Notation "F '_1' m" (at level 10, no associativity).
-Reserved Notation "f ^*" (at level 20).
-Reserved Notation "f ^$" (at level 20).
+Reserved Notation "f ^*" (at level 3, format "f '^*'").
+Reserved Notation "f ^$" (at level 3, format "f '^$'").
 Reserved Notation "f *E g" (at level 40, no associativity).
 Reserved Notation "f +E g" (at level 50, left associativity).
 Reserved Notation "f == g" (at level 70, no associativity).

--- a/theories/Homotopy/Suspension.v
+++ b/theories/Homotopy/Suspension.v
@@ -220,6 +220,9 @@ Section UnivProp.
   (** Here is the domain of the equivalence: sections of [P] over [Susp X]. *)
   Definition Susp_ind_type := forall z:Susp X, P z.
 
+  Local Instance isgraph_Susp_ind_type : IsGraph Susp_ind_type.
+  Proof. apply isgraph_forall; intros; apply isgraph_paths. Defined.
+
   Local Instance is01cat_Susp_ind_type : Is01Cat Susp_ind_type.
   Proof. apply is01cat_forall; intros; apply is01cat_paths. Defined.
 
@@ -229,6 +232,9 @@ Section UnivProp.
   (** The codomain is a sigma-groupoid of this family, consisting of input data for [Susp_ind]. *)
   Definition Susp_ind_data' (NS : P North * P South)
     := forall x:X, DPath P (merid x) (fst NS) (snd NS).
+
+  Local Instance isgraph_Susp_ind_data' NS : IsGraph (Susp_ind_data' NS).
+  Proof. apply isgraph_forall; intros; apply isgraph_paths. Defined.
 
   Local Instance is01cat_Susp_ind_data' NS : Is01Cat (Susp_ind_data' NS).
   Proof. apply is01cat_forall; intros; apply is01cat_paths. Defined.
@@ -297,11 +303,14 @@ Section UnivPropNat.
   Context {X Y : Type} (f : X -> Y) (P : Susp Y -> Type).
 
   (** We recall all those instances from the previous section. *)
-  Local Existing Instances is01cat_Susp_ind_type is0gpd_Susp_ind_type is01cat_Susp_ind_data' is0gpd_Susp_ind_data' is01cat_Susp_ind_data is0gpd_Susp_ind_data.
+  Local Existing Instances isgraph_Susp_ind_type is01cat_Susp_ind_type is0gpd_Susp_ind_type isgraph_Susp_ind_data' is01cat_Susp_ind_data' is0gpd_Susp_ind_data' is01cat_Susp_ind_data is0gpd_Susp_ind_data.
 
   (** Here is an intermediate family of groupoids that we have to use, since precomposition with [f] doesn't land in quite the right place. *)
   Definition Susp_ind_data'' (NS : P North * P South)
     := forall x:X, DPath P (merid (f x)) (fst NS) (snd NS).
+
+  Local Instance isgraph_Susp_ind_data'' NS : IsGraph (Susp_ind_data'' NS).
+  Proof. apply isgraph_forall; intros; apply isgraph_paths. Defined.
 
   Local Instance is01cat_Susp_ind_data'' NS : Is01Cat (Susp_ind_data'' NS).
   Proof. apply is01cat_forall; intros; apply is01cat_paths. Defined.

--- a/theories/Pointed.v
+++ b/theories/Pointed.v
@@ -6,3 +6,4 @@ Require Export Pointed.pEquiv.
 Require Export Pointed.pTrunc.
 Require Export Pointed.pHomotopy.
 Require Export Pointed.pSusp.
+Require Export Pointed.pType.

--- a/theories/Pointed/pType.v
+++ b/theories/Pointed/pType.v
@@ -10,31 +10,47 @@ Local Open Scope path_scope.
 
 (** * pType as a wild category *)
 
-Global Instance is01cat_ptype : Is01Cat pType
-  := Build_Is01Cat pType pMap (@pmap_idmap) (@pmap_compose).
+Global Instance isgraph_ptype : IsGraph pType
+  := Build_IsGraph pType pMap.
 
-Global Instance is01cat_pmap (A B : pType) : Is01Cat (A ->* B).
+Global Instance is01cat_ptype : Is01Cat pType
+  := Build_Is01Cat pType _ (@pmap_idmap) (@pmap_compose).
+
+Global Instance isgraph_pmap (A B : pType) : IsGraph (A $-> B)
+  := Build_IsGraph _ (@pHomotopy A B).
+
+Global Instance is01cat_pmap (A B : pType) : Is01Cat (A $-> B).
 Proof.
-  srapply (Build_Is01Cat (A ->* B) (@pHomotopy A B)).
+  econstructor.
   - reflexivity.
   - intros a b c f g; transitivity b; assumption.
 Defined.
 
-Global Instance is0gpd_pmap (A B : pType) : Is0Gpd (A ->* B).
+Global Instance is0gpd_pmap (A B : pType) : Is0Gpd (A $-> B).
 Proof.
   srapply Build_Is0Gpd.
   intros; symmetry; assumption.
 Defined.
 
+Global Instance is0functor_ptype_postcomp (a b c : pType) (g : b $-> c)
+  : Is0Functor (cat_postcomp a g).
+Proof.
+  apply Build_Is0Functor.
+  intros x y z.
+  by apply pmap_postwhisker.
+Defined.
+
+Global Instance is0functor_ptype_precomp (a b c : pType) (g : a $-> b)
+  : Is0Functor (cat_precomp c g).
+Proof.
+  apply Build_Is0Functor.
+  intros x y z.
+  by apply pmap_prewhisker.
+Defined.
+
 Global Instance is1cat_ptype : Is1Cat pType.
 Proof.
-  econstructor.
-  - intros A B C h; rapply Build_Is0Functor.
-    intros f g p; cbn.
-    apply pmap_postwhisker; assumption.
-  - intros A B C h; rapply Build_Is0Functor.
-    intros f g p; cbn.
-    apply pmap_prewhisker; assumption.
+  refine (Build_Is1Cat pType _ _ _ _ _ _ _ _ _ _).
   - intros ? ? ? ? f g h; exact (pmap_compose_assoc h g f).
   - intros ? ? f; exact (pmap_postcompose_idmap f).
   - intros ? ? f; exact (pmap_precompose_idmap f).
@@ -43,14 +59,11 @@ Defined.
 Global Instance hasmorext_ptype `{Funext} : HasMorExt pType.
 Proof.
   srapply Build_HasMorExt; intros A B f g.
-  refine (isequiv_homotopic (equiv_path_pmap f g)^-1 _).
-  intros []; reflexivity.
-Defined.
-
+Abort.
 
 Global Instance hasequivs_ptype : HasEquivs pType.
 Proof.
-  srapply (Build_HasEquivs _ _ _ pEquiv (fun A B f => IsEquiv f));
+  srapply (Build_HasEquivs _ _ _ _ pEquiv (fun A B f => IsEquiv f));
     intros A B f; cbn; intros.
   - exact f.
   - exact _.
@@ -67,11 +80,4 @@ Defined.
 Global Instance isunivalent_ptype `{Univalence} : IsUnivalent1Cat pType.
 Proof.
   srapply Build_IsUnivalent1Cat; intros A B.
-  refine (isequiv_homotopic (equiv_path_ptype A B)^-1 _).
-  intros []; apply path_pequiv.
-  cbn.
-  srefine (Build_pHomotopy _ _).
-  - intros x; reflexivity.
-  - cbn.
-    (* Some messy path algebra here. *)
 Abort.

--- a/theories/Pointed/pType.v
+++ b/theories/Pointed/pType.v
@@ -59,7 +59,9 @@ Defined.
 Global Instance hasmorext_ptype `{Funext} : HasMorExt pType.
 Proof.
   srapply Build_HasMorExt; intros A B f g.
-Abort.
+  refine (isequiv_homotopic (equiv_path_pmap f g)^-1 _).
+  intros []; reflexivity.
+Defined.
 
 Global Instance hasequivs_ptype : HasEquivs pType.
 Proof.

--- a/theories/WildCat/EmptyCat.v
+++ b/theories/WildCat/EmptyCat.v
@@ -3,6 +3,11 @@ Require Import WildCat.Core.
 
 (** Empty category *)
 
+Global Instance isgraph_empty : IsGraph Empty.
+Proof.
+  by apply Build_IsGraph.
+Defined.
+
 Global Instance is01cat_empty : Is01Cat Empty.
 Proof.
   srapply Build_Is01Cat; intros [].

--- a/theories/WildCat/EquivGpd.v
+++ b/theories/WildCat/EquivGpd.v
@@ -13,7 +13,7 @@ Class SplEssSurj {A B : Type} `{Is0Gpd A, Is0Gpd B}
       (F : A -> B) `{!Is0Functor F} 
   := esssurj : forall b:B, { a:A & F a $== b }.
 
-Arguments esssurj {A B _ _ _ _} F {_ _} b.
+Arguments esssurj {A B _ _ _ _ _ _} F {_ _} b.
 
 (** A 0-functor between 0-groupoids is an equivalence if it is essentially surjective and reflects the existence of morphisms.  This is "surjective and injective" in setoid-language.  (To define essential surjectivity for non-groupoids, we would need [HasEquivs] from [WildCat.Equiv]. *)
 Class IsEquiv0Gpd {A B : Type} `{Is0Gpd A, Is0Gpd B}
@@ -24,7 +24,7 @@ Class IsEquiv0Gpd {A B : Type} `{Is0Gpd A, Is0Gpd B}
 }.
 
 Global Existing Instance esssurj_isequiv0gpd.
-Arguments essinj0 {A B _ _ _ _} F {_ _ x y} f.
+Arguments essinj0 {A B _ _ _ _ _ _} F {_ _ x y} f.
 
 Definition equiv0gpd_inv {A B : Type} (F : A -> B) `{IsEquiv0Gpd A B F} : B -> A
   := fun b => (esssurj F b).1.
@@ -216,10 +216,9 @@ Defined.
 (** Equivalences and essential surjectivity are preserved by sigmas (for now, just over constant bases), and essential surjectivity at least is also reflected. *)
 
 Definition isesssurj_iff_sigma {A : Type} (B C : A -> Type)
-       {bc : forall a, Is01Cat (B a)} {bg : forall a, Is0Gpd (B a)}
-       {cc : forall a, Is01Cat (C a)} {cg : forall a, Is0Gpd (C a)}
-       (F : forall a, B a -> C a)
-       {ff : forall a, Is0Functor (F a)}
+ `{forall a, IsGraph (B a)} `{forall a, Is01Cat (B a)} `{forall a, Is0Gpd (B a)}
+ `{forall a, IsGraph (C a)} `{forall a, Is01Cat (C a)} `{forall a, Is0Gpd (C a)}
+  (F : forall a, B a -> C a) {ff : forall a, Is0Functor (F a)}
   : SplEssSurj (fun (x:sig B) => (x.1 ; F x.1 x.2))
     <-> (forall a, SplEssSurj (F a)).
 Proof.
@@ -237,10 +236,10 @@ Proof.
 Defined.
 
 Definition isequiv0gpd_sigma {A : Type} (B C : A -> Type)
-       {bc : forall a, Is01Cat (B a)} {bg : forall a, Is0Gpd (B a)}
-       {cc : forall a, Is01Cat (C a)} {cg : forall a, Is0Gpd (C a)}
-       (F : forall a, B a -> C a)
-       {ff : forall a, Is0Functor (F a)} {fs : forall a, IsEquiv0Gpd (F a)}
+ `{forall a, IsGraph (B a)} `{forall a, Is01Cat (B a)} `{forall a, Is0Gpd (B a)}
+ `{forall a, IsGraph (C a)} `{forall a, Is01Cat (C a)} `{forall a, Is0Gpd (C a)}
+  (F : forall a, B a -> C a)
+  `{forall a, Is0Functor (F a)} `{forall a, IsEquiv0Gpd (F a)}
   : IsEquiv0Gpd (fun (x:sig B) => (x.1 ; F x.1 x.2)).
 Proof.
   constructor.

--- a/theories/WildCat/Forall.v
+++ b/theories/WildCat/Forall.v
@@ -9,19 +9,26 @@ Require Import WildCat.Core.
 
 (** ** Indexed product of categories *)
 
+Global Instance isgraph_forall (A : Type) (B : A -> Type)
+  `{forall a, IsGraph (B a)}
+  : IsGraph (forall a, B a).
+Proof.
+  srapply Build_IsGraph.
+  intros x y; exact (forall (a : A), x a $-> y a).
+Defined.
+
 Global Instance is01cat_forall (A : Type) (B : A -> Type)
-  {c : forall a, Is01Cat (B a)}
+  `{forall a, IsGraph (B a)} `{forall a, Is01Cat (B a)}
   : Is01Cat (forall a, B a).
 Proof.
   srapply Build_Is01Cat.
-  + intros x y; exact (forall (a : A), x a $-> y a).
   + intros x a; exact (Id (x a)).
   + intros x y z f g a; exact (f a $o g a).
 Defined.
 
 Global Instance is0gpd_forall (A : Type) (B : A -> Type)
   (* Apparently when there's a [forall] there, Coq can't automatically add the [Is01Cat] instance from the [Is0Gpd] instance. *)
-  `{forall a, Is01Cat (B a)} `{forall a, Is0Gpd (B a)}
+  `{forall a, IsGraph (B a)} `{forall a, Is01Cat (B a)} `{forall a, Is0Gpd (B a)}
   : Is0Gpd (forall a, B a).
 Proof.
   constructor.
@@ -29,12 +36,14 @@ Proof.
 Defined.
 
 Global Instance is1cat_forall (A : Type) (B : A -> Type)
-  {c1 : forall a, Is01Cat (B a)} {c2 : forall a, Is1Cat (B a)}
+  `{forall a, IsGraph (B a)} `{forall a, Is01Cat (B a)}
+  `{forall a, Is1Cat (B a)}
   : Is1Cat (forall a, B a).
 Proof.
   srapply Build_Is1Cat.
+  + intros x y; srapply Build_IsGraph.
+    intros f g; exact (forall a, f a $== g a).
   + intros x y; srapply Build_Is01Cat.
-    - intros f g; exact (forall a, f a $== g a).
     - intros f a; apply Id.
     - intros f g h q p a; exact (p a $@ q a).
   + intros x y; srapply Build_Is0Gpd.

--- a/theories/WildCat/FunctorCat.v
+++ b/theories/WildCat/FunctorCat.v
@@ -24,11 +24,16 @@ Definition NatTrans {A B : Type} `{IsGraph A} `{Is1Cat B} (F G : A -> B)
 
 (** Note that even if [A] and [B] are fully coherent oo-categories, the objects of our "functor category" are not fully coherent.  Thus we cannot in general expect this "functor category" to itself be fully coherent.  However, it is at least a 0-coherent 1-category, as long as [B] is a 1-coherent 1-category. *)
 
+Global Instance isgraph_fun01 (A B : Type) `{IsGraph A} `{Is1Cat B} : IsGraph (Fun01 A B).
+Proof.
+  srapply Build_IsGraph.
+  intros [F ?] [G ?].
+  exact (NatTrans F G).
+Defined.
+
 Global Instance is0cat_fun01 (A B : Type) `{IsGraph A} `{Is1Cat B} : Is01Cat (Fun01 A B).
 Proof.
   srapply Build_Is01Cat.
-  - intros [F ?] [G ?].
-    exact (NatTrans F G).
   - intros [F ?]; cbn.
     exists (id_transformation F); exact _.
   - intros [F ?] [G ?] [K ?] [gamma ?] [alpha ?]; cbn in *.
@@ -40,9 +45,10 @@ Defined.
 Global Instance is0coh2cat_fun01 (A B : Type) `{IsGraph A} `{Is1Cat B} : Is1Cat (Fun01 A B).
 Proof.
   srapply Build_Is1Cat.
+  - intros [F ?] [G ?]; apply Build_IsGraph.
+    intros [alpha ?] [gamma ?].
+    exact (forall a, alpha a $== gamma a).
   - intros [F ?] [G ?]; srapply Build_Is01Cat.
-    + intros [alpha ?] [gamma ?].
-      exact (forall a, alpha a $== gamma a).
     + intros [alpha ?] a; cbn.
       reflexivity.
     + intros [alpha ?] [gamma ?] [phi ?] nu mu a.
@@ -87,7 +93,7 @@ Proof.
     + cbn. refine (is1natural_homotopic alpha _).
       intros a; apply cate_buildequiv_fun.
   - cbn; intros; apply cate_buildequiv_fun.
-  - intros ?; exists (fun a => (alpha a)^-1$).
+  - exists (fun a => (alpha a)^-1$).
     apply Build_Is1Natural; intros a b f.
     refine ((cat_idr _)^$ $@ _).
     refine ((_ $@L (cate_isretr (alpha a))^$) $@ _).
@@ -126,17 +132,18 @@ Proof.
   exists F; exact _.
 Defined.
 
-Global Instance is01cat_fun11 {A B : Type} `{Is1Cat A} `{Is1Cat B} : Is01Cat (Fun11 A B).
-Proof.
-  exact (induced_01cat (fun01_fun11)).
-Defined.
+Global Instance isgraph_fun11 {A B : Type} `{Is1Cat A} `{Is1Cat B}
+  : IsGraph (Fun11 A B)
+  := induced_graph fun01_fun11.
 
-Global Instance is1cat_fun11 {A B :Type} `{Is1Cat A} `{Is1Cat B} : Is1Cat (Fun11 A B).
-Proof.
-  exact (induced_1cat (fun01_fun11)).
-Defined.
+Global Instance is01cat_fun11 {A B : Type} `{Is1Cat A} `{Is1Cat B}
+  : Is01Cat (Fun11 A B)
+  := induced_01cat fun01_fun11.
 
-Global Instance hasequivs_fun11 {A B : Type} `{Is1Cat A} `{HasEquivs B} : HasEquivs (Fun11 A B).
-Proof.
-  exact (induced_hasequivs fun01_fun11).
-Defined.
+Global Instance is1cat_fun11 {A B :Type} `{Is1Cat A} `{Is1Cat B}
+  : Is1Cat (Fun11 A B)
+  := induced_1cat fun01_fun11.
+
+Global Instance hasequivs_fun11 {A B : Type} `{Is1Cat A} `{HasEquivs B}
+  : HasEquivs (Fun11 A B)
+  := induced_hasequivs fun01_fun11.

--- a/theories/WildCat/Induced.v
+++ b/theories/WildCat/Induced.v
@@ -12,12 +12,17 @@ This needs to be separate from Core because of HasEquivs usage.  We don't make t
 
 Section Induced_category.
   Context {A B : Type} (f : A -> B).
-  
-  Local Instance induced_01cat `{Is01Cat B}: Is01Cat A.
+
+  Local Instance induced_graph `{IsGraph B} : IsGraph A.
+  Proof.
+    srapply Build_IsGraph.
+    intros a1 a2. 
+    exact (f a1 $-> f a2).
+  Defined.
+
+  Local Instance induced_01cat `{Is01Cat B} : Is01Cat A.
   Proof.
     srapply Build_Is01Cat.
-    + intros a1 a2. 
-      exact (f a1 $-> f a2).
     + intro a. cbn in *. 
       exact (Id (f a)).
     + intros a b c; cbn in *; intros g1 g2.
@@ -42,6 +47,7 @@ Section Induced_category.
     srapply Build_Is1Cat.
     + intros a b. cbn in *. exact _.
     + intros a b. cbn in *. exact _.
+    + intros a b. cbn in *. exact _.
     + intros a b c. cbn in *. exact _.
     + intros a b c h.
       exact (is0functor_precomp (f a) (f b) (f c) h).
@@ -61,9 +67,9 @@ Section Induced_category.
     + intros a b c g h. cbn in *. exact (Id _). 
   Defined.
 
-  Instance induced_hasmorext `{HasMorExt B} : HasMorExt A.
+  Instance induced_hasmorext `{X : HasMorExt B} : HasMorExt A.
   Proof.
-    constructor. intros. apply H1.
+    constructor. intros. apply X.
   Defined.
 
   Definition induced_hasequivs `{HasEquivs B} : HasEquivs A.

--- a/theories/WildCat/NatTrans.v
+++ b/theories/WildCat/NatTrans.v
@@ -17,7 +17,7 @@ Class Is1Natural {A B : Type} `{IsGraph A} `{Is1Cat B}
      (alpha a') $o (fmap F f) $== (fmap G f) $o (alpha a);
 }.
 
-Arguments isnat {_ _ _ _ _ _ _ _ _} alpha {alnat _ _} f : rename.
+Arguments isnat {_ _ _ _ _ _ _ _ _ _} alpha {alnat _ _} f : rename.
 
 (** The transposed natural square *)
 Definition isnat_tr {A B : Type} `{IsGraph A} `{Is1Cat B}

--- a/theories/WildCat/Opposite.v
+++ b/theories/WildCat/Opposite.v
@@ -148,8 +148,8 @@ Defined.
 
 Definition transformation_op {A} {B} `{Is01Cat B}
            (F : A -> B) (G : A -> B) (alpha : F $=> G)
-  : (@Transformation (A^op) (B^op) _
-                     (G : (A^op) -> (B^op)) (F : (A^op) -> (B^op))).
+  : @Transformation A^op B^op _
+                     (G : A^op -> B^op) (F : A^op -> B^op).
 Proof.
   unfold op in *.
   cbn in *.

--- a/theories/WildCat/Opposite.v
+++ b/theories/WildCat/Opposite.v
@@ -1,12 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 
-(* Don't import the old WildCat *)
-Require Import Basics.Overture.
-Require Import Basics.PathGroupoids.
-Require Import Basics.Notations.
-Require Import Basics.Contractible.
-Require Import Basics.Equivalences.
-
+Require Import Basics.
 Require Import WildCat.Core.
 Require Import WildCat.Equiv.
 Require Import WildCat.NatTrans.
@@ -19,30 +13,48 @@ Notation "A ^op" := (op A).
 (** This stops typeclass search from trying to unfold op. *)
 Typeclasses Opaque op.
 
-Global Instance is01cat_op A `{Is01Cat A} : Is01Cat (A ^op)
-  := Build_Is01Cat A (fun a b => b $-> a) Id (fun a b c g f => f $o g).
+Section Op.
 
-Global Instance is1cat_op A `{Is1Cat A} : Is1Cat A^op.
-Proof.
-  srapply Build_Is1Cat; unfold op in *; cbn in *.
-  - intros a b.
-    apply is01cat_hom.
-  - intros a b.
-    apply isgpd_hom.
-  - intros a b c h.
-    srapply Build_Is0Functor.
-    intros f g p.
-    cbn in *.
-    exact (p $@R h).
-  - intros a b c h.
-    srapply Build_Is0Functor.
-    intros f g p.
-    cbn in *.
-    exact (h $@L p).
-  - intros a b c d f g h; exact (cat_assoc_opp h g f).
-  - intros a b f; exact (cat_idr f).
-  - intros a b f; exact (cat_idl f).
- Defined.
+  Context (A : Type) `{Is1Cat A}.
+
+  Global Instance isgraph_op : IsGraph A^op.
+  Proof.
+    apply Build_IsGraph.
+    unfold op; exact (fun a b => b $-> a).
+  Defined.
+
+  Global Instance is01cat_op : Is01Cat A^op.
+  Proof.
+    apply Build_Is01Cat.
+    + cbv; exact Id.
+    + cbv; exact (fun a b c g f => f $o g).
+  Defined.
+
+  Global Instance is1cat_op : Is1Cat A^op.
+  Proof.
+    srapply Build_Is1Cat; unfold op in *; cbv in *.
+    - intros a b.
+      apply isgraph_hom.
+    - intros a b.
+      apply is01cat_hom.
+    - intros a b.
+      apply isgpd_hom.
+    - intros a b c h.
+      srapply Build_Is0Functor.
+      intros f g p.
+      cbn in *.
+      exact (p $@R h).
+    - intros a b c h.
+      srapply Build_Is0Functor.
+      intros f g p.
+      cbn in *.
+      exact (h $@L p).
+    - intros a b c d f g h; exact (cat_assoc_opp h g f).
+    - intros a b f; exact (cat_idr f).
+    - intros a b f; exact (cat_idl f).
+   Defined.
+
+End Op.
 
 Global Instance is1cat_strong_op A `{Is1Cat_Strong A}
   : Is1Cat_Strong (A ^op).
@@ -136,7 +148,7 @@ Defined.
 
 Definition transformation_op {A} {B} `{Is01Cat B}
            (F : A -> B) (G : A -> B) (alpha : F $=> G)
-  : (@Transformation (A^op) (B^op) (@isgraph_1cat _ (is01cat_op B))
+  : (@Transformation (A^op) (B^op) _
                      (G : (A^op) -> (B^op)) (F : (A^op) -> (B^op))).
 Proof.
   unfold op in *.
@@ -156,8 +168,7 @@ Proof.
   unfold transformation_op.
   cbn.
   intros a b f.
-  apply isnat_tr.
-  assumption.
+  srapply isnat_tr.
 Defined.
 
 (** Opposite categories preserve having equivalences. *)
@@ -179,7 +190,7 @@ Defined.
 
 Global Instance isequivs_op {A : Type} `{HasEquivs A}
        {a b : A} (f : a $-> b) {ief : CatIsEquiv f}
-  : @CatIsEquiv A^op _ _ _ b a f.
+  : @CatIsEquiv A^op _ _ _ _ b a f.
 Proof.
   assumption.
 Defined.

--- a/theories/WildCat/Paths.v
+++ b/theories/WildCat/Paths.v
@@ -4,10 +4,15 @@ Require Export WildCat.Core.
 (** * Path groupoids as wild categories *)
 
 (** Not global instances for now *)
+Local Instance isgraph_paths (A : Type) : IsGraph A.
+Proof.
+  constructor.
+  intros x y; exact (x = y).
+Defined.
+
 Local Instance is01cat_paths (A : Type) : Is01Cat A.
 Proof.
   unshelve econstructor.
-  - constructor; intros x y; exact (x = y).
   - intros a; reflexivity.
   - intros a b c q p; exact (p @ q).
 Defined.

--- a/theories/WildCat/Prod.v
+++ b/theories/WildCat/Prod.v
@@ -18,7 +18,7 @@ Global Instance isgraph_prod A B `{IsGraph A} `{IsGraph B}
 Global Instance is01cat_prod A B `{Is01Cat A} `{Is01Cat B}
   : Is01Cat (A * B).
 Proof.
-  refine (Build_Is01Cat (A * B) (fun x y => (fst x $-> fst y) * (snd x $-> snd y)) _ _).
+  econstructor.
   - intros [a b]; exact (Id a, Id b).
   - intros [a1 b1] [a2 b2] [a3 b3] [f1 g1] [f2 g2]; cbn in *.
     exact (f1 $o f2 , g1 $o g2).
@@ -30,7 +30,6 @@ Definition fmap11 {A B C : Type} `{IsGraph A} `{IsGraph B} `{IsGraph C}
   {a1 a2 : A} {b1 b2 : B} (f1 : a1 $-> a2) (f2 : b1 $-> b2)
   : F a1 b1 $-> F a2 b2
   := @fmap _ _ _ _ (uncurry F) H2 (a1, b1) (a2, b2) (f1, f2).
-
 
 Global Instance is0gpd_prod A B `{Is0Gpd A} `{Is0Gpd B}
  : Is0Gpd (A * B).
@@ -45,6 +44,8 @@ Global Instance is1cat_prod A B `{Is1Cat A} `{Is1Cat B}
   : Is1Cat (A * B).
 Proof.
   srapply (Build_Is1Cat).
+  - intros [x1 x2] [y1 y2].
+    rapply isgraph_prod.
   - intros [x1 x2] [y1 y2].
     rapply is01cat_prod.
   - intros [x1 x2] [y1 y2].
@@ -62,7 +63,7 @@ Proof.
     intros [f1 f2] [g1 g2] [p1 p2]; cbn in *. 
     exact ( p1 $@R h1 , p2 $@R h2 ).
   - intros [a1 a2] [b1 b2] [c1 c2] [d1 d2] [f1 f2] [g1 g2] [h1 h2].
-    cbn in *. 
+    cbn in *.
     exact(cat_assoc f1 g1 h1, cat_assoc f2 g2 h2).
   - intros [a1 a2] [b1 b2] [f1 f2].
     cbn in *.
@@ -70,9 +71,7 @@ Proof.
   - intros [a1 a2] [b1 b2] [g1 g2].
     cbn in *.
     exact (cat_idr _, cat_idr _). 
-Defined. 
-
-
+Defined.
 
 
 (** Product categories inherit equivalences *)
@@ -80,7 +79,7 @@ Defined.
 Global Instance hasequivs_prod A B `{HasEquivs A} `{HasEquivs B}
   : HasEquivs (A * B).
 Proof.
-  srefine (Build_HasEquivs (A * B) _ _
+  srefine (Build_HasEquivs (A * B) _ _ _
              (fun a b => (fst a $<~> fst b) * (snd a $<~> snd b))
              _ _ _ _ _ _ _ _ _).
   1:intros a b f; exact (CatIsEquiv (fst f) * CatIsEquiv (snd f)).
@@ -91,9 +90,9 @@ Proof.
     + exact (Build_CatEquiv (fst f)).
     + exact (Build_CatEquiv (snd f)).
   - intros [fe1 fe2]; cbn; split; apply cate_buildequiv_fun.
-  - intros [fe1 fe2]; split; [ exact ((fst f)^-1$) | exact ((snd f)^-1$) ].
-  - intros [fe1 fe2]; split; apply cate_issect.
-  - intros [fe1 fe2]; split; apply cate_isretr.
+  - split; [ exact ((fst f)^-1$) | exact ((snd f)^-1$) ].
+  - split; apply cate_issect.
+  - split; apply cate_isretr.
   - intros g r s; split.
     + exact (catie_adjointify (fst f) (fst g) (fst r) (fst s)).
     + exact (catie_adjointify (snd f) (snd g) (snd r) (snd s)).
@@ -102,7 +101,7 @@ Defined.
 Global Instance isequivs_prod A B `{HasEquivs A} `{HasEquivs B}
        {a1 a2 : A} {b1 b2 : B} {f : a1 $-> a2} {g : b1 $-> b2}
        {ef : CatIsEquiv f} {eg : CatIsEquiv g}
-  : @CatIsEquiv (A*B) _ _ _ (a1,b1) (a2,b2) (f,g) := (ef,eg).
+  : @CatIsEquiv (A*B) _ _ _ _ (a1,b1) (a2,b2) (f,g) := (ef,eg).
 
 (** More coherent two-variable functors. *)
 
@@ -111,17 +110,16 @@ Definition fmap22 {A B C : Type} `{Is1Cat A} `{Is1Cat B} `{Is1Cat C}
   {a1 a2 : A} {b1 b2 : B} (f1 : a1 $-> a2) (f2 : b1 $-> b2) (g1 : a1 $-> a2) (g2 : b1 $-> b2)
   (alpha : f1 $== g1) (beta : f2 $== g2)
   : (fmap11 F f1 f2) $== (fmap11 F g1 g2)
-  := @fmap2 _ _ _ _ _ _ (uncurry F) _ _ (a1, b1) (a2, b2) (f1, f2) (g1, g2) (alpha, beta).
+  := @fmap2 _ _ _ _ _ _ _ _ (uncurry F) _ _ (a1, b1) (a2, b2) (f1, f2) (g1, g2) (alpha, beta).
 
 Global Instance iemap11 {A B C : Type} `{HasEquivs A} `{HasEquivs B} `{HasEquivs C}
            (F : A -> B -> C) `{!Is0Functor (uncurry F), !Is1Functor (uncurry F)}
-           {a1 a2 : A} {b1 b2 : B} (f1 : a1 $-> a2) (f2 : b1 $-> b2)
-           {f1e : CatIsEquiv f1} {f2e : CatIsEquiv f2}
+           {a1 a2 : A} {b1 b2 : B} (f1 : a1 $<~> a2) (f2 : b1 $<~> b2)
   : CatIsEquiv (fmap11 F f1 f2)
-  := @iemap _ _ _ _ _ _ _ _ (uncurry F) _ _ (a1, b1) (a2, b2) (f1, f2) _.
+  := @iemap _ _ _ _ _ _ _ _ _ _ (uncurry F) _ _ (a1, b1) (a2, b2) (f1, f2).
 
 Definition emap11 {A B C : Type} `{HasEquivs A} `{HasEquivs B} `{HasEquivs C}
            (F : A -> B -> C) `{!Is0Functor (uncurry F), !Is1Functor (uncurry F)}
            {a1 a2 : A} {b1 b2 : B} (fe1 : a1 $<~> a2)
            (fe2 : b1 $<~> b2) : (F a1 b1) $<~> (F a2 b2)
-  := @emap _ _ _ _ _ _ _ _ (uncurry F) _ _ (a1, b1) (a2, b2) (fe1, fe2).
+  := @emap _ _ _ _ _ _ _ _ _ _ (uncurry F) _ _ (a1, b1) (a2, b2) (fe1, fe2).

--- a/theories/WildCat/Sigma.v
+++ b/theories/WildCat/Sigma.v
@@ -5,13 +5,23 @@ Require Import WildCat.Core.
 
 (** ** Indexed sum of categories *)
 
-Global Instance is01cat_sigma (A : Type) (B : A -> Type)
-  {c : forall a, Is01Cat (B a)}
-  : Is01Cat (sig B).
+Section Sigma.
+
+  Context (A : Type) (B : A -> Type)
+    `{forall a, IsGraph (B a)}
+    `{forall a, Is01Cat (B a)}
+    `{forall a, Is0Gpd (B a)}.
+
+Global Instance isgraph_sigma : IsGraph (sig B).
+Proof.
+  srapply Build_IsGraph.
+  intros [x u] [y v].
+  exact {p : x = y & p # u $-> v}.
+Defined.
+
+Global Instance is01cat_sigma : Is01Cat (sig B).
 Proof.
   srapply Build_Is01Cat.
-  + intros [x u] [y v].
-    exact {p : x = y & p # u $-> v}.
   + intros [x u].
     exists idpath. exact (Id u).
   + intros [x u] [y v] [z w] [q g] [p f].
@@ -20,9 +30,7 @@ Proof.
     exact (g $o f).
 Defined.
 
-Global Instance is0gpd_sigma (A : Type) (B : A -> Type)
-  `{forall a, Is01Cat (B a)} `{forall a, Is0Gpd (B a)}
-  : Is0Gpd (sig B).
+Global Instance is0gpd_sigma : Is0Gpd (sig B).
 Proof.
   constructor.
   intros [x u] [y v] [p f].
@@ -31,8 +39,11 @@ Proof.
   exact (f^$).
 Defined.
 
+End Sigma.
+
 Global Instance is0functor_sigma {A : Type} (B C : A -> Type)
-       {bc : forall a, Is01Cat (B a)} {cc : forall a, Is01Cat (C a)}
+       `{forall a, IsGraph (B a)} `{forall a, IsGraph (C a)}
+       `{forall a, Is01Cat (B a)} `{forall a, Is01Cat (C a)}
        (F : forall a, B a -> C a) {ff : forall a, Is0Functor (F a)}
   : Is0Functor (fun (x:sig B) => (x.1 ; F x.1 x.2)).
 Proof.

--- a/theories/WildCat/Sum.v
+++ b/theories/WildCat/Sum.v
@@ -5,18 +5,24 @@ Require Import WildCat.Core.
 
 (** ** Sum categories *)
 
+Global Instance isgraph_sum A B `{IsGraph A} `{IsGraph B}
+  : IsGraph (A + B).
+Proof.
+  econstructor.
+  intros [a1 | b1] [a2 | b2].
+  + exact (a1 $-> a2).
+  + exact Empty.
+  + exact Empty.
+  + exact (b1 $-> b2).
+Defined.
+
 Global Instance is01cat_sum A B `{ Is01Cat A } `{ Is01Cat B}
   : Is01Cat (A + B).
 Proof.
   srapply Build_Is01Cat.
-  - intros [a1 | b1] [a2 | b2].
-    + exact (a1 $-> a2).
-    + exact Empty.
-    + exact Empty.
-    + exact (b1 $-> b2).
-  - intros [a | b]; apply Id.
+  - intros [a | b]; cbn; apply Id.
   - intros [a | b] [a1 | b1] [a2 | b2];
-    try contradiction; apply cat_comp.
+    try contradiction; cbn; apply cat_comp.
 Defined.
 
 (* Note: [try contradiction] deals with empty cases. *)
@@ -24,11 +30,14 @@ Global Instance is1cat_sum A B `{ Is1Cat A } `{ Is1Cat B}
   : Is1Cat (A + B).
 Proof.
   srapply Build_Is1Cat.
+  - intros x y; apply Build_IsGraph.
+    destruct x as [a1 | b1], y as [a2 | b2];
+    try contradiction; cbn; apply Hom.
   - intros x y.
     srapply Build_Is01Cat;
     destruct x as [a1 | b1], y as [a2 | b2];
     try contradiction; cbn;
-    (apply Hom || apply Id || intros a b c; apply cat_comp).
+    (apply Id || intros a b c; apply cat_comp).
   - intros x y; srapply Build_Is0Gpd.
     destruct x as [a1 | b1], y as [a2 | b2];
     try contradiction; cbn; intros f g; apply gpd_rev.

--- a/theories/WildCat/Type.v
+++ b/theories/WildCat/Type.v
@@ -4,13 +4,25 @@ Require Export WildCat.Equiv.
 
 (** ** The category of types *)
 
-Global Instance is01cat_type : Is01Cat Type
-  := Build_Is01Cat Type (fun a b => a -> b)
-                      (fun a => idmap) (fun a b c g f => g o f).
+Global Instance isgraph_type : IsGraph Type
+  := Build_IsGraph Type (fun a b => a -> b).
 
-Global Instance is01cat_arrow {A B : Type}: Is01Cat (A $-> B)
-  := Build_Is01Cat _ (fun f g => f == g) (fun f a => idpath)
-                      (fun f g h p q a => q a @ p a).
+Global Instance is01cat_type : Is01Cat Type.
+Proof.
+  econstructor.
+  + intro; exact idmap.
+  + exact (fun a b c g f => g o f).
+Defined.
+
+Global Instance isgraph_arrow {A B : Type} : IsGraph (A $-> B)
+  := Build_IsGraph _ (fun f g => f == g).
+
+Global Instance is01cat_arrow {A B : Type} : Is01Cat (A $-> B).
+Proof.
+  econstructor.
+  - exact (fun f a => idpath).
+  - exact (fun f g h p q a => q a @ p a).
+Defined.
 
 Global Instance is0gpd_arrow {A B : Type}: Is0Gpd (A $-> B).
 Proof.
@@ -48,15 +60,15 @@ Defined.
 
 Global Instance hasequivs_type : HasEquivs Type.
 Proof.
-  srefine (Build_HasEquivs Type _ _ Equiv (@IsEquiv) _ _ _ _ _ _ _ _); intros A B.
+  srefine (Build_HasEquivs Type _ _ _ Equiv (@IsEquiv) _ _ _ _ _ _ _ _); intros A B.
   all:intros f.
   - exact f.
   - exact _.
   - apply Build_Equiv.
   - intros; reflexivity.
   - intros; exact (f^-1).
-  - cbn. intros ? x; apply eissect.
-  - cbn. intros ? x; apply eisretr.
+  - cbn. intros ?; apply eissect.
+  - cbn. intros ?; apply eisretr.
   - intros g r s; refine (isequiv_adjointify f g r s).
 Defined.
 
@@ -67,3 +79,19 @@ Proof.
 Defined.
 
 Hint Immediate catie_isequiv : typeclass_instances.
+
+Global Instance isinitial_zero : IsInitial Empty.
+Proof.
+  intro A.
+  exists (Empty_rec _).
+  intros g.
+  rapply Empty_ind.
+Defined.
+
+Global Instance isterminal_unit : IsTerminal Unit.
+Proof.
+  intros A.
+  exists (fun _ => tt).
+  intros f x.
+  by destruct (f x).
+Defined.

--- a/theories/WildCat/UnitCat.v
+++ b/theories/WildCat/UnitCat.v
@@ -3,10 +3,15 @@ Require Import WildCat.Core.
 
 (** Unit category *)
 
+Global Instance isgraph_unit : IsGraph Unit.
+Proof.
+  apply Build_IsGraph.
+  intros; exact Unit.
+Defined.
+
 Global Instance is01cat_unit : Is01Cat Unit.
 Proof.
   srapply Build_Is01Cat.
-  1: intros; exact Unit.
   all: intros; exact tt.
 Defined.
 

--- a/theories/WildCat/Yoneda.v
+++ b/theories/WildCat/Yoneda.v
@@ -21,7 +21,7 @@ Defined.
 
 (** This requires morphism extensionality! *)
 Global Instance is1functor_hom {A} `{HasMorExt A}
-  : @Is1Functor (A^op * A) Type _ _ _ _ (uncurry (@Hom A _)) _.
+  : @Is1Functor (A^op * A) Type _ _ _ _ _ _ (uncurry (@Hom A _)) _.
 Proof.
   apply Build_Is1Functor.
   - intros [a1 a2] [b1 b2] [f1 f2] [g1 g2] [p1 p2] q; cbn in *.
@@ -44,7 +44,7 @@ Defined.
 
 (** This is easier than the contravariant version because it doesn't involve any "op"s. *)
 
-Definition opyon {A : Type} `{Is01Cat A} (a : A) : A -> Type
+Definition opyon {A : Type} `{IsGraph A} (a : A) : A -> Type
   := fun b => (a $-> b).
 
 Global Instance is0coh1functor_opyon {A : Type} `{Is01Cat A} (a : A)
@@ -129,50 +129,53 @@ Defined.
 
 (** We can deduce this from the covariant version with some boilerplate. *)
 
-Definition yon {A : Type} `{Is01Cat A} (a : A) : A^op -> Type
+Definition yon {A : Type} `{IsGraph A} (a : A) : A^op -> Type
   := @opyon (A^op) _ a.
 
-Global Instance is0coh1functor_yon {A : Type} `{Is01Cat A} (a : A)
-  : Is0Functor (yon a)
-  := @is0coh1functor_opyon A _ a.
+Global Instance is0coh1functor_yon {A : Type} `{H : Is01Cat A} (a : A)
+  : Is0Functor (yon a).
+Proof.
+  apply is0coh1functor_opyon.
+Defined.
 
 Definition yoneda {A : Type} `{Is01Cat A} (a : A)
            (F : A^op -> Type) `{!Is0Functor F}
   : F a -> (yon a $=> F)
-  := @opyoneda (A^op) _ a F _.
+  := @opyoneda (A^op) _ _ a F _.
 
 Definition un_yoneda {A : Type} `{Is01Cat A} (a : A)
            (F : A^op -> Type) `{!Is0Functor F}
   : (yon a $=> F) -> F a
-  := @un_opyoneda (A^op) _ a F _.
+  := @un_opyoneda (A^op) _ _ a F _.
 
 Global Instance is1natural_yoneda {A : Type} `{Is1Cat A} (a : A)
        (F : A^op -> Type) `{!Is0Functor F, !Is1Functor F} (x : F a)
   : Is1Natural (yon a) F (yoneda a F x)
-  := @is1natural_opyoneda (A^op) _ _ a F _ _ x.
+  := @is1natural_opyoneda (A^op) _ _ _ a F _ _ x.
 
 Definition yoneda_issect {A : Type} `{Is1Cat A} (a : A)
            (F : A^op -> Type) `{!Is0Functor F, !Is1Functor F} (x : F a)
   : un_yoneda a F (yoneda a F x) = x
-  := @opyoneda_issect (A^op) _ _ a F _ _ x.
+  := @opyoneda_issect (A^op) _ _ _ a F _ _ x.
 
 Definition yoneda_isretr {A : Type} `{Is1Cat_Strong A} (a : A)
            (F : A^op -> Type) `{!Is0Functor F}
            (* Without the hint here, Coq guesses to first project from [Is1Cat_Strong A] and then pass to opposites, whereas what we need is to first pass to opposites and then project. *)
-           `{@Is1Functor _ _ _ (is1cat_is1cat_strong A^op) _ _ F _}
+           `{@Is1Functor _ _ _ _ (is1cat_is1cat_strong A^op) _ _ _ F _}
            (alpha : yon a $=> F) {alnat : Is1Natural (yon a) F alpha}
            (b : A)
   : yoneda a F (un_yoneda a F alpha) b $== alpha b
-  := @opyoneda_isretr A^op _ (is1cat_strong_op A) a F _ _ alpha alnat b.
+  := @opyoneda_isretr A^op _ _ (is1cat_strong_op A) a F _ _ alpha alnat b.
 
 Definition yon_cancel {A : Type} `{Is01Cat A} (a b : A)
   : (yon a $=> yon b) -> (a $-> b)
   := un_yoneda a (yon b).
 
 Definition yon1 {A : Type} `{Is01Cat A} (a : A) : Fun01 A^op Type
-  := opyon1 a.
+  := @opyon1 A^op _ _ a.
 
 Definition yon_equiv {A : Type} `{HasEquivs A} `{!Is1Cat_Strong A}
            (a b : A)
   : (yon1 a $<~> yon1 b) -> (a $<~> b)
-  := (@opyon_equiv A^op _ _ _ _ a b).
+  := (@opyon_equiv A^op _ _ _ _ _ a b).
+


### PR DESCRIPTION
The original definition of wild categories had the underlying directed graph as a field of the typeclass rather than a parameter.  This was kind of a kludge -- I was pretty sure even at the time that it ought to be a parameter, but the graph typeclass was introduced while other people were working on various stuff downstream and we didn't want to change the foundations too much.  Recently @Alizter went back and made IsGraph into a parameter the way it should be in the wildcat branch; this PR imports that change back into master.