### PR TITLE
O_inverts_functor_coeq without funext, closes #1259

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -186,6 +186,7 @@ theories/Limits/Pullback.v
 
 theories/Colimits/Pushout.v
 theories/Colimits/SpanPushout.v
+theories/Colimits/MappingCylinder.v
 theories/Colimits/Quotient.v
 
 theories/Colimits/Colimit.v

--- a/theories/Colimits/MappingCylinder.v
+++ b/theories/Colimits/MappingCylinder.v
@@ -87,8 +87,7 @@ Section MappingCylinder.
         symmetry; apply cyglue.
       + intros b; reflexivity.
       + intros a; cbn.
-        apply dp_path_transport.
-        rewrite transport_paths_FFlr.
+        apply dp_paths_FFlr.
         rewrite Cyl_rec_beta_cyglue.
         apply concat_pV_p.
     - intros b; reflexivity.

--- a/theories/Colimits/MappingCylinder.v
+++ b/theories/Colimits/MappingCylinder.v
@@ -1,0 +1,208 @@
+(* -*- mode: coq; mode: visual-line -*- *)
+
+(** * Mapping Cylinders *)
+
+Require Import HoTT.Basics HoTT.Types Cubical.DPath Cubical.PathSquare.
+Require Import HIT.Coeq Colimits.Pushout.
+Local Open Scope path_scope.
+
+(** As in topology, the mapping cylinder of a function [f : A -> B] is a way to replace it with an equivalent cofibration (dually to how [hfiber] replaces it with an equivalent fibration).  We can't talk *internally* in type theory about cofibrations, but we can say metatheoretically what they are: functions with the isomorphism extension property.  So while we can't literally say "let [f] be a cofibration" we can do a mostly equivalent thing and say "let [f] be a map and consider its mapping cylinder".  Replacing a map by a cofibration can be useful because it allows us to make more equalities true definitionally. *)
+
+(** ** Definitions *)
+
+(** We define the mapping cylinder as the pushout of [f] and an identity map.  Peter Lumsdaine has given a definition of HIT mapping cylinders that are dependent on the codomain, so that the second factor is not just an equivalence but a trivial fibration.  However, at the moment we don't have a need for that.  *)
+
+Definition Cyl {A B : Type} (f : A -> B) : Type
+  := Pushout idmap f.
+
+Section MappingCylinder.
+  Context {A B : Type} {f : A -> B}.
+
+  Definition cyl (a : A) : Cyl f
+    := pushl a.
+  
+  Definition cyr (b : B) : Cyl f
+    := pushr b.
+
+  Definition cyglue (a : A)
+    : cyl a = cyr (f a)
+    := pglue a.
+
+  Section CylInd.
+    Context (P : Cyl f -> Type)
+            (cyla : forall a, P (cyl a))
+            (cylb : forall b, P (cyr b))
+            (cylg : forall a, DPath P (cyglue a) (cyla a) (cylb (f a))).
+
+    Definition Cyl_ind : forall c, P c.
+    Proof.
+      srapply Pushout_ind.
+      - apply cyla.
+      - apply cylb.
+      - intros a; apply dp_path_transport^-1, cylg.
+    Defined.
+
+    Definition Cyl_ind_beta_cyglue (a : A)
+      : dp_apD Cyl_ind (cyglue a) = cylg a.
+    Proof.
+      unfold Cyl_ind.
+      refine ((dp_path_transport_apD _ _)^ @ _).
+      apply moveR_equiv_M.
+      rapply Pushout_ind_beta_pglue.
+    Defined.
+
+  End CylInd.
+
+  Section CylRec.
+    Context {P : Type} (cyla : A -> P) (cylb : B -> P) (cylg : cyla == cylb o f).
+
+    Definition Cyl_rec : Cyl f -> P.
+    Proof.
+      srapply Pushout_rec.
+      - apply cyla.
+      - apply cylb.
+      - apply cylg.
+    Defined.
+
+    Definition Cyl_rec_beta_cyglue (a : A)
+      : ap Cyl_rec (cyglue a) = cylg a.
+    Proof.
+      rapply Pushout_rec_beta_pglue.
+    Defined.
+
+  End CylRec.
+
+  Definition pr_cyl : Cyl f <~> B.
+  Proof.
+    (** Rather than adjointifying, we give all parts of the equivalence explicitly, so we can be sure of retaining the computational behavior of [eissect] and [eisretr].  However, it's easier to prove [eisadj] on the other side, so we reverse the equivalence first. *)
+    symmetry.
+    srapply Build_Equiv.
+    1:apply cyr.
+    srapply Build_IsEquiv.
+    - srapply Cyl_rec.
+      + exact f.
+      + exact idmap.
+      + reflexivity.
+    - srapply Cyl_ind.
+      + intros a; cbn.
+        symmetry; apply cyglue.
+      + intros b; reflexivity.
+      + intros a; cbn.
+        apply dp_path_transport.
+        rewrite transport_paths_FFlr.
+        rewrite Cyl_rec_beta_cyglue.
+        apply concat_pV_p.
+    - intros b; reflexivity.
+    - intros b; reflexivity.
+  Defined.
+
+  Definition ap_pr_cyl_cyglue (a : A)
+    : ap pr_cyl (cyglue a) = 1
+    := Cyl_rec_beta_cyglue _ _ _ a.
+
+  (** The original map [f] factors definitionally through [Cyl f]. *)
+  Definition pr_cyl_cyl (a : A) : pr_cyl (cyl a) = f a
+    := 1.
+
+End MappingCylinder.
+
+(** Sometimes we have to specify the map explicitly. *)
+Definition cyl' {A B} (f : A -> B) : A -> Cyl f := cyl.
+Definition pr_cyl' {A B} (f : A -> B) : Cyl f -> B := pr_cyl.
+
+(** ** Functoriality *)
+
+Section FunctorCyl.
+  Context {A B A' B': Type} {f : A -> B} {f' : A' -> B'}
+          {ga : A -> A'} {gb : B -> B'}
+          (g : f' o ga == gb o f).
+
+  Definition functor_cyl : Cyl f -> Cyl f'.
+  Proof.
+    srapply Cyl_rec.
+    - exact (cyl o ga).
+    - exact (cyr o gb).
+    - intros a.
+      refine (_ @ ap cyr (g a)).
+      exact (cyglue (ga a)).
+  Defined.
+
+  Definition ap_functor_cyl_cyglue (a : A)
+    : ap functor_cyl (cyglue a) = cyglue (ga a) @ ap cyr (g a)
+    := Cyl_rec_beta_cyglue _ _ _ a.
+
+  (** The benefit of passing to the mapping cylinder is that it makes a square commute definitionally. *)
+  Definition functor_cyl_cyl (a : A) : cyl (ga a) = functor_cyl (cyl a)
+    := 1.
+
+  (** The other square also commutes, though not definitionally. *)
+  Definition pr_functor_cyl (c : Cyl f)
+    : pr_cyl (functor_cyl c) = gb (pr_cyl c)
+    := ap (pr_cyl o functor_cyl) (eissect pr_cyl c)^.
+      
+  Definition pr_functor_cyl_cyl (a : A)
+    : pr_functor_cyl (cyl a) = g a.
+  Proof.
+    (** Here we need [eissect pr_cyl (cyl a)] to compute. *)
+    refine (ap _ (inv_V _) @ _).
+    refine (ap_compose functor_cyl pr_cyl (cyglue a) @ _).
+    refine (ap _ (ap_functor_cyl_cyglue a) @ _).
+    refine (ap_pp _ _ _ @ _).
+    refine (whiskerR (ap_pr_cyl_cyglue (ga a)) _ @ concat_1p _ @ _).
+    refine ((ap_compose cyr _ (g a))^ @ _).
+    apply ap_idmap.
+  Defined.
+
+End FunctorCyl.
+
+(** ** Coequalizers *)
+
+(** A particularly useful application is to replace a map of coequalizers with one where both squares commute definitionally. *)
+
+Section CylCoeq.
+  Context {B A f g B' A' f' g'}
+          {h : B -> B'} {k : A -> A'}
+          (p : k o f == f' o h) (q : k o g == g' o h).
+
+  Definition CylCoeq : Type
+    := Coeq (functor_cyl p) (functor_cyl q).
+
+  Definition cyl_cylcoeq : Coeq f g -> CylCoeq
+    := functor_coeq cyl cyl (functor_cyl_cyl p) (functor_cyl_cyl q).
+
+  Definition ap_cyl_cylcoeq_cglue (b : B)
+    : ap cyl_cylcoeq (cglue b) = cglue (cyl b).
+  Proof.
+    etransitivity.
+    1:rapply functor_coeq_beta_cglue.
+    exact (concat_p1 _ @ concat_1p _).
+  Defined.
+
+  Definition pr_cylcoeq : CylCoeq <~> Coeq f' g'
+    := equiv_functor_coeq pr_cyl pr_cyl (pr_functor_cyl p) (pr_functor_cyl q).
+
+  Definition ap_pr_cylcoeq_cglue (x : Cyl h)
+    : PathSquare (ap pr_cylcoeq (cglue x)) (cglue (pr_cyl x))
+                 (ap coeq (pr_functor_cyl p x))
+                 (ap coeq (pr_functor_cyl q x)).
+  Proof.
+    apply sq_path.
+    apply moveR_pM.
+    rewrite <- (ap_V coeq).
+    rapply functor_coeq_beta_cglue.
+  Defined.
+
+  Definition pr_cyl_cylcoeq
+    : functor_coeq h k p q == pr_cylcoeq o cyl_cylcoeq.
+  Proof.
+    intros c.
+    refine (_ @ functor_coeq_compose cyl cyl (functor_cyl_cyl p) (functor_cyl_cyl q)
+              pr_cyl pr_cyl (pr_functor_cyl p) (pr_functor_cyl q) c).
+    srapply functor_coeq_homotopy.
+    1-2:reflexivity.
+    all:intros b; cbn.
+    all:refine (concat_1p _ @ concat_1p _ @ _ @ (concat_p1 _)^).
+    all:apply pr_functor_cyl_cyl.
+  Defined.
+
+End CylCoeq.

--- a/theories/Colimits/MappingCylinder.v
+++ b/theories/Colimits/MappingCylinder.v
@@ -33,7 +33,7 @@ Section MappingCylinder.
             (cylb : forall b, P (cyr b))
             (cylg : forall a, DPath P (cyglue a) (cyla a) (cylb (f a))).
 
-    Definition Cyl_ind : forall c, P c.
+    Definition Cyl_ind_dp : forall c, P c.
     Proof.
       srapply Pushout_ind.
       - apply cyla.
@@ -41,10 +41,10 @@ Section MappingCylinder.
       - intros a; apply dp_path_transport^-1, cylg.
     Defined.
 
-    Definition Cyl_ind_beta_cyglue (a : A)
-      : dp_apD Cyl_ind (cyglue a) = cylg a.
+    Definition Cyl_ind_dp_beta_cyglue (a : A)
+      : dp_apD Cyl_ind_dp (cyglue a) = cylg a.
     Proof.
-      unfold Cyl_ind.
+      unfold Cyl_ind_dp.
       refine ((dp_path_transport_apD _ _)^ @ _).
       apply moveR_equiv_M.
       rapply Pushout_ind_beta_pglue.
@@ -82,7 +82,7 @@ Section MappingCylinder.
       + exact f.
       + exact idmap.
       + reflexivity.
-    - srapply Cyl_ind.
+    - srapply Cyl_ind_dp.
       + intros a; cbn.
         symmetry; apply cyglue.
       + intros b; reflexivity.

--- a/theories/Colimits/MappingCylinder.v
+++ b/theories/Colimits/MappingCylinder.v
@@ -20,7 +20,6 @@ Section MappingCylinder.
 
   Definition cyl (a : A) : Cyl f
     := pushl a.
-  
   Definition cyr (b : B) : Cyl f
     := pushr b.
 

--- a/theories/Cubical/DPath.v
+++ b/theories/Cubical/DPath.v
@@ -270,23 +270,29 @@ Proof.
 Defined.
 
 Definition dp_compose' {A B} (f : A -> B) (P : B -> Type) {x y : A}
-  {p : x = y} {q : f x = f y} (r : ap f p = q) (u : P (f x)) (v : P (f y))
+  {p : x = y} {q : f x = f y} (r : ap f p = q) {u : P (f x)} {v : P (f y)}
   : DPath (fun x => P (f x)) p u v <~> DPath P q u v.
 Proof.
   by destruct r, p.
 Defined.
 
 Definition dp_compose {A B} (f : A -> B) (P : B -> Type) {x y : A}
-  (p : x = y) (u : P (f x)) (v : P (f y))
+  (p : x = y) {u : P (f x)} {v : P (f y)}
   : DPath (fun x => P (f x)) p u v <~> DPath P (ap f p) u v
-  := dp_compose' f P (idpath (ap f p)) u v.
+  := dp_compose' f P (idpath (ap f p)).
+
+Definition dp_apD_compose' {A B : Type} (f : A -> B) (P : B -> Type)
+           {x y : A} {p : x = y} {q : f x = f y} (r : ap f p = q) (g : forall b:B, P b)
+  : dp_apD (g o f) p = (dp_compose' f P r)^-1 (dp_apD g q).
+Proof.
+  by destruct r, p.
+Defined.
 
 Definition dp_apD_compose {A B : Type} (f : A -> B) (P : B -> Type)
            {x y : A} (p : x = y) (g : forall b:B, P b)
-  : dp_apD (g o f) p = (dp_compose f P p (g (f x)) (g (f y)))^-1 (dp_apD g (ap f p)).
-Proof.
-  by destruct p.
-Defined.
+  : dp_apD (g o f) p = (dp_compose f P p)^-1 (dp_apD g (ap f p))
+  := dp_apD_compose' f P (idpath (ap f p)) g.
+
 
 (* Type constructors *)
 

--- a/theories/Cubical/DPath.v
+++ b/theories/Cubical/DPath.v
@@ -43,7 +43,7 @@ Proof.
 Defined.
 
 (* Here is a notation for DPaths that can make it easier to use *)
-Notation "x =[ q ] y" := (DPath (fun t => DPath _ t _ _) q x y) (at level 10)
+Notation "x =[ q ] y" := (DPath (fun t => DPath _ t _ _) q x y) (at level 25)
   : dpath_scope.
 
 (* We have reflexivity for DPaths, this helps coq guess later *)
@@ -108,8 +108,26 @@ Proof.
   exact concat.
 Defined.
 
-(* TODO: Is level correct? *)
-Notation "x '@D' y" := (dp_concat x y) (at level 10) : dpath_scope.
+Notation "x '@D' y" := (dp_concat x y) (at level 20) : dpath_scope.
+
+(* Concatenation of dependent paths with non-dependent paths *)
+Definition dp_concat_r {A} {P : A -> Type} {a0 a1}
+  {p : a0 = a1} {b0 : P a0} {b1 b2 : P a1}
+  : DPath P p b0 b1 -> (b1 = b2) -> DPath P p b0 b2.
+Proof.
+  destruct p; exact concat.
+Defined.
+
+Notation "x '@Dr' y" := (dp_concat_r x y) (at level 20) : dpath_scope.
+
+Definition dp_concat_l {A} {P : A -> Type} {a1 a2}
+  {q : a1 = a2} {b0 b1 : P a1} {b2 : P a2}
+  : (b0 = b1) -> DPath P q b1 b2 -> DPath P q b0 b2.
+Proof.
+  destruct q; exact concat.
+Defined.
+
+Notation "x '@Dl' y" := (dp_concat_l x y) (at level 20) : dpath_scope.
 
 (* Inverse of dependent paths *)
 Definition dp_inverse {A} {P : A -> Type} {a0 a1} {p : a0 = a1}
@@ -120,7 +138,7 @@ Proof.
 Defined.
 
 (* TODO: Is level correct? *)
-Notation "x '^D'" := (dp_inverse x) (at level 20) : dpath_scope.
+Notation "x '^D'" := (dp_inverse x) (at level 3) : dpath_scope.
 
 (* dp_apD distributes over concatenation *)
 Definition dp_apD_pp (A : Type) (P : A -> Type) (f : forall a, P a)

--- a/theories/Cubical/DPathSquare.v
+++ b/theories/Cubical/DPathSquare.v
@@ -149,11 +149,50 @@ Section Kan.
     destruct s; apply sq_fill_l.
   Defined.
 
+  Definition ds_fill_l_uniq {qx1 : DPath P px1 b01 b11}
+             {q0x : DPath P p0x b00 b01} {q1x : DPath P p1x b10 b11}
+             {qx0 : DPath P px0 b00 b10}
+             (t : DPathSquare P s qx0 qx1 q0x q1x)
+             {qx0' : DPath P px0 b00 b10}
+             (t' : DPathSquare P s qx0' qx1 q0x q1x)
+    : qx0 = qx0'.
+  Proof.
+    destruct s.
+    exact (sq_fill_l_uniq t t').
+  Defined.
+
   Definition ds_fill_r (qx0 : DPath P px0 b00 b10)
              (q0x : DPath P p0x b00 b01) (q1x : DPath P p1x b10 b11)
     : {qx1 : DPath P px1 b01 b11 & DPathSquare P s qx0 qx1 q0x q1x}.
   Proof.
     destruct s; apply sq_fill_r.
+  Defined.
+
+  Definition ds_fill_r_uniq {qx0 : DPath P px0 b00 b10}
+             {q0x : DPath P p0x b00 b01} {q1x : DPath P p1x b10 b11}
+             {qx1 : DPath P px1 b01 b11}
+             (t : DPathSquare P s qx0 qx1 q0x q1x)
+             {qx1' : DPath P px1 b01 b11}
+             (t' : DPathSquare P s qx0 qx1' q0x q1x)
+    : qx1 = qx1'.
+  Proof.
+    destruct s.
+    exact (sq_fill_r_uniq t t').
+  Defined.
+
+  Definition equiv_ds_fill_lr
+             {q0x : DPath P p0x b00 b01} {q1x : DPath P p1x b10 b11}
+    : (DPath P px0 b00 b10) <~> (DPath P px1 b01 b11).
+  Proof.
+    srapply equiv_adjointify.
+    - intros qx0; exact (ds_fill_r qx0 q0x q1x).1.
+    - intros qx1; exact (ds_fill_l qx1 q0x q1x).1.
+    - intros qx1.
+      exact (ds_fill_r_uniq (ds_fill_r _ q0x q1x).2
+                            (ds_fill_l qx1 q0x q1x).2).
+    - intros qx0.
+      exact (ds_fill_l_uniq (ds_fill_l _ q0x q1x).2
+                            (ds_fill_r qx0 q0x q1x).2).
   Defined.
 
   Definition ds_fill_t (qx0 : DPath P px0 b00 b10)

--- a/theories/Cubical/PathSquare.v
+++ b/theories/Cubical/PathSquare.v
@@ -430,11 +430,47 @@ Section Kan.
     by destruct px1, p0x, p1x.
   Defined.
 
+  Definition sq_fill_l_uniq
+             {px1 : a01 = a11} {p0x : a00 = a01} {p1x : a10 = a11}
+             {px0 : a00 = a10} (s : PathSquare px0 px1 p0x p1x)
+             {px0' : a00 = a10} (s' : PathSquare px0' px1 p0x p1x)
+    : px0 = px0'.
+  Proof.
+    destruct s.
+    apply sq_path^-1 in s'.
+    exact (s'^ @ concat_p1 _).
+  Defined.
+
   Definition sq_fill_r (px0 : a00 = a10) (p0x : a00 = a01) (p1x : a10 = a11)
     : {px1 : a01 = a11 & PathSquare px0 px1 p0x p1x}.
   Proof.
     exists (p0x^ @ px0 @ p1x).
     by destruct px0, p0x, p1x.
+  Defined.
+
+  Definition sq_fill_r_uniq
+             {px0 : a00 = a10} {p0x : a00 = a01} {p1x : a10 = a11}
+             {px1 : a01 = a11} (s : PathSquare px0 px1 p0x p1x)
+             {px1' : a01 = a11} (s' : PathSquare px0 px1' p0x p1x)
+    : px1 = px1'.
+  Proof.
+    destruct s.
+    apply sq_path^-1 in s'.
+    exact (s' @ concat_1p _).
+  Defined.
+
+  Definition equiv_sq_fill_lr (p0x : a00 = a01) (p1x : a10 = a11)
+    : (a00 = a10) <~> (a01 = a11).
+  Proof.
+    srapply equiv_adjointify.
+    - intros px0; exact (sq_fill_r px0 p0x p1x).1.
+    - intros px1; exact (sq_fill_l px1 p0x p1x).1.
+    - intros px1.
+      exact (sq_fill_r_uniq (sq_fill_r _ p0x p1x).2
+                            (sq_fill_l px1 p0x p1x).2).
+    - intros px0.
+      exact (sq_fill_l_uniq (sq_fill_l _ p0x p1x).2
+                            (sq_fill_r px0 p0x p1x).2).
   Defined.
 
   Definition sq_fill_t (px0 : a00 = a10) (px1 : a01 = a11) (p1x : a10 = a11)

--- a/theories/Extensions.v
+++ b/theories/Extensions.v
@@ -444,8 +444,8 @@ Definition cyl_extension {A B} (f : A -> B) (C : Cyl f -> Type)
   : ExtensionAlong cyl C g.
 Proof.
   srefine (Cyl_ind_dp C g (ext.1 o cyr) _ ; _); intros a.
-  + pose (p := dp_apD ext.1 (cyglue a)).
-    exact (transport (fun u => DPath C _ u _) (ext.2 a) p).
+  + refine ((ext.2 a)^ @Dl _)%dpath.
+    apply dp_apD.
   + reflexivity. (** The point is that this equality is now definitional. *)
 Defined.
 

--- a/theories/Extensions.v
+++ b/theories/Extensions.v
@@ -5,6 +5,8 @@
 Require Import HoTT.Basics HoTT.Types.
 Require Import HProp FunextVarieties EquivalenceVarieties PathAny.
 Require Import HoTT.Tactics.
+Require Import Cubical.DPath Cubical.PathSquare Cubical.DPathSquare.
+Require Import HIT.Coeq Colimits.MappingCylinder.
 
 Local Open Scope nat_scope.
 Local Open Scope path_scope.
@@ -433,7 +435,68 @@ Section Extensions.
 
 End Extensions.
 
-(** Extendability along [functor_sum] *)
+(** ** Extendability along cofibrations *)
+
+(** If a family is extendable along a cofibration (i.e. a mapping cylinder), it is extendable definitionally. *)
+Definition cyl_extension {A B} (f : A -> B) (C : Cyl f -> Type)
+           (g : forall a, C (cyl a))
+           (ext : ExtensionAlong cyl C g)
+  : ExtensionAlong cyl C g.
+Proof.
+  srefine (Cyl_ind C g (ext.1 o cyr) _ ; _); intros a.
+  + pose (p := dp_apD ext.1 (cyglue a)).
+    exact (transport (fun u => DPath C _ u _) (ext.2 a) p).
+  + reflexivity. (** The point is that this equality is now definitional. *)
+Defined.
+
+Definition cyl_extendable (n : nat)
+           {A B} (f : A -> B) (C : Cyl f -> Type)
+           (ext : ExtendableAlong n cyl C)
+  : ExtendableAlong n cyl C.
+Proof.
+  revert C ext; simple_induction n n IH; intros C ext; [ exact tt | split ].
+  - intros g.
+    apply cyl_extension.
+    exact (fst ext g).
+  - intros h k; apply IH.
+    exact (snd ext h k).
+Defined.
+
+Definition cyl_ooextendable
+           {A B} (f : A -> B) (C : Cyl f -> Type)
+           (ext : ooExtendableAlong cyl C)
+  : ooExtendableAlong cyl C
+  := fun n => cyl_extendable n f C (ext n).
+
+Definition cyl_extension'
+           {A B} (f : A -> B) (C : B -> Type)
+           (g : forall a, C (pr_cyl (cyl a)))
+           (ext : ExtensionAlong f C g)
+  : ExtensionAlong cyl (C o pr_cyl) g.
+Proof.
+  rapply cyl_extension.
+  exists (ext.1 o pr_cyl).
+  intros x; apply ext.2.
+Defined.
+
+Definition cyl_extendable' (n : nat)
+           {A B} (f : A -> B) (C : B -> Type)
+           (ext : ExtendableAlong n f C)
+  : ExtendableAlong n cyl (C o (pr_cyl' f)).
+Proof.
+  rapply cyl_extendable.
+  refine (cancelL_extendable n C cyl pr_cyl _ ext).
+  rapply extendable_equiv.
+Defined.
+
+Definition cyl_ooextendable'
+           {A B} (f : A -> B) (C : B -> Type)
+           (ext : ooExtendableAlong f C)
+  : ooExtendableAlong cyl (C o (pr_cyl' f))
+  := fun n => cyl_extendable' n f C (ext n).
+
+
+(** ** Extendability along [functor_sum] *)
 
 Definition extendable_functor_sum (n : nat)
            {A B A' B'} (f : A -> A') (g : B -> B')
@@ -464,3 +527,124 @@ Definition ooextendable_functor_sum
 Proof.
   intros n; apply extendable_functor_sum; [ apply ef | apply eg ].
 Defined.
+
+
+(** ** Extendability along [functor_coeq] *)
+
+(** The path algebra in these proofs is terrible on its own.  But by replacing the maps with cofibrations so that many equalities hold definitionally, and modifying the extensions to also be strict, it becomes manageable with a bit of dependent-path technology. *)
+
+(** First we show that if we can extend in [C] along [k], and we can extend in appropriate dependent path-types of [C] along [h], then we can extend in [C] along [functor_coeq].  This is where the hard work is. *)
+Definition extension_functor_coeq {B A f g B' A' f' g'}
+           {h : B -> B'} {k : A -> A'}
+           {p : k o f == f' o h} {q : k o g == g' o h}
+           {C : Coeq f' g' -> Type}
+           (ek : ExtendableAlong 1 k (C o coeq))
+           (eh : forall (u v : forall x : B', C (coeq (g' x))),
+               ExtendableAlong 1 h (fun x => u x = v x))
+           (s : forall x, C (functor_coeq h k p q x))
+  : ExtensionAlong (functor_coeq h k p q) C s.
+Proof.
+  (** We start by change the problem to involve [CylCoeq] with cofibrations. *)
+  set (C' := C o pr_cylcoeq p q).
+  set (s' x := pr_cyl_cylcoeq p q x # s x).
+  assert (e : ExtensionAlong (cyl_cylcoeq p q) C' s').
+  2:{ pose (ex := fst (extendable_equiv 1 C (pr_cylcoeq p q)) e.1).
+      exists (ex.1); intros x.
+      apply (equiv_inj (transport C (pr_cyl_cylcoeq p q x))).
+      exact (apD _ (pr_cyl_cylcoeq p q x) @ ex.2 _ @ e.2 x). }
+  (** We have to transfer the hypotheses along those equivalences too.  We do it using [cyl_extendable] so that the resulting extensions compute definitionally.  Note that this means we never need to refer to the [.2] parts of the extensions, since they are identity paths. *)
+  pose (ea1 := fun u => (fst (cyl_extendable' 1 _ _ ek) u).1).
+  assert (eb'' : forall u v,
+             ExtendableAlong 1 cyl (fun x:Cyl h => DPath C' (cglue x) (u x) (v x))).
+  { intros u v.
+    rapply extendable_postcompose'.
+    2:{ rapply (cancelL_extendable 1 _ cyl pr_cyl).
+        - rapply extendable_equiv.
+        - exact (eh (fun x => cglue x # u (cyr x)) (v o cyr)). }
+    intros x; subst C'.
+    refine (_ oE dp_path_transport).
+    refine ((dp_compose (pr_cylcoeq p q) C _)^-1 oE _).
+    symmetry; srapply equiv_ds_fill_lr.
+    3:rapply ap_pr_cylcoeq_cglue.
+    all:srapply (transport (fun r => DPath C r _ _)).
+    3:exact (dp_inverse (dp_compose _ C _ (dp_apD u (eissect pr_cyl x)))).
+    4:exact (dp_inverse (dp_compose _ C _ (dp_apD v (eissect pr_cyl x)))).
+    1:change (fun y => pr_cylcoeq p q (coeq (functor_cyl p y)))
+      with (fun y => coeq (f := f') (g := g') (pr_cyl (functor_cyl p y))).
+    2:change (fun y => pr_cylcoeq p q (coeq (functor_cyl q y)))
+      with (fun y => coeq (f := f') (g := g') (pr_cyl (functor_cyl q y))).
+    all:refine ((ap_V _ (eissect pr_cyl x))^ @ _).
+    all:rapply ap_compose. }
+  pose (eb1 := fun u v w => (fst (cyl_extendable _ _ _ (eb'' u v)) w).1).
+  (** Now we construct an extension using Coeq-induction, and prove that it *is* an extension also using Coeq-induction. *)
+  srefine (_;_); srapply Coeq_ind_dp.
+  + exact (ea1 (s' o coeq)).
+  + apply eb1; intros b.
+    rapply (dp_compose' _ _ (ap_cyl_cylcoeq_cglue p q b)).
+    exact (dp_apD s' (cglue b)).
+  + (** Since we're using cofibrations, this holds definitionally. *)
+    intros a; reflexivity.
+  + (** And this one is much simpler than it would be otherwise. *)
+    intros b.
+    apply ds_dp.
+    rapply ds_G1.
+    refine (dp_apD_compose' _ _ (ap_cyl_cylcoeq_cglue p q b) _ @ _).
+    apply moveR_equiv_V.
+    rapply (Coeq_ind_dp_beta_cglue C').
+Defined.
+
+(** Now we can easily iterate into higher extendability. *)
+Definition extendable_functor_coeq (n : nat)
+           {B A f g B' A' f' g'}
+           {h : B -> B'} {k : A -> A'}
+           {p : k o f == f' o h} {q : k o g == g' o h}
+           {C : Coeq f' g' -> Type}
+           (ek : ExtendableAlong n k (C o coeq))
+           (eh : forall (u v : forall x : B', C (coeq (g' x))),
+               ExtendableAlong n h (fun x => u x = v x))
+  : ExtendableAlong n (functor_coeq h k p q) C.
+Proof.
+  revert C ek eh; simple_induction n n IH; intros C ek eh; [ exact tt | split ].
+  - apply extension_functor_coeq.
+    + exact (fst ek , fun _ _ => tt).
+    + exact (fun u v => (fst (eh u v) , fun _ _ => tt)).
+  - intros u v; apply IH.
+    + exact (snd ek (u o coeq) (v o coeq)).
+    + exact (snd (eh (u o coeq o g') (v o coeq o g'))).
+Defined.
+
+Definition ooextendable_functor_coeq
+           {B A f g B' A' f' g'}
+           {h : B -> B'} {k : A -> A'}
+           {p : k o f == f' o h} {q : k o g == g' o h}
+           {C : Coeq f' g' -> Type}
+           (ek : ooExtendableAlong k (C o coeq))
+           (eh : forall (u v : forall x : B', C (coeq (g' x))),
+               ooExtendableAlong h (fun x => u x = v x))
+  : ooExtendableAlong (functor_coeq h k p q) C
+  := fun n => extendable_functor_coeq n (ek n) (fun u v => eh u v n).
+
+(** In addition, to extend at level [n] into path-types of [C], it suffices to extend at level [n.+1] into [C] itself. *)
+Definition extendable_functor_coeq' (n : nat)
+           {B A f g B' A' f' g'}
+           {h : B -> B'} {k : A -> A'}
+           {p : k o f == f' o h} {q : k o g == g' o h}
+           {C : Coeq f' g' -> Type}
+           (ek : ExtendableAlong n k (C o coeq))
+           (eh : ExtendableAlong n.+1 h (C o coeq o g'))
+  : ExtendableAlong n (functor_coeq h k p q) C.
+Proof.
+  apply extendable_functor_coeq.
+  1:assumption.
+  exact (snd eh).
+Defined.
+
+Definition ooextendable_functor_coeq'
+           {B A f g B' A' f' g'}
+           {h : B -> B'} {k : A -> A'}
+           {p : k o f == f' o h} {q : k o g == g' o h}
+           {C : Coeq f' g' -> Type}
+           (ek : ooExtendableAlong k (C o coeq))
+           (eh : ooExtendableAlong h (C o coeq o g'))
+  : ooExtendableAlong (functor_coeq h k p q) C
+  := fun n => extendable_functor_coeq' n (ek n) (eh n.+1).

--- a/theories/Extensions.v
+++ b/theories/Extensions.v
@@ -443,7 +443,7 @@ Definition cyl_extension {A B} (f : A -> B) (C : Cyl f -> Type)
            (ext : ExtensionAlong cyl C g)
   : ExtensionAlong cyl C g.
 Proof.
-  srefine (Cyl_ind C g (ext.1 o cyr) _ ; _); intros a.
+  srefine (Cyl_ind_dp C g (ext.1 o cyr) _ ; _); intros a.
   + pose (p := dp_apD ext.1 (cyglue a)).
     exact (transport (fun u => DPath C _ u _) (ext.2 a) p).
   + reflexivity. (** The point is that this equality is now definitional. *)

--- a/theories/Extensions.v
+++ b/theories/Extensions.v
@@ -533,7 +533,7 @@ Defined.
 
 (** The path algebra in these proofs is terrible on its own.  But by replacing the maps with cofibrations so that many equalities hold definitionally, and modifying the extensions to also be strict, it becomes manageable with a bit of dependent-path technology. *)
 
-(** First we show that if we can extend in [C] along [k], and we can extend in appropriate dependent path-types of [C] along [h], then we can extend in [C] along [functor_coeq].  This is where the hard work is. *)
+(** First we show that if we can extend in [C] along [k], and we can extend in appropriate path-types of [C] along [h], then we can extend in [C] along [functor_coeq].  This is where the hard work is. *)
 Definition extension_functor_coeq {B A f g B' A' f' g'}
            {h : B -> B'} {k : A -> A'}
            {p : k o f == f' o h} {q : k o g == g' o h}
@@ -624,7 +624,7 @@ Definition ooextendable_functor_coeq
   : ooExtendableAlong (functor_coeq h k p q) C
   := fun n => extendable_functor_coeq n (ek n) (fun u v => eh u v n).
 
-(** In addition, to extend at level [n] into path-types of [C], it suffices to extend at level [n.+1] into [C] itself. *)
+(** Since extending at level [n.+1] into [C] implies extending at level [n] into path-types of [C], we get the following corollary. *)
 Definition extendable_functor_coeq' (n : nat)
            {B A f g B' A' f' g'}
            {h : B -> B'} {k : A -> A'}

--- a/theories/HIT/Coeq.v
+++ b/theories/HIT/Coeq.v
@@ -4,6 +4,7 @@
 
 Require Import HoTT.Basics UnivalenceImpliesFunext.
 Require Import Types.Paths Types.Forall Types.Sigma Types.Arrow Types.Universe.
+Require Import Cubical.DPath.
 Local Open Scope path_scope.
 
 (** ** Definition *)
@@ -46,6 +47,25 @@ Proof.
   eapply (cancelL (transport_const (cglue b) _)).
   refine ((apD_const (@Coeq_ind B A f g (fun _ => P) coeq' _) (cglue b))^ @ _).
   refine (Coeq_ind_beta_cglue (fun _ => P) _ _ _).
+Defined.
+
+Definition Coeq_ind_dp {B A f g} (P : @Coeq B A f g -> Type)
+             (coeq' : forall a, P (coeq a))
+             (cglue' : forall b, DPath P (cglue b) (coeq' (f b)) (coeq' (g b)))
+  : forall w, P w.
+Proof.
+  srapply (Coeq_ind P coeq'); intros b.
+  apply dp_path_transport^-1, cglue'.
+Defined.
+
+Definition Coeq_ind_dp_beta_cglue {B A f g} (P : @Coeq B A f g -> Type)
+             (coeq' : forall a, P (coeq a))
+             (cglue' : forall b, DPath P (cglue b) (coeq' (f b)) (coeq' (g b)))
+             (b : B)
+  : dp_apD (Coeq_ind_dp P coeq' cglue') (cglue b) = cglue' b.
+Proof.
+  apply dp_apD_path_transport.
+  srapply Coeq_ind_beta_cglue.
 Defined.
 
 (** ** Universal property *)

--- a/theories/HoTT.v
+++ b/theories/HoTT.v
@@ -68,6 +68,8 @@ Require Export HoTT.Limits.Limit.
 
 Require Export HoTT.Colimits.Pushout.
 Require Export HoTT.Colimits.SpanPushout.
+Require Export HoTT.Colimits.Quotient.
+Require Export HoTT.Colimits.MappingCylinder.
 Require Export HoTT.Colimits.Colimit.
 Require Export HoTT.Colimits.Colimit_Pushout.
 Require Export HoTT.Colimits.Colimit_Coequalizer.

--- a/theories/Homotopy/BlakersMassey.v
+++ b/theories/Homotopy/BlakersMassey.v
@@ -139,7 +139,7 @@ Section GBM.
       (** *** Codes for glue *)
 
       Section CodeGlue.
-        Context `{Funext} {y1 : Y} (q11 : Q x1 y1).
+        Context {y1 : Y} (q11 : Q x1 y1).
 
         (** We prove that codes respect glue as a chain of equivalences between types built from pushouts and double-pushouts.  The first step is to add the data of our hypothesized-to-be-connected type inside [codeleft2]. *)
 
@@ -554,7 +554,7 @@ Now we claim that the left-hand map of this span is also an equivalence.  Rather
       (** Then we notice that if we tried rewriting with [code_beta_glue] here, the unmanageable-looking result is actually fully general over the path [glue q01], so we can prove by path induction that it equals the nicer expression we'd like to see.  This is the purpose of the lemma [transport_singleton]. *)
       rewrite (transport_singleton
                  code (glue q01) _
-                 (fun r => @codeglue x0 x0 r _ y1 q01) (* Funext _ in the middle. *)
+                 (fun r => @codeglue x0 x0 r y1 q01)
                  (code_beta_glue x0 y1 q01 (glue q01))).
       unfold codeglue.
       (** Now we evaluate [codeglue] step by step using our lemmas. *)


### PR DESCRIPTION
This is on top of #1246; review the last two commits.

I found a way to do it directly with extendability, analogously to the proof for sums, without using wild categories at all.  It's a neat trick that I'm surprised never occurred to me before: just as we can make _sections_ commute definitionally by using dependent types, i.e. fibrations, we can make _extensions_ commute definitionally by using cofibrations.  Book HoTT doesn't have a way to talk internally about cofibrations the way it can about fibrations, but we can still replace any map by one that is a cofibration, namely its mapping cylinder, and make use of the definitional behavior of the latter.  This gives a way to make a bunch of squares commute strictly, and with a bit of cubical technology added the path algebra becomes tractable.

The resulting proof of `O_inverts_functor_coeq` is, of course, much shorter, since all the work is happening in `extension_functor_coeq`.  I'm not sure whether this way of factoring the proof is easier or harder to understand overall, given the complication in the latter.  Overall the timing change seems to be negligible.  But in addition to avoiding funext (which is cute but not really dispositive) the extendability lemmas may have other applications (e.g. to pushouts or suspensions).

I included one little application that I just noticed (although I expect it could easily be proven in the funext style too): when applying `O_inverts_functor_coeq` to the universe `L'` of `L`-separated types, instead of assuming `h` (the map between the domains of the parallel pairs being coequalized) is an `L'`-equivalence, it suffices for it to be `L`-connected -- together with `k`, the map between codomains, being an `L'`-equivalence, this suffices for `functor_coeq` to be an `L'`-equivalence.  I wonder if this is good for anything (and did we know it already?).
