### PR TITLE
Applications of extensions to connected maps and preservation of colimits

### DIFF
--- a/theories/Colimits/Pushout.v
+++ b/theories/Colimits/Pushout.v
@@ -154,8 +154,8 @@ equiv_adjointify pushout_sym_map pushout_sym_map sect_pushout_sym_map sect_pusho
 (** ** Functoriality *)
 
 Definition functor_pushout
-           {A B C} (f : A -> B) (g : A -> C)
-           {A' B' C'} (f' : A' -> B') (g' : A' -> C')
+           {A B C} {f : A -> B} {g : A -> C}
+           {A' B' C'} {f' : A' -> B'} {g' : A' -> C'}
            (h : A -> A') (k : B -> B') (l : C -> C')
            (p : k o f == f' o h) (q : l o g == g' o h)
   : Pushout f g -> Pushout f' g'.

--- a/theories/Extensions.v
+++ b/theories/Extensions.v
@@ -589,7 +589,7 @@ Definition HomotopyExtensionAlong {A B} {Q : B -> Type}
   := { q : forall (b:B) (v:Q b), C (b;v) & forall a v, q (f a) v = p a v }.
 
 Fixpoint HomotopyExtendableAlong (n : nat)
-         {A B} {Q : B -> Type} (f : A -> B) (C : sig Q -> Type)
+         {A B} {Q : B -> Type} (f : A -> B) (C : sig Q -> Type) : Type
   := match n with
      | 0 => Unit
      | S n => ((forall (p : forall (a:A) (v:Q (f a)), C (f a;v)),

--- a/theories/Extensions.v
+++ b/theories/Extensions.v
@@ -496,7 +496,176 @@ Definition cyl_ooextendable'
   := fun n => cyl_extendable' n f C (ext n).
 
 
+(** ** Extendability along [functor_prod] *)
+
+Definition extension_functor_prod
+           {A B A' B'} (f : A -> A') (g : B -> B')
+           (P : A' * B' -> Type)
+           (ef : forall b', ExtendableAlong 1 f (fun a' => P (a',b')))
+           (eg : forall a', ExtendableAlong 1 g (fun b' => P (a',b')))
+           (s : forall z, P (functor_prod f g z))
+  : ExtensionAlong (functor_prod f g) P s.
+Proof.
+  srefine (_;_).
+  - intros [a' b']; revert b'.
+    refine ((fst (eg a') _).1).
+    intros b; revert a'.
+    refine ((fst (ef (g b)) _).1).
+    intros a.
+    exact (s (a,b)).
+  - intros [a b]; cbn.
+    refine ((fst (eg (f a)) _).2 b @ _).
+    exact ((fst (ef (g b)) _).2 a).
+Defined.
+
+Definition extendable_functor_prod (n : nat)
+           {A B A' B'} (f : A -> A') (g : B -> B')
+           (P : A' * B' -> Type)
+           (ef : forall b', ExtendableAlong n f (fun a' => P (a',b')))
+           (eg : forall a', ExtendableAlong n g (fun b' => P (a',b')))
+  : ExtendableAlong n (functor_prod f g) P.
+Proof.
+  revert P ef eg; simple_induction n n IH; intros P ef eg; [ exact tt | split ].
+  - apply extension_functor_prod.
+    + intros b'; exact (fst (ef b'), fun _ _ => tt).
+    + intros a'; exact (fst (eg a'), fun _ _ => tt).
+  - intros h k; apply IH.
+    + intros b'; apply (snd (ef b')).
+    + intros a'; apply (snd (eg a')).
+Defined.
+
+Definition ooextendable_functor_prod
+           {A B A' B'} (f : A -> A') (g : B -> B')
+           (P : A' * B' -> Type)
+           (ef : forall b', ooExtendableAlong f (fun a' => P (a',b')))
+           (eg : forall a', ooExtendableAlong g (fun b' => P (a',b')))
+  : ooExtendableAlong (functor_prod f g) P
+  := fun n => extendable_functor_prod n f g P (fun b' => ef b' n) (fun a' => eg a' n).
+
+
+(** ** Extendability along [functor_sigma] *)
+
+Definition extension_functor_sigma_id
+           {A} {P Q : A -> Type} (f : forall a, P a -> Q a)
+           (C : sig Q -> Type)
+           (ef : forall a, ExtendableAlong 1 (f a) (fun v => C (a;v)))
+           (s : forall z, C (functor_sigma idmap f z))
+  : ExtensionAlong (functor_sigma idmap f) C s.
+Proof.
+  srefine (_;_).
+  - intros [a v]; revert v.
+    refine ((fst (ef a) _).1).
+    intros u.
+    exact (s (a;u)).
+  - intros [a u]; cbn.
+    exact ((fst (ef a) _).2 u).
+Defined.
+
+Definition extendable_functor_sigma_id n
+           {A} {P Q : A -> Type} (f : forall a, P a -> Q a)
+           (C : sig Q -> Type)
+           (ef : forall a, ExtendableAlong n (f a) (fun v => C (a;v)))
+  : ExtendableAlong n (functor_sigma idmap f) C.
+Proof.
+  revert C ef; simple_induction n n IH; intros C ef; [ exact tt | split ].
+  - apply extension_functor_sigma_id.
+    intros a; exact (fst (ef a) , fun _ _ => tt).
+  - intros h k; apply IH.
+    intros a; apply (snd (ef a)).
+Defined.
+
+Definition ooextendable_functor_sigma_id
+           {A} {P Q : A -> Type} (f : forall a, P a -> Q a)
+           (C : sig Q -> Type)
+           (ef : forall a, ooExtendableAlong (f a) (fun v => C (a;v)))
+  : ooExtendableAlong (functor_sigma idmap f) C
+  := fun n => extendable_functor_sigma_id n f C (fun a => ef a n).
+
+(** Unfortunately, the technology of [ExtensionAlong] seems to be insufficient to state a general, funext-free version of [extension_functor_sigma] with a nonidentity map on the bases; the hypothesis on the fiberwise map would have to be the existence of an extension in a function-type "up to pointwise equality".  With wild oo-groupoids we could probably manage it.  For now, we say something a bit hacky. *)
+
+Definition HomotopyExtensionAlong {A B} {Q : B -> Type}
+           (f : A -> B) (C : sig Q -> Type)
+           (p : forall (a:A) (v:Q (f a)), C (f a;v))
+  := { q : forall (b:B) (v:Q b), C (b;v) & forall a v, q (f a) v = p a v }.
+
+Fixpoint HomotopyExtendableAlong (n : nat)
+         {A B} {Q : B -> Type} (f : A -> B) (C : sig Q -> Type)
+  := match n with
+     | 0 => Unit
+     | S n => ((forall (p : forall (a:A) (v:Q (f a)), C (f a;v)),
+                   HomotopyExtensionAlong f C p) *
+               (forall (h k : forall z, C z),
+                   HomotopyExtendableAlong n f (fun z => h z = k z)))
+     end.
+
+Definition ooHomotopyExtendableAlong
+           {A B} {Q : B -> Type} (f : A -> B) (C : sig Q -> Type)
+  := forall n, HomotopyExtendableAlong n f C.
+
+Definition extension_functor_sigma
+           {A B} {P : A -> Type} {Q : B -> Type}
+           (f : A -> B) (g : forall a, P a -> Q (f a))
+           (C : sig Q -> Type)
+           (ef : HomotopyExtendableAlong 1 f C)
+           (eg : forall a, ExtendableAlong 1 (g a) (fun v => C (f a ; v)))
+           (s : forall z, C (functor_sigma f g z))
+  : ExtensionAlong (functor_sigma f g) C s.
+Proof.
+  srefine (_;_).
+  - intros [b v]; revert b v.
+    refine ((fst ef _).1).
+    intros a.
+    refine ((fst (eg a) _).1).
+    intros u.
+    exact (s (a;u)).
+  - intros [a u]; cbn.
+    refine ((fst ef _).2 _ _ @ _).
+    exact ((fst (eg a) _).2 u).
+Defined.
+
+Definition extendable_functor_sigma (n : nat)
+           {A B} {P : A -> Type} {Q : B -> Type}
+           (f : A -> B) (g : forall a, P a -> Q (f a))
+           (C : sig Q -> Type)
+           (ef : HomotopyExtendableAlong n f C)
+           (eg : forall a, ExtendableAlong n (g a) (fun v => C (f a ; v)))
+  : ExtendableAlong n (functor_sigma f g) C.
+Proof.
+  revert C ef eg; simple_induction n n IH; intros C ef eg; [ exact tt | split ].
+  - apply extension_functor_sigma.
+    + exact (fst ef, fun _ _ => tt).
+    + intros a; exact (fst (eg a) , fun _ _ => tt).
+  - intros h k; apply IH.
+    + exact (snd ef h k).
+    + intros a; apply (snd (eg a)).
+Defined.
+
+Definition ooextendable_functor_sigma
+           {A B} {P : A -> Type} {Q : B -> Type}
+           (f : A -> B) (g : forall a, P a -> Q (f a))
+           (C : sig Q -> Type)
+           (ef : ooHomotopyExtendableAlong f C)
+           (eg : forall a, ooExtendableAlong (g a) (fun v => C (f a ; v)))
+  : ooExtendableAlong (functor_sigma f g) C
+  := fun n => extendable_functor_sigma n f g C (ef n) (fun a => eg a n).
+
+
 (** ** Extendability along [functor_sum] *)
+
+Definition extension_functor_sum
+           {A B A' B'} (f : A -> A') (g : B -> B')
+           (P : A' + B' -> Type)
+           (ef : ExtendableAlong 1 f (P o inl))
+           (eg : ExtendableAlong 1 g (P o inr))
+           (h : forall z, P (functor_sum f g z))
+  : ExtensionAlong (functor_sum f g) P h.
+Proof.
+  srefine (sum_ind _ _ _ ; sum_ind _ _ _).
+  + exact (fst ef (h o inl)).1.
+  + exact (fst eg (h o inr)).1.
+  + exact (fst ef (h o inl)).2.
+  + exact (fst eg (h o inr)).2.
+Defined.
 
 Definition extendable_functor_sum (n : nat)
            {A B A' B'} (f : A -> A') (g : B -> B')
@@ -506,12 +675,9 @@ Definition extendable_functor_sum (n : nat)
   : ExtendableAlong n (functor_sum f g) P.
 Proof.
   revert P ef eg; induction n as [|n IH]; intros P ef eg; [ exact tt | split ].
-  - intros h.
-    srefine (sum_ind _ _ _ ; sum_ind _ _ _).
-    + exact (fst ef (h o inl)).1.
-    + exact (fst eg (h o inr)).1.
-    + exact (fst ef (h o inl)).2.
-    + exact (fst eg (h o inr)).2.
+  - intros h; apply extension_functor_sum.
+    + exact (fst ef, fun _ _ => tt).
+    + exact (fst eg, fun _ _ => tt).
   - intros h k.
     apply IH.
     + exact (snd ef (h o inl) (k o inl)).

--- a/theories/Homotopy/BlakersMassey.v
+++ b/theories/Homotopy/BlakersMassey.v
@@ -321,9 +321,11 @@ Section GBM.
           unfold equiv_Ocodeleft2.
           Opaque equiv_Ocodeleft2plus.
           cbn.
-          rewrite to_O_natural, O_rec_beta, to_O_natural.
-          apply ap; cbn.
-          apply Ocodeleft02plus_02b.
+          refine (ap _ (ap _ (to_O_natural _ _ _)) @ _).
+          refine (ap _ (to_O_natural _ _ _) @ _).
+          refine (to_O_natural _ _ _ @ _).
+          apply ap.
+          rapply Ocodeleft02plus_02b.
         Qed.
 
         (** Thus, our pushout in which one vertex is itself a pushout can be written as a "double pushout"

--- a/theories/Modalities/Descent.v
+++ b/theories/Modalities/Descent.v
@@ -94,7 +94,7 @@ Proof.
   - refine (equiv_O_sigma_O O _ oE _ oE (equiv_O_sigma_O O _)^-1).
     refine (Build_Equiv _ _ (O_functor O (functor_sigma f (fun x => O_functor O (g x)))) _).
   - apply O_indpaths. intros [x u]; cbn.
-    rewrite O_rec_beta, to_O_natural, O_rec_beta; cbn.
+    rewrite !to_O_natural, O_rec_beta; cbn.
     rewrite !to_O_natural, O_rec_beta.
     reflexivity.
 Defined.

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -694,49 +694,47 @@ Section Reflective_Subuniverse.
 
     (** We show that [OA*OB] has the same universal property as [O(A*B)] *)
 
-    Definition equiv_O_prod_unit_precompose
-               {fs : Funext} (A B C : Type) `{In O C}
-    : ((O A) * (O B) -> C) <~> (A * B -> C).
-    Proof.
-      refine (equiv_uncurry A B C oE _).
-      refine (_ oE (equiv_uncurry (O A) (O B) C)^-1).
-      refine (equiv_o_to_O O A (B -> C) oE _); simpl.
-      apply equiv_postcompose'.
-      exact (equiv_o_to_O _ B C).
-    Defined.
-
-    (** The preceding equivalence turns out to be actually (judgmentally!) precomposition with the following function. *)
+    (** Here is the map witnessing the universal property.  *)
     Definition O_prod_unit (A B : Type) : A * B -> O A * O B
       := functor_prod (to O A) (to O B).
 
-    (** From this, we can define the comparison map for products, and show that precomposing with it is also an equivalence. *)
+    (** We express the universal property without funext, using extensions. *)
+    Definition ooextendable_O_prod_unit (A B C : Type) `{In O C}
+      : ooExtendableAlong (O_prod_unit A B) (fun _ => C).
+    Proof.
+      apply ooextendable_functor_prod.
+      all:intros; rapply extendable_to_O.
+    Defined.
+
+    (** Here's the version with funext. *)
+    Definition isequiv_O_prod_unit_precompose
+               {fs : Funext} (A B C : Type) `{In O C}
+      : IsEquiv (fun (f : (O A) * (O B) -> C) => f o O_prod_unit A B).
+    Proof.
+      rapply isequiv_ooextendable.
+      rapply ooextendable_O_prod_unit.
+    Defined.
+
+    Definition equiv_O_prod_unit_precompose
+               {fs : Funext} (A B C : Type) `{In O C}
+      : ((O A) * (O B) -> C) <~> (A * B -> C)
+      := Build_Equiv _ _ _ (isequiv_O_prod_unit_precompose A B C).
+
+    (** The (funext-free) universal property implies that [O_prod_unit] is an [O]-equivalence, hence induces an equivalence between [O (A*B)] and [O A * O B]. *)
+    Global Instance O_inverts_O_prod_unit (A B : Type)
+      : O_inverts (O_prod_unit A B).
+    Proof.
+      rapply O_inverts_from_extendable.
+      intros; rapply ooextendable_O_prod_unit.
+    Defined.
+
     Definition O_prod_cmp (A B : Type) : O (A * B) -> O A * O B
       := O_rec (O_prod_unit A B).
 
     Global Instance isequiv_O_prod_cmp (A B : Type)
-    : IsEquiv (O_prod_cmp A B).
+      : IsEquiv (O_prod_cmp A B).
     Proof.
-      simple refine (isequiv_adjointify _ _ _ _).
-      { apply prod_ind; intro a.
-        apply O_rec; intro b; revert a.
-        apply O_rec; intro a.
-        apply (to O).
-        exact (a, b). }
-      { unfold prod_ind, O_prod_cmp, O_prod_unit.
-        intros [oa ob].
-        revert ob; refine (O_indpaths _ _ _); intros b.
-        revert oa; refine (O_indpaths _ _ _); intros a.
-        cbn. abstract (repeat rewrite O_rec_beta; reflexivity). }
-      { unfold prod_ind, O_prod_cmp, O_prod_unit.
-        refine (O_indpaths _ _ _); intros [a b]; cbn.
-        abstract (repeat (rewrite O_rec_beta; cbn); reflexivity). }
-    Defined.
-
-    Definition isequiv_O_prod_cmp_precompose
-      {fs : Funext} (A B C : Type) {C_inO : In O C}
-    : IsEquiv (fun h : O A * O B -> C => h o O_prod_cmp A B).
-    Proof.
-      apply isequiv_precompose; exact _.
+      rapply isequiv_O_rec_O_inverts.
     Defined.
 
     Definition equiv_O_prod_cmp (A B : Type)
@@ -811,20 +809,31 @@ Section Reflective_Subuniverse.
       apply ap, p.
     Defined.
 
-    (** Theorem 7.3.9: The reflector [O] can be discarded inside a reflected sum. *)
-    Definition equiv_O_sigma_O {A} (P : A -> Type)
-    : O {x:A & O (P x)} <~> O {x:A & P x}.
+    (** [functor_sigma] over [idmap] preserves [O]-equivalences. *)
+    Definition O_inverts_functor_sigma_id {A} {P Q : A -> Type}
+           (g : forall a, P a -> Q a) `{forall a, O_inverts (g a)}
+      : O_inverts (functor_sigma idmap g).
     Proof.
-      simple refine (equiv_adjointify _ _ _ _).
+      apply O_inverts_from_extendable; intros Z Z_inO.
+      apply ooextendable_functor_sigma_id; intros a.
+      nrapply ooextendable_O_inverts; exact _.
+    Defined.
+
+    (** Theorem 7.3.9: The reflector [O] can be discarded inside a reflected sum.  This can be obtained from [O_inverts_functor_sigma_id] applied to the family of units [to O (P x)], but unfortunately the definitional behavior of the inverse obtained thereby (which here we take as the "forwards" direction) is poor.  So instead we give an explicit proof, but note that the "backwards" direction here is precisely [functor_sigma]. *)
+    Definition equiv_O_sigma_O {A} (P : A -> Type)
+      : O {x:A & O (P x)} <~> O {x:A & P x}.
+      (** := (Build_Equiv _ _ _ (O_inverts_functor_sigma_id (fun x => to O (P x))))^-1. *)
+    Proof.
+      srapply equiv_adjointify.
       - apply O_rec; intros [a op]; revert op.
         apply O_rec; intros p.
         exact (to O _ (a;p)).
-      - apply O_rec; intros [a p].
-        exact (to O _ (a ; to O _ p)).
-      - unfold Sect; rapply O_indpaths.
+      - apply O_functor.
+        exact (functor_sigma idmap (fun x => to O (P x))).
+      - unfold Sect, O_functor; rapply O_indpaths.
         intros [a p]; simpl.
         abstract (repeat (simpl rewrite @O_rec_beta); reflexivity).
-      - unfold Sect; rapply O_indpaths.
+      - unfold Sect, O_functor; rapply O_indpaths.
         intros [a op]; revert op; rapply O_indpaths; intros p; simpl.
         abstract (repeat (simpl rewrite @O_rec_beta); reflexivity).
     Defined.
@@ -905,7 +914,7 @@ Section Reflective_Subuniverse.
 
     (** ** Coproducts *)
 
-    Definition O_inverts_sum {A B A' B'} (f : A -> A') (g : B -> B')
+    Definition O_inverts_functor_sum {A B A' B'} (f : A -> A') (g : B -> B')
                `{O_inverts f} `{O_inverts g}
       : O_inverts (functor_sum f g).
     Proof.
@@ -916,7 +925,7 @@ Section Reflective_Subuniverse.
     Definition equiv_O_functor_sum {A B A' B'} (f : A -> A') (g : B -> B')
                `{O_inverts f} `{O_inverts g}
       : O (A + B) <~> O (A' + B')
-      := Build_Equiv _ _ _ (O_inverts_sum f g).
+      := Build_Equiv _ _ _ (O_inverts_functor_sum f g).
 
     Definition equiv_O_sum {A B} :
       O (A + B) <~> O (O A + O B)
@@ -928,7 +937,7 @@ Section Reflective_Subuniverse.
       Context {B A : Type} (f g : B -> A).
 
       Definition O_inverts_functor_coeq
-                 {B' A' : Type} (f' g' : B' -> A')
+                 {B' A' : Type} {f' g' : B' -> A'}
                  (h : B -> B') (k : A -> A')
                  (p : k o f == f' o h) (q : k o g == g' o h)
                  `{O_inverts k} `{O_inverts h}
@@ -946,7 +955,7 @@ Section Reflective_Subuniverse.
                  (p : k o f == f' o h) (q : k o g == g' o h)
                  `{O_inverts k} `{O_inverts h}
         : O (Coeq f g) <~> O (Coeq f' g')
-        := Build_Equiv _ _ _ (O_inverts_functor_coeq f' g' h k p q).
+        := Build_Equiv _ _ _ (O_inverts_functor_coeq h k p q).
 
       Definition coeq_cmp : Coeq f g -> Coeq (O_functor f) (O_functor g)
         := functor_coeq (to O B) (to O A)
@@ -983,23 +992,21 @@ Section Reflective_Subuniverse.
     Section OPushout.
       Context {A B C : Type} (f : A -> B) (g : A -> C).
 
-      Definition equiv_O_pushout
-        : O (Pushout f g) <~> O (Pushout (O_functor f) (O_functor g)).
+      Definition O_inverts_functor_pushout
+             {A' B' C'} {f' : A' -> B'} {g' : A' -> C'}
+             (h : A -> A') (k : B -> B') (l : C -> C')
+             (p : k o f == f' o h) (q : l o g == g' o h)
+             `{O_inverts h} `{O_inverts k} `{O_inverts l}
+        : O_inverts (functor_pushout h k l p q).
       Proof.
-        unfold Pushout.
-        srapply equiv_O_functor_coeq.
-        - exact (to O A).
-        - intros [b | c]; [ exact (inl (to O B b)) | exact (inr (to O C c)) ].
-        - intro a.
-          apply (ap inl).
-          unfold O_functor.
-          symmetry; apply (O_rec_beta ((to O B) o f)).
-        - intro a.
-          apply (ap inr).
-          symmetry; apply (O_rec_beta ((to O C) o g)).
-        - rapply O_inverts_sum.
-        - exact _.
+        rapply O_inverts_functor_coeq; rapply O_inverts_functor_sum.
       Defined.
+
+      Definition equiv_O_pushout
+        : O (Pushout f g) <~> O (Pushout (O_functor f) (O_functor g))
+        := Build_Equiv _ _ _ (O_inverts_functor_pushout (to O A) (to O B) (to O C)
+                                                        (fun x => (to_O_natural f x)^)
+                                                        (fun x => (to_O_natural g x)^)).
 
       Definition equiv_O_pushout_to_O_pushl (b : B)
         : equiv_O_pushout (to O (Pushout f g) (pushl b))
@@ -1729,24 +1736,10 @@ Section ConnectedMaps.
   (** Lemma 7.5.14: Connected maps are inverted by [O]. *)
   Global Instance O_inverts_conn_map {A B : Type} (f : A -> B)
          `{IsConnMap O _ _ f}
-  : IsEquiv (O_functor O f).
+    : O_inverts O f.
   Proof.
-    simple refine (isequiv_adjointify _ _ _ _).
-    - apply O_rec; intros y.
-      exact (O_functor O pr1 (center (O (hfiber f y)))).
-    - unfold Sect; rapply O_indpaths; intros b.
-      refine (ap (O_functor O f) (O_rec_beta _ b) @ _).
-      refine ((O_functor_compose _ _ _ _)^ @ _).
-      set (x := (center (O (hfiber f b)))).
-      clearbody x; revert x; rapply O_indpaths; intros [a p].
-      refine (O_rec_beta (to O B o (f o pr1)) (a;p) @ _).
-      exact (ap (to O B) p).
-    - unfold Sect; rapply O_indpaths; intros a.
-      refine (ap (O_rec _) (to_O_natural O f a) @ _).
-      refine (O_rec_beta _ _ @ _).
-      transitivity (O_functor O pr1 (to O (hfiber f (f a)) (a;1))).
-      + apply ap, contr.
-      + refine (to_O_natural _ _ _).
+    rapply O_inverts_from_extendable.
+    intros; rapply extendable_conn_map_inO.
   Defined.
 
   (** As a consequence, connected maps between modal types are equivalences. *)
@@ -1761,6 +1754,43 @@ Section ConnectedMaps.
   Proof.
     unfold O_functor.
     rapply conn_map_compose.
+  Defined.
+
+  (** Connected maps are preserved by coproducts *)
+  Definition conn_map_sum {A B A' B'} (f : A -> A') (g : B -> B')
+             `{IsConnMap O _ _ f} `{IsConnMap O _ _ g}
+    : IsConnMap O (functor_sum f g).
+  Proof.
+    apply conn_map_from_extension_elim; intros.
+    apply extension_functor_sum; rapply ooextendable_conn_map_inO.
+  Defined.
+
+  (** Connected maps are preserved by coequalizers *)
+  Definition conn_map_functor_coeq {B A B' A'}
+             {f g : B -> A} {f' g' : B' -> A'}
+             (h : B -> B') (k : A -> A')
+             (p : k o f == f' o h) (q : k o g == g' o h)
+             `{IsConnMap O _ _ k} `{IsConnMap O _ _ h}
+    : IsConnMap O (functor_coeq h k p q).
+  Proof.
+    apply conn_map_from_extension_elim; intros.
+    apply extension_functor_coeq.
+    - rapply ooextendable_conn_map_inO.
+    - intros; rapply ooextendable_conn_map_inO.
+  Defined.
+
+  (** And by pushouts *)
+  Definition conn_map_functor_pushout {A B C A' B' C'}
+             (f : A -> B) (g : A -> C) {f' : A' -> B'} {g' : A' -> C'}
+             (h : A -> A') (k : B -> B') (l : C -> C')
+             (p : k o f == f' o h) (q : l o g == g' o h)
+             `{IsConnMap O _ _ h} `{IsConnMap O _ _ k} `{IsConnMap O _ _ l}
+    : IsConnMap O (functor_pushout h k l p q).
+  Proof.
+    apply conn_map_from_extension_elim; intros.
+    apply extension_functor_coeq.
+    - apply extendable_functor_sum; rapply ooextendable_conn_map_inO.
+    - intros; rapply ooextendable_conn_map_inO.
   Defined.
 
 End ConnectedMaps.
@@ -1935,4 +1965,52 @@ Proof.
   - nrapply (ooextendable_O_inverts O'); assumption.
   - pose (inO_leq O' (Sep O)).
     intros u v; rapply (extendable_conn_map_inO O).
+Defined.
+
+(** And a similar property for pushouts *)
+Definition OO_inverts_functor_pushout
+           (O O' : ReflectiveSubuniverse) `{O' <= Sep O}
+           {A B C A' B' C'}
+           (f : A -> B) (g : A -> C) {f' : A' -> B'} {g' : A' -> C'}
+           (h : A -> A') (k : B -> B') (l : C -> C')
+           (p : k o f == f' o h) (q : l o g == g' o h)
+           `{IsConnMap O _ _ h} `{O_inverts O' k} `{O_inverts O' l}
+  : O_inverts O' (functor_pushout h k l p q).
+Proof.
+  nrapply (OO_inverts_functor_coeq O O').
+  1,3:exact _.
+  rapply O_inverts_functor_sum.
+Defined.
+
+(** And similar properties for connected maps *)
+Definition OO_conn_map_functor_coeq
+           (O O' : ReflectiveSubuniverse) `{O' <= Sep O}
+           {B A B' A'}
+           {f g : B -> A} {f' g' : B' -> A'}
+           (h : B -> B') (k : A -> A')
+           (p : k o f == f' o h) (q : k o g == g' o h)
+           `{IsConnMap O' _ _ k} `{IsConnMap O _ _ h}
+  : IsConnMap O' (functor_coeq h k p q).
+Proof.
+  apply conn_map_from_extension_elim; intros.
+  apply extension_functor_coeq.
+  - rapply ooextendable_conn_map_inO.
+  - pose (inO_leq O' (Sep O));
+    intros; rapply (ooextendable_conn_map_inO O).
+Defined.
+
+Definition OO_conn_map_functor_pushout
+           (O O' : ReflectiveSubuniverse) `{O' <= Sep O}
+           {A B C A' B' C'}
+           (f : A -> B) (g : A -> C) {f' : A' -> B'} {g' : A' -> C'}
+           (h : A -> A') (k : B -> B') (l : C -> C')
+           (p : k o f == f' o h) (q : l o g == g' o h)
+           `{IsConnMap O _ _ h} `{IsConnMap O' _ _ k} `{IsConnMap O' _ _ l}
+  : IsConnMap O' (functor_pushout h k l p q).
+Proof.
+  apply conn_map_from_extension_elim; intros.
+  apply extension_functor_coeq.
+  - apply extendable_functor_sum; rapply ooextendable_conn_map_inO.
+  - pose (inO_leq O' (Sep O));
+    intros; rapply ooextendable_conn_map_inO.
 Defined.


### PR DESCRIPTION
One commit on top of #1264.  Using extendability more systematically simplifies the proofs that reflectors preserve products and pushouts and invert connected maps, and implies that colimits preserve connected maps (with enhancements for separated pairs of subuniverses).

It would also simplify the proof of `equiv_O_sigma_O`, but unfortunately the simpler proof of that has worse computational behavior, and we rely on its computational behavior in several places.  We could change those places to reason differently, but it's probably better to keep the good computational behavior and just note that the inverse is definitionally the same as what the simple proof would give.  To emphasize this, I changed the inverse to be syntactically the same as well, which required some trivial changes in a couple of places downstream.

In making one of those trivial changes to `BlakersMassey`, I managed to speed it up by ~30%, probably due to replacing some `rewrites` and a `cbn` with `refine`s.
