### PR TITLE
Tactic make_equiv for rearranging sigma and record types, close #1194

### DIFF
--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -822,4 +822,4 @@ End Examples.
 >>
 *)
 
-(** Some "real-world" examples where [make_equiv_contr_basedpaths] simplifies things a lot includi [hfiber_compose] in [Fibrations.v], [hfiber_pullback_along] in [Limits/Pullback.v], and [equiv_Ocodeleft2plus] in [BlakersMassey.v]. *)
+(** Some "real-world" examples where [make_equiv_contr_basedpaths] simplifies things a lot include [hfiber_compose] in [Fibrations.v], [hfiber_pullback_along] in [Limits/Pullback.v], and [equiv_Ocodeleft2plus] in [BlakersMassey.v]. *)

--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -578,7 +578,7 @@ Ltac make_equiv :=
     | decomposing_intros; exact idpath
     | decomposing_intros; exact idpath ].
 
-(** In case anyone ever needs it, here's the version that doesn't adjointify. *)
+(** In case anyone ever needs it, here's the version that doesn't adjointify. It's not the default, because it can be slow. *)
 Ltac make_equiv_without_adjointification :=
   simple notypeclasses refine (Build_Equiv _ _ _ _);
     [ decomposing_intros; build_record |

--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -543,12 +543,14 @@ Ltac ev_equiv :=
              change ((equiv_inverse f) a) with (f^-1 a)
          end.
 
+(** ** Building equivalences between nested sigma and record types *)
+
 (** The following tactic [make_equiv] builds an equivalence between two types built out of arbitrarily nested sigma and record types, not necessarily right-associated, as long as they have all the same underyling components.  This is more general than [issig] in that it doesn't just prove equivalences between a single record type and a single right-nested tower of sigma types, but less powerful in that it can't deduce the latter nested tower of sigmas automatically: you have to have both sides of the equivalence known. *)
 
 (* Perform [intros] repeatedly, recursively destructing all possibly-nested record types. *)
 Ltac decomposing_intros :=
   let x := fresh in
-  intros x; hnf in x;
+  intros x; cbn in x;
   try match type of x with
   | ?a = ?b => fail 1           (** Don't destruct paths *)
   | forall y:?A, ?B => fail 1   (** Don't apply functions *)
@@ -570,7 +572,7 @@ Ltac build_record :=
 
 (* Construct an equivalence between two possibly-nested record/sigma types that differ only by associativity and permutation of their components.  We could use [Build_Equiv] and directly construct [eisadj] by decomposing to reflexivity as well, but often with large nested types it seems to be faster to adjointify. *)
 Ltac make_equiv :=
-  snrapply equiv_adjointify;
+  simple notypeclasses refine (equiv_adjointify _ _ _ _);
     [ decomposing_intros; build_record
     | decomposing_intros; build_record
     | decomposing_intros; exact idpath
@@ -578,55 +580,246 @@ Ltac make_equiv :=
 
 (** In case anyone ever needs it, here's the version that doesn't adjointify. *)
 Ltac make_equiv_without_adjointification :=
-  snrapply Build_Equiv;
+  simple notypeclasses refine (Build_Equiv _ _ _ _);
     [ decomposing_intros; build_record |
-      snrapply Build_IsEquiv;
+      simple notypeclasses refine (Build_IsEquiv _ _ _ _ _ _ _);
       [ decomposing_intros; build_record
       | decomposing_intros; exact idpath
       | decomposing_intros; exact idpath
       | decomposing_intros; exact idpath ] ].
 
-(** This version is willing to destruct paths as well, but only as a (multisuccess) second choice. *)
+(** Here are some examples of the use of this tactic that you can uncomment and explore. *)
+
+(**
+<<
+Goal forall (A : Type) (B : A -> Type) (C : forall a:A, B a -> Type) (D : forall (a:A) (b:B a), C a b -> Type),
+     { ab : {a : A & B a } & { c : C ab.1 ab.2 & D ab.1 ab.2 c } }
+     <~> { a : A & { bc : { b : B a & C a b } & D a bc.1 bc.2 } }.
+  intros A B C D.
+  make_equiv.
+  Undo.
+  (** Here's the eventually successful proof script produced by [make_equiv], extracted from [Info 0 make_equiv] and prettified, so you can step through it and see how the tactic works. *)
+  simple notypeclasses refine (equiv_adjointify _ _ _ _).
+  - (** Here begins [decomposing_intros] *)
+    intros x; cbn in x.
+    elim x; clear x.
+    intros x; cbn in x.
+    elim x; clear x.
+    intros a; cbn in a.
+    intros b; cbn in b.
+    intros x; cbn in x.
+    elim x; clear x.
+    intros c; cbn in c. 
+    intros d; cbn in d.
+    (** Here begins [build_record] *)
+    cbn; unshelve econstructor.
+    { cbn; exact a. }
+    { cbn; unshelve econstructor.
+      { cbn; unshelve econstructor.
+        { cbn; exact b. }
+        { cbn; exact c. } }
+      { cbn; exact d. } }
+  - intros x; cbn in x.
+    elim x; clear x.
+    intros a; cbn in a.
+    intros x; cbn in x.
+    elim x; clear x.
+    intros x; cbn in x.
+    elim x; clear x. 
+    intros b; cbn in b.
+    intros c; cbn in c.
+    intros d; cbn in d.
+    cbn; unshelve econstructor.
+    { cbn; unshelve econstructor.
+      { cbn; exact a. }
+      { cbn; exact b. } }
+    { cbn; unshelve econstructor.
+      { cbn; exact c. }
+      { cbn; exact d. } }
+  - intros x; cbn in x.
+    elim x; clear x.
+    intros a; cbn in a.
+    intros x; cbn in x.
+    elim x; clear x.
+    intros x; cbn in x.
+    elim x; clear x. 
+    intros b; cbn in b.
+    intros c; cbn in c.
+    intros d; cbn in d.
+    cbn; exact idpath.
+  - intros x; cbn in x.
+    elim x; clear x.
+    intros x; cbn in x.
+    elim x; clear x.
+    intros a; cbn in a.
+    intros b; cbn in b.
+    intros x; cbn in x.
+    elim x; clear x.
+    intros c; cbn in c. 
+    intros d; cbn in d.
+    cbn; exact idpath.
+Defined.
+>>
+*)
+
+(** Here is an example illustrating the need for [multi_assumption] instead of just [assumption]. *)
+(**
+<<
+Goal forall (A:Type) (R:A->A->Type),
+    { x : A & { y : A & R x y } } <~> { xy : A * A & R (fst xy) (snd xy) }.
+  intros A R.
+  make_equiv.
+  Undo.
+  simple notypeclasses refine (equiv_adjointify _ _ _ _).
+  - intros x; cbn in x.
+    elim x; clear x.
+    intros a1; cbn in a1.
+    intros x; cbn in x.
+    elim x; clear x.
+    intros a2; cbn in a2.
+    intros r; cbn in r.
+    cbn; unshelve econstructor.
+    { cbn; unshelve econstructor. 
+      { (** [build_record] can't guess at this point that it needs to use [a1] instead of [a2], and in fact it tries [a2] first; but later on, [exact r] fails in that case, causing backtracking to this point and a re-try with [a1].  *)
+        cbn; exact a1. }
+      { cbn; exact a2. } }
+    cbn; exact r.
+  - intros x; cbn in x.
+    elim x; clear x.
+    intros x; cbn in x.
+    elim x; clear x.
+    intros a1; cbn in a1.
+    intros a2; cbn in a2.
+    intros r; cbn in r.
+    cbn; unshelve econstructor.
+    { cbn; exact a1. }
+    { cbn; unshelve econstructor.
+      { cbn; exact a2. }
+      { cbn; exact r. } }
+  - intros x; cbn in x.
+    elim x; clear x.
+    intros x; cbn in x.
+    elim x; clear x.
+    intros a1; cbn in a1.
+    intros a2; cbn in a2.
+    intros r; cbn in r.
+    cbn; exact idpath.
+  - intros x; cbn in x.
+    elim x; clear x.
+    intros a1; cbn in a1.
+    intros x; cbn in x.
+    elim x; clear x.
+    intros a2; cbn in a2.
+    intros r; cbn in r.
+    cbn; exact idpath.
+Defined.
+>>
+*)
+
+(** Some "real-world" examples where [make_equiv] simplifies things a lot include  the associativity/symmetry proofs in [Types/Sigma.v], [issig_pequiv'] in [Pointed/pEquiv.v], and [loop_susp_adjoint] in [Pointed/pSusp.v]. *)
+
+(** Now we give a version of [make_equiv] that can also prove equivalences of nested sigma- and record types that involve contracting based path-spaces on either or both sides.  The basepoint and the path don't have to appear together, but can be in arbitrarily separated parts of the nested structure.  It does this by selectively applying path-induction to based paths appearing on both sides, if needed. *)
+
+(** We start with a version of [decomposing_intros] that is willing to destruct paths, though as a second choice. *)
 Ltac decomposing_intros_with_paths :=
   let x := fresh in
   intros x; cbn in x;
   multimatch type of x with
-  | ?a = ?b =>
-    (** Don't destruct paths *)
-    try decomposing_intros_with_paths
-  | forall y:?A, ?B =>
-    (** Don't apply functions *)
-    try decomposing_intros_with_paths
   | _ =>
-    try (elim x; clear x);
+    try match type of x with
+        | (** Don't destruct paths at first *)
+          ?a = ?b => fail 1
+        | (** Don't apply functions at first *)
+          forall y:?A, ?B => fail 1
+        | _ => elim x; clear x
+        end;
     try decomposing_intros_with_paths
   | ?a = ?b =>
-    (** Destruct paths as a second choice *)
-    (* Sometimes [destruct] isn't smart enough to generalize the other hypotheses that use the free endpoint. *)
-    ((move x before b;
+    (** Destruct paths as a second choice.  But sometimes [destruct] isn't smart enough to generalize the other hypotheses that use the free endpoint, so we manually apply [paths_ind], or its right-handed version, instead. *)
+    ((move x before b; (** Ensure that [b] and [x] come first in the [forall] goal resulting from [generalize dependent], so that [paths_ind] can apply to it. *)
       generalize dependent b;
+      not (move b at top); (** Check that [b] was actually reverted.  (If it's a section variable that the goal depends on, [generalize dependent b] will "succeed", but actually fail to generalize the goal over [b] (since that can't be done within the section) and not clear [b] from the context.)  *)
       refine (paths_ind _ _ _)) +
-     (* We do a multisuccess choice here because if [b] is a section variable, [generalize dependent] appears to succeed but doesn't actually do the correct thing (since the implicit dependence of the goal on that variable can't be generalized while inside the section), so in that case we want to be able to backtrack into trying to generalize [a] instead. *)
+     (** Try the other endpoint too. *)
      (move x before a;
       generalize dependent a;
+      not (move a at top);
       refine (paths_ind_r _ _ _)));
-    try decomposing_intros_with_paths
-  | _ =>
     try decomposing_intros_with_paths
   end.
 
-(** This version is willing to create evars, in hopes that a later idpath will determine them.  Note that if there are other fields that depend on this one that occur before the idpath, the evar will -- and, indeed, must -- get instantiated by them instead.  This is why [multi_assumption], above, must be willing to instantiate evars. *)
+(** Going the other direction, we have to be willing to insert identity paths to fill in the based path-spaces that got destructed.  In fact [econstructor] is already willing to do that, since [idpath] is the constructor of [paths].  However, our previous [build_record] won't manage to get to the point of being able to apply [econstructor] to the necessary paths, since it'll get stuck earlier on trying to find the basepoint.  Thus, we give a version of [build_record] that is willing to create existential variables ("evars") for goals that it can't solve, in hopes that a later [idpath] (produced by [econstructor]) will determine them by unification.  Note that if there are other fields that depend on the basepoint that occur before the [idpath], the evar will -- and, indeed, must -- get instantiated by them instead.  This is why [multi_assumption], above, must be willing to instantiate evars. *)
 Ltac build_record_with_evars :=
   first [ cbn; multi_assumption
         | cbn; unshelve econstructor; build_record_with_evars
+        (** Create a fresh evar to solve this goal *)
         | match goal with
             |- ?G => let x := fresh in evar (x : G); exact x
           end; build_record_with_evars ].
 
+(** Now here's the improved version of [make_equiv]. *)
 Ltac make_equiv_contr_basedpaths :=
   simple notypeclasses refine (equiv_adjointify _ _ _ _);
-    (** [solve [ unshelve X ]] ensures that [X] succeeds without leaving any leftover evars. *)
+    (** [solve [ unshelve TAC ]] ensures that [TAC] succeeds without leaving any leftover evars. *)
     [ decomposing_intros_with_paths; solve [ unshelve build_record_with_evars ]
     | decomposing_intros_with_paths; solve [ unshelve build_record_with_evars ]
     | decomposing_intros_with_paths; exact idpath
     | decomposing_intros_with_paths; exact idpath ].
+
+(** As before, we give some examples. *)
+
+(**
+<<
+Section Examples.
+  Context (A : Type) (B : A -> Type) (a0 : A).
+  Goal { a : A & { b : B a & a = a0 } } <~> B a0.
+  Proof.
+    make_equiv_contr_basedpaths.
+    Undo.
+    simple notypeclasses refine (equiv_adjointify _ _ _ _).
+    - (** Here begins [decomposing_intros_with_paths] *)
+      intros x; cbn in x.
+      elim x; clear x.
+      intros a; cbn in a.
+      intros x; cbn in x. 
+      elim x; clear x.
+      intros b; cbn in b.
+      intros p; cbn in p.
+      (** [decomposing_intros] wouldn't be willing to destruct [p] here, because it's a path.  But [decomposing_intros_with_paths] will try it when all else fails. *)
+      move p before a.
+      generalize dependent a.
+      not (move a at top).
+      refine (paths_ind_r _ _ _).
+      intros b; cbn in b.
+      (** Here begins [build_record_with_evars] *)
+      exact b.
+    - (** Here begins [decomposing_intros_with_paths] *)
+      intros b; cbn in b.
+      (** Here begins [build_record_with_evars] *)
+      cbn; unshelve econstructor.
+      { let x := fresh in evar (x : A); exact x. }
+      cbn; unshelve econstructor.
+      { (** This instantiates the evar. *)
+        exact b. }
+      { cbn; unshelve econstructor. }
+    - intros b; cbn in b.
+      exact idpath.
+    - intros x; cbn in x.
+      elim x; clear x.
+      intros a; cbn in a.
+      intros x; cbn in x. 
+      elim x; clear x.
+      intros b; cbn in b.
+      intros p; cbn in p.
+      move p before a.
+      generalize dependent a.
+      not (move a at top).
+      refine (paths_ind_r _ _ _).
+      intros b; cbn in b.
+      exact idpath.
+  Defined.
+End Examples.
+>>
+*)
+
+(** Some "real-world" examples where [make_equiv_contr_basedpaths] simplifies things a lot includi [hfiber_compose] in [Fibrations.v], [hfiber_pullback_along] in [Limits/Pullback.v], and [equiv_Ocodeleft2plus] in [BlakersMassey.v]. *)

--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -716,7 +716,7 @@ Defined.
 >>
 *)
 
-(** Some "real-world" examples where [make_equiv] simplifies things a lot include  the associativity/symmetry proofs in [Types/Sigma.v], [issig_pequiv'] in [Pointed/pEquiv.v], and [loop_susp_adjoint] in [Pointed/pSusp.v]. *)
+(** Some "real-world" examples where [make_equiv] simplifies things a lot include the associativity/symmetry proofs in [Types/Sigma.v], [issig_pequiv'] in [Pointed/pEquiv.v], and [loop_susp_adjoint] in [Pointed/pSusp.v]. *)
 
 (** Now we give a version of [make_equiv] that can also prove equivalences of nested sigma- and record types that involve contracting based path-spaces on either or both sides.  The basepoint and the path don't have to appear together, but can be in arbitrarily separated parts of the nested structure.  It does this by selectively applying path-induction to based paths appearing on both sides, if needed. *)
 

--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -737,13 +737,13 @@ Ltac decomposing_intros_with_paths :=
   | ?a = ?b =>
     (** Destruct paths as a second choice.  But sometimes [destruct] isn't smart enough to generalize the other hypotheses that use the free endpoint, so we manually apply [paths_ind], or its right-handed version, instead. *)
     ((move x before b; (** Ensure that [b] and [x] come first in the [forall] goal resulting from [generalize dependent], so that [paths_ind] can apply to it. *)
-      generalize dependent b;
-      not (move b at top); (** Check that [b] was actually reverted.  (If it's a section variable that the goal depends on, [generalize dependent b] will "succeed", but actually fail to generalize the goal over [b] (since that can't be done within the section) and not clear [b] from the context.)  *)
+      revert dependent b;
+      assert_fails (move b at top); (** Check that [b] was actually reverted.  (If it's a section variable that the goal depends on, [generalize dependent b] will "succeed", but actually fail to generalize the goal over [b] (since that can't be done within the section) and not clear [b] from the context.)  *)
       refine (paths_ind _ _ _)) +
      (** Try the other endpoint too. *)
      (move x before a;
-      generalize dependent a;
-      not (move a at top);
+      revert dependent a;
+      assert_fails (move a at top);
       refine (paths_ind_r _ _ _)));
     try decomposing_intros_with_paths
   end.

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -251,6 +251,17 @@ Proof.
   apply H.
 Defined.
 
+(** And here's the "right-sided" Paulin-Mohring eliminator. *)
+
+Definition paths_ind_r {A : Type} (a : A)
+           (P : forall b : A, b = a -> Type) (u : P a idpath)
+  : forall (y : A) (p : y = a), P y p.
+Proof.
+  intros y p.
+  destruct p.
+  exact u.
+Defined.                                  
+
 (** We declare a scope in which we shall place path notations. This way they can be turned on and off by the user. *)
 
 (** We bind [path_scope] to [paths] so that when we are constructing arguments to things like [concat], we automatically are in [path_scope]. *)

--- a/theories/Basics/PathGroupoids.v
+++ b/theories/Basics/PathGroupoids.v
@@ -710,14 +710,23 @@ Proof.
   (* subst u. rewrite X. *)
 Defined.
 
-(** Occasionally [paths_rect] shows up; this lets us turn it into transport. *)
+(** Occasionally the induction principles for the identity type show up explicitly; these let us turn them into transport. *)
 Definition paths_rect_transport {A : Type} (P : A -> Type) {x y : A}
            (p : x = y) (u : P x)
-  : paths_rect A x (fun a _ => P a) u y p = transport P p u.
+  : paths_rect A x (fun a _ => P a) u y p = transport P p u
+  := 1.
+
+Definition paths_ind_transport {A : Type} (P : A -> Type) {x y : A}
+           (p : x = y) (u : P x)
+  : paths_ind x (fun a _ => P a) u y p = transport P p u
+  := 1.
+
+Definition paths_ind_r_transport {A : Type} (P : A -> Type) {x y : A}
+           (p : x = y) (u : P y)
+  : paths_ind_r y (fun b _ => P b) u x p = transport P p^ u.
 Proof.
   by destruct p.
-Defined.           
-
+Defined.
 
 (** ** [ap11] *)
 

--- a/theories/Basics/PathGroupoids.v
+++ b/theories/Basics/PathGroupoids.v
@@ -710,6 +710,14 @@ Proof.
   (* subst u. rewrite X. *)
 Defined.
 
+(** Occasionally [paths_rect] shows up; this lets us turn it into transport. *)
+Definition paths_rect_transport {A : Type} (P : A -> Type) {x y : A}
+           (p : x = y) (u : P x)
+  : paths_rect A x (fun a _ => P a) u y p = transport P p u.
+Proof.
+  by destruct p.
+Defined.           
+
 
 (** ** [ap11] *)
 

--- a/theories/Fibrations.v
+++ b/theories/Fibrations.v
@@ -78,16 +78,14 @@ Definition hfiber_functor_hfiber {A B C D}
   <~> hfiber (functor_hfiber (fun x => (p x)^) c) (b;q^).
 Proof.
   unfold hfiber, functor_hfiber, functor_sigma.
-  refine (_ oE (equiv_sigma_assoc _ _)^-1).
-  refine (equiv_sigma_assoc _ _ oE _).
-  apply equiv_functor_sigma_id; intros a; cbn.
-  refine (_ oE (equiv_functor_sigma_id _)^-1).
-  2:intros; apply equiv_path_sigma.
-  refine (equiv_functor_sigma_id _ oE _).
-  1:intros; apply equiv_path_sigma. cbn.
-  refine (equiv_sigma_symm _ oE _).
-  apply equiv_functor_sigma_id; intros r.
-  apply equiv_functor_sigma_id; intros s; cbn.
+  rapply (equiv_functor_sigma_id _ oE _ oE equiv_functor_sigma_id _).
+  1:intros; rapply equiv_path_sigma.
+  2:intros; symmetry; rapply equiv_path_sigma.
+  cbn.
+  transitivity {ar : {a : A & f a = b} & {s : h ar.1 = c & transport (fun x : B => k x = g c) ar.2 (((p ar.1)^)^ @ ap g s) = q^}}.
+  2:make_equiv.
+  apply equiv_functor_sigma_id; intros [a r].
+  apply equiv_functor_sigma_id; intros s.
   refine (equiv_concat_l (transport_paths_Fl _ _) _ oE _).
   refine (_ oE (equiv_concat_l (transport_paths_Fl _ _) _)^-1).
   refine ((equiv_ap inverse _ _)^-1 oE _).
@@ -140,30 +138,23 @@ Section UnstableOctahedral.
   : hfiber (hfiber_compose_map b) (b;1) <~> hfiber f b.
   Proof.
     unfold hfiber, hfiber_compose_map.
+    refine (_ oE equiv_functor_sigma_id
+              (fun p => (equiv_path_sigma _ _ _)^-1)); cbn.
     refine (_ oE (equiv_sigma_assoc _ _)^-1).
     apply equiv_functor_sigma_id; intros a; simpl.
-    refine (_ oE _); revgoals.
-    - refine (equiv_functor_sigma_id
-                (fun p => (equiv_path_sigma _ _ _)^-1)).
-    - cbn. refine (_ oE equiv_sigma_symm _).
-      apply equiv_sigma_contr; intros p.
-      destruct p; simpl; exact _.
+    refine (_ oE equiv_sigma_symm _).
+    apply equiv_sigma_contr; intros p.
+    destruct p; simpl; exact _.
   Defined.
 
   Definition hfiber_compose (c : C)
   : hfiber (g o f) c <~> { w : hfiber g c & hfiber f w.1 }.
   Proof.
     unfold hfiber.
-    refine (equiv_sigma_assoc _ _ oE _).
-    refine (equiv_functor_sigma_id _ oE _).
-    1: intros; apply equiv_sigma_symm.
-    refine (equiv_sigma_symm _ oE _).
-    apply equiv_functor_sigma_id; intros a; cbn.
-    refine (equiv_functor_sigma_id _ oE _).
-    1: intros; apply equiv_sigma_symm0.
-    refine ((equiv_sigma_assoc' _ _)^-1 oE _).
-    symmetry.
-    refine (_ oE equiv_contr_sigma _).
+    transitivity {a:A & {bp : {b:B & f a = b} & g bp.1 = c}}.
+    2:make_equiv.
+    apply equiv_functor_sigma_id; intros a.
+    symmetry; refine (_ oE equiv_contr_sigma _).
     reflexivity.
   Defined.
 
@@ -198,10 +189,8 @@ Proof.
   unfold hfiber, functor_sigma.
   refine (_ oE equiv_functor_sigma_id _).
   2:intros; symmetry; apply equiv_path_sigma.
-  refine (_ oE (equiv_sigma_assoc P _)^-1).
-  refine (_ oE equiv_functor_sigma_id _).
-  2:intros a; cbn; apply equiv_sigma_symm.
-  refine (_ oE equiv_sigma_assoc' _ _).
+  transitivity {w : {x : A & f x = b} & {x : P w.1 & (w.2) # (g w.1 x) = v}}.
+  1:make_equiv.
   apply equiv_functor_sigma_id; intros [a p]; simpl.
   apply equiv_functor_sigma_id; intros u; simpl.
   apply equiv_moveL_transport_V.

--- a/theories/Fibrations.v
+++ b/theories/Fibrations.v
@@ -138,7 +138,7 @@ Section UnstableOctahedral.
     refine (_ oE _); revgoals.
     - refine (equiv_functor_sigma_id
                 (fun p => (equiv_path_sigma _ _ _)^-1)).
-    - cbn; refine (_ oE equiv_sigma_symm _).
+    - cbn. refine (_ oE equiv_sigma_symm _).
       apply equiv_sigma_contr; intros p.
       destruct p; simpl; exact _.
   Defined.
@@ -146,12 +146,7 @@ Section UnstableOctahedral.
   Definition hfiber_compose (c : C)
   : hfiber (g o f) c <~> { w : hfiber g c & hfiber f w.1 }.
   Proof.
-    unfold hfiber.
-    transitivity {a:A & {bp : {b:B & f a = b} & g bp.1 = c}}.
-    2:make_equiv.
-    apply equiv_functor_sigma_id; intros a.
-    symmetry; refine (_ oE equiv_contr_sigma _).
-    reflexivity.
+    make_equiv_contr_basedpaths.
   Defined.
 
   Global Instance istruncmap_compose `{!IsTruncMap n g} `{!IsTruncMap n f}

--- a/theories/Fibrations.v
+++ b/theories/Fibrations.v
@@ -77,21 +77,16 @@ Definition hfiber_functor_hfiber {A B C D}
 : hfiber (functor_hfiber p b) (c;q)
   <~> hfiber (functor_hfiber (fun x => (p x)^) c) (b;q^).
 Proof.
-  unfold hfiber, functor_hfiber, functor_sigma.
-  rapply (equiv_functor_sigma_id _ oE _ oE equiv_functor_sigma_id _).
-  1:intros; rapply equiv_path_sigma.
-  2:intros; symmetry; rapply equiv_path_sigma.
-  cbn.
-  transitivity {ar : {a : A & f a = b} & {s : h ar.1 = c & transport (fun x : B => k x = g c) ar.2 (((p ar.1)^)^ @ ap g s) = q^}}.
-  2:make_equiv.
-  apply equiv_functor_sigma_id; intros [a r].
-  apply equiv_functor_sigma_id; intros s.
-  refine (equiv_concat_l (transport_paths_Fl _ _) _ oE _).
-  refine (_ oE (equiv_concat_l (transport_paths_Fl _ _) _)^-1).
+  rapply (equiv_functor_sigma_id _ oE _ oE (equiv_functor_sigma_id _)^-1).
+  1,3:intros; rapply equiv_path_sigma.
+  refine (equiv_sigma_assoc _ _ oE _ oE (equiv_sigma_assoc _ _)^-1).
+  apply equiv_functor_sigma_id; intros a; cbn.
+  refine (equiv_sigma_symm _ oE _).
+  do 2 (apply equiv_functor_sigma_id; intro).
   refine ((equiv_ap inverse _ _)^-1 oE _).
   refine (equiv_concat_r (inv_V q)^ _ oE _).
   apply equiv_concat_l.
-  abstract (rewrite !inv_pp, !inv_V, concat_pp_p; reflexivity).
+  abstract (rewrite !transport_paths_Fl, !inv_pp, !inv_V, concat_pp_p; reflexivity).
 Defined.
 
 (** ** Replacing a map with a fibration *)
@@ -138,13 +133,14 @@ Section UnstableOctahedral.
   : hfiber (hfiber_compose_map b) (b;1) <~> hfiber f b.
   Proof.
     unfold hfiber, hfiber_compose_map.
-    refine (_ oE equiv_functor_sigma_id
-              (fun p => (equiv_path_sigma _ _ _)^-1)); cbn.
     refine (_ oE (equiv_sigma_assoc _ _)^-1).
     apply equiv_functor_sigma_id; intros a; simpl.
-    refine (_ oE equiv_sigma_symm _).
-    apply equiv_sigma_contr; intros p.
-    destruct p; simpl; exact _.
+    refine (_ oE _); revgoals.
+    - refine (equiv_functor_sigma_id
+                (fun p => (equiv_path_sigma _ _ _)^-1)).
+    - cbn; refine (_ oE equiv_sigma_symm _).
+      apply equiv_sigma_contr; intros p.
+      destruct p; simpl; exact _.
   Defined.
 
   Definition hfiber_compose (c : C)

--- a/theories/Homotopy/BlakersMassey.v
+++ b/theories/Homotopy/BlakersMassey.v
@@ -190,48 +190,25 @@ Section GBM.
         Proof.
           refine ((equiv_sigma_pushout _ _ _ _ _)^-1 oE _).
           srefine (equiv_pushout _ _ _ _ _).
-          - unfold Ocodeleft2a.
-            srefine (equiv_functor_sigma_id _ oE _).
-            + intros [y0 [q00 [q10 u]]].
-              exact { s  : x0 = x1 &
-                    { sq : transport (fun x => Q x y0) s q00 = q10 &
-                    { t  : y0 = y1 &
-                           transport (Q x1) t q10 = q11 } } }.
-            + intros [y0 [q00 [q10 u]]]; cbn.
-              refine (equiv_functor_prod' _ _ oE _).
-              1-2:apply equiv_path_sigma.
-              exact (equiv_sigma_prod0 _ _ oE equiv_sigma_assoc _ _).
-            + transitivity {s : x0 = x1 & {ap : {a : Y & a = y1} & {b : {q00 : Q x0 ap.1 & {q10 : Q x1 ap.1 & glue q00 @ (glue q10)^ = r}} & {_ : transport (fun x : X => Q x ap.1) s b.1 = (b.2).1 & ap.2 # (b.2).1 = q11}}}}.
-              2:make_equiv.
-              apply equiv_functor_sigma_id; intros s.
-              refine ((equiv_contr_sigma _)^-1 oE _); cbn.
-              transitivity {q01 : Q x0 y1 & {ap : {a : Q x1 y1 & a = q11} & {_ : glue q01 @ (glue ap.1)^ = r & transport (fun x : X => Q x y1) s q01 = ap.1}}}.
-              2:make_equiv.
-              refine (equiv_functor_sigma_id _); intros q01.
-              refine ((equiv_contr_sigma _)^-1 oE _); cbn.
-              apply equiv_sigma_symm0.
-          - unfold Ocodeleft2b.
-            srefine (equiv_functor_sigma_id _ oE _).
-            + intros [y0 [q00 [q10 u]]].
-              exact { s  : x0 = x1 &
-                    (* sq : *) transport (fun x => Q x y0) s q00 = q10 }.
-            + intros [y0 [q00 [q10 u]]]; cbn.
-              refine (equiv_path_sigma _ (x0;q00) (x1;q10)).
-            + make_equiv.
-          - unfold Ocodeleft2c.
-            srefine (equiv_functor_sigma_id _ oE _).
-            + intros [y0 [q00 [q10 u]]].
-              exact { t  : y0 = y1 &
-                           transport (Q x1) t q10 = q11 }.
-            + intros [y0 [q00 [q10 u]]]; cbn.
-              refine (equiv_path_sigma _ (y0;q10) (y1;q11)).
-            + transitivity {ap : {a : Y & a = y1} & {b : {q00 : Q x0 ap.1 & {q10 : Q x1 ap.1 & glue q00 @ (glue q10)^ = r}} & transport (Q x1) ap.2 (b.2).1 = q11}}.
-              2:make_equiv.
-              refine ((equiv_contr_sigma _)^-1 oE _); cbn.
-              transitivity {q01 : Q x0 y1 & {ap : {a : Q x1 y1 & a = q11} & glue q01 @ (glue ap.1)^ = r}}.
-              2:make_equiv.
-              apply equiv_functor_sigma_id; intros q01.
-              refine ((equiv_contr_sigma _)^-1 oE _); reflexivity.
+          - srefine (equiv_functor_sigma_id _ oE _).
+            2:intro; refine (equiv_functor_prod' _ _); apply equiv_path_sigma.
+            transitivity {s : x0 = x1 & { yp : { y0 : Y & y0 = y1} & {q00 : Q x0 yp.1 & { q10p : { q10 : Q x1 yp.1 & transport (fun y => Q x1 y) yp.2 q10 = q11 } & { _ : transport (fun x => Q x yp.1) s q00 = q10p.1 & glue q00 @ (glue q10p.1)^ = r }}}}}.
+            2:make_equiv.
+            apply equiv_functor_sigma_id; intros s.
+            refine ((equiv_contr_sigma _)^-1 oE _); cbn.
+            refine (equiv_functor_sigma_id _); intros q01.
+            refine ((equiv_contr_sigma _)^-1 oE _).
+            cbn. reflexivity.
+          - srefine (equiv_functor_sigma_id _ oE _).
+            2:intro; apply equiv_path_sigma.
+            make_equiv.
+          - srefine (equiv_functor_sigma_id _ oE _).
+            2:intro; apply equiv_path_sigma.
+            transitivity {yp : {y0 : Y & y0 = y1} & {qp : {q10 : Q x1 yp.1 & transport (Q x1) yp.2 q10 = q11} & {q00 : Q x0 yp.1 & glue q00 @ (glue qp.1)^ = r}}}.
+            2:make_equiv.
+            refine ((equiv_contr_sigma _)^-1 oE _); cbn.
+            refine ((equiv_contr_sigma _)^-1 oE _).
+            reflexivity.
           - intros [s [q01 [w u]]]; reflexivity.
           - intros [s [q01 [w u]]]; reflexivity.
         Defined.
@@ -253,17 +230,7 @@ Section GBM.
 
         Definition Ocodeleft02b : codeleft0 <~> Ocodeleft2b.
         Proof.
-          unfold codeleft0, Ocodeleft2b.
-          apply equiv_functor_sigma_id; intros s.
-          apply equiv_functor_sigma_id; intros y0.
-          refine (_ oE equiv_sigma_symm _).
-          apply equiv_functor_sigma_id; intros q00.
-          refine (_ oE equiv_sigma_symm _).
-          apply equiv_functor_sigma_id; intros q10.
-          refine (_ oE equiv_sigma_symm _).
-          apply equiv_functor_sigma_id; intros w.
-          refine (_ oE equiv_sigma_symm _).
-          refine (equiv_sigma_contr _).
+          make_equiv_contr_basedpaths.
         Defined.
 
         Definition Ocodeleft02 (c : codeleft0)

--- a/theories/Homotopy/BlakersMassey.v
+++ b/theories/Homotopy/BlakersMassey.v
@@ -199,34 +199,17 @@ Section GBM.
                            transport (Q x1) t q10 = q11 } } }.
             + intros [y0 [q00 [q10 u]]]; cbn.
               refine (equiv_functor_prod' _ _ oE _).
-              * apply equiv_path_sigma.
-              * apply equiv_path_sigma.
-              * refine (equiv_sigma_prod0 _ _ oE _); cbn.
-                refine (equiv_sigma_assoc _ _).
-            + cbn.
-              refine (equiv_sigma_symm _ oE _).
+              1-2:apply equiv_path_sigma.
+              exact (equiv_sigma_prod0 _ _ oE equiv_sigma_assoc _ _).
+            + transitivity {s : x0 = x1 & {ap : {a : Y & a = y1} & {b : {q00 : Q x0 ap.1 & {q10 : Q x1 ap.1 & glue q00 @ (glue q10)^ = r}} & {_ : transport (fun x : X => Q x ap.1) s b.1 = (b.2).1 & ap.2 # (b.2).1 = q11}}}}.
+              2:make_equiv.
               apply equiv_functor_sigma_id; intros s.
-              refine (equiv_sigma_assoc _ _ oE _).
-              refine (equiv_functor_sigma_id _ oE _).
-              * intros y0.
-                refine (equiv_functor_sigma_id _ oE _).
-                { intros ?.
-                  refine (equiv_sigma_symm _). }
-                refine (equiv_sigma_symm _).
-              * cbn.
-                refine ((equiv_sigma_assoc' _ _)^-1 oE _).
-                refine ((equiv_contr_sigma _)^-1 oE _); cbn.
-                refine (equiv_sigma_assoc _ _ oE _).
-                refine (equiv_functor_sigma_id _); intros q01; cbn.
-                refine (equiv_functor_sigma_id _ oE _).
-                { intros ?; apply (equiv_sigma_symm0 _ _). }
-                refine (equiv_sigma_assoc _ _ oE _).
-                refine (equiv_functor_sigma_id _ oE _).
-                { intros q; cbn; apply equiv_sigma_symm. }
-                cbn.
-                refine ((equiv_sigma_assoc' _ _)^-1 oE _).
-                refine ((equiv_contr_sigma _)^-1 oE _); cbn.
-                apply equiv_sigma_symm0.
+              refine ((equiv_contr_sigma _)^-1 oE _); cbn.
+              transitivity {q01 : Q x0 y1 & {ap : {a : Q x1 y1 & a = q11} & {_ : glue q01 @ (glue ap.1)^ = r & transport (fun x : X => Q x y1) s q01 = ap.1}}}.
+              2:make_equiv.
+              refine (equiv_functor_sigma_id _); intros q01.
+              refine ((equiv_contr_sigma _)^-1 oE _); cbn.
+              apply equiv_sigma_symm0.
           - unfold Ocodeleft2b.
             srefine (equiv_functor_sigma_id _ oE _).
             + intros [y0 [q00 [q10 u]]].
@@ -234,16 +217,7 @@ Section GBM.
                     (* sq : *) transport (fun x => Q x y0) s q00 = q10 }.
             + intros [y0 [q00 [q10 u]]]; cbn.
               refine (equiv_path_sigma _ (x0;q00) (x1;q10)).
-            + cbn.
-              refine (equiv_sigma_symm _ oE _).
-              apply equiv_functor_sigma_id; intros s.
-              refine (equiv_sigma_assoc _ _ oE _).
-              apply equiv_functor_sigma_id; intros y0.
-              refine (equiv_sigma_assoc _ _ oE _).
-              apply equiv_functor_sigma_id; intros q00.
-              refine (equiv_sigma_assoc _ _ oE _).
-              apply equiv_functor_sigma_id; intros q10.
-              apply equiv_sigma_symm0.
+            + make_equiv.
           - unfold Ocodeleft2c.
             srefine (equiv_functor_sigma_id _ oE _).
             + intros [y0 [q00 [q10 u]]].
@@ -251,22 +225,13 @@ Section GBM.
                            transport (Q x1) t q10 = q11 }.
             + intros [y0 [q00 [q10 u]]]; cbn.
               refine (equiv_path_sigma _ (y0;q10) (y1;q11)).
-            + cbn.
-              refine (equiv_sigma_assoc _ _ oE _).
-              refine (equiv_functor_sigma_id _ oE _).
-              { intros y0; apply equiv_sigma_symm. }
-              cbn.
-              refine ((equiv_sigma_assoc' _ _)^-1 oE _).
-                refine ((equiv_contr_sigma _)^-1 oE _); cbn.
-                refine (equiv_sigma_assoc _ _ oE _).
-                apply equiv_functor_sigma_id; intros q01; cbn.
-                refine (equiv_sigma_assoc _ _ oE _).
-                refine (equiv_functor_sigma_id _ oE _).
-                { intros q; cbn; apply equiv_sigma_symm0. }
-                cbn.
-                refine ((equiv_sigma_assoc' _ _)^-1 oE _).
-                refine ((equiv_contr_sigma _)^-1 oE _); cbn.
-                apply equiv_idmap.
+            + transitivity {ap : {a : Y & a = y1} & {b : {q00 : Q x0 ap.1 & {q10 : Q x1 ap.1 & glue q00 @ (glue q10)^ = r}} & transport (Q x1) ap.2 (b.2).1 = q11}}.
+              2:make_equiv.
+              refine ((equiv_contr_sigma _)^-1 oE _); cbn.
+              transitivity {q01 : Q x0 y1 & {ap : {a : Q x1 y1 & a = q11} & glue q01 @ (glue ap.1)^ = r}}.
+              2:make_equiv.
+              apply equiv_functor_sigma_id; intros q01.
+              refine ((equiv_contr_sigma _)^-1 oE _); reflexivity.
           - intros [s [q01 [w u]]]; reflexivity.
           - intros [s [q01 [w u]]]; reflexivity.
         Defined.

--- a/theories/Homotopy/BlakersMassey.v
+++ b/theories/Homotopy/BlakersMassey.v
@@ -99,40 +99,41 @@ Section GBM.
     Section CodeLeft.
       Context {x0 x1 : X} (r : left x0 = left x1).
 
-      (** The left codes are themselves a pushout, of what is morally also a dependent span, but we formulate it as an ordinary pushout of projections between iterated Sigma-types.  The span is [codeleft1] <- [codeleft0] -> [codeleft2]. *)
+      (** The left codes are themselves a pushout, of what is morally also a dependent span, but we formulate it as an ordinary pushout of projections between iterated Sigma-types, most of which we express as records for performance reasons.  The span is [codeleft1] <- [codeleft0] -> [codeleft2]. *)
 
       Definition codeleft1 : Type
         := { s : x0 = x1 &
           (* v : *) ap left s = r}.
 
-      Definition codeleft2 : Type
-        := { y0  : Y &
-           { q00 : Q x0 y0 &
-           { q10 : Q x1 y0 &
-          (* u   : *) glue q00 @ (glue q10)^ = r } } }.
+      Record codeleft2
+        := { codeleft2_y0  : Y ;
+             codeleft2_q00 : Q x0 codeleft2_y0 ;
+             codeleft2_q10 : Q x1 codeleft2_y0 ;
+             codeleft2_u   : glue codeleft2_q00 @ (glue codeleft2_q10)^ = r }.
 
-      Definition codeleft0 : Type
-        := { s   : x0 = x1 &
-           { y0  : Y &
-           { v   : ap left s = r &
-           { q00 : Q x0 y0 &
-           { q10 : Q x1 y0 &
-           { w   : transport (fun x => Q x y0) s q00 = q10 &
-           { u   : glue q00 @ (glue q10)^ = r &
+      Record codeleft0
+        := { codeleft0_s   : x0 = x1 ;
+             codeleft0_y0  : Y ;
+             codeleft0_v   : ap left codeleft0_s = r ;
+             codeleft0_q00 : Q x0 codeleft0_y0 ;
+             codeleft0_q10 : Q x1 codeleft0_y0 ;
+             codeleft0_w   : transport (fun x => Q x codeleft0_y0) codeleft0_s codeleft0_q00
+                             = codeleft0_q10 ;
+             codeleft0_u   : glue codeleft0_q00 @ (glue codeleft0_q10)^ = r ;
                    (** Note the first use of frobnicate here. *)
-                   frobnicate r s y0 q10 (q00;w;u) = v
-           } } } } } } }.
+             codeleft0_d   : frobnicate r codeleft0_s codeleft0_y0 codeleft0_q10
+                                        (codeleft0_q00 ; codeleft0_w ; codeleft0_u) = codeleft0_v }.
 
       Definition codeleft01 : codeleft0 -> codeleft1.
       Proof.
-        intros [s [y0 [v [q00 [q10 [w [u d]]]]]]].
+        intros [s y0 v q00 q10 w u d].
         exact (s;v).
       Defined.
 
       Definition codeleft02 : codeleft0 -> codeleft2.
       Proof.
-        intros [s [y0 [v [q00 [q10 [w [u d]]]]]]].
-        exact (y0;q00;q10;u).
+        intros [s y0 v q00 q10 w u d].
+        exact (Build_codeleft2 y0 q00 q10 u).
       Defined.
 
       Definition codeleft : Type
@@ -147,46 +148,45 @@ Section GBM.
 
         Definition codeleft2plus :=
           {yqqu : codeleft2 &
-                  Join ((x0; yqqu.2.1) = (x1; yqqu.2.2.1)
-                                           :> {x:X & Q x yqqu.1})
-                       ((yqqu.1; yqqu.2.2.1) = (y1; q11)
+                  Join ((x0; codeleft2_q00 yqqu) = (x1; codeleft2_q10 yqqu)
+                                           :> {x:X & Q x (codeleft2_y0 yqqu)})
+                       ((codeleft2_y0 yqqu; codeleft2_q10 yqqu) = (y1; q11)
                                            :> {y:Y & Q x1 y})}.
 
-        (** Since this connected type is itself a join, hence a pushout, the second step is to distribute this and reexpress the whole thing as another pushout of iterated Sigma-types. *)
+        (** Since this connected type is itself a join, hence a pushout, the second step is to distribute this and reexpress the whole thing as another pushout of iterated Sigma-types (again mostly expressed as records for performance reasons). *)
 
-        Definition Ocodeleft2b
-        := { s   : x0 = x1 &
-           { y0  : Y &
-           { q00 : Q x0 y0 &
-           { q10 : Q x1 y0 &
-           { w   : transport (fun x => Q x y0) s q00 = q10 &
-           (* u:*) glue q00 @ (glue q10)^ = r
-           } } } } }.
+        Record Ocodeleft2b
+        := { Ocodeleft2b_s   : x0 = x1 ;
+             Ocodeleft2b_y0  : Y ;
+             Ocodeleft2b_q00 : Q x0 Ocodeleft2b_y0 ;
+             Ocodeleft2b_q10 : Q x1 Ocodeleft2b_y0 ;
+             Ocodeleft2b_w   : transport (fun x => Q x Ocodeleft2b_y0) Ocodeleft2b_s Ocodeleft2b_q00
+                               = Ocodeleft2b_q10 ;
+             Ocodeleft2b_u   : glue Ocodeleft2b_q00 @ (glue Ocodeleft2b_q10)^ = r }.
 
         Definition Ocodeleft2c
           := { q01 : Q x0 y1 &
             (* u: *) glue q01 @ (glue q11)^ = r }.
 
-        Definition Ocodeleft2a
-        := { s   : x0 = x1 &
-           { q01 : Q x0 y1 &
-           { w   : transport (fun x => Q x y1) s q01 = q11 &
-           (* u:*) glue q01 @ (glue q11)^ = r
-           } } }.
+        Record Ocodeleft2a
+        := { Ocodeleft2a_s   : x0 = x1 ;
+             Ocodeleft2a_q01 : Q x0 y1 ;
+             Ocodeleft2a_w   : transport (fun x => Q x y1) Ocodeleft2a_s Ocodeleft2a_q01 = q11 ;
+             Ocodeleft2a_u   : glue Ocodeleft2a_q01 @ (glue q11)^ = r }.
 
         Definition Ocodeleft2ab : Ocodeleft2a -> Ocodeleft2b.
         Proof.
-          intros [s [q01 [w u]]].
-          exact (s;y1;q01;q11;w;u).
+          intros [s q01 w u].
+          exact (Build_Ocodeleft2b s y1 q01 q11 w u).
         Defined.
 
         Definition Ocodeleft2ac : Ocodeleft2a -> Ocodeleft2c.
         Proof.
-          intros [s [q01 [w u]]].
+          intros [s q01 w u].
           exact (q01;u).
         Defined.
 
-        (** This proof is basically just rearranging Sigma-types and paths in Sigma-types and contracting based path spaces. *)
+        (** This proof is basically just rearranging Sigma-types/records and paths in Sigma-types and contracting based path spaces. *)
         Definition equiv_Ocodeleft2plus
           : Pushout Ocodeleft2ab Ocodeleft2ac <~> codeleft2plus.
         Proof.
@@ -201,8 +201,8 @@ Section GBM.
           - srefine (equiv_functor_sigma_id _ oE _).
             2:intro; apply equiv_path_sigma.
             make_equiv_contr_basedpaths.
-          - intros [s [q01 [w u]]]; reflexivity.
-          - intros [s [q01 [w u]]]; reflexivity.
+          - intros; reflexivity.
+          - intros; reflexivity.
         Defined.
 
         (** Now we combine this equivalence with the insertion of our connected type. *)
@@ -211,8 +211,8 @@ Section GBM.
         Proof.
           refine ((equiv_O_functor O (equiv_sigma_contr
                   (fun yqqu : codeleft2 =>
-                     O (Join ((x0; yqqu.2.1) = (x1; yqqu.2.2.1))
-                             ((yqqu.1 ; yqqu.2.2.1) = (y1; q11)))))) oE _).
+                     O (Join ((x0; codeleft2_q00 yqqu) = (x1; codeleft2_q10 yqqu))
+                             ((codeleft2_y0 yqqu ; codeleft2_q10 yqqu) = (y1; q11)))))) oE _).
           refine ((equiv_O_sigma_O O _)^-1 oE _).
           apply equiv_O_functor.
           apply equiv_Ocodeleft2plus.
@@ -232,8 +232,7 @@ Section GBM.
         Definition Ocodeleft02plus_02b (c : codeleft0)
           : (equiv_Ocodeleft2plus (Ocodeleft02 c)).1 = codeleft02 c.
         Proof.
-          destruct c as [s [y0 [v [q00 [q10 [w [u d]]]]]]].
-          reflexivity.
+          destruct c; reflexivity.
         Qed.
 
         (** And here we show that this equivalence is indeed a factor of the relevant map in the original pushout. *)
@@ -241,10 +240,10 @@ Section GBM.
         Definition Ocodeleft02_02b (c : codeleft0)
           : equiv_Ocodeleft2 (to O _ (Ocodeleft02 c)) = to O _ (codeleft02 c).
         Proof.
-          destruct c as [s [y0 [v [q00 [q10 [w [u d]]]]]]].
+          destruct c.
           unfold equiv_Ocodeleft2.
           Opaque equiv_Ocodeleft2plus.
-          cbn. (* This is really slow, but without it the subsequent [refine] fails. *)
+          cbn.
           refine (ap _ (ap _ (to_O_natural _ _ _)) @ _).
           refine (ap _ (to_O_natural _ _ _) @ _).
           refine (to_O_natural _ _ _ @ _).
@@ -264,18 +263,18 @@ Now we claim that the left-hand map of this span is also an equivalence.  Rather
 
         Definition Ocodeleft2a1 : Ocodeleft2a <~> codeleft1.
         Proof.
-          unfold Ocodeleft2a, codeleft1.
-          apply equiv_functor_sigma_id; intros s; cbn.
-          (** Here's frobnicate showing up again! *)
-          apply frobnicate.
+          etransitivity.
+          2:{ rapply equiv_functor_sigma_id; intros s.
+              (** Here's frobnicate showing up again! *)
+              apply frobnicate. }
+          make_equiv.
         Defined.
 
         (** And now we check that the two are equal.  Because we used the same proof of [frobnicate] in two places, this equality becomes definitional after simply decomposing up a Sigma-type! *)
         Definition Ocodeleft2a1_through_2b0
           : Ocodeleft2a1 == codeleft01 o Ocodeleft02b^-1 o Ocodeleft2ab.
         Proof.
-          intros [s [q01 [w u]]].
-          reflexivity.
+          intros; reflexivity.
         Defined.
 
         (** Now we're finally ready to prove the glue equivalence.  Since later on we'll have to compute its action on inputs from [codeleft1], we decompose it into seven steps, each of which with a corresponding computation lemma.  (These lemmas seem to be much easier to prove step-by-step than all at once if we proved the whole equivalence in a big shebang.) *)
@@ -364,7 +363,8 @@ Now we claim that the left-hand map of this span is also an equivalence.  Rather
 
         Definition codeglue6_pushl (s : x0 = x1) (v : ap left s = r)
           : codeglue6 (to O _ (pushl (s;v)))
-            = to O Ocodeleft2c (Ocodeleft2ac (s ; (frobnicate r s y1 q11)^-1 v))
+            = let z := (frobnicate r s y1 q11)^-1 v in
+              to O Ocodeleft2c (Ocodeleft2ac (Build_Ocodeleft2a s z.1 z.2.1 z.2.2))
           := to_O_equiv_natural _ _ _.
 
         Definition codeglue7

--- a/theories/Homotopy/BlakersMassey.v
+++ b/theories/Homotopy/BlakersMassey.v
@@ -81,6 +81,8 @@ Section GBM.
       exact (equiv_concat_l (concat_pp_V _ _)^ _).
       (** Although we proved this lemma with [rewrite], we make it transparent, not so that *we* can reason about it, but so that Coq can evaluate it. *)
     Defined.
+    (* But except in one place, we don't want it to try (otherwise things get really slow). *)
+    Opaque frobnicate.
 
     (** ** Codes *)
 
@@ -184,7 +186,7 @@ Section GBM.
           exact (q01;u).
         Defined.
 
-        (** This proof is long, but most of it is just rearranging Sigma-types and paths in Sigma-types. *)
+        (** This proof is basically just rearranging Sigma-types and paths in Sigma-types and contracting based path spaces. *)
         Definition equiv_Ocodeleft2plus
           : Pushout Ocodeleft2ab Ocodeleft2ac <~> codeleft2plus.
         Proof.
@@ -192,23 +194,13 @@ Section GBM.
           srefine (equiv_pushout _ _ _ _ _).
           - srefine (equiv_functor_sigma_id _ oE _).
             2:intro; refine (equiv_functor_prod' _ _); apply equiv_path_sigma.
-            transitivity {s : x0 = x1 & { yp : { y0 : Y & y0 = y1} & {q00 : Q x0 yp.1 & { q10p : { q10 : Q x1 yp.1 & transport (fun y => Q x1 y) yp.2 q10 = q11 } & { _ : transport (fun x => Q x yp.1) s q00 = q10p.1 & glue q00 @ (glue q10p.1)^ = r }}}}}.
-            2:make_equiv.
-            apply equiv_functor_sigma_id; intros s.
-            refine ((equiv_contr_sigma _)^-1 oE _); cbn.
-            refine (equiv_functor_sigma_id _); intros q01.
-            refine ((equiv_contr_sigma _)^-1 oE _).
-            cbn. reflexivity.
+            make_equiv_contr_basedpaths.
           - srefine (equiv_functor_sigma_id _ oE _).
             2:intro; apply equiv_path_sigma.
             make_equiv.
           - srefine (equiv_functor_sigma_id _ oE _).
             2:intro; apply equiv_path_sigma.
-            transitivity {yp : {y0 : Y & y0 = y1} & {qp : {q10 : Q x1 yp.1 & transport (Q x1) yp.2 q10 = q11} & {q00 : Q x0 yp.1 & glue q00 @ (glue qp.1)^ = r}}}.
-            2:make_equiv.
-            refine ((equiv_contr_sigma _)^-1 oE _); cbn.
-            refine ((equiv_contr_sigma _)^-1 oE _).
-            reflexivity.
+            make_equiv_contr_basedpaths.
           - intros [s [q01 [w u]]]; reflexivity.
           - intros [s [q01 [w u]]]; reflexivity.
         Defined.
@@ -252,7 +244,7 @@ Section GBM.
           destruct c as [s [y0 [v [q00 [q10 [w [u d]]]]]]].
           unfold equiv_Ocodeleft2.
           Opaque equiv_Ocodeleft2plus.
-          cbn.
+          cbn. (* This is really slow, but without it the subsequent [refine] fails. *)
           refine (ap _ (ap _ (to_O_natural _ _ _)) @ _).
           refine (ap _ (to_O_natural _ _ _) @ _).
           refine (to_O_natural _ _ _ @ _).
@@ -500,7 +492,9 @@ Now we claim that the left-hand map of this span is also an equivalence.  Rather
       apply ap; unfold hfiber; rewrite transport_sigma'.
       apply ap; rewrite transport_paths_r.
       (** Finally, we have another terrible-looking thing involving [frobnicate].  However, there are enough identity paths that [frobnicate] evaluates to... something that's almost fully path-general!  So with just a little bit of further work, we can reduce it also to something we can prove with path-induction. *)
-      cbn.
+      Transparent frobnicate.
+      cbn. (* This is slow, but without it we can't [rewrite]. *)
+      Opaque frobnicate.
       rewrite (transport_compose (fun q => glue q @ (glue q01)^ = 1%path) pr1).
       unfold path_sigma'; rewrite ap_V, ap_pr1_path_sigma, transport_1.
       destruct (glue q01); reflexivity.

--- a/theories/Idempotents.v
+++ b/theories/Idempotents.v
@@ -831,40 +831,25 @@ Definition contr_splitting_preidem_idmap {ua : Univalence} (X : Type)
 : Contr (Splitting_PreIdempotent (preidem_idmap X)).
 Proof.
   refine (contr_equiv' {Y : Type & X <~> Y} _).
-  unfold Splitting_PreIdempotent, Splitting; simpl.
-  refine (equiv_sigma_assoc _ _ oE _); simpl.
-  simple refine (equiv_functor_sigma' (issig_retractof X) _ oE _).
-  - intros [A [r [s H]]]; simpl in *.
-    exact {p : s o r == idmap &
-           forall x, ((ap idmap (p x)^ @ (p (s (r x)))^)
-                        @ ap s (H (r x))) @ p x = isidem idmap x }.
-  - intros [A [r [s H]]]; simpl. apply equiv_idmap.
-  - refine (equiv_sigma_assoc _ _ oE _); simpl.
-    apply equiv_functor_sigma_id; intros Y; simpl.
-    refine (equiv_sigma_assoc _ _ oE _); simpl.
-    refine (_ oE (issig_equiv X Y)^-1).
-    apply equiv_functor_sigma_id; intros r; simpl.
-    refine (equiv_sigma_assoc _ _ oE _).
-    refine (_ oE (issig_isequiv r)^-1).
-    apply equiv_functor_sigma_id; intros s; simpl.
-    unfold Sect.
-    apply equiv_functor_sigma_id; intros eta; simpl.
-    apply equiv_functor_sigma_id; intros ep; simpl.
-    apply equiv_functor_forall_id.
-    intros x; unfold isidem, ispreidem_idmap; simpl.
-    rewrite ap_idmap, !concat_pp_p.
-    refine (equiv_moveR_Vp _ _ _ oE _).
-    rewrite concat_p1, concat_p_pp.
-    refine (equiv_concat_r (concat_1p _) _ oE _).
-    refine (equiv_whiskerR _ _ _ oE _).
-    refine (equiv_moveR_Vp _ _ _ oE _).
-    rewrite concat_p1.
-    refine (equiv_concat_r (y := ap s (ap r (ep x))) _ _ oE _).
-    { refine (cancelR _ _ (ep x) _).
-      rewrite <- ap_compose.
-      refine (concat_A1p ep (ep x)). }
-    pose (isequiv_adjointify s r ep eta).
-    exact (equiv_ap (ap s) _ _).
+  transitivity { S : Splitting (preidem_idmap X) &
+                     forall x : X, (retract_issect S.1) (retract_retr S.1 x) = ap (retract_retr S.1) (S.2 x) }.
+  1:make_equiv.
+  apply equiv_functor_sigma_id; intros [[Y r s eta] ep]; cbn in *.
+  apply equiv_functor_forall_id; intros x.
+  unfold ispreidem_idmap; simpl.
+  rewrite ap_idmap, !concat_pp_p.
+  refine (equiv_moveR_Vp _ _ _ oE _).
+  rewrite concat_p1, concat_p_pp.
+  refine (equiv_concat_r (concat_1p _) _ oE _).
+  refine (equiv_whiskerR _ _ _ oE _).
+  refine (equiv_moveR_Vp _ _ _ oE _).
+  rewrite concat_p1.
+  pose (isequiv_adjointify s r ep eta).
+  refine (_ oE equiv_ap (ap s) _ _).
+  apply equiv_concat_r.
+  refine (cancelR _ _ (ep x) _).
+  rewrite <- ap_compose.
+  refine (concat_A1p ep (ep x)).
 Qed.
 
 (** Therefore, there is a unique coherentification of the canonical witness [preidem_idmap] of pre-idempotency for the identity.  Hence, to show that not every quasi-idempotent is coherent, it suffices to give a witness of quasi-idempotency extending [preidem_idmap] which is nontrivial (i.e. not equal to [qidem_idmap]).  Such a witness is exactly an element of the 2-center, and we know that some types such as [BAut (BAut Bool)] have nontrivial 2-centers.  In [Spaces.BAut.Bool.IncoherentIdempotent] we use this to construct an explicit counterexample. *)

--- a/theories/Limits/Pullback.v
+++ b/theories/Limits/Pullback.v
@@ -136,12 +136,8 @@ Notation "f ^*" := (pullback_along f) : function_scope.
 Definition hfiber_pullback_along {A B C} (f : B -> A) (g : C -> A) (b:B)
 : hfiber (f ^* g) b <~> hfiber g (f b).
 Proof.
-  unfold hfiber, Pullback.
-  refine (_ oE (equiv_sigma_assoc _ _)^-1).
-  simpl.
-  refine (_ oE equiv_functor_sigma_id _).
-  2:intros; apply equiv_sigma_symm0.
-  refine (_ oE equiv_sigma_assoc' _ _).
+  transitivity {ap : {a : B & a = b} & {c : C & f ap.1 = g c}}.
+  1:make_equiv.
   refine (_ oE equiv_contr_sigma _).
   exact (equiv_functor_sigma_id (fun c => equiv_path_inverse _ _)).
 Defined.
@@ -158,16 +154,10 @@ Notation "g ^*'" := (pullback_along' g) : function_scope.
 Definition hfiber_pullback_along' {A B C} (g : C -> A) (f : B -> A) (c:C)
 : hfiber (g ^*' f) c <~> hfiber f (g c).
 Proof.
-  unfold hfiber, Pullback.
-  refine (_ oE (equiv_sigma_assoc _ _)^-1).
+  transitivity {b:B & {ap : {a : C & a = c} & f b = g ap.1}}.
+  1:make_equiv.
   apply equiv_functor_sigma_id; intros b.
-  refine (_ oE (equiv_sigma_assoc _ _)^-1).
-  simpl.
-  refine (_ oE equiv_functor_sigma_id _).
-  2:intros; apply equiv_sigma_symm0.
-  refine (_ oE equiv_sigma_assoc' _ _).
-  refine (_ oE equiv_contr_sigma _).
-  apply equiv_idmap.
+  refine (_ oE equiv_contr_sigma _); reflexivity.
 Defined.
 
 Section Functor_Pullback.
@@ -248,21 +238,12 @@ Section PullbackSigma.
     : {p : Pullback f g & Pullback (transport A p.2.2 o r p.1) (s p.2.1)}
       <~> Pullback (functor_sigma f r) (functor_sigma g s).
   Proof.
-    refine (_ oE (equiv_sigma_assoc _ _)^-1).
-    refine (equiv_sigma_assoc _ _ oE _).
-    apply equiv_functor_sigma_id; intro y.
-    refine (_ oE (equiv_sigma_assoc _ _)^-1).
-    refine (equiv_functor_sigma_id _ oE _).
-    1: intro; apply equiv_sigma_assoc.
-    refine (equiv_sigma_symm _ oE _).
-    refine (equiv_functor_sigma_id _); intro z.
-    refine (_ oE _).
-    { refine (equiv_functor_sigma_id _); intro b.
-      refine (equiv_functor_sigma_id _); intro c.
-      apply equiv_path_sigma. }
-    refine (equiv_functor_sigma_id _ oE _).
-    1: intro b; cbn; apply equiv_sigma_symm.
-    cbn; apply equiv_sigma_symm.
+    unfold Pullback, functor_sigma.
+    transitivity {b:{y:Y & B y} & {c:{z:Z & C z} & { p : f b.1 = g c.1 & p # (r b.1 b.2) = s c.1 c.2 }}}.
+    1:make_equiv.
+    apply equiv_functor_sigma_id; intros.
+    apply equiv_functor_sigma_id; intros.
+    refine (equiv_path_sigma _ _ _ oE _); reflexivity.
   Defined.
 
 End PullbackSigma.

--- a/theories/Limits/Pullback.v
+++ b/theories/Limits/Pullback.v
@@ -136,10 +136,8 @@ Notation "f ^*" := (pullback_along f) : function_scope.
 Definition hfiber_pullback_along {A B C} (f : B -> A) (g : C -> A) (b:B)
 : hfiber (f ^* g) b <~> hfiber g (f b).
 Proof.
-  transitivity {ap : {a : B & a = b} & {c : C & f ap.1 = g c}}.
-  1:make_equiv.
-  refine (_ oE equiv_contr_sigma _).
-  exact (equiv_functor_sigma_id (fun c => equiv_path_inverse _ _)).
+  refine (equiv_functor_sigma_id (fun c => equiv_path_inverse _ _) oE _).
+  make_equiv_contr_basedpaths.
 Defined.
 
 (** And the dual sort of pullback *)
@@ -154,10 +152,7 @@ Notation "g ^*'" := (pullback_along' g) : function_scope.
 Definition hfiber_pullback_along' {A B C} (g : C -> A) (f : B -> A) (c:C)
 : hfiber (g ^*' f) c <~> hfiber f (g c).
 Proof.
-  transitivity {b:B & {ap : {a : C & a = c} & f b = g ap.1}}.
-  1:make_equiv.
-  apply equiv_functor_sigma_id; intros b.
-  refine (_ oE equiv_contr_sigma _); reflexivity.
+  make_equiv_contr_basedpaths.
 Defined.
 
 Section Functor_Pullback.
@@ -238,12 +233,9 @@ Section PullbackSigma.
     : {p : Pullback f g & Pullback (transport A p.2.2 o r p.1) (s p.2.1)}
       <~> Pullback (functor_sigma f r) (functor_sigma g s).
   Proof.
-    unfold Pullback, functor_sigma.
-    transitivity {b:{y:Y & B y} & {c:{z:Z & C z} & { p : f b.1 = g c.1 & p # (r b.1 b.2) = s c.1 c.2 }}}.
-    1:make_equiv.
-    apply equiv_functor_sigma_id; intros.
-    apply equiv_functor_sigma_id; intros.
-    refine (equiv_path_sigma _ _ _ oE _); reflexivity.
+    refine (equiv_functor_sigma_id (fun _ => equiv_functor_sigma_id _) oE _).
+    - intros; rapply equiv_path_sigma.
+    - make_equiv.
   Defined.
 
 End PullbackSigma.

--- a/theories/Modalities/Lex.v
+++ b/theories/Modalities/Lex.v
@@ -243,12 +243,13 @@ Section ImpliesLex.
     refine (isconnected_equiv' O _ _ (cc (x;1))).
     unfold hfiber.
     subst h; unfold functor_hfiber, functor_sigma; cbn.
+    refine (_ oE (equiv_sigma_assoc _ _)^-1).
+    apply equiv_functor_sigma_id; intros y; cbn.
     refine (_ oE (equiv_functor_sigma_id _)).
     2:intros; symmetry; apply equiv_path_sigma.
     cbn.
-    transitivity {yp : {y:Y & f y = x} & {q : g (f yp.1) = g x & transport (fun x' => g x' = g x) yp.2 (1 @ ap idmap q) = idpath } }.
-    1:make_equiv.
-    apply equiv_sigma_contr; intros [y p].
+    refine (_ oE equiv_sigma_symm _).
+    apply equiv_sigma_contr; intros p.
     destruct p; cbn.
     refine (contr_equiv' { p : g (f y) = g (f y) & p = 1%path } _).
     apply equiv_functor_sigma_id; intros p; cbn.

--- a/theories/Modalities/Lex.v
+++ b/theories/Modalities/Lex.v
@@ -243,13 +243,12 @@ Section ImpliesLex.
     refine (isconnected_equiv' O _ _ (cc (x;1))).
     unfold hfiber.
     subst h; unfold functor_hfiber, functor_sigma; cbn.
-    refine (_ oE (equiv_sigma_assoc _ _)^-1).
-    apply equiv_functor_sigma_id; intros y; cbn.
     refine (_ oE (equiv_functor_sigma_id _)).
     2:intros; symmetry; apply equiv_path_sigma.
     cbn.
-    refine (_ oE equiv_sigma_symm _).
-    apply equiv_sigma_contr; intros p.
+    transitivity {yp : {y:Y & f y = x} & {q : g (f yp.1) = g x & transport (fun x' => g x' = g x) yp.2 (1 @ ap idmap q) = idpath } }.
+    1:make_equiv.
+    apply equiv_sigma_contr; intros [y p].
     destruct p; cbn.
     refine (contr_equiv' { p : g (f y) = g (f y) & p = 1%path } _).
     apply equiv_functor_sigma_id; intros p; cbn.

--- a/theories/Modalities/Modality.v
+++ b/theories/Modalities/Modality.v
@@ -293,22 +293,17 @@ Proof.
   { refine (inO_pullback O' _ _).
     exact (inO_equiv_inO' _ (equiv_sigprod_pullback B B)^-1). }
   unfold Pullback.
-  (** The rest is just contracting a couple of based path spaces.  It seems like it should be less work than this. *)
+  (** The rest is just extracting paths from sigma- and product types and contracting a couple of based path spaces. *)
   apply equiv_functor_sigma_id; intros z; cbn. 
   refine (_ oE equiv_functor_sigma_id _).
   2:intros; symmetry; apply equiv_path_sigma.
-  refine (_ oE (equiv_sigma_assoc _ _)^-1%equiv); cbn.
-  refine (_ oE equiv_functor_sigma_id _).
-  2:intros; apply equiv_sigma_symm.
-  refine (_ oE (equiv_sigma_assoc' _ _)). 
+  refine (_ oE equiv_functor_sigma_id (fun z => equiv_functor_sigma_id (fun p => _))).
+  2:symmetry; apply equiv_path_prod.
+  transitivity {xp : { x : O_reflector O' A & z = x } & { bq : { b : B xp.1 & snd (transport (fun a => B a * B a) xp.2 (h z, k z)) = b } & fst (transport (fun a => B a * B a) xp.2 (h z, k z)) = bq.1 }}.
+  1:make_equiv.
   refine (_ oE equiv_contr_sigma _); cbn.
-  refine (_ oE equiv_functor_sigma_id _).
-  2:{ intros; symmetry; etransitivity; revgoals.
-      - apply equiv_path_prod.
-      - apply equiv_sigma_prod0. }
-  refine (_ oE equiv_sigma_assoc' _ _).
   refine (_ oE equiv_contr_sigma _); cbn.
-  apply equiv_path_inverse.
+  reflexivity.
 Defined.
 
 (** Thus, if this holds for all sigma-types, we get the dependent universal property.  Making this an [Instance] causes typeclass search to spin.  Note the slightly different hypotheses, which mean that we can't just use the previous result: here we need only assume that the [O']-reflection of [A] exists rather than that [O'] is fully reflective, at the cost of assuming that [O] is fully reflective (although actually, closed under path-spaces would suffice). *)

--- a/theories/Modalities/Modality.v
+++ b/theories/Modalities/Modality.v
@@ -299,11 +299,7 @@ Proof.
   2:intros; symmetry; apply equiv_path_sigma.
   refine (_ oE equiv_functor_sigma_id (fun z => equiv_functor_sigma_id (fun p => _))).
   2:symmetry; apply equiv_path_prod.
-  transitivity {xp : { x : O_reflector O' A & z = x } & { bq : { b : B xp.1 & snd (transport (fun a => B a * B a) xp.2 (h z, k z)) = b } & fst (transport (fun a => B a * B a) xp.2 (h z, k z)) = bq.1 }}.
-  1:make_equiv.
-  refine (_ oE equiv_contr_sigma _); cbn.
-  refine (_ oE equiv_contr_sigma _); cbn.
-  reflexivity.
+  cbn. make_equiv_contr_basedpaths.
 Defined.
 
 (** Thus, if this holds for all sigma-types, we get the dependent universal property.  Making this an [Instance] causes typeclass search to spin.  Note the slightly different hypotheses, which mean that we can't just use the previous result: here we need only assume that the [O']-reflection of [A] exists rather than that [O'] is fully reflective, at the cost of assuming that [O] is fully reflective (although actually, closed under path-spaces would suffice). *)
@@ -528,7 +524,7 @@ Section ModalFact.
       transitivity (to O _ (existT (fun (w : hfiber h b) => (hfiber g w.1))
                          (g a; p) (a ; 1))).
       + cbn; repeat rewrite O_rec_beta; reflexivity.
-      + symmetry; apply to_O_natural.
+      + destruct p; symmetry; apply to_O_natural.
   Qed.
 
   Section TwoFactorizations.

--- a/theories/Pointed/pEquiv.v
+++ b/theories/Pointed/pEquiv.v
@@ -68,14 +68,7 @@ Definition path_pequiv `{Funext} {A B : pType} (f g : A <~>* B)
 Definition issig_pequiv' (A B : pType)
   : { f : A <~> B & f (point A) = point B } <~> (A <~>* B).
 Proof.
-  transitivity { f : A ->* B & IsEquiv f }.
-  2: issig.
-  refine (equiv_functor_sigma_pb (issig_pmap A B) oE _).
-  refine (_ oE (equiv_functor_sigma_pb (issig_equiv A B))^-1).
-  refine (_ oE (equiv_sigma_assoc _ _)^-1).
-  refine (equiv_sigma_assoc _ _ oE _).
-  apply equiv_functor_sigma_id.
-  intro; cbn; apply equiv_sigma_symm0.
+  make_equiv.
 Defined.
 
 (* Sometimes we wish to construct a pEquiv from an equiv and a proof that it is pointed *)

--- a/theories/Pointed/pFiber.v
+++ b/theories/Pointed/pFiber.v
@@ -24,9 +24,8 @@ Definition pfiber2_loops {A B : pType} (f : A ->* B)
 : pfiber (pfib f) <~>* loops B.
 Proof.
   apply issig_pequiv'; simple refine (_;_).
-  - transitivity {ap : {a : A & a = point A} & f ap.1 = point B}.
-    1:make_equiv.
-    refine (_ oE equiv_contr_sigma _); simpl.
+  - transitivity (f (point A) = point B).
+    1:make_equiv_contr_basedpaths.
     apply equiv_concat_l.
     symmetry; apply point_eq.
   - simpl.
@@ -40,20 +39,16 @@ Definition pfiber2_loops_functor {A B : pType} (f : A ->* B)
 Proof.
   pointed_reduce.
   simple refine (Build_pHomotopy _ _).
-  - intros [[xp q] r]. simpl in *.
-    rewrite !transport_paths_Fl.
-    rewrite inv_pp, !ap_V, !inv_V, ap_compose, !ap_pp, inv_pp.
-    simpl; rewrite !concat_1p, !concat_p1.
-    rewrite ap_pr1_path_basedpaths'.
-    rewrite ap_V, inv_V; apply whiskerR.
-    match goal with
-        |- ?a = ap f (ap ?g ?z) =>
-        change (a = ap f (ap (pr1 o pr1) z))
-    end.
-    rewrite (ap_compose pr1 pr1).
-    rewrite ap_pr1_path_basedpaths'.
-    (** In order to destruct [r], we have to invert it to match Paulin-Mohring path induction.  I don't know why the [set] fails to catch the [r^] in the conclusion. *)
-    set (s := r^); change ((xp.2)^ = ap f (ap pr1 s)).
-    clearbody s; clear r; destruct s; reflexivity.
+  - intros [[[x p] q] r]. simpl in *.
+    (** Apparently [destruct q] isn't smart enough to generalize over [p]. *)
+    move q before x; generalize dependent x;
+      refine (paths_ind_r _ _ _); intros p r; cbn.
+    rewrite !concat_1p, concat_p1.
+    rewrite paths_rect_transport.
+    rewrite transport_paths_Fl, concat_p1.
+    rewrite ap_V; apply inverse2.
+    refine (((r^)..2)^ @ _).
+    rewrite transport_paths_Fl; cbn.
+    rewrite concat_p1, pr1_path_V, ap_V, inv_V; reflexivity.
   - reflexivity.
 Qed.

--- a/theories/Pointed/pFiber.v
+++ b/theories/Pointed/pFiber.v
@@ -24,13 +24,8 @@ Definition pfiber2_loops {A B : pType} (f : A ->* B)
 : pfiber (pfib f) <~>* loops B.
 Proof.
   apply issig_pequiv'; simple refine (_;_).
-  - simpl; unfold hfiber.
-    refine (_ oE (equiv_sigma_assoc _ _)^-1); simpl.
-    refine (_ oE (equiv_functor_sigma'
-                   (P := fun a => {_ : f a = point B & a = point A})
-                   (Q := fun a => {_ : a = point A & f a = point B })
-                   1 (fun a => equiv_sigma_symm0 _ _))).
-    refine (_ oE equiv_sigma_assoc' _ _).
+  - transitivity {ap : {a : A & a = point A} & f ap.1 = point B}.
+    1:make_equiv.
     refine (_ oE equiv_contr_sigma _); simpl.
     apply equiv_concat_l.
     symmetry; apply point_eq.

--- a/theories/Pointed/pFiber.v
+++ b/theories/Pointed/pFiber.v
@@ -41,12 +41,12 @@ Proof.
   simple refine (Build_pHomotopy _ _).
   - intros [[[x p] q] r]. simpl in *.
     (** Apparently [destruct q] isn't smart enough to generalize over [p]. *)
-    move q before x; generalize dependent x;
+    move q before x; revert dependent x;
       refine (paths_ind_r _ _ _); intros p r; cbn.
     rewrite !concat_1p, concat_p1.
-    rewrite paths_rect_transport.
-    rewrite transport_paths_Fl, concat_p1.
-    rewrite ap_V; apply inverse2.
+    rewrite paths_ind_r_transport.
+    rewrite transport_arrow_toconst, transport_paths_Fl. 
+    rewrite concat_p1, inv_V, ap_V. apply inverse2.
     refine (((r^)..2)^ @ _).
     rewrite transport_paths_Fl; cbn.
     rewrite concat_p1, pr1_path_V, ap_V, inv_V; reflexivity.

--- a/theories/Pointed/pSusp.v
+++ b/theories/Pointed/pSusp.v
@@ -102,21 +102,14 @@ Module Book_Loop_Susp_Adjunction.
     refine (_ oE (equiv_functor_sigma_pb
                  (Q := fun NSm => fst NSm.1 = point B)
                  (equiv_Susp_rec A B))).
-    refine (_ oE (equiv_sigma_assoc _ _)^-1); simpl.
-    refine (_ oE equiv_functor_sigma_id _).
-    2:intros; apply equiv_sigma_symm0.
-    refine (_ oE (equiv_sigma_prod _)^-1); simpl.
-    refine (_ oE equiv_functor_sigma_id _).
-    2:intros; apply equiv_sigma_symm.
-    refine (_ oE equiv_sigma_assoc' _ _).
+    transitivity {bp : {b:B & b = point B} & {b:B & A -> bp.1 = b} }.
+    1:make_equiv.
     refine (_ oE equiv_contr_sigma _); simpl.
     refine (_ oE (equiv_sigma_contr
                    (A := {p : B & A -> point B = p})
                    (fun pm => { q : point B = pm.1 & pm.2 (point A) = q }))^-1).
-    refine (_ oE (equiv_sigma_assoc _ _)^-1); simpl.
-    refine (_ oE equiv_functor_sigma_id _).
-    2:intros; apply equiv_sigma_symm.
-    refine (_ oE equiv_sigma_assoc' _ _).
+    transitivity {bp : {b:B & point B = b} & {f : A -> point B = bp.1 & f (point A) = bp.2} }.
+    1:make_equiv.
     refine (_ oE equiv_contr_sigma _); simpl.
     refine (issig_pmap A (loops B)).
   Defined.
@@ -130,7 +123,7 @@ Module Book_Loop_Susp_Adjunction.
     ==* loops_functor g o* loop_susp_adjoint A B f.
   Proof.
     pointed_reduce.
-    refine (Build_pHomotopy _ _).
+    srefine (Build_pHomotopy _ _).
     - intros a. simpl.
       refine (_ @ (concat_1p _)^).
       refine (_ @ (concat_p1 _)^).

--- a/theories/Types/Prod.v
+++ b/theories/Types/Prod.v
@@ -270,30 +270,18 @@ Definition iff_functor_prod {A A' B B' : Type} (f : A <-> A') (g : B <-> B')
 
 (** This is a special property of [prod], of course, not an instance of a general family of facts about types. *)
 
-Definition equiv_prod_symm (A B : Type) : A * B <~> B * A
-  := Build_Equiv
-       _ _ _
-       (Build_IsEquiv
-          (A*B) (B*A)
-          (fun ab => (snd ab, fst ab))
-          (fun ba => (snd ba, fst ba))
-          (fun _ => 1)
-          (fun _ => 1)
-          (fun _ => 1)).
+Definition equiv_prod_symm (A B : Type) : A * B <~> B * A.
+Proof.
+  make_equiv.
+Defined.
 
 (** ** Associativity *)
 
 (** This, too, is a special property of [prod], of course, not an instance of a general family of facts about types. *)
-Definition equiv_prod_assoc (A B C : Type) : A * (B * C) <~> (A * B) * C
-  := Build_Equiv
-       _ _ _
-       (Build_IsEquiv
-          (A * (B * C)) ((A * B) * C)
-          (fun abc => ((fst abc, fst (snd abc)), snd (snd abc)))
-          (fun abc => (fst (fst abc), (snd (fst abc), snd abc)))
-          (fun _ => 1)
-          (fun _ => 1)
-          (fun _ => 1)).
+Definition equiv_prod_assoc (A B C : Type) : A * (B * C) <~> (A * B) * C.
+Proof.
+  make_equiv.
+Defined.
 
 (** ** Unit and annihilation *)
 

--- a/theories/Types/Sigma.v
+++ b/theories/Types/Sigma.v
@@ -493,66 +493,44 @@ Defined.
 
 (** ** Associativity *)
 
+(** All of the following lemmas are proven easily with the [make_equiv] tactic.  If you have a more complicated rearrangement of sigma-types to do, it is usually possible to do it by putting together these equivalences, but it is often simpler and faster to just use [make_equiv] directly. *)
+
 Definition equiv_sigma_assoc `(P : A -> Type) (Q : {a : A & P a} -> Type)
-: {a : A & {p : P a & Q (a;p)}} <~> sigT Q
-  := @Build_Equiv
-       _ _ _
-       (@Build_IsEquiv
-          {a : A & {p : P a & Q (a;p)}} (sigT Q)
-          (fun apq => ((apq.1; apq.2.1); apq.2.2))
-          (fun apq => (apq.1.1; (apq.1.2; apq.2)))
-          (fun _ => 1)
-          (fun _ => 1)
-          (fun _ => 1)).
+  : {a : A & {p : P a & Q (a;p)}} <~> sigT Q.
+Proof.
+  make_equiv.
+Defined.
 
 Definition equiv_sigma_assoc' `(P : A -> Type) (Q : forall a : A, P a -> Type)
-: {a : A & {p : P a & Q a p}} <~> {ap : sigT P & Q ap.1 ap.2}
-  := @Build_Equiv
-       _ _ _
-       (@Build_IsEquiv
-          {a : A & {p : P a & Q a p}} {ap : sigT P & Q ap.1 ap.2}
-          (fun apq => ((apq.1; apq.2.1); apq.2.2))
-          (fun apq => (apq.1.1; (apq.1.2; apq.2)))
-          (fun _ => 1)
-          (fun _ => 1)
-          (fun _ => 1)).
+  : {a : A & {p : P a & Q a p}} <~> {ap : sigT P & Q ap.1 ap.2}.
+Proof.
+  make_equiv.
+Defined.
 
 Definition equiv_sigma_prod `(Q : (A * B) -> Type)
-: {a : A & {b : B & Q (a,b)}} <~> sigT Q
-  := @Build_Equiv
-       _ _ _
-       (@Build_IsEquiv
-          {a : A & {b : B & Q (a,b)}} (sigT Q)
-          (fun apq => ((apq.1, apq.2.1); apq.2.2))
-          (fun apq => (fst apq.1; (snd apq.1; apq.2)))
-          (fun _ => 1)
-          (fun _ => 1)
-          (fun _ => 1)).
+  : {a : A & {b : B & Q (a,b)}} <~> sigT Q.
+Proof.
+  make_equiv.
+Defined.
 
-Definition equiv_sigma_prod0 A B
-: {a : A & B} <~> A * B
-  := Build_Equiv _ _ _
-       (Build_IsEquiv
-          {a : A & B} (A * B)
-          (fun (ab : {a:A & B}) => (ab.1 , ab.2))
-          (fun (ab : A*B) => (fst ab ; snd ab))
-          (fun _ => 1) (fun _ => 1) (fun _ => 1)).
+Definition equiv_sigma_prod0 (A B : Type)
+  : {a : A & B} <~> A * B.
+Proof.
+  make_equiv.
+Defined.
 
 (** ** Symmetry *)
 
 Definition equiv_sigma_symm `(P : A -> B -> Type)
-: {a : A & {b : B & P a b}} <~> {b : B & {a : A & P a b}}
-  := ((equiv_sigma_prod (fun x => P (snd x) (fst x)))^-1)
-       oE (equiv_functor_sigma' (equiv_prod_symm A B)
-                                (fun x => equiv_idmap (P (fst x) (snd x))))
-       oE (equiv_sigma_prod (fun x => P (fst x) (snd x))).
+  : {a : A & {b : B & P a b}} <~> {b : B & {a : A & P a b}}.
+Proof.
+  make_equiv.
+Defined.
 
 Definition equiv_sigma_symm0 (A B : Type)
 : {a : A & B} <~> {b : B & A}.
 Proof.
-  refine (Build_Equiv _ _ (fun (w:{a:A & B}) => (w.2 ; w.1)) _).
-  simple refine (Build_IsEquiv _ _ _ (fun (z:{b:B & A}) => (z.2 ; z.1))
-                       _ _ _); intros [x y]; reflexivity.
+  make_equiv.
 Defined.
 
 (** ** Universal mapping properties *)


### PR DESCRIPTION
I'm making this a draft PR for now because I think we need to discuss how widely this tactic should be used.  For now, I tried using it almost everywhere I could find where it might conceivably be helpful, so we can see what it _could_ be used for.  I think some of those are clear wins, like `issig_pequiv'` and the lemmas in `Types/Prod` and `Types/Sigma`, but others are less clear.

Generally it seems that this tactic has to be prefixed with a `transitivity` stating exactly what you want the new sigma-type to look like, which is sometimes quite verbose.  Also, often what we want isn't exactly just a rearrangement of sigma-types, but also includes applying some other equivalence in the middle or at the top, often something like `equiv_path_sigma`, so this tactic is less helpful there than it might be otherwise.  So, everyone please opine on where you think this tactic should and shouldn't be used.

One place I could have used this tactic but didn't is `PropResizing/Nat`; my first attempt created universe problems (like pretty much any attempt to modify that darned file now) and I gave up.

Timing-wise, the diff seems mostly noise, except that `BlakersMassey` got over 50% slower.  So at least some of the uses of `make_equiv` in that file are almost certainly out, unless we can speed it up somehow; I haven't tried yet to figure out whether some of the uses there are okay.