### PR TITLE
Move contr_basedhomotopy out of FunextVarieties, reducing the need to import it

### DIFF
--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -24,7 +24,7 @@
 *)
 
 Require Import HoTT Coq.Init.Peano.
-Require Import UnivalenceImpliesFunext.
+Require Import FunextVarieties UnivalenceImpliesFunext.
 
 Local Open Scope path_scope.
 

--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -427,6 +427,33 @@ Proof.
   refine (isequiv_homotopic _ p).
 Defined.
 
+(** Based homotopy spaces *)
+
+Global Instance contr_basedhomotopy `{Funext}
+       {A:Type} {B : A -> Type} (f : forall x, B x)
+: Contr {g : forall x, B x & f == g }.
+Proof.
+  refine (contr_equiv' { g : forall x, B x & f = g } _).
+  srapply equiv_adjointify; intros [g h].
+  - exact (g; apD10 h).
+  - exact (g; path_forall _ _ h).
+  - apply ap, eisretr.
+  - apply ap, eissect.
+Defined.
+
+Global Instance contr_basedhomotopy' `{Funext}
+       {A:Type} {B : A -> Type} (f : forall x, B x)
+: Contr {g : forall x, B x & g == f }.
+Proof.
+  refine (contr_equiv' { g : forall x, B x & g = f } _).
+  srapply equiv_adjointify; intros [g h].
+  - exact (g; apD10 h).
+  - exact (g; path_forall _ _ h).
+  - apply ap, eisretr.
+  - apply ap, eissect.
+Defined.
+
+
 (** The function [equiv_ind] says that given an equivalence [f : A <~> B], and a hypothesis from [B], one may always assume that the hypothesis is in the image of [e].
 
 In fibrational terms, if we have a fibration over [B] which has a section once pulled back along an equivalence [f : A <~> B], then it has a section over all of [B].  *)

--- a/theories/Constant.v
+++ b/theories/Constant.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 Require Import HoTT.Basics HoTT.Types.
-Require Import HProp FunextVarieties.
+Require Import HProp.
 Require Import Extensions Factorization Modalities.Modality.
 Require Import HoTT.Truncations.
 

--- a/theories/Extensions.v
+++ b/theories/Extensions.v
@@ -3,7 +3,7 @@
 (** * Extensions and extendible maps *)
 
 Require Import HoTT.Basics HoTT.Types.
-Require Import HProp FunextVarieties EquivalenceVarieties PathAny.
+Require Import HProp EquivalenceVarieties PathAny.
 Require Import HoTT.Tactics.
 Require Import Cubical.DPath Cubical.PathSquare Cubical.DPathSquare.
 Require Import HIT.Coeq Colimits.MappingCylinder.

--- a/theories/Factorization.v
+++ b/theories/Factorization.v
@@ -3,7 +3,7 @@
 (** * Factorizations and factorization systems. *)
 
 Require Import HoTT.Basics HoTT.Types.
-Require Import HProp FunextVarieties UnivalenceImpliesFunext Extensions PathAny.
+Require Import HProp UnivalenceImpliesFunext Extensions PathAny.
 Require Import HoTT.Tactics.
 Local Open Scope path_scope.
 

--- a/theories/FunextVarieties.v
+++ b/theories/FunextVarieties.v
@@ -173,14 +173,3 @@ Proof.
   case (H (Lift A) (fun x => Lift (P x)) f g (fun x => ap lift (H' x))).
   exact idpath.
 Defined.
-
-(** We re-declare this instance depending on the global [Funext] typeclass, since it is useful on its own. *)
-Global Instance contr_basedhomotopy `{Funext}
-       {A:Type} {B : A -> Type} (f : forall x, B x)
-: Contr {g : forall x, B x & f == g }.
-Proof.
-  apply contr_basedhtpy.
-  apply NaiveFunext_implies_WeakFunext.
-  apply Funext_implies_NaiveFunext.
-  unfold Funext_type; exact _.
-Defined.

--- a/theories/HoTT.v
+++ b/theories/HoTT.v
@@ -17,7 +17,7 @@ Require Export HoTT.HSet.
 Require Export HoTT.EquivGroupoids.
 Require Export HoTT.EquivalenceVarieties.
 
-Require Export HoTT.FunextVarieties.
+(* Require Export HoTT.FunextVarieties. *)
 Require Export HoTT.UnivalenceVarieties.
 Require Export HoTT.Extensions.
 Require Export HoTT.Misc.

--- a/theories/Idempotents.v
+++ b/theories/Idempotents.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 Require Import HoTT.Basics HoTT.Types.
-Require Import Fibrations FunextVarieties UnivalenceImpliesFunext EquivalenceVarieties Constant.
+Require Import Fibrations UnivalenceImpliesFunext EquivalenceVarieties Constant.
 Require Import HoTT.Truncations.
 Require Import PathAny.
 

--- a/theories/Modalities/Topological.v
+++ b/theories/Modalities/Topological.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 Require Import HoTT.Basics HoTT.Types HProp UnivalenceImpliesFunext.
-Require Import EquivalenceVarieties FunextVarieties Extensions.
+Require Import EquivalenceVarieties Extensions.
 Require Import HoTT.Truncations.
 Require Import Modality Accessible Lex Nullification.
 

--- a/theories/PathAny.v
+++ b/theories/PathAny.v
@@ -1,4 +1,4 @@
-Require Import HoTT.Basics HoTT.Types Fibrations FunextVarieties.
+Require Import HoTT.Basics HoTT.Types Fibrations.
 
 (** A nice method for proving characterizations of path-types of nested sigma-types, due to Rijke. *)
 

--- a/theories/Pointed/pMap.v
+++ b/theories/Pointed/pMap.v
@@ -1,4 +1,4 @@
-Require Import Basics Types PathAny FunextVarieties.
+Require Import Basics Types PathAny.
 Require Import Pointed.Core.
 Require Import Pointed.pHomotopy.
 

--- a/theories/Types/Equiv.v
+++ b/theories/Types/Equiv.v
@@ -18,15 +18,13 @@ Section AssumeFunext.
     apply hprop_inhabited_contr; intros feq.
     nrefine (contr_equiv' _ (issig_isequiv f oE (equiv_sigma_assoc' _ _)^-1)).
     snrefine (contr_equiv' _ (equiv_contr_sigma' _ (f^-1 ; eisretr f))^-1); only 2: exact _.
-    (** Each of these types is equivalent to a based path space. *)
-    - refine (contr_equiv' { g : B -> A & g = f^-1 } _).
+    (** Each of these types is equivalent to a based homotopy space. *)
+    - refine (contr_equiv' { g : B -> A & g == f^-1 } _).
       apply equiv_functor_sigma_id; intros g.
-      refine (_ oE equiv_ap10 _ _).
       apply equiv_functor_forall_id; intros b.
       apply equiv_moveR_equiv_M.
-    - refine (contr_equiv' { s : f^-1 o f == idmap & eissect f = s } _).
+    - refine (contr_equiv' { s : f^-1 o f == idmap & eissect f == s } _).
       apply equiv_functor_sigma_id; intros s; cbn.
-      refine (_ oE equiv_apD10 _ _ _).
       apply equiv_functor_forall_id; intros a.
       refine (equiv_concat_l (eisadj f a) _ oE _).
       rapply equiv_ap.


### PR DESCRIPTION
On top of #1271.  The only remaining imports of `FunextVarieties` are in the other metatheory files `TruncImpliesFunext` and `IntervalImpliesFunext`, which need `Funext_type`.