### PR TITLE
Reorganised Notations.v and moved cubical notations

### DIFF
--- a/theories/Basics/Notations.v
+++ b/theories/Basics/Notations.v
@@ -3,17 +3,63 @@ Notation "'forall'  x .. y , P" := (forall x , .. (forall y, P) ..) (at level 20
 
 (** Work around bug 5569, https://coq.inria.fr/bugs/show_bug.cgi?id=5569, Warning skip-spaces-curly,parsing seems bogus *)
 Local Set Warnings Append "-skip-spaces-curly".
+
+(** Numeric *)
+Reserved Notation "n .+1" (at level 2, left associativity, format "n .+1").
+Reserved Notation "n .+2" (at level 2, left associativity, format "n .+2").
+Reserved Notation "n .+3" (at level 2, left associativity, format "n .+3").
+Reserved Notation "n .+4" (at level 2, left associativity, format "n .+4").
+Reserved Notation "n .+5" (at level 2, left associativity, format "n .+5").
+Reserved Notation "n '.-1'" (at level 2, left associativity, format "n .-1").
+Reserved Notation "n '.-2'" (at level 2, left associativity, format "n .-2").
+Reserved Notation "m +2+ n" (at level 50, left associativity).
+
+(** Pointed *)
 Reserved Infix "@*" (at level 30).
-Reserved Infix "-|" (at level 60, right associativity).
-Reserved Infix "<~=~>" (at level 70, no associativity).
-Reserved Infix "==*" (at level 70, no associativity).
 Reserved Infix "<~>*" (at level 85).
 Reserved Infix "->*" (at level 99).
 Reserved Infix "->**" (at level 99).
-Reserved Infix "=n" (at level 70, no associativity).
 Reserved Infix "o*" (at level 40).
-Reserved Infix "oL" (at level 40, left associativity).
-Reserved Infix "oR" (at level 40, left associativity).
+Reserved Infix "==*" (at level 70, no associativity).
+Reserved Notation "g ^*'" (at level 20).
+Reserved Notation "f ^*" (at level 3, format "f '^*'").
+Reserved Notation "f ^-1*" (at level 3, format "f '^-1*'").
+Reserved Notation "p ^" (at level 3, format "p '^'").
+Reserved Notation "g o*E f" (at level 40, left associativity).
+
+(** Sigma type *)
+Reserved Notation "x .1" (at level 3, format "x '.1'").
+Reserved Notation "x .2" (at level 3, format "x '.2'").
+
+(** Paths *)
+Reserved Notation "p @ q" (at level 20).
+Reserved Notation "p # x" (right associativity, at level 65).
+Reserved Notation "p # x" (right associativity, at level 65, only parsing).
+Reserved Notation "p @@ q" (at level 20).
+Reserved Notation "p @' q" (at level 21, left associativity, format "'[v' p '/' '@''  q ']'").
+Reserved Notation "f == g" (at level 70, no associativity).
+
+(** Equivalences *)
+Reserved Notation "A <~> B" (at level 85).
+Reserved Notation "f ^-1" (at level 3, format "f '^-1'").
+Reserved Notation "m ^-1" (at level 3, format "m '^-1'").
+Reserved Notation "g 'oE' f" (at level 40, left associativity).
+Reserved Notation "f *E g" (at level 40, no associativity).
+Reserved Notation "f +E g" (at level 50, left associativity).
+
+(** Categories *)
+Reserved Infix "-|" (at level 60, right associativity).
+Reserved Infix "<~=~>" (at level 70, no associativity).
+Reserved Notation "a // 'CAT'" (at level 40, left associativity).
+Reserved Notation "a \\ 'CAT'" (at level 40, left associativity).
+Reserved Notation "'CAT' // a" (at level 40, left associativity).
+Reserved Notation "'CAT' \\ a" (at level 40, left associativity).
+Reserved Notation "C ^op" (at level 3, format "C '^op'").
+
+(** Natural numbers *)
+Reserved Infix "=n" (at level 70, no associativity).
+
+(** Wild cat *)
 Reserved Infix "$->" (at level 99).
 Reserved Infix "$<~>" (at level 85).
 Reserved Infix "$o" (at level 40).
@@ -24,61 +70,39 @@ Reserved Infix "$@" (at level 30).
 Reserved Infix "$@L" (at level 30).
 Reserved Infix "$@R" (at level 30).
 Reserved Infix "$=>" (at level 99).
+Reserved Notation "T ^op" (at level 3, format "T ^op").
+Reserved Notation "f ^-1$" (at level 3, format "f '^-1$'").
+Reserved Notation "f ^$" (at level 3, format "f '^$'").
+
+(** Cubical *)
+Reserved Notation "x =[ q ] y" (at level 10).
+Reserved Notation "x '@lr' y"  (at level 10).
+
+(** Other / Not sorted yet *)
+
+Reserved Infix "oL" (at level 40, left associativity).
+Reserved Infix "oR" (at level 40, left associativity).
+
 Reserved Notation "~~ A" (at level 75, right associativity, only parsing).
-Reserved Notation "A <~> B" (at level 85).
-Reserved Notation "a // 'CAT'" (at level 40, left associativity).
-Reserved Notation "a \\ 'CAT'" (at level 40, left associativity).
 Reserved Notation "a \ C" (at level 40, left associativity).
 Reserved Notation "a <=_{ x } b" (at level 70, no associativity).
-Reserved Notation "'CAT' // a" (at level 40, left associativity).
-Reserved Notation "'CAT' \\ a" (at level 40, left associativity).
-Reserved Notation "C ^op" (at level 3, format "C '^op'").
 Reserved Notation "D1 ~d~ D2" (at level 65).
 Reserved Notation "D '_f' g" (at level 10).
 Reserved Notation "F '_0' x" (at level 10, no associativity).
 Reserved Notation "F '_0' x" (at level 10, no associativity, only parsing).
-Reserved Notation "f ^-1" (at level 3, format "f '^-1'").
-Reserved Notation "f ^-1*" (at level 3, format "f '^-1*'").
-Reserved Notation "f ^-1$" (at level 3, format "f '^-1$'").
 Reserved Notation "F '_1' m" (at level 10, no associativity).
-Reserved Notation "f ^*" (at level 3, format "f '^*'").
-Reserved Notation "f ^$" (at level 3, format "f '^$'").
-Reserved Notation "f *E g" (at level 40, no associativity).
-Reserved Notation "f +E g" (at level 50, left associativity).
-Reserved Notation "f == g" (at level 70, no associativity).
 Reserved Notation "F ^op" (at level 3, format "F ^op").
 Reserved Notation "'forall'  x .. y , P" (at level 200, x binder, y binder, right associativity).
-Reserved Notation "g ^*'" (at level 20).
 Reserved Notation "g 'oD' f" (at level 40, left associativity).
-Reserved Notation "g 'oE' f" (at level 40, left associativity).
-Reserved Notation "g o*E f" (at level 40, left associativity).
 Reserved Notation "g 'o' f" (at level 40, left associativity).
-Reserved Notation "m ^-1" (at level 3, format "m '^-1'").
-Reserved Notation "m +2+ n" (at level 50, left associativity).
 Reserved Notation "m <= n" (at level 70, no associativity).
-Reserved Notation "n .+1" (at level 2, left associativity, format "n .+1").
-Reserved Notation "n .+2" (at level 2, left associativity, format "n .+2").
-Reserved Notation "n .+3" (at level 2, left associativity, format "n .+3").
-Reserved Notation "n .+4" (at level 2, left associativity, format "n .+4").
-Reserved Notation "n .+5" (at level 2, left associativity, format "n .+5").
-Reserved Notation "n '.-1'" (at level 2, left associativity, format "n .-1").
-Reserved Notation "n '.-2'" (at level 2, left associativity, format "n .-2").
 Reserved Notation "n -Type" (at level 1).
 Reserved Notation "p ..1" (at level 3).
 Reserved Notation "p ..2" (at level 3).
-Reserved Notation "p ^" (at level 3, format "p '^'").
 Reserved Notation "!! P" (at level 75, right associativity).
-Reserved Notation "p @ q" (at level 20).
-Reserved Notation "p @@ q" (at level 20).
-Reserved Notation "p @' q" (at level 21, left associativity, format "'[v' p '/' '@''  q ']'").
-Reserved Notation "p # x" (right associativity, at level 65).
-Reserved Notation "p # x" (right associativity, at level 65, only parsing).
-Reserved Notation "T ^op" (at level 3, format "T ^op").
 Reserved Notation "[ u ]" (at level 9).
 Reserved Notation "u ~~ v" (at level 30).
 Reserved Notation " [ u , v ] " (at level 9).
-Reserved Notation "x .1" (at level 3, format "x '.1'").
-Reserved Notation "x .2" (at level 3, format "x '.2'").
 Reserved Notation "! x" (at level 3, format "'!' x").
 Reserved Notation "x \\ F" (at level 40, left associativity).
 Reserved Notation "x // F" (at level 40, left associativity).

--- a/theories/Basics/Notations.v
+++ b/theories/Basics/Notations.v
@@ -75,7 +75,7 @@ Reserved Notation "f ^-1$" (at level 3, format "f '^-1$'").
 Reserved Notation "f ^$" (at level 3, format "f '^$'").
 
 (** Cubical *)
-Reserved Notation "x =[ q ] y" (at level 10).
+Reserved Notation "x =[ q ] y" (at level 25).
 Reserved Notation "x '@lr' y"  (at level 10).
 
 (** Other / Not sorted yet *)

--- a/theories/Basics/Notations.v
+++ b/theories/Basics/Notations.v
@@ -75,8 +75,9 @@ Reserved Notation "f ^-1$" (at level 3, format "f '^-1$'").
 Reserved Notation "f ^$" (at level 3, format "f '^$'").
 
 (** Cubical *)
-Reserved Notation "x =[ q ] y" (at level 25).
-Reserved Notation "x '@lr' y"  (at level 10).
+Reserved Infix "@@h" (at level 30).
+Reserved Infix "@@v" (at level 30).
+Reserved Infix "@lr" (at level 30).
 
 (** Other / Not sorted yet *)
 

--- a/theories/Cubical/DPath.v
+++ b/theories/Cubical/DPath.v
@@ -42,9 +42,6 @@ Proof.
   apply dp_path_transport, path_ishprop.
 Defined.
 
-(* Here is a notation for DPaths that can make it easier to use *)
-Notation "x =[ q ] y" := (DPath (fun t => DPath _ t _ _) q x y) : dpath_scope.
-
 (* We have reflexivity for DPaths, this helps coq guess later *)
 Definition dp_id {A} {P : A -> Type} {a : A} {x : P a} : DPath P 1 x x := 1%path.
 
@@ -167,25 +164,29 @@ Section DGroupoid.
   Context {A} {P : A -> Type} {a0 a1} {p : a0 = a1}
     {b0 : P a0} {b1 : P a1} {dp : DPath P p b0 b1}.
 
-  Definition dp_concat_p1 : (dp @D 1) =[concat_p1 _] dp.
+  Definition dp_concat_p1
+    : DPath (fun t => DPath _ t _ _) (concat_p1 _) (dp @D 1) dp.
   Proof.
     destruct p.
     apply concat_p1.
   Defined.
 
-  Definition dp_concat_1p : (1 @D dp) =[concat_1p _] dp.
+  Definition dp_concat_1p
+    : DPath (fun t => DPath _ t _ _) (concat_1p _) (1 @D dp) dp.
   Proof.
     destruct p.
     apply concat_1p.
   Defined.
 
-  Definition dp_concat_Vp : dp^D @D dp =[concat_Vp _] 1.
+  Definition dp_concat_Vp
+    : DPath (fun t => DPath _ t _ _) (concat_Vp _) (dp^D @D dp) 1.
   Proof.
     destruct p.
     apply concat_Vp.
   Defined.
 
-  Definition dp_concat_pV : dp @D (dp^D) =[concat_pV _] 1.
+  Definition dp_concat_pV
+    : DPath (fun t => DPath _ t _ _) (concat_pV _) (dp @D dp^D) 1.
   Proof.
     destruct p.
     apply concat_pV.
@@ -198,14 +199,16 @@ Section DGroupoid.
        (dq : DPath P q b1 b2) (dr : DPath P  r b2 b3).
 
     Definition dp_concat_pp_p
-      : ((dp @D dq) @D dr) =[concat_pp_p _ _ _] (dp @D (dq @D dr)).
+      : DPath (fun t => DPath _ t _ _) (concat_pp_p _ _ _)
+        ((dp @D dq) @D dr) (dp @D (dq @D dr)).
     Proof.
       destruct p, q, r.
       apply concat_pp_p.
     Defined.
 
     Definition dp_concat_p_pp
-      : (dp @D (dq @D dr)) =[concat_p_pp _ _ _] ((dp @D dq) @D dr).
+      : DPath (fun t => DPath _ t _ _) (concat_p_pp _ _ _)
+        (dp @D (dq @D dr)) ((dp @D dq) @D dr).
     Proof.
       destruct p, q, r.
       apply concat_p_pp.

--- a/theories/Cubical/DPath.v
+++ b/theories/Cubical/DPath.v
@@ -43,8 +43,7 @@ Proof.
 Defined.
 
 (* Here is a notation for DPaths that can make it easier to use *)
-Notation "x =[ q ] y" := (DPath (fun t => DPath _ t _ _) q x y) (at level 10)
-  : dpath_scope.
+Notation "x =[ q ] y" := (DPath (fun t => DPath _ t _ _) q x y) : dpath_scope.
 
 (* We have reflexivity for DPaths, this helps coq guess later *)
 Definition dp_id {A} {P : A -> Type} {a : A} {x : P a} : DPath P 1 x x := 1%path.

--- a/theories/Cubical/PathCube.v
+++ b/theories/Cubical/PathCube.v
@@ -76,7 +76,7 @@ Definition cu_path {A} {x000 x010 x100 x110 x001 x011 x101 x111 : A}
   (s0ii : PathSquare p0i0 p0i1 p00i p01i) (s1ii : PathSquare p1i0 p1i1 p10i p11i)
   (sii0 : PathSquare p0i0 p1i0 pi00 pi10) (sii1 : PathSquare p0i1 p1i1 pi01 pi11)
   (si0i : PathSquare p00i p10i pi00 pi01) (si1i : PathSquare p01i p11i pi10 pi11)
-  : (tr (fv s0ii)) @h (si0i @h (tr s1ii)) =
+  : sq_concat_h (tr (fv s0ii)) (sq_concat_h si0i (tr s1ii)) =
       sq_ccGG
         (moveL_Vp _ _ _ (sq_path^-1 sii0))
         (moveL_Vp _ _ _ (sq_path^-1 sii1)) si1i
@@ -233,7 +233,7 @@ Section PathCubesFromPaths.
   Proof.
     destruct s.
     refine (cu_path oE _).
-    refine (equiv_concat_l (sq_concat_h_1s (1%square @h (tr s'))
+    refine (equiv_concat_l (sq_concat_h_1s (sq_concat_h 1%square (tr s'))
       (p0y:=1) (p1y:=1)) _ oE _).
     refine (equiv_concat_l (sq_concat_h_1s (tr s')
       (p0y:=1) (p1y:=1)) _ oE _).
@@ -533,7 +533,7 @@ Section PathCubeConcat.
 End PathCubeConcat.
 
 (* Notation for left right concatenation *)
-Notation "x '@lr' y" := (cu_concat_lr x y) (at level 10) : cube_scope.
+Notation "x '@lr' y" := (cu_concat_lr x y) : cube_scope.
 
 Local Notation apc := (ap_compose_sq _ _ _).
 

--- a/theories/Cubical/PathSquare.v
+++ b/theories/Cubical/PathSquare.v
@@ -376,10 +376,6 @@ Section PathSquareConcat.
 
 End PathSquareConcat.
 
-(* Notations for horizontal and vertical concatenation *)
-Infix "@h" := sq_concat_h (at level 10) : square_scope.
-Infix "@v" := sq_concat_v (at level 10) : square_scope.
-
 (* Horizontal groupoid laws for concatenation *)
 Section GroupoidLawsH.
 
@@ -396,20 +392,20 @@ Section GroupoidLawsH.
   Local Open Scope square_scope.
   Notation hr := (sq_refl_h _).
 
-  Definition sq_concat_h_s1 : s @h hr = sq_ccGG (concat_p1 _)^ (concat_p1 _)^ s.
+  Definition sq_concat_h_s1 : sq_concat_h s hr = sq_ccGG (concat_p1 _)^ (concat_p1 _)^ s.
   Proof.
     by destruct s.
   Defined.
 
-  Definition sq_concat_h_1s : hr @h s = sq_ccGG (concat_1p _)^ (concat_1p _)^ s.
+  Definition sq_concat_h_1s : sq_concat_h hr s = sq_ccGG (concat_1p _)^ (concat_1p _)^ s.
   Proof.
     by destruct s.
   Defined.
 
   Context (t : PathSquare px1 px2 p0y p1y) (u : PathSquare px2 px3 p0z p1z).
 
-  Definition sq_concat_h_ss_s : (s @h t) @h u
-    = sq_ccGG (concat_p_pp _ _ _) (concat_p_pp _ _ _) (s @h (t @h u)).
+  Definition sq_concat_h_ss_s : sq_concat_h (sq_concat_h s t) u
+    = sq_ccGG (concat_p_pp _ _ _) (concat_p_pp _ _ _) (sq_concat_h s (sq_concat_h t u)).
   Proof.
     by destruct s, u, (sq_1G^-1 t), p0y.
   Defined.

--- a/theories/Cubical/PathSquare.v
+++ b/theories/Cubical/PathSquare.v
@@ -362,6 +362,8 @@ Section PathSquareConcat.
     1,2: apply inverse, concat_p1.
   Defined.
 
+  Infix "@@h" := sq_concat_h : square_scope.
+
   (* Vertical concatenation of squares *)
   Definition sq_concat_v {a20 a21 : A}
     {py0 : a10 = a20} {py1 : a11 = a21} {p2x : a20 = a21}
@@ -373,6 +375,8 @@ Section PathSquareConcat.
     refine (sq_GGcc _ _ a).
     1,2: apply inverse, concat_p1.
   Defined.
+
+  Infix "@@v" := sq_concat_v : square_scope.
 
 End PathSquareConcat.
 


### PR DESCRIPTION
This closes #1265 and closes #1173. I have gotten rid of the notations `@h` and @v` for horizontal and vertical square concatenation. The notation `@lr` is kept since it is a rare string to type.