### PR TITLE
Make contr_equiv and trunc_equiv transparent; close #1091

### DIFF
--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -1125,7 +1125,7 @@ Proof.
     refine ((equiv_concat_l (transport_paths_lr q p)^ p)^-1 oE _).
     refine ((equiv_concat_l (concat_p_pp _ _ _) _)^-1 oE _).
     apply equiv_moveR_Vp. }
-  assert (HK := trunc_equiv _ e^-1).
+  assert (HK := @trunc_equiv _ _ e^-1 (-1)).
   assert (u : forall (X:Type) (p:X=X), p @ 1 = 1 @ p).
   { intros X p; rewrite concat_p1, concat_1p; reflexivity. }
   pose (alpha := (fun X p => (idpath X ; u X p)) : K).

--- a/theories/Algebra/Group.v
+++ b/theories/Algebra/Group.v
@@ -406,7 +406,7 @@ Proof.
   srapply Build_HasMorExt.
   intros A B f g; cbn in *.
   snrapply @isequiv_homotopic.
-  1: exact equiv_path_grouphomomorphism^-1.
+  1: exact (equiv_path_grouphomomorphism^-1%equiv).
   1: exact _.
   intros []; reflexivity. 
 Defined.

--- a/theories/Basics/Contractible.v
+++ b/theories/Basics/Contractible.v
@@ -22,12 +22,12 @@ Proof.
 Defined.
 
 (** It follows that any space of paths in a contractible space is contractible. *)
-(** Because [Contr] is a notation, and [Contr_internal] is the record, we need to iota expand to fool Coq's typeclass machinery into accepting supposedly "mismatched" contexts. *)
 
-Global Instance contr_paths_contr `{Contr A} (x y : A) : Contr (x = y) | 10000 := let c := {|
-  center := (contr x)^ @ contr y;
-  contr := path2_contr ((contr x)^ @ contr y)
-|} in c.
+Global Instance contr_paths_contr `{Contr A} (x y : A) : Contr (x = y) | 10000.
+Proof.
+  exists ((contr x)^ @ contr y).
+  exact (path2_contr ((contr x)^ @ contr y)).
+Defined.
 
 (** Also, the total space of any based path space is contractible.  We define the [contr] fields as separate definitions, so that we can give them [simpl nomatch] annotations. *)
 
@@ -102,3 +102,11 @@ Definition contr_retract {X Y : Type} `{Contr X}
            (r : X -> Y) (s : Y -> X) (h : forall y, r (s y) = y)
   : Contr Y
   := Build_Contr _ (r (center X)) (fun y => (ap r (contr _)) @ h _).
+
+(** Sometimes the easiest way to prove that a type is contractible doesn't produce the definitionally-simplest center.  (In particular, this can affect performance, as Coq spends a long time tracing through long proofs of contractibility to find the center.)  So we give a way to modify the center. *)
+Definition contr_change_center {A : Type} (a : A) `{Contr A}
+  : Contr A.
+Proof.
+  exists a.
+  intros; apply path_contr.
+Defined.

--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -172,17 +172,33 @@ Definition moveR_equiv_M `{IsEquiv A B f} (x : A) (y : B) (p : x = f^-1 y)
   : (f x = y)
   := ap f p @ eisretr f y.
 
+Definition moveR_equiv_M' `(f : A <~> B) (x : A) (y : B) (p : x = f^-1 y)
+  : (f x = y)
+  := moveR_equiv_M x y p.
+
 Definition moveL_equiv_M `{IsEquiv A B f} (x : A) (y : B) (p : f^-1 y = x)
   : (y = f x)
   := (eisretr f y)^ @ ap f p.
+
+Definition moveL_equiv_M' `(f : A <~> B) (x : A) (y : B) (p : f^-1 y = x)
+  : (y = f x)
+  := moveL_equiv_M x y p.
 
 Definition moveR_equiv_V `{IsEquiv A B f} (x : B) (y : A) (p : x = f y)
   : (f^-1 x = y)
   := ap (f^-1) p @ eissect f y.
 
+Definition moveR_equiv_V' `(f : A <~> B) (x : B) (y : A) (p : x = f y)
+  : (f^-1 x = y)
+  := moveR_equiv_V x y p.
+
 Definition moveL_equiv_V `{IsEquiv A B f} (x : B) (y : A) (p : f y = x)
   : (y = f^-1 x)
   := (eissect f y)^ @ ap (f^-1) p.
+
+Definition moveL_equiv_V' `(f : A <~> B) (x : B) (y : A) (p : f y = x)
+  : (y = f^-1 x)
+  := moveL_equiv_V x y p.
 
 (** Equivalence preserves contractibility (which of course is trivial under univalence). *)
 Lemma contr_equiv A {B} (f : A -> B) `{IsEquiv A B f} `{Contr A}
@@ -192,7 +208,7 @@ Proof.
   intro y.
   apply moveR_equiv_M.
   apply contr.
-Qed.
+Defined.
 
 Definition contr_equiv' A {B} `(f : A <~> B) `{Contr A}
   : Contr B

--- a/theories/Basics/Trunc.v
+++ b/theories/Basics/Trunc.v
@@ -300,7 +300,7 @@ Proof.
   - intros x y.
     exact (IH (f^-1 x = f^-1 y) (H (f^-1 x) (f^-1 y))
       (x = y) ((ap (f^-1))^-1) _).
-Qed.
+Defined.
 
 Definition trunc_equiv' A {B} (f : A <~> B) `{IsTrunc n A}
   : IsTrunc n B

--- a/theories/Classes/theory/rationals.v
+++ b/theories/Classes/theory/rationals.v
@@ -560,7 +560,7 @@ Lemma Qpos_is_enumerator :
 Proof.
 apply BuildIsSurjection.
 unfold hfiber.
-intros e;generalize (center _ (enumerator_issurj Q (' e))). apply (Trunc_ind _).
+intros e;generalize (@center _ (enumerator_issurj Q (' e))). apply (Trunc_ind _).
 intros [n E]. apply tr;exists n.
 unfold Qpos_enumerator. destruct (le_or_lt (enumerator Q n) 0) as [E1|E1].
 - destruct (irreflexivity lt 0). apply lt_le_trans with (enumerator Q n);trivial.

--- a/theories/Extensions.v
+++ b/theories/Extensions.v
@@ -81,10 +81,8 @@ Section Extensions.
   Global Instance isequiv_path_extension `{Funext} {A B : Type} {f : A -> B}
          {P : B -> Type} {d : forall x:A, P (f x)}
          (ext ext' : ExtensionAlong f P d)
-  : IsEquiv (path_extension ext ext') | 0.
-  Proof.
-    exact _.
-  Defined.
+    : IsEquiv (path_extension ext ext') | 0
+    := equiv_isequiv _.
 
   (** Here is the iterated version. *)
 

--- a/theories/HIT/surjective_factor.v
+++ b/theories/HIT/surjective_factor.v
@@ -15,7 +15,7 @@ Section surjective_factor.
   Proof.
     intros. apply Sigma.ishprop_sigma_disjoint.
     intros c1 c2 E1 E2.
-    generalize (center _ (Esurj b));apply (Trunc_ind _).
+    generalize (@center _ (Esurj b)); apply (Trunc_ind _).
     intros [a p];destruct p.
     path_via (f a).
   Qed.

--- a/theories/Homotopy/Join.v
+++ b/theories/Homotopy/Join.v
@@ -188,6 +188,7 @@ Section Join.
     : IsConnected (m +2+ n) (Join A B).
   Proof.
     apply isconnected_from_elim; intros C ? k.
+    pose @istrunc_inO_tr.
     pose proof (istrunc_extension_along_conn
                   (fun b:B => tt) (fun _ => C) (k o pushr)).
     unfold ExtensionAlong in *.

--- a/theories/Pointed/pMap.v
+++ b/theories/Pointed/pMap.v
@@ -26,13 +26,13 @@ Definition path_pmap `{Funext} {A B : pType} {f g : A ->* B}
 
 (* We note that the inverse of [path_pmap] computes definitionally on reflexivity, and hence [path_pmap] itself computes typally so.  *)
 Definition equiv_inverse_path_pmap_1 `{Funext} {A B} {f : A ->* B}
-  : (equiv_path_pmap f f)^-1 1%path = reflexivity f
+  : (equiv_path_pmap f f)^-1%equiv 1%path = reflexivity f
   := 1.
 
 Definition equiv_path_pmap_1 `{Funext} {A B} {f : A ->* B}
   : path_pmap (reflexivity f) = 1%path.
 Proof.
-  apply moveR_equiv_M.
+  apply moveR_equiv_M'.
   reflexivity.
 Defined.
 

--- a/theories/Pointed/pType.v
+++ b/theories/Pointed/pType.v
@@ -58,7 +58,7 @@ Defined.
 Global Instance hasmorext_ptype `{Funext} : HasMorExt pType.
 Proof.
   srapply Build_HasMorExt; intros A B f g.
-  refine (isequiv_homotopic (equiv_path_pmap f g)^-1 _).
+  refine (isequiv_homotopic (equiv_path_pmap f g)^-1%equiv _).
   intros []; reflexivity.
 Defined.
 

--- a/theories/Spaces/BAut/Rigid.v
+++ b/theories/Spaces/BAut/Rigid.v
@@ -26,6 +26,7 @@ Defined.
 Global Instance contr_baut_rigid `{Univalence} {A : Type} `{IsRigid A}
   : Contr (BAut A).
 Proof.
+  refine (contr_change_center (point (BAut A))).
   refine (contr_trunc_conn (Tr 0)).
   intros Z W; baut_reduce.
   refine (trunc_equiv (n := -1) (A <~> A)

--- a/theories/Spaces/Card.v
+++ b/theories/Spaces/Card.v
@@ -4,6 +4,8 @@ Require Import HoTT.Basics HoTT.Types HoTT.HSet HoTT.TruncType.
 Require Import HoTT.Classes.interfaces.abstract_algebra.
 Require Import HoTT.Truncations.
 
+Opaque trunc_equiv. (** This speeds things up considerably *)
+
 (** ** Definitions and operations *)
 
 Definition Card := Trunc 0 hSet.

--- a/theories/Types/Equiv.v
+++ b/theories/Types/Equiv.v
@@ -17,9 +17,10 @@ Section AssumeFunext.
     (** We will show that assuming [f] is an equivalence, [IsEquiv f] decomposes into a sigma of two contractible types. *)
     apply hprop_inhabited_contr; intros feq.
     nrefine (contr_equiv' _ (issig_isequiv f oE (equiv_sigma_assoc' _ _)^-1)).
-    snrefine (contr_equiv' _ (equiv_contr_sigma' _ (f^-1 ; eisretr f))^-1); only 2: exact _.
+    srefine (contr_equiv' _ (equiv_contr_sigma _)^-1).
     (** Each of these types is equivalent to a based homotopy space. *)
-    - refine (contr_equiv' { g : B -> A & g == f^-1 } _).
+    - refine (contr_change_center (f^-1 ; eisretr f)).
+      refine (contr_equiv' { g : B -> A & g == f^-1 } _).
       apply equiv_functor_sigma_id; intros g.
       apply equiv_functor_forall_id; intros b.
       apply equiv_moveR_equiv_M.

--- a/theories/Types/Sigma.v
+++ b/theories/Types/Sigma.v
@@ -490,10 +490,6 @@ Proof.
     apply transport_pV.
 Defined.
 
-Definition equiv_contr_sigma' {A : Type} (P : A -> Type) `{Contr A} (a : A)
-  : { x : A & P x } <~> P a
-  := equiv_transport P _ _ (contr a) oE equiv_contr_sigma P.
-
 
 (** ** Associativity *)
 


### PR DESCRIPTION
I still don't entirely understand everything that's going on, but it seems to work for now.

Making `contr_equiv` transparent caused a blowup on a `cbn` in `Spaces/Universe`, which I tracked down to Coq spending a long time looking for the center of `contr_baut_rigid`.  Using `contr_change_center`, as Dan suggested in #1271, to give the obvious center explicitly fixed that.

Making `trunc_equiv` also transparent caused, as Ali noted in #1091, a blowup in `Spaces/Card` -- not on `strip_truncations`, but on another `cbn`.  I'm not sure exactly why, but looking at the proof term I saw that Coq was unnecessarily passing back and forth between `IsTrunc n` and `In (Tr n)` (e.g. deducing truncatedness of `Unit` from `inO_unit`), so I tried to increase the cost of the hint `istrunc_inO_tr` to prevent this.

That got me into some weeds with the meaning of `Hint Immediate`.  As I noted at coq/coq#11697, the documentation suggests that `Hint Immediate` should be equivalent to `Hint Extern` with `simple apply term; trivial`, but this doesn't seem to be the case since the latter can leave over subgoals whereas `Hint Immediate` is not supposed to.  On the other hand, `Hint Immediate` does sometimes appear to leave over subgoals that can be solved by further typeclass inference in a way that `Hint Extern` with `simple apply term; solve [ trivial ]` does not; see the comments added to `Trunc_min` in `Truncations/Core.v`.  But the upshot is that I managed to increase the cost by making `istrunc_inO_tr` a `Hint Extern` instead, at the price of modifying the proofs of `Trunc_min` and `isconnected_join` in two places where, if I understand the documentation of `Hint Immediate` correctly, they _shouldn't_ have been working in the first place.

Fortunately, increasing this cost seemed to be sufficient to make `Spaces/Card` compile.

Then I had to also modify a couple of proofs in `HIT/surjective_factor` and `Classes/theory/rationals`.  I have no idea why these worked in the first place; they were calling `center _ c` with `c` a proof of contractibility, but the second argument of `center` is (and always has been) _implicit_, so this shouldn't make any sense.  Nor do I understand why the changes that I made here caused them to suddenly break.

I also had to modify a proof in `HoTTBookExercises`, which I also don't think should have worked in the first place.  It was calling `trunc_equiv _ e` to get a function of the form `IsTrunc A -> IsEquiv e -> IsTrunc B`, but the last arguments of `trunc_equiv` are implicit and _maximally inserted_, so it seems that Coq should have (as it now does) complained that it was unable to fill them in.  My only guess here is that somehow transparent and opaque constants behave differently with respect to insertion of implicit arguments. 

At this point the library compiled, but some things had gotten very slow:

```
After    | File Name                      | Before   || Change    | % Change 
-----------------------------------------------------------------------------
7m04.93s | Total                          | 5m59.32s || +1m05.60s | +18.25%  
-----------------------------------------------------------------------------
0m43.01s | Spaces/Card.vo                 | 0m02.04s || +0m40.96s | +2008.33%
0m09.91s | Pointed/pMap.vo                | 0m00.81s || +0m09.09s | +1123.45%
0m10.01s | Algebra/Group.vo               | 0m02.52s || +0m07.49s | +297.22% 
0m07.82s | Pointed/pType.vo               | 0m00.25s || +0m07.57s | +3028.00%
0m03.87s | Extensions.vo                  | 0m01.44s || +0m02.43s | +168.75% 
0m06.68s | Algebra/AbelianGroup.vo        | 0m05.68s || +0m01.00s | +17.60%  
```

So I tried adding `Opaque trunc_equiv`.  This sped `Card` right back up to where it used to be.

In `pMap`, `Group`, `pType`, and `Extensions` the culprit was typeclass inference searching for `equiv_isequiv`.  I was able to solve this by calling it explicitly, adding `%equiv`, and defining versions of the `moveX_equiv_Y` lemmas that act on bundled equivalences (more evidence for #1240).  But I'm not sure why these changes suddenly made those searches so much slower.

I still don't know what slowed down `AbelianGroup`.  The new slowest line is the `Defined` of `Abel_ind_beta_ab_comm`; I don't see any inverses of equivalences, and `Opaque` doesn't help.  But at least this slowdown is relatively minor.

So now at least we have a transparent `contr_equiv` and `trunc_equiv`.  But if anyone can help explain any of the points where I'm confused, I'd be much obliged.
