### PR TITLE
Prove O_inverts_sum without funext

### DIFF
--- a/theories/Extensions.v
+++ b/theories/Extensions.v
@@ -432,3 +432,35 @@ Section Extensions.
   Defined.
 
 End Extensions.
+
+(** Extendability along [functor_sum] *)
+
+Definition extendable_functor_sum (n : nat)
+           {A B A' B'} (f : A -> A') (g : B -> B')
+           (P : A' + B' -> Type)
+           (ef : ExtendableAlong n f (P o inl))
+           (eg : ExtendableAlong n g (P o inr))
+  : ExtendableAlong n (functor_sum f g) P.
+Proof.
+  revert P ef eg; induction n as [|n IH]; intros P ef eg; [ exact tt | split ].
+  - intros h.
+    srefine (sum_ind _ _ _ ; sum_ind _ _ _).
+    + exact (fst ef (h o inl)).1.
+    + exact (fst eg (h o inr)).1.
+    + exact (fst ef (h o inl)).2.
+    + exact (fst eg (h o inr)).2.
+  - intros h k.
+    apply IH.
+    + exact (snd ef (h o inl) (k o inl)).
+    + exact (snd eg (h o inr) (k o inr)).
+Defined.
+
+Definition ooextendable_functor_sum
+           {A B A' B'} (f : A -> A') (g : B -> B')
+           (P : A' + B' -> Type)
+           (ef : ooExtendableAlong f (P o inl))
+           (eg : ooExtendableAlong g (P o inr))
+  : ooExtendableAlong (functor_sum f g) P.
+Proof.
+  intros n; apply extendable_functor_sum; [ apply ef | apply eg ].
+Defined.

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -907,27 +907,20 @@ Section Reflective_Subuniverse.
 
     Local Notation O_inverts f := (IsEquiv (O_functor f)).
 
-    Definition O_inverts_sum `{Funext} {A B A' B'} (f : A -> A') (g : B -> B')
+    Definition O_inverts_sum {A B A' B'} (f : A -> A') (g : B -> B')
                `{O_inverts f} `{O_inverts g}
       : O_inverts (functor_sum f g).
     Proof.
-      apply O_inverts_from_isequiv_precompose.
-      intros Z Z_inO.
-      srapply isequiv_commsq'; cbn.
-      4,5: rapply ((equiv_sum_ind (fun _ => Z))^-1).
-      { srapply equiv_functor_prod'.
-        - srapply (Build_Equiv _ _ _ (isequiv_precompose_O_inverts f Z)).
-        - srapply (Build_Equiv _ _ _ (isequiv_precompose_O_inverts g Z)). }
-      1: reflexivity.
-      all: try exact _.
+      apply O_inverts_from_extendable; intros.
+      apply extendable_functor_sum; apply ooextendable_O_inverts; assumption.
     Defined.
 
-    Definition equiv_O_functor_sum `{Funext} {A B A' B'} (f : A -> A') (g : B -> B')
+    Definition equiv_O_functor_sum {A B A' B'} (f : A -> A') (g : B -> B')
                `{O_inverts f} `{O_inverts g}
       : O (A + B) <~> O (A' + B')
       := Build_Equiv _ _ _ (O_inverts_sum f g).
 
-    Definition equiv_O_sum `{Funext} {A B} :
+    Definition equiv_O_sum {A B} :
       O (A + B) <~> O (O A + O B)
       := equiv_O_functor_sum (to O A) (to O B).
 


### PR DESCRIPTION
In this case, the direct approach with funext-free yoneda is quite easy.