### PR TITLE
Allow compilation in a multiple git working trees

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -13,7 +13,7 @@ fi
 
 if [ "$1" != "-skip-submodules" ] && command -v git >/dev/null 2>&1
 then # git found
-    if test -d .git
+    if test -d .git -o -f .git
     then # we're in a git repository
 	git submodule sync # update possibly changed urls
 	git submodule update --init --recursive

--- a/autogen.sh
+++ b/autogen.sh
@@ -13,7 +13,7 @@ fi
 
 if [ "$1" != "-skip-submodules" ] && command -v git >/dev/null 2>&1
 then # git found
-    if test -d .git -o -f .git
+    if [ -d .git ] || [ -f .git ]
     then # we're in a git repository
 	git submodule sync # update possibly changed urls
 	git submodule update --init --recursive

--- a/etc/install_coq.sh
+++ b/etc/install_coq.sh
@@ -11,9 +11,9 @@ pushd "$DIR" 1>/dev/null || exit 1
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 pushd "$ROOT_DIR" 1>/dev/null || exit 1
 
-if test ! -d .git
+if test ! ( -d .git -o -f .git )
 then
-    echo 'Error: .git directory does not exist.'
+    echo 'Error: we do not seem to be in a git working tree.'
     echo 'This script only works on a git clone of the HoTT repository.'
     exit 1
 fi

--- a/etc/install_coq.sh
+++ b/etc/install_coq.sh
@@ -11,7 +11,7 @@ pushd "$DIR" 1>/dev/null || exit 1
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 pushd "$ROOT_DIR" 1>/dev/null || exit 1
 
-if test ! ( -d .git -o -f .git )
+if ! ( [ -d .git ] || [ -f .git ] )
 then
     echo 'Error: we do not seem to be in a git working tree.'
     echo 'This script only works on a git clone of the HoTT repository.'


### PR DESCRIPTION
The `git worktree` command allows to have several working trees for a
single repository.  The additional working trees then get a _file_
`.git` containing the gitdir, rather than a full `.git` directory.  In
order to support this, the build files should additionally allow
`.git` to be a file rather than a directory.