### PR TITLE
Add O_inverts_functor_coeq

### DIFF
--- a/theories/HIT/Coeq.v
+++ b/theories/HIT/Coeq.v
@@ -48,6 +48,37 @@ Proof.
   refine (Coeq_ind_beta_cglue (fun _ => P) _ _ _).
 Defined.
 
+(** ** Universal property *)
+
+Definition Coeq_unrec {B A} (f g : B -> A) {P}
+           (h : Coeq f g -> P)
+  : {k : A -> P & k o f == k o g}.
+Proof.
+  exists (h o coeq).
+  intros b. exact (ap h (cglue b)).
+Defined.
+
+Definition isequiv_Coeq_rec `{Funext} {B A} (f g : B -> A) P
+  : IsEquiv (fun p : {h : A -> P & h o f == h o g} => Coeq_rec P p.1 p.2).
+Proof.
+  srapply (isequiv_adjointify _ (Coeq_unrec f g)).
+  - intros h.
+    apply path_arrow.
+    srapply Coeq_ind; intros b.
+    1:reflexivity.
+    cbn.
+    abstract (rewrite transport_paths_FlFr, concat_p1, Coeq_rec_beta_cglue, concat_Vp; reflexivity).
+  - intros [h q]; srapply path_sigma'.
+    + reflexivity.
+    + cbn.
+      rapply path_forall; intros b.
+      apply Coeq_rec_beta_cglue.
+Defined.
+
+Definition equiv_Coeq_rec `{Funext} {B A} (f g : B -> A) P
+  : {h : A -> P & h o f == h o g} <~> (Coeq f g -> P)
+  := Build_Equiv _ _ _ (isequiv_Coeq_rec f g P).
+
 (** ** Functoriality *)
 
 Definition functor_coeq {B A f g B' A' f' g'}

--- a/theories/Homotopy/BlakersMassey.v
+++ b/theories/Homotopy/BlakersMassey.v
@@ -139,7 +139,7 @@ Section GBM.
       (** *** Codes for glue *)
 
       Section CodeGlue.
-        Context {y1 : Y} (q11 : Q x1 y1).
+        Context `{Funext} {y1 : Y} (q11 : Q x1 y1).
 
         (** We prove that codes respect glue as a chain of equivalences between types built from pushouts and double-pushouts.  The first step is to add the data of our hypothesized-to-be-connected type inside [codeleft2]. *)
 
@@ -554,7 +554,7 @@ Now we claim that the left-hand map of this span is also an equivalence.  Rather
       (** Then we notice that if we tried rewriting with [code_beta_glue] here, the unmanageable-looking result is actually fully general over the path [glue q01], so we can prove by path induction that it equals the nicer expression we'd like to see.  This is the purpose of the lemma [transport_singleton]. *)
       rewrite (transport_singleton
                  code (glue q01) _
-                 (fun r => @codeglue x0 x0 r y1 q01)
+                 (fun r => @codeglue x0 x0 r _ y1 q01) (* Funext _ in the middle. *)
                  (code_beta_glue x0 y1 q01 (glue q01))).
       unfold codeglue.
       (** Now we evaluate [codeglue] step by step using our lemmas. *)

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -978,23 +978,23 @@ Section Reflective_Subuniverse.
                        (fun y => (to_O_natural f y)^)
                        (fun y => (to_O_natural g y)^).
 
-      Global Instance isequiv_O_coeq_cmp `{Funext} : O_inverts coeq_cmp.
+      Global Instance isequiv_O_coeq_cmp : O_inverts coeq_cmp.
       Proof.
         rapply O_inverts_functor_coeq.
       Defined.
 
-      Definition equiv_O_coeq `{Funext}
+      Definition equiv_O_coeq
       : O (Coeq f g) <~> O (Coeq (O_functor f) (O_functor g))
         := Build_Equiv _ _ (O_functor coeq_cmp) _.
 
-      Definition equiv_O_coeq_to_O `{Funext} (a : A)
+      Definition equiv_O_coeq_to_O (a : A)
         : equiv_O_coeq (to O (Coeq f g) (coeq a))
           = to O (Coeq (O_functor f) (O_functor g)) (coeq (to O A a)).
       Proof.
         refine (to_O_natural _ _).
       Defined.
 
-      Definition inverse_equiv_O_coeq_to_O `{Funext} (a : A)
+      Definition inverse_equiv_O_coeq_to_O (a : A)
         : equiv_O_coeq^-1 (to O (Coeq (O_functor f) (O_functor g)) (coeq (to O A a)))
           = to O (Coeq f g) (coeq a).
       Proof.


### PR DESCRIPTION
This allows us to prove `isequiv_O_coeq_cmp` without rewrites.

But the proof of `equiv_O_pushout_to_O_pushl` gets stuck.  See the comments there.  Any ideas what's going on?

This PR includes the universal property of coequalizers, from #1245 .