### PR TITLE
Isolate the metatheory files in a subdirectory

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -156,12 +156,10 @@ theories/Comodalities/CoreflectiveSubuniverse.v
 #
 
 theories/HIT/Circle.v
-theories/HIT/TruncImpliesFunext.v
 theories/HIT/Coeq.v
 theories/HIT/FreeIntQuotient.v
 theories/HIT/Flattening.v
 theories/HIT/Interval.v
-theories/HIT/IntervalImpliesFunext.v
 theories/HIT/Spheres.v
 theories/HIT/TwoSphere.v
 theories/HIT/epi.v
@@ -232,11 +230,8 @@ theories/Fibrations.v
 theories/Conjugation.v
 theories/HProp.v
 theories/EquivalenceVarieties.v
-theories/FunextVarieties.v
-theories/UnivalenceVarieties.v
 theories/Extensions.v
 theories/HSet.v
-theories/UnivalenceImpliesFunext.v
 theories/TruncType.v
 theories/DProp.v
 theories/Functorish.v
@@ -253,6 +248,17 @@ theories/PathAny.v
 theories/Utf8.v
 theories/HoTT.v
 theories/Tests.v
+
+#
+#   Metatheory
+#
+theories/Metatheory/Core.v
+theories/Metatheory/FunextVarieties.v
+theories/Metatheory/TruncImpliesFunext.v
+theories/Metatheory/IntervalImpliesFunext.v
+theories/Metatheory/UnivalenceImpliesFunext.v
+theories/Metatheory/UnivalenceVarieties.v
+
 
 #
 #   Contrib

--- a/contrib/HoTTBook.v
+++ b/contrib/HoTTBook.v
@@ -58,7 +58,7 @@
 *)
 
 Require Import HoTT.
-Require Import HoTT.HIT.IntervalImpliesFunext.
+Require Import HoTT.Metatheory.Core HoTT.Metatheory.IntervalImpliesFunext HoTT.Metatheory.UnivalenceImpliesFunext.
 Require HoTT.Categories.
 From HoTT.Classes Require
   interfaces.abstract_algebra
@@ -701,12 +701,12 @@ Definition Book_4_8_4 := @HoTT.ObjectClassifier.objclasspb_is_fibrantreplacement
 (* ================================================== weakfunext *)
 (** Definition 4.9.1 *)
 
-Definition Book_4_9_1 := @HoTT.FunextVarieties.WeakFunext.
+Definition Book_4_9_1 := @HoTT.Metatheory.FunextVarieties.WeakFunext.
 
 (* ================================================== UA-eqv-hom-eqv *)
 (** Lemma 4.9.2 *)
 
-Definition Book_4_9_2 := @HoTT.UnivalenceImpliesFunext.univalence_isequiv_postcompose.
+Definition Book_4_9_2 := @HoTT.Metatheory.UnivalenceImpliesFunext.univalence_isequiv_postcompose.
 
 (* ================================================== contrfamtotalpostcompequiv *)
 (** Corollary 4.9.3 *)
@@ -716,12 +716,12 @@ Definition Book_4_9_2 := @HoTT.UnivalenceImpliesFunext.univalence_isequiv_postco
 (* ================================================== uatowfe *)
 (** Theorem 4.9.4 *)
 
-Definition Book_4_9_4 := @HoTT.UnivalenceImpliesFunext.Univalence_implies_WeakFunext.
+Definition Book_4_9_4 := @HoTT.Metatheory.UnivalenceImpliesFunext.Univalence_implies_WeakFunext.
 
 (* ================================================== wfetofe *)
 (** Theorem 4.9.5 *)
 
-Definition Book_4_9_5 := @HoTT.FunextVarieties.WeakFunext_implies_Funext.
+Definition Book_4_9_5 := @HoTT.Metatheory.FunextVarieties.WeakFunext_implies_Funext.
 
 (* ================================================== thm:nat-uniq *)
 (** Theorem 5.1.1 *)
@@ -807,7 +807,7 @@ Definition Book_6_3_1 := @HoTT.HIT.Interval.contr_interval.
 (* ================================================== thm:interval-funext *)
 (** Lemma 6.3.2 *)
 
-Definition Book_6_3_2 := @HoTT.HIT.IntervalImpliesFunext.funext_type_from_interval.
+Definition Book_6_3_2 := @HoTT.Metatheory.IntervalImpliesFunext.funext_type_from_interval.
 
 (* ================================================== thm:loop-nontrivial *)
 (** Lemma 6.4.1 *)

--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -24,7 +24,7 @@
 *)
 
 Require Import HoTT Coq.Init.Peano.
-Require Import FunextVarieties UnivalenceImpliesFunext.
+Require Import HoTT.Metatheory.Core HoTT.Metatheory.FunextVarieties HoTT.Metatheory.UnivalenceImpliesFunext.
 
 Local Open Scope path_scope.
 

--- a/theories/Algebra/AbelianGroup.v
+++ b/theories/Algebra/AbelianGroup.v
@@ -1,4 +1,4 @@
-Require Import HoTT.Basics HoTT.Types UnivalenceImpliesFunext.
+Require Import HoTT.Basics HoTT.Types.
 Require Import Truncations.
 Require Import HIT.Coeq.
 Require Import Algebra.Group.

--- a/theories/Algebra/Group.v
+++ b/theories/Algebra/Group.v
@@ -1,4 +1,4 @@
-Require Import HoTT.Basics HoTT.Types UnivalenceImpliesFunext.
+Require Import HoTT.Basics HoTT.Types.
 Require Import PathAny.
 Require Export Classes.interfaces.abstract_algebra.
 Require Export Classes.theory.groups.

--- a/theories/Algebra/QuotientGroup.v
+++ b/theories/Algebra/QuotientGroup.v
@@ -1,4 +1,4 @@
-Require Import HoTT.Basics HoTT.Types UnivalenceImpliesFunext.
+Require Import HoTT.Basics HoTT.Types.
 Require Import Algebra.Group.
 Require Import Algebra.Subgroup.
 Require Import Algebra.Congruence.

--- a/theories/Categories/Functor/Attributes.v
+++ b/theories/Categories/Functor/Attributes.v
@@ -1,6 +1,6 @@
 (** * Attributes of functors (full, faithful, split essentially surjective) *)
 Require Import Category.Core Functor.Core HomFunctor Category.Morphisms Category.Dual Functor.Dual Category.Prod Functor.Prod NaturalTransformation.Core SetCategory.Core Functor.Composition.Core.
-Require Import Basics.Trunc HIT.epi Types.Universe HSet HIT.iso HoTT.Truncations UnivalenceImpliesFunext TruncType.
+Require Import Basics.Trunc HIT.epi Types.Universe HSet HIT.iso HoTT.Truncations TruncType.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Categories/Grothendieck/ToSet/Univalent.v
+++ b/theories/Categories/Grothendieck/ToSet/Univalent.v
@@ -6,7 +6,6 @@ Require Import SetCategory.Core.
 Require Import Grothendieck.ToSet.Core Grothendieck.ToSet.Morphisms.
 Require Import HoTT.Basics.Equivalences HoTT.Basics.Trunc.
 Require Import HoTT.Types.Universe HoTT.Types.Paths HoTT.Types.Sigma.
-Require Import HoTT.UnivalenceImpliesFunext.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Categories/GroupoidCategory/Dual.v
+++ b/theories/Categories/GroupoidCategory/Dual.v
@@ -1,6 +1,6 @@
 (** * Propositional self-duality of groupoid categories *)
 Require Import Category.Core GroupoidCategory.Core Category.Paths Category.Dual.
-Require Import HoTT.Types HoTT.UnivalenceImpliesFunext.
+Require Import HoTT.Types.
 Require Import Basics.Trunc.
 
 Set Universe Polymorphism.

--- a/theories/Categories/SetCategory/Core.v
+++ b/theories/Categories/SetCategory/Core.v
@@ -1,6 +1,6 @@
 (** * PreCategories [set_cat] and [prop_cat] *)
 Require Import Category.Core Category.Strict.
-Require Import HoTT.Basics HoTT.Types HProp HSet UnivalenceImpliesFunext TruncType.
+Require Import HoTT.Basics HoTT.Types HProp HSet TruncType.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Categories/SetCategory/Morphisms.v
+++ b/theories/Categories/SetCategory/Morphisms.v
@@ -3,7 +3,7 @@ Require Import Category.Core Functor.Core NaturalTransformation.Core.
 Require Import Category.Morphisms NaturalTransformation.Paths.
 Require Import Category.Univalent.
 Require Import SetCategory.Core.
-Require Import HoTT.Basics HoTT.Types HProp HSet Equivalences UnivalenceImpliesFunext TruncType.
+Require Import HoTT.Basics HoTT.Types HProp HSet Equivalences TruncType.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Classes/categories/ua_category.v
+++ b/theories/Classes/categories/ua_category.v
@@ -1,7 +1,6 @@
 Require Import
   HoTT.Basics
   HoTT.Types
-  HoTT.UnivalenceImpliesFunext
   HoTT.Categories.Category.Core
   HoTT.Categories.Category.Univalent
   HoTT.Classes.theory.ua_isomorphic.

--- a/theories/Classes/theory/ua_first_isomorphism.v
+++ b/theories/Classes/theory/ua_first_isomorphism.v
@@ -9,7 +9,6 @@ Require Import
   HoTT.Types.Universe
   HoTT.HSet
   HoTT.HIT.quotient
-  HoTT.UnivalenceImpliesFunext
   HoTT.Classes.interfaces.canonical_names
   HoTT.Classes.theory.ua_isomorphic
   HoTT.Classes.theory.ua_subalgebra

--- a/theories/Classes/theory/ua_homomorphism.v
+++ b/theories/Classes/theory/ua_homomorphism.v
@@ -11,8 +11,7 @@ Require Import
   HoTT.Fibrations
   HoTT.HProp
   HoTT.HSet
-  HoTT.Tactics
-  UnivalenceImpliesFunext.
+  HoTT.Tactics.
 
 Import algebra_notations ne_list.notations.
 

--- a/theories/Classes/theory/ua_isomorphic.v
+++ b/theories/Classes/theory/ua_isomorphic.v
@@ -6,7 +6,6 @@ Require Export HoTT.Classes.theory.ua_homomorphism.
 Require Import
   HoTT.Basics
   HoTT.Types
-  HoTT.UnivalenceImpliesFunext
   HoTT.HProp
   HoTT.Tactics.
 

--- a/theories/Classes/theory/ua_quotient_algebra.v
+++ b/theories/Classes/theory/ua_quotient_algebra.v
@@ -7,7 +7,6 @@ Require Import
   HoTT.HSet
   HoTT.HIT.quotient
   HoTT.Truncations
-  HoTT.UnivalenceImpliesFunext
   HoTT.Classes.implementations.list
   HoTT.Classes.interfaces.canonical_names
   HoTT.Classes.theory.ua_homomorphism.

--- a/theories/Classes/theory/ua_second_isomorphism.v
+++ b/theories/Classes/theory/ua_second_isomorphism.v
@@ -5,7 +5,6 @@ Require Import
   HoTT.Types.Universe
   HoTT.HSet
   HoTT.HIT.quotient
-  HoTT.UnivalenceImpliesFunext
   HoTT.Classes.interfaces.canonical_names
   HoTT.Classes.theory.ua_isomorphic
   HoTT.Classes.theory.ua_subalgebra

--- a/theories/Classes/theory/ua_subalgebra.v
+++ b/theories/Classes/theory/ua_subalgebra.v
@@ -3,7 +3,6 @@ Require Import
   HoTT.TruncType
   HoTT.HProp
   HoTT.Types
-  HoTT.UnivalenceImpliesFunext
   HoTT.Classes.theory.ua_homomorphism.
 
 Import algebra_notations ne_list.notations.

--- a/theories/Classes/theory/ua_third_isomorphism.v
+++ b/theories/Classes/theory/ua_third_isomorphism.v
@@ -3,7 +3,6 @@
 Require Import
   HoTT.Types.Universe
   HoTT.HIT.quotient
-  HoTT.UnivalenceImpliesFunext
   HoTT.Classes.interfaces.canonical_names
   HoTT.Classes.theory.ua_quotient_algebra
   HoTT.Classes.theory.ua_isomorphic

--- a/theories/Colimits/Colimit_Flattening.v
+++ b/theories/Colimits/Colimit_Flattening.v
@@ -5,7 +5,6 @@ Require Import Diagrams.Graph.
 Require Import Diagrams.Cocone.
 Require Import Diagrams.DDiagram.
 Require Import Colimits.Colimit.
-Require Import UnivalenceImpliesFunext.
 
 Local Open Scope path_scope.
 

--- a/theories/Colimits/Colimit_Pushout_Flattening.v
+++ b/theories/Colimits/Colimit_Pushout_Flattening.v
@@ -8,7 +8,6 @@ Require Import Diagrams.Cocone.
 Require Import Colimits.Colimit.
 Require Import Colimits.Colimit_Pushout.
 Require Import Colimits.Colimit_Flattening.
-Require Import UnivalenceImpliesFunext.
 
 (** * Pushout case *)
 

--- a/theories/Colimits/Quotient.v
+++ b/theories/Colimits/Quotient.v
@@ -2,7 +2,6 @@ Require Import Basics.
 Require Import Types.
 Require Import HSet.
 Require Import HProp.
-Require Import UnivalenceImpliesFunext.
 Require Import TruncType.
 Require Import HIT.epi.
 Require Import HIT.Coeq.

--- a/theories/Comodalities/CoreflectiveSubuniverse.v
+++ b/theories/Comodalities/CoreflectiveSubuniverse.v
@@ -1,6 +1,5 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 Require Import HoTT.Basics HoTT.Types.
-Require Import UnivalenceImpliesFunext.
 Require Import Modalities.Modality Modalities.Open.
 
 Local Open Scope path_scope.

--- a/theories/DProp.v
+++ b/theories/DProp.v
@@ -3,7 +3,7 @@
 (** * Decidable propositions *)
 
 Require Import HoTT.Basics HoTT.Types.
-Require Import TruncType HProp UnivalenceImpliesFunext.
+Require Import TruncType HProp.
 Require Import HoTT.Truncations.
 
 Local Open Scope path_scope.

--- a/theories/Factorization.v
+++ b/theories/Factorization.v
@@ -3,7 +3,7 @@
 (** * Factorizations and factorization systems. *)
 
 Require Import HoTT.Basics HoTT.Types.
-Require Import HProp UnivalenceImpliesFunext Extensions PathAny.
+Require Import HProp Extensions PathAny.
 Require Import HoTT.Tactics.
 Local Open Scope path_scope.
 

--- a/theories/Functorish.v
+++ b/theories/Functorish.v
@@ -1,4 +1,4 @@
-Require Import HoTT.Basics Types.Universe TruncType UnivalenceImpliesFunext.
+Require Import HoTT.Basics Types.Universe TruncType.
 
 Local Open Scope path_scope.
 

--- a/theories/HIT/Circle.v
+++ b/theories/HIT/Circle.v
@@ -3,7 +3,7 @@
 (** * Theorems about the circle [S1]. *)
 
 Require Import HoTT.Basics HoTT.Types HProp.
-Require Import HSet UnivalenceImpliesFunext.
+Require Import HSet.
 Require Import Spaces.Pos.
 Require Import Spaces.Int.
 Require Import HIT.Coeq.

--- a/theories/HIT/Coeq.v
+++ b/theories/HIT/Coeq.v
@@ -2,7 +2,7 @@
 
 (** * Homotopy coequalizers *)
 
-Require Import HoTT.Basics UnivalenceImpliesFunext.
+Require Import HoTT.Basics.
 Require Import Types.Paths Types.Forall Types.Sigma Types.Arrow Types.Universe.
 Require Import Cubical.DPath.
 Local Open Scope path_scope.

--- a/theories/HIT/Flattening.v
+++ b/theories/HIT/Flattening.v
@@ -2,7 +2,7 @@
 
 (** * The flattening lemma. *)
 
-Require Import HoTT.Basics UnivalenceImpliesFunext.
+Require Import HoTT.Basics.
 Require Import Types.Paths Types.Forall Types.Sigma Types.Arrow Types.Universe.
 Local Open Scope path_scope.
 Require Import HoTT.HIT.Coeq.

--- a/theories/HIT/FreeIntQuotient.v
+++ b/theories/HIT/FreeIntQuotient.v
@@ -1,5 +1,5 @@
 (* -*- mode: coq; mode: visual-line -*- *)
-Require Import HoTT.Basics HoTT.Types UnivalenceImpliesFunext.
+Require Import HoTT.Basics HoTT.Types.
 Require Import TruncType HProp HSet.
 Require Import Spaces.Int.
 Require Import HIT.Coeq HIT.Circle HIT.Flattening Truncations.

--- a/theories/HIT/V.v
+++ b/theories/HIT/V.v
@@ -3,7 +3,7 @@
 (** * The cumulative hierarchy [V]. *)
 
 Require Import HoTT.Basics HoTT.Basics.Utf8 HoTT.Types.
-Require Import HProp HSet UnivalenceImpliesFunext TruncType.
+Require Import HProp HSet TruncType.
 Require Import Colimits.SpanPushout.
 Require Import HoTT.Truncations Colimits.Quotient.
 Local Open Scope nat_scope.

--- a/theories/HIT/epi.v
+++ b/theories/HIT/epi.v
@@ -3,7 +3,6 @@ Require Import Types.
 Require Import HProp.
 Require Import HSet.
 Require Import TruncType.
-Require Import UnivalenceImpliesFunext.
 Require Import Colimits.Pushout Truncations HIT.SetCone.
 
 Local Open Scope path_scope.

--- a/theories/HIT/iso.v
+++ b/theories/HIT/iso.v
@@ -1,6 +1,6 @@
 Require Import HoTT.Basics.
 Require Import Types.Universe.
-Require Import HSet UnivalenceImpliesFunext TruncType.
+Require Import HSet TruncType.
 Require Import HIT.epi HIT.unique_choice HoTT.Truncations.
 
 Local Open Scope path_scope.

--- a/theories/HIT/quotient.v
+++ b/theories/HIT/quotient.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 Require Import HoTT.Basics HoTT.Types.
-Require Import HSet HProp UnivalenceImpliesFunext TruncType.
+Require Import HSet HProp TruncType.
 Require Import HIT.epi Truncations.
 
 Local Open Scope path_scope.

--- a/theories/HoTT.v
+++ b/theories/HoTT.v
@@ -17,8 +17,6 @@ Require Export HoTT.HSet.
 Require Export HoTT.EquivGroupoids.
 Require Export HoTT.EquivalenceVarieties.
 
-(* Require Export HoTT.FunextVarieties. *)
-Require Export HoTT.UnivalenceVarieties.
 Require Export HoTT.Extensions.
 Require Export HoTT.Misc.
 Require Export HoTT.PathAny.
@@ -141,7 +139,7 @@ Require Export HoTT.Tactics.EvalIn.
 Require Export HoTT.Tactics.Nameless.
 Require Export HoTT.Tactics.RewriteModuloAssociativity.
 
-(** We do _not_ export [UnivalenceAxiom], [FunextAxiom], [UnivalenceImpliesFunext], [HIT.IntervalImpliesFunext], nor [HIT.TruncImpliesFunext] from this file; thus importing it does not prevent you from tracking usage of [Univalence] and [Funext] theorem-by-theorem in the same way that the library does.  If you want any of those files, you should import them separately. *)
+(** We do _not_ export [UnivalenceAxiom], [FunextAxiom], or any of the files in [Metatheory] from this file.  Thus, importing this file does not prevent you from tracking usage of [Univalence] and [Funext] theorem-by-theorem in the same way that the library does.  If you want any of those files, you should import them separately. *)
 
 (** We check that UnivalenceAxiom, FunextAxiom aren't being leaked. This is so that these can be imported seperately. *)
 Fail Check HoTT.UnivalenceAxiom.univalence_axiom.

--- a/theories/Homotopy/BlakersMassey.v
+++ b/theories/Homotopy/BlakersMassey.v
@@ -1,4 +1,4 @@
-Require Import HoTT.Basics HoTT.Types HProp UnivalenceImpliesFunext.
+Require Import HoTT.Basics HoTT.Types HProp.
 Require Import Colimits.Pushout.
 Require Import Colimits.SpanPushout.
 Require Import Homotopy.Join.

--- a/theories/Homotopy/ClassifyingSpace.v
+++ b/theories/Homotopy/ClassifyingSpace.v
@@ -7,7 +7,6 @@ Require Import Algebra.AbelianGroup.
 Require Import Homotopy.HSpace.
 Require Import TruncType.
 Require Import Truncations.
-Require Import UnivalenceImpliesFunext.
 
 Local Open Scope pointed_scope.
 Local Open Scope trunc_scope.

--- a/theories/Homotopy/EMSpace.v
+++ b/theories/Homotopy/EMSpace.v
@@ -9,7 +9,6 @@ Require Import Homotopy.Suspension.
 Require Import Homotopy.ClassifyingSpace.
 Require Import Homotopy.HSpace.
 Require Import TruncType.
-Require Import UnivalenceImpliesFunext.
 
 (* Formalisation of Eilenberg-MacLane spaces *)
 

--- a/theories/Homotopy/HSpace.v
+++ b/theories/Homotopy/HSpace.v
@@ -1,6 +1,6 @@
 Require Import Basics.
 Require Import Types.
-Require Import Truncations UnivalenceImpliesFunext.
+Require Import Truncations.
 Require Export Classes.interfaces.abstract_algebra.
 
 Local Open Scope trunc_scope.

--- a/theories/Homotopy/WhiteheadsPrinciple.v
+++ b/theories/Homotopy/WhiteheadsPrinciple.v
@@ -2,7 +2,7 @@ Require Import Basics.
 Require Import Types.
 Require Import Pointed.
 Require Import Fibrations.
-Require Import EquivalenceVarieties UnivalenceImpliesFunext.
+Require Import EquivalenceVarieties.
 Require Import Algebra.Group.
 Require Import Homotopy.HomotopyGroup.
 Require Import Truncations.

--- a/theories/Idempotents.v
+++ b/theories/Idempotents.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 Require Import HoTT.Basics HoTT.Types.
-Require Import Fibrations UnivalenceImpliesFunext EquivalenceVarieties Constant.
+Require Import Fibrations EquivalenceVarieties Constant.
 Require Import HoTT.Truncations.
 Require Import PathAny.
 

--- a/theories/Metatheory/Core.v
+++ b/theories/Metatheory/Core.v
@@ -1,0 +1,17 @@
+(* -*- mode: coq; mode: visual-line -*- *)
+
+Require Import HoTT.Basics HoTT.Types.
+
+(** * Metatheory *)
+
+(** This directory contains files that prove important metatheoretic results about HoTT, but that are not important for internal development of mathematics in HoTT.  Thus, no files in this directory should ever need to be imported by files outside of this directory. *)
+
+(** Many of these results are about ways to prove univalence and function extensionality (which in the main library we simply assert as axioms, though we track their usage with dummy typeclasses).  For convenience, here we define the types of these two statements. *)
+
+Definition Funext_type@{i j max} :=
+  forall (A : Type@{i}) (P : A -> Type@{j}) f g,
+    IsEquiv (@apD10@{i j max} A P f g).
+
+(** Univalence is a property of a single universe; its statement lives in a higher universe *)
+Definition Univalence_type@{i iplusone} : Type@{iplusone} :=
+  forall (A B : Type@{i}), IsEquiv (equiv_path@{i i iplusone i} A B).

--- a/theories/Metatheory/FunextVarieties.v
+++ b/theories/Metatheory/FunextVarieties.v
@@ -1,7 +1,9 @@
 (* -*- mode: coq; mode: visual-line -*- *)
+
 (** * Varieties of function extensionality *)
 
 Require Import HoTT.Basics HoTT.Types EquivalenceVarieties.
+Require Import Metatheory.Core.
 Local Open Scope path_scope.
 
 (** In the Overture, we defined function extensionality to be the assertion that the map [apD10] is an equivalence.   We now prove that this follows from a couple of weaker-looking forms of function extensionality.  We do require eta conversion, which Coq 8.4+ has judgmentally.
@@ -28,11 +30,6 @@ Definition WeakFunext :=
   forall (A : Type) (P : A -> Type),
     (forall x, Contr (P x)) -> Contr (forall x, P x).
 Check WeakFunext@{i j max}.
-
-(** We define a variant of [Funext] which does not invoke an axiom. *)
-Definition Funext_type :=
-  forall (A : Type) (P : A -> Type) f g, IsEquiv (@apD10 A P f g).
-Check Funext_type@{i j max}.
 
 (** The obvious implications are
    Funext -> NaiveFunext -> WeakFunext and NaiveFunext -> NaiveNondepFunext.

--- a/theories/Metatheory/IntervalImpliesFunext.v
+++ b/theories/Metatheory/IntervalImpliesFunext.v
@@ -2,8 +2,9 @@
 
 (** * Theorems about the homotopical interval. *)
 
-Require Import HoTT.Basics FunextVarieties.
+Require Import HoTT.Basics.
 Require Import HIT.Interval.
+Require Import Metatheory.Core Metatheory.FunextVarieties.
 
 (** ** From an interval type, we can prove function extensionality. *)
 
@@ -13,6 +14,3 @@ Definition funext_type_from_interval : Funext_type
       let h := fun (x:interval) (a:A) =>
         interval_rec _ (f a) (g a) (p a) x
         in ap h seg)).
-(** As justified by the above proof, we may assume [Funext] given the interval. *)
-Global Instance funext_from_interval : Funext.
-Admitted.

--- a/theories/Metatheory/TruncImpliesFunext.v
+++ b/theories/Metatheory/TruncImpliesFunext.v
@@ -2,8 +2,8 @@
 
 (** * Theorems about trunctions *)
 
-Require Import HoTT.Basics FunextVarieties.
-Require Import HoTT.Truncations HoTT.Types.Bool.
+Require Import HoTT.Basics HoTT.Truncations HoTT.Types.Bool.
+Require Import Metatheory.Core Metatheory.FunextVarieties.
 
 (** ** We can construct an interval type as [Trunc -1 Bool] *)
 
@@ -31,7 +31,3 @@ Definition funext_type_from_trunc : Funext_type
       let h := fun (x:interval) (a:A) =>
         interval_rec _ (f a) (g a) (p a) x
         in ap h seg)).
-
-(** As justified by the above proof, we may assume [Funext] given [Trunc]. *)
-Global Instance funext_from_trunc : Funext.
-Admitted.

--- a/theories/Metatheory/UnivalenceImpliesFunext.v
+++ b/theories/Metatheory/UnivalenceImpliesFunext.v
@@ -1,16 +1,10 @@
-Require Import HoTT.Basics Types.Universe Types.Paths Types.Unit FunextVarieties.
+Require Import HoTT.Basics.
+Require Import Types.Universe Types.Paths Types.Unit.
+Require Import Metatheory.Core Metatheory.FunextVarieties.
 
 Generalizable All Variables.
 
 (** * Univalence Implies Functional Extensionality *)
-
-(** Here we prove that univalence implies function extensionality. *)
-Set Printing Universes.
-(** We define an axiom-free variant of [Univalence] *)
-Definition Univalence_type := forall (A B : Type@{i}), IsEquiv (equiv_path A B).
-
-(** Univalence is a property of a single universe; its statement lives in a higher universe *)
-Check Univalence_type@{i iplusone} : Type@{iplusone}.
 
 Section UnivalenceImpliesFunext.
   Context `{ua : Univalence_type}.

--- a/theories/Metatheory/UnivalenceVarieties.v
+++ b/theories/Metatheory/UnivalenceVarieties.v
@@ -2,10 +2,9 @@
 (** * Varieties of univalence *)
 
 Require Import HoTT.Basics HoTT.Types.
-Require Import Fibrations Idempotents EquivalenceVarieties UnivalenceImpliesFunext.
+Require Import Fibrations Idempotents EquivalenceVarieties.
+Require Import Metatheory.Core.
 Local Open Scope path_scope.
-
-(** The standard univalence axiom type [Univalence_type] is defined in [UnivalenceImpliesFunext]. *)
 
 (** A weaker form that only asserts that we can make equivalences into paths with a computation rule (no uniqueness rule). *)
 Definition WeakUnivalence :=

--- a/theories/Modalities/Descent.v
+++ b/theories/Modalities/Descent.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 Require Import HoTT.Basics HoTT.Types.
-Require Import Fibrations Extensions Pullback UnivalenceImpliesFunext.
+Require Import Fibrations Extensions Pullback.
 Require Import ReflectiveSubuniverse Modality Accessible Localization.
 
 Local Open Scope path_scope.

--- a/theories/Modalities/Fracture.v
+++ b/theories/Modalities/Fracture.v
@@ -1,5 +1,5 @@
 (* -*- mode: coq; mode: visual-line -*- *)
-Require Import HoTT.Basics HoTT.Types UnivalenceImpliesFunext.
+Require Import HoTT.Basics HoTT.Types.
 Require Import Fibrations Extensions Pullback NullHomotopy.
 Require Import Modality Lex Open Closed Nullification.
 Require Import HoTT.Tactics.

--- a/theories/Modalities/Lex.v
+++ b/theories/Modalities/Lex.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 Require Import HoTT.Basics HoTT.Types.
-Require Import EquivalenceVarieties Fibrations Extensions Pullback NullHomotopy Factorization UnivalenceImpliesFunext PathAny.
+Require Import EquivalenceVarieties Fibrations Extensions Pullback NullHomotopy Factorization PathAny.
 Require Import Modality Accessible Localization Descent Separated.
 Require Import HoTT.Tactics.
 

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 Require Import HoTT.Basics HoTT.Types.
-Require Import UnivalenceImpliesFunext EquivalenceVarieties Extensions HProp Fibrations NullHomotopy Pullback.
+Require Import EquivalenceVarieties Extensions HProp Fibrations NullHomotopy Pullback.
 Require Import HoTT.Tactics PathAny.
 Require Import HIT.Coeq Colimits.Pushout.
 Require Import Tactics.RewriteModuloAssociativity.

--- a/theories/Modalities/Separated.v
+++ b/theories/Modalities/Separated.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 Require Import HoTT.Basics HoTT.Types HoTT.Cubical.DPath.
-Require Import Fibrations Extensions Factorization UnivalenceImpliesFunext.
+Require Import Fibrations Extensions Factorization.
 Require Import ReflectiveSubuniverse Modality Accessible Localization Descent.
 Require Import Truncations.Core.
 Require Import Homotopy.Suspension.

--- a/theories/Modalities/Topological.v
+++ b/theories/Modalities/Topological.v
@@ -1,5 +1,5 @@
 (* -*- mode: coq; mode: visual-line -*- *)
-Require Import HoTT.Basics HoTT.Types HProp UnivalenceImpliesFunext.
+Require Import HoTT.Basics HoTT.Types HProp.
 Require Import EquivalenceVarieties Extensions.
 Require Import HoTT.Truncations.
 Require Import Modality Accessible Lex Nullification.

--- a/theories/ObjectClassifier.v
+++ b/theories/ObjectClassifier.v
@@ -3,7 +3,7 @@ This equivalence is close to the existence of an object classifier.
 *)
 
 Require Import HoTT.Basics HoTT.Types.
-Require Import Fibrations HProp EquivalenceVarieties UnivalenceImpliesFunext Pullback.
+Require Import Fibrations HProp EquivalenceVarieties Pullback.
 
 Local Open Scope path_scope.
 

--- a/theories/Pointed/Loops.v
+++ b/theories/Pointed/Loops.v
@@ -1,6 +1,5 @@
 Require Import HoTT.Basics HoTT.Types.
 Require Import HSet Fibrations Factorization HoTT.Truncations HProp.
-Require Import UnivalenceImpliesFunext.
 Require Import Pointed.Core Pointed.pMap Pointed.pEquiv Pointed.pHomotopy.
 
 Local Open Scope pointed_scope.

--- a/theories/Pointed/pEquiv.v
+++ b/theories/Pointed/pEquiv.v
@@ -1,7 +1,6 @@
 Require Import Basics.
 Require Import Types.
 Require Import Pointed.Core Pointed.pMap Pointed.pHomotopy.
-Require Import UnivalenceImpliesFunext.
 
 Local Open Scope pointed_scope.
 

--- a/theories/Pointed/pType.v
+++ b/theories/Pointed/pType.v
@@ -3,7 +3,6 @@ Require Import Basics Types.
 Require Import Pointed.Core.
 Require Import WildCat.
 Require Import pHomotopy pMap pEquiv.
-Require Import UnivalenceImpliesFunext.
 
 Local Open Scope pointed_scope.
 Local Open Scope path_scope.

--- a/theories/PropResizing/ImpredicativeTruncation.v
+++ b/theories/PropResizing/ImpredicativeTruncation.v
@@ -1,7 +1,7 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 (** * Impredicative truncations. *)
 
-Require Import HoTT.Basics HoTT.Types UnivalenceImpliesFunext HProp.
+Require Import HoTT.Basics HoTT.Types HProp.
 Require Import PropResizing.PropResizing.
 Local Open Scope path_scope.
 

--- a/theories/PropResizing/Nat.v
+++ b/theories/PropResizing/Nat.v
@@ -2,7 +2,6 @@
 (** * Defining the natural numbers from univalence and propresizing. *)
 Require Import Basics.
 Require Import Types.
-Require Import UnivalenceImpliesFunext.
 Require Import HProp.
 Require Import PropResizing.PropResizing.
 Require Import PropResizing.ImpredicativeTruncation.

--- a/theories/PropResizing/PropResizing.v
+++ b/theories/PropResizing/PropResizing.v
@@ -1,7 +1,7 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 (** * Propositional resizing *)
 
-Require Import HoTT.Basics HoTT.Types UnivalenceImpliesFunext HProp.
+Require Import HoTT.Basics HoTT.Types HProp.
 Local Open Scope path_scope.
 
 (** See the note by [Funext] in Overture.v regarding classes for axioms *)

--- a/theories/Spaces/BAut.v
+++ b/theories/Spaces/BAut.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 Require Import HoTT.Basics HoTT.Types HProp.
-Require Import Constant Factorization UnivalenceImpliesFunext.
+Require Import Constant Factorization.
 Require Import Modalities.Modality HoTT.Truncations.
 Require Export Algebra.ooGroup Algebra.Aut.
 

--- a/theories/Spaces/BAut/Bool.v
+++ b/theories/Spaces/BAut/Bool.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 Require Import HoTT.Basics HoTT.Types.
-Require Import Constant Factorization UnivalenceImpliesFunext.
+Require Import Constant Factorization.
 Require Import Modalities.Modality HoTT.Truncations.
 Require Import Spaces.BAut.
 

--- a/theories/Spaces/BAut/Cantor.v
+++ b/theories/Spaces/BAut/Cantor.v
@@ -1,5 +1,5 @@
 (* -*- mode: coq; mode: visual-line -*- *)
-Require Import HoTT.Basics HoTT.Types UnivalenceImpliesFunext.
+Require Import HoTT.Basics HoTT.Types.
 Require Import Idempotents.
 Require Import HoTT.Truncations Spaces.BAut Spaces.Cantor.
 

--- a/theories/Spaces/BAut/Rigid.v
+++ b/theories/Spaces/BAut/Rigid.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 Require Import HoTT.Basics HoTT.Types.
-Require Import HProp UnivalenceImpliesFunext Fibrations.
+Require Import HProp Fibrations.
 Require Import Modalities.Modality Truncations.
 Require Import Spaces.BAut.
 

--- a/theories/Spaces/Card.v
+++ b/theories/Spaces/Card.v
@@ -1,7 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 (** Representation of cardinals, see Chapter 10 of the HoTT book. *)
 Require Import HoTT.Basics HoTT.Types HoTT.HSet HoTT.TruncType.
-Require Import UnivalenceImpliesFunext.
 Require Import HoTT.Classes.interfaces.abstract_algebra.
 Require Import HoTT.Truncations.
 

--- a/theories/Spaces/Finite.v
+++ b/theories/Spaces/Finite.v
@@ -8,7 +8,6 @@ Require Import Spaces.Nat.
 Require Import Fibrations.
 Require Import Factorization.
 Require Import EquivalenceVarieties.
-Require Import UnivalenceImpliesFunext.
 Require Import Truncations.
 Require Import Colimits.Quotient.
 

--- a/theories/Spaces/No/Addition.v
+++ b/theories/Spaces/No/Addition.v
@@ -1,5 +1,5 @@
 (* -*- mode: coq; mode: visual-line -*- *)
-Require Import HoTT.Basics HoTT.Types UnivalenceImpliesFunext.
+Require Import HoTT.Basics HoTT.Types.
 Require Import HoTT.Spaces.No.Core HoTT.Spaces.No.Negation.
 
 Local Open Scope path_scope.

--- a/theories/Spaces/No/Core.v
+++ b/theories/Spaces/No/Core.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 Require Import HoTT.Basics HoTT.Types.
-Require Import UnivalenceImpliesFunext TruncType HSet.
+Require Import TruncType HSet.
 Require Import HoTT.Truncations.
 
 Local Open Scope nat_scope.

--- a/theories/Spaces/Torus/TorusHomotopy.v
+++ b/theories/Spaces/Torus/TorusHomotopy.v
@@ -9,7 +9,6 @@ Require Import Spaces.Int.
 Require Import HIT.Circle.
 Require Import Truncations.
 Require Import Homotopy.HomotopyGroup.
-Require Import UnivalenceImpliesFunext.
 
 Require Import Torus.
 Require Import TorusEquivCircles.

--- a/theories/Spaces/Universe.v
+++ b/theories/Spaces/Universe.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 Require Import HoTT.Basics HoTT.Types.
-Require Import HProp UnivalenceImpliesFunext Fibrations.
+Require Import HProp Fibrations.
 Require Import Modalities.Modality HoTT.Truncations.
 Require Import Spaces.BAut Spaces.BAut.Rigid.
 Require Import ExcludedMiddle.

--- a/theories/Spectra/Coinductive.v
+++ b/theories/Spectra/Coinductive.v
@@ -3,7 +3,6 @@
 Require Import Basics.
 Require Import Types.
 Require Import Pointed.
-Require Import UnivalenceImpliesFunext.
 Require Import HoTT.Truncations Homotopy.Suspension.
 
 Local Open Scope path_scope.

--- a/theories/TruncType.v
+++ b/theories/TruncType.v
@@ -2,7 +2,7 @@
 (** * Universes of truncated types. *)
 
 Require Import HoTT.Basics HoTT.Types.
-Require Import HProp UnivalenceImpliesFunext.
+Require Import HProp.
 
 
 Generalizable Variables A B n f.

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -4,7 +4,6 @@ Require Import Basics.
 Require Import Types.
 Require Import TruncType.
 
-Require Import UnivalenceImpliesFunext.
 Require Import HProp.
 Require Import EquivalenceVarieties.
 Require Import Extensions.

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -1,7 +1,7 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 
 Require Import Basics Types.
-Require Import TruncType HProp UnivalenceImpliesFunext.
+Require Import TruncType HProp.
 Require Import Modalities.Modality Modalities.Identity Modalities.Descent.
 
 (** * Truncations of types, in all dimensions. *)

--- a/theories/Types/Universe.v
+++ b/theories/Types/Universe.v
@@ -37,6 +37,10 @@ Existing Class Univalence.
 Axiom isequiv_equiv_path : forall `{Univalence} (A B : Type), IsEquiv (equiv_path A B).
 Global Existing Instance isequiv_equiv_path.
 
+(** A proof that univalence implies function extensionality can be found in the metatheory file [UnivalenceImpliesFunext], but that actual proof can't be used on our dummy typeclasses.  So we assert the following axiomatic instance.  *)
+Global Instance Univalence_implies_Funext `{Univalence} : Funext.
+Admitted.
+
 Section Univalence.
 Context `{Univalence}.
 

--- a/theories/UnivalenceImpliesFunext.v
+++ b/theories/UnivalenceImpliesFunext.v
@@ -108,6 +108,4 @@ Definition Univalence_type_implies_Funext_type
   := NaiveNondepFunext_implies_Funext
        (@Univalence_implies_FunextNondep ua).
 
-(** As justified by the above proof, we may assume [Univalence -> Funext]. *)
-Global Instance Univalence_implies_Funext `{Univalence} : Funext.
-Admitted.
+(** The above proof justifies assuming [Univalence -> Funext], which we did axiomatically in [Types/Universe.v]. *)


### PR DESCRIPTION
I didn't put `EquivalenceVarieties` in here because it's not really metatheory, and is not really a dead end in the same way.  (E.g. `Extensions` uses `PathSplit` from there.)  However, we may also want to move some of the more important facts out of it, to reduce the need to import it.