### PR TITLE
Add some tactics from the stdlib to Overture

### DIFF
--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -719,16 +719,16 @@ Global Arguments hfiber {A B}%type_scope f%function_scope y.
 
 (** *** More tactics *)
 
-(** Clear a hypothesis and also its dependencies.  Taken from Coq stdlib. *)
-
+(** Clear a hypothesis and also its dependencies.  Taken from Coq stdlib, with the performance-enhancing change to [lazymatch] suggested at [https://github.com/coq/coq/issues/11689]. *)
 Tactic Notation "clear" "dependent" hyp(h) :=
   let rec depclear h :=
   clear h ||
-  match goal with
+  lazymatch goal with
    | H : context [ h ] |- _ => depclear H; depclear h
   end ||
   fail "hypothesis to clear is used in the conclusion (maybe indirectly)"
  in depclear h.
+
 
 (** A version of [generalize dependent] that applies only to a hypothesis.  Taken from Coq stdlib. *)
 Tactic Notation "revert" "dependent" hyp(h) :=

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -719,6 +719,21 @@ Global Arguments hfiber {A B}%type_scope f%function_scope y.
 
 (** *** More tactics *)
 
+(** Clear a hypothesis and also its dependencies.  Taken from Coq stdlib. *)
+
+Tactic Notation "clear" "dependent" hyp(h) :=
+  let rec depclear h :=
+  clear h ||
+  match goal with
+   | H : context [ h ] |- _ => depclear H; depclear h
+  end ||
+  fail "hypothesis to clear is used in the conclusion (maybe indirectly)"
+ in depclear h.
+
+(** A version of [generalize dependent] that applies only to a hypothesis.  Taken from Coq stdlib. *)
+Tactic Notation "revert" "dependent" hyp(h) :=
+  generalize dependent h.
+
 (** Applying a tactic to a term with increasingly many arguments *)
 Tactic Notation "do_with_holes" tactic3(x) uconstr(p) :=
   x uconstr:(p) ||
@@ -794,6 +809,7 @@ Tactic Notation "nrefine" uconstr(term) := notypeclasses refine term.
 (** A shorter name for [simple notypeclasses refine]. *)
 Tactic Notation "snrefine" uconstr(term) := simple notypeclasses refine term.
 
+(** Note that the Coq standard library has a [rapply], but it is like our [rapply'] with many-holes first.  We prefer fewer-holes first, for instance so that a theorem producing an equivalence will by preference be used to produce an equivalence rather than to apply the coercion of that equivalence to a function. *)
 Tactic Notation "rapply" uconstr(term)
   := do_with_holes ltac:(fun x => refine x) term.
 Tactic Notation "rapply'" uconstr(term)
@@ -860,21 +876,21 @@ Tactic Notation "funext" simple_intropattern(a) simple_intropattern(b) simple_in
 Tactic Notation "funext" simple_intropattern(a) simple_intropattern(b) simple_intropattern(c) simple_intropattern(d) simple_intropattern(e) simple_intropattern(f)
   := funext a; funext b; funext c; funext d; funext e; funext f.
 
+(* Test whether a tactic fails or succeeds, without actually doing anything.  Taken from Coq stdlib. *)
+Ltac assert_fails tac :=
+  tryif (once tac) then gfail 0 tac "succeeds" else idtac.
+Ltac assert_succeeds tac :=
+  tryif (assert_fails tac) then gfail 0 tac "fails" else idtac.
+Tactic Notation "assert_succeeds" tactic3(tac) :=
+  assert_succeeds tac.
+Tactic Notation "assert_fails" tactic3(tac) :=
+  assert_fails tac.
 
-
-(** [not tac] is equivalent to [fail tac "succeeds"] if [tac] succeeds, and is equivalent to [idtac] if [tac] fails *)
-Tactic Notation "not" tactic3(tac) :=
-  (tryif tac then fail 0 tac "succeeds" else idtac); (* error if the tactic solved all goals *) [].
-
-(** Test if a tactic succeeds, but always roll-back the results *)
-Tactic Notation "test" tactic3(tac) := tryif not tac then fail 0 tac "fails" else idtac.
-
-(** Removed auto. We can write "by (path_induction;auto with path_hints)"
- if we want to.*)
+(** This tactic doesn't end with [auto], but you can always write "by (path_induction;auto with path_hints)" if you want.*)
 Ltac path_induction :=
   intros; repeat progress (
     match goal with
-      | [ p : ?x = ?y  |- _ ] => not constr_eq x y; induction p
+      | [ p : ?x = ?y  |- _ ] => assert_fails constr_eq x y; induction p
     end
   ).
 
@@ -911,7 +927,7 @@ Ltac atomic x :=
     | match _ with _ => _ end => fail 1 x "is not atomic (match)"
     | _ => is_fix x; fail 1 x "is not atomic (fix)"
     | _ => is_cofix x; fail 1 x "is not atomic (cofix)"
-    | context[?E] => (* catch-all *) (not constr_eq E x); fail 1 x "is not atomic (has subterm" E ")"
+    | context[?E] => (* catch-all *) (assert_fails constr_eq E x); fail 1 x "is not atomic (has subterm" E ")"
     | _ => idtac
   end.
 

--- a/theories/EquivalenceVarieties.v
+++ b/theories/EquivalenceVarieties.v
@@ -3,7 +3,6 @@
 
 Require Import HoTT.Basics HoTT.Types.
 Require Import HProp.
-Require Import HoTT.Tactics.
 
 Local Open Scope nat_scope.
 Local Open Scope path_scope.

--- a/theories/Extensions.v
+++ b/theories/Extensions.v
@@ -4,7 +4,6 @@
 
 Require Import HoTT.Basics HoTT.Types.
 Require Import HProp EquivalenceVarieties PathAny.
-Require Import HoTT.Tactics.
 Require Import Cubical.DPath Cubical.PathSquare Cubical.DPathSquare.
 Require Import HIT.Coeq Colimits.MappingCylinder.
 

--- a/theories/Factorization.v
+++ b/theories/Factorization.v
@@ -4,7 +4,6 @@
 
 Require Import HoTT.Basics HoTT.Types.
 Require Import HProp Extensions PathAny.
-Require Import HoTT.Tactics.
 Local Open Scope path_scope.
 
 

--- a/theories/Modalities/Accessible.v
+++ b/theories/Modalities/Accessible.v
@@ -2,7 +2,7 @@
 
 (** * Accessible subuniverses and modalities *)
 
-Require Import HoTT.Basics HoTT.Types HoTT.Tactics.
+Require Import HoTT.Basics HoTT.Types.
 Require Import Extensions NullHomotopy EquivalenceVarieties.
 Require Import ReflectiveSubuniverse Modality.
 

--- a/theories/Modalities/Fracture.v
+++ b/theories/Modalities/Fracture.v
@@ -2,7 +2,6 @@
 Require Import HoTT.Basics HoTT.Types.
 Require Import Fibrations Extensions Pullback NullHomotopy.
 Require Import Modality Lex Open Closed Nullification.
-Require Import HoTT.Tactics.
 
 Local Open Scope path_scope.
 

--- a/theories/Modalities/Lex.v
+++ b/theories/Modalities/Lex.v
@@ -2,7 +2,6 @@
 Require Import HoTT.Basics HoTT.Types.
 Require Import EquivalenceVarieties Fibrations Extensions Pullback NullHomotopy Factorization PathAny.
 Require Import Modality Accessible Localization Descent Separated.
-Require Import HoTT.Tactics.
 
 Local Open Scope path_scope.
 Local Open Scope subuniverse_scope.

--- a/theories/Modalities/Modality.v
+++ b/theories/Modalities/Modality.v
@@ -2,7 +2,6 @@
 Require Import HoTT.Basics HoTT.Types.
 Require Import Fibrations EquivalenceVarieties Extensions Factorization NullHomotopy HProp Pullback.
 Require Export ReflectiveSubuniverse. (* [Export] because many of the lemmas and facts about reflective subuniverses are equally important for modalities. *)
-Require Import HoTT.Tactics.
 
 Local Open Scope path_scope.
 

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -1,9 +1,8 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 Require Import HoTT.Basics HoTT.Types.
 Require Import EquivalenceVarieties Extensions HProp Fibrations NullHomotopy Pullback.
-Require Import HoTT.Tactics PathAny.
+Require Import PathAny.
 Require Import HIT.Coeq Colimits.Pushout.
-Require Import Tactics.RewriteModuloAssociativity.
 
 Local Open Scope nat_scope.
 Local Open Scope path_scope.
@@ -832,10 +831,10 @@ Section Reflective_Subuniverse.
         exact (functor_sigma idmap (fun x => to O (P x))).
       - unfold Sect, O_functor; rapply O_indpaths.
         intros [a p]; simpl.
-        abstract (repeat (simpl rewrite @O_rec_beta); reflexivity).
+        abstract (repeat (rewrite O_rec_beta); reflexivity).
       - unfold Sect, O_functor; rapply O_indpaths.
         intros [a op]; revert op; rapply O_indpaths; intros p; simpl.
-        abstract (repeat (simpl rewrite @O_rec_beta); reflexivity).
+        abstract (repeat (rewrite O_rec_beta); reflexivity).
     Defined.
 
     (** ** Equivalences *)

--- a/theories/Spectra/Spectrum.v
+++ b/theories/Spectra/Spectrum.v
@@ -3,7 +3,6 @@
 (** * Spectra *)
 
 Require Import HoTT.Basics HoTT.Types.
-Require Import HoTT.Tactics.
 Require Import Pointed.
 Require Import HoTT.Truncations.
 

--- a/theories/Tactics/BinderApply.v
+++ b/theories/Tactics/BinderApply.v
@@ -5,8 +5,8 @@ Require Import Basics.Overture Tactics.EvalIn.
 (** There are some cases where [apply lem] will fail, but [intros; apply lem] will succeed.  The tactic [binder apply] is like [intros; apply lem], but it cleans up after itself by [revert]ing the things it introduced.  The tactic [binder apply lem in H] is to [binder apply lem], as [apply lem in H] is to [apply lem].  Note, however, that the implementation of [binder apply lem in H] is completely different and significantly more complicated. *)
 
 Ltac can_binder_apply apply_tac fail1_tac :=
-  first [ test apply_tac
-        | test (intro; can_binder_apply apply_tac fail1_tac)
+  first [ assert_succeeds apply_tac
+        | assert_succeeds (intro; can_binder_apply apply_tac fail1_tac)
         | fail1_tac ].
 Ltac binder_apply apply_tac fail1_tac :=
   can_binder_apply apply_tac fail1_tac;


### PR DESCRIPTION
While I was at it, I removed a bunch of unnecessary imports of `HoTT.Tactics`.  Currently the tactics therein are only used in `Categories`, three places in `Classes`, and one place in `Diagrams/Diagram.v`.