### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,6 +11,8 @@ Git and make can be installed through your package manager.  On Debian
 or any distribution with `apt-get` you can run the script
 `./etc/install_coq_deps.sh` in the HoTT directory (see step 2) which
 installs some dependencies automatically.
+(Beware: on Ubuntu you also need the dependencies `m4` and `autoconf`,
+and `libgtksourceviewmm-3.0-dev`.)
 
 On OSX you can instead use the brew package manager:
 
@@ -35,7 +37,14 @@ You can then initialize opam with
     opam init
 
 It is recommended to allow opam to change your .profile file when it
-asks for permission.  You may also need to run
+asks for permission.
+
+After that switch to ocaml version 4.07.1 using
+
+    opam switch create 4.07.1
+    opam switch 4.07.1
+
+You may also need to run
 
     eval `opam env`
 
@@ -43,10 +52,6 @@ to continue working in the same terminal.  Then you can install the
 required dependencies:
 
     opam install ocaml camlp5 lablgtk3 lablgtk3-sourceview3 ocamlfind num
-
-If opam complains that you do not have a switch installed, run
-
-    opam switch create 4.0.7`.
 
 [1]:https://opam.ocaml.org/doc/Install.html
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,8 +11,6 @@ Git and make can be installed through your package manager.  On Debian
 or any distribution with `apt-get` you can run the script
 `./etc/install_coq_deps.sh` in the HoTT directory (see step 2) which
 installs some dependencies automatically.
-(Beware: on Ubuntu you also need the dependencies `m4` and `autoconf`,
-and `libgtksourceviewmm-3.0-dev`.)
 
 On OSX you can instead use the brew package manager:
 

--- a/etc/install_coq_deps.sh
+++ b/etc/install_coq_deps.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 
 sudo apt-get update -q
-sudo apt-get install -q curl sed grep wget tar libgtk-3-dev libgtk3sourceview-3.0-dev libexpat1-dev
-
+sudo apt-get install -q curl sed grep wget tar m4 autoconf libgtk-3-dev libgtksourceview-3.0-dev libexpat1-dev


### PR DESCRIPTION
The INSTALL instructions didn't work for me on a recent Ubuntu. In particular, the `opam switch create`  command didn't work (because the version number had a typo), and without switching to the correct version I got many errors that I didn't understand. (First time ocaml user here.)