### PR TITLE
Implement a 1-dimensional Sperner's lemma

### DIFF
--- a/theories/Spaces/Finite.v
+++ b/theories/Spaces/Finite.v
@@ -1115,6 +1115,11 @@ Ltac FinIndOn X := repeat
 (** This tactic can be used to generate n cases from a goal like forall (x : Fin n), _ *)
 Ltac FinInd := let X := fresh "X" in intro X; FinIndOn X.
 
+(** The 1-dimensional version of Sperner's lemma says that given any
+finite sequence of decidable hProps, where the sequence starts with
+true and ends with false, we can find a point in the sequence where
+the sequence changes from true to false. This is like a discrete
+intermediate value theorem. *)
 Section Sperner.
 
   Fixpoint sperners_lemma_1d {n} : forall (f : Fin (n.+2) -> DHProp)

--- a/theories/Spaces/Finite.v
+++ b/theories/Spaces/Finite.v
@@ -26,6 +26,27 @@ Fixpoint Fin (n : nat) : Type
        | S n => Fin n + Unit
      end.
 
+Fixpoint Fin_left {n : nat} : Fin (S n)
+  := match n with
+     | 0 => inr tt
+     | S n => inl Fin_left
+     end.
+
+Definition Fin_right {n : nat} : Fin (S n) := inr tt.
+
+Definition Fin_inc_l {n : nat} (k : Fin n) : Fin (S n) := inl k.
+Fixpoint Fin_inc_r {n : nat} : Fin n -> Fin (S n)
+  := match n with
+     | 0 => fun k =>
+              match k with
+              end
+     | S n => fun k =>
+                match k with
+                | inl l => inl (Fin_inc_r l)
+                | inr tt => inr tt
+                end
+     end.
+
 Global Instance decidable_fin (n : nat)
 : Decidable (Fin n).
 Proof.
@@ -1108,3 +1129,22 @@ Ltac FinIndOn X := repeat
 
 (** This tactic can be used to generate n cases from a goal like forall (x : Fin n), _ *)
 Ltac FinInd := let X := fresh "X" in intro X; FinIndOn X.
+
+Section Sperner.
+
+  Fixpoint sperners_lemma_1d {n} : forall (f : Fin (n.+2) -> DHProp)
+        (left_true : f Fin_left)
+        (right_false : ~ f Fin_right),
+    {k : Fin n.+1 & f (Fin_inc_l k) /\ ~ f (Fin_inc_r k)}.
+  Proof.
+    intros ???.
+    destruct n as [|n].
+    - exists Fin_left. split; assumption.
+    - destruct (dec (f (Fin_inc_l Fin_right))) as [prev_true|prev_false].
+      + exists Fin_right. split; assumption.
+      + destruct (sperners_lemma_1d _ (f o Fin_inc_l) left_true prev_false) as [k' [fleft fright]].
+        exists (Fin_inc_l k').
+        split; assumption.
+  Defined.
+
+End Sperner.

--- a/theories/Spaces/Finite.v
+++ b/theories/Spaces/Finite.v
@@ -26,27 +26,6 @@ Fixpoint Fin (n : nat) : Type
        | S n => Fin n + Unit
      end.
 
-Fixpoint Fin_left {n : nat} : Fin (S n)
-  := match n with
-     | 0 => inr tt
-     | S n => inl Fin_left
-     end.
-
-Definition Fin_right {n : nat} : Fin (S n) := inr tt.
-
-Definition Fin_inc_l {n : nat} (k : Fin n) : Fin (S n) := inl k.
-Fixpoint Fin_inc_r {n : nat} : Fin n -> Fin (S n)
-  := match n with
-     | 0 => fun k =>
-              match k with
-              end
-     | S n => fun k =>
-                match k with
-                | inl l => inl (Fin_inc_r l)
-                | inr tt => inr tt
-                end
-     end.
-
 Global Instance decidable_fin (n : nat)
 : Decidable (Fin n).
 Proof.
@@ -77,6 +56,12 @@ Fixpoint fin_zero {n : nat} : Fin n.+1 :=
   | O => inr tt
   | S n' => inl fin_zero
   end.
+
+(** Where `fin_zero` computes the first element of Fin (S n), `fin_last` computes the last. *)
+Definition fin_last {n : nat} : Fin (S n) := inr tt.
+
+(** Injection Fin n -> Fin n.+1 mapping the kth element to the kth element. *)
+Definition fin_incl {n : nat} (k : Fin n) : Fin (S n) := inl k.
 
 (** There is an injection from Fin n -> Fin n.+1 that maps the kth element to the (k+1)th element. *)
 Fixpoint fsucc {n : nat} : Fin n -> Fin n.+1 :=
@@ -1133,17 +1118,17 @@ Ltac FinInd := let X := fresh "X" in intro X; FinIndOn X.
 Section Sperner.
 
   Fixpoint sperners_lemma_1d {n} : forall (f : Fin (n.+2) -> DHProp)
-        (left_true : f Fin_left)
-        (right_false : ~ f Fin_right),
-    {k : Fin n.+1 & f (Fin_inc_l k) /\ ~ f (Fin_inc_r k)}.
+        (left_true : f fin_zero)
+        (right_false : ~ f fin_last),
+    {k : Fin n.+1 & f (fin_incl k) /\ ~ f (fsucc k)}.
   Proof.
     intros ???.
     destruct n as [|n].
-    - exists Fin_left. split; assumption.
-    - destruct (dec (f (Fin_inc_l Fin_right))) as [prev_true|prev_false].
-      + exists Fin_right. split; assumption.
-      + destruct (sperners_lemma_1d _ (f o Fin_inc_l) left_true prev_false) as [k' [fleft fright]].
-        exists (Fin_inc_l k').
+    - exists fin_zero. split; assumption.
+    - destruct (dec (f (fin_incl fin_last))) as [prev_true|prev_false].
+      + exists fin_last. split; assumption.
+      + destruct (sperners_lemma_1d _ (f o fin_incl) left_true prev_false) as [k' [fleft fright]].
+        exists (fin_incl k').
         split; assumption.
   Defined.
 

--- a/theories/Spaces/Finite.v
+++ b/theories/Spaces/Finite.v
@@ -1115,26 +1115,19 @@ Ltac FinIndOn X := repeat
 (** This tactic can be used to generate n cases from a goal like forall (x : Fin n), _ *)
 Ltac FinInd := let X := fresh "X" in intro X; FinIndOn X.
 
-(** The 1-dimensional version of Sperner's lemma says that given any
-finite sequence of decidable hProps, where the sequence starts with
-true and ends with false, we can find a point in the sequence where
-the sequence changes from true to false. This is like a discrete
-intermediate value theorem. *)
-Section Sperner.
-
-  Fixpoint sperners_lemma_1d {n} : forall (f : Fin (n.+2) -> DHProp)
-        (left_true : f fin_zero)
-        (right_false : ~ f fin_last),
+(** The 1-dimensional version of Sperner's lemma says that given any finite sequence of decidable hProps, where the sequence starts with true and ends with false, we can find a point in the sequence where the sequence changes from true to false. This is like a discrete intermediate value theorem. *)
+Fixpoint sperners_lemma_1d {n} :
+  forall (f : Fin (n.+2) -> DHProp)
+         (left_true : f fin_zero)
+         (right_false : ~ f fin_last),
     {k : Fin n.+1 & f (fin_incl k) /\ ~ f (fsucc k)}.
-  Proof.
-    intros ???.
-    destruct n as [|n].
-    - exists fin_zero. split; assumption.
-    - destruct (dec (f (fin_incl fin_last))) as [prev_true|prev_false].
-      + exists fin_last. split; assumption.
-      + destruct (sperners_lemma_1d _ (f o fin_incl) left_true prev_false) as [k' [fleft fright]].
-        exists (fin_incl k').
-        split; assumption.
-  Defined.
-
-End Sperner.
+Proof.
+  intros ???.
+  destruct n as [|n].
+  - exists fin_zero. split; assumption.
+  - destruct (dec (f (fin_incl fin_last))) as [prev_true|prev_false].
+    + exists fin_last. split; assumption.
+    + destruct (sperners_lemma_1d _ (f o fin_incl) left_true prev_false) as [k' [fleft fright]].
+      exists (fin_incl k').
+      split; assumption.
+Defined.


### PR DESCRIPTION
Given a finite sequence of bits, if the first bit is 1 and the last bit is 0, then there is a point where the sequence swaps from 1 to 0. This proves that.