### PR TITLE
[.gitignore] Ignore .vscode/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ contrib/*.bak.*
 
 
 *.crashcoqide
+.vscode/


### PR DESCRIPTION
When using VSCoq, there are certain project-specific settings that are
nice to have.