### PR TITLE
Make some proofs about pointed maps transparent.  Note X ->* Y is ptd.

### DIFF
--- a/theories/Pointed/pEquiv.v
+++ b/theories/Pointed/pEquiv.v
@@ -106,24 +106,24 @@ Arguments pSect _ _ / _ _.
 (* A pointed equivalence is a section of its inverse *)
 Definition peissect {A B : pType} (f : A <~>* B) : pSect f f^-1*.
 Proof.
-  pointed_reduce.
+  pointed_reduce_pmap f.
   srefine (Build_pHomotopy _ _).
   1: apply (eissect f).
-  pointed_reduce.
-  unfold moveR_equiv_V.
-  apply inverse, concat_1p.
-Qed.
+  unfold moveR_equiv_V; cbn.
+  refine (concat_p1 _ @ (concat_1p _)^ @ (concat_1p _)^).
+Defined.
 
 (* A pointed equivalence is a retraction of its inverse *)
 Definition peisretr {A B : pType} (f : A <~>* B) : pSect f^-1* f.
 Proof.
   srefine (Build_pHomotopy _ _).
   1: apply (eisretr f).
-  pointed_reduce.
-  unfold moveR_equiv_V.
-  hott_simpl.
+  pointed_reduce_pmap f.
+  unfold moveR_equiv_V; cbn.
+  apply whiskerR.
+  refine (_ @ (ap _ (concat_1p _))^).
   apply eisadj.
-Qed.
+Defined.
 
 (* A version of equiv_adjointify for pointed equivalences
   where all data is pointed. There is a lot of unecessery data here

--- a/theories/Pointed/pHomotopy.v
+++ b/theories/Pointed/pHomotopy.v
@@ -18,31 +18,36 @@ Defined.
 Definition pmap_postwhisker {A B C : pType} {f g : A ->* B}
   (h : B ->* C) (p : f ==* g) : h o* f ==* h o* g.
 Proof.
-  pointed_reduce.
+  pointed_reduce'.
   simple refine (Build_pHomotopy _ _); cbn.
   - intros a; apply ap, p.
-  - reflexivity.
-Qed.
+  - apply whiskerR.
+    apply ap.
+    symmetry.
+    apply concat_p1.
+Defined.
 
 Definition pmap_prewhisker {A B C : pType} (f : A ->* B)
   {g h : B ->* C} (p : g ==* h) : g o* f ==* h o* f.
 Proof.
-  pointed_reduce.
+  pointed_reduce'.
   simple refine (Build_pHomotopy _ _); cbn.
   - intros a; apply p.
-  - refine (concat_p1 _ @ (concat_1p _)^).
-Qed.
+  - symmetry; apply concat_1p.
+Defined.
 
 (** ** Composition of pointed homotopies *)
 
 Definition phomotopy_compose {A B : pType} {f g h : A ->* B}
   (p : f ==* g) (q : g ==* h) : f ==* h.
 Proof.
-  pointed_reduce.
   simple refine (Build_pHomotopy _ _); cbn.
-  - intros x; exact (p x @ q x).
-  - apply concat_p1.
-Qed.
+  - intros x; exact ((pointed_htpy p) x @ (pointed_htpy q) x).
+  - simpl.
+    refine (concat_pp_p _ _ _ @ _).
+    refine (whiskerL _ (point_htpy q) @ _).
+    exact (point_htpy p).
+Defined.
 
 Infix "@*" := phomotopy_compose : pointed_scope.
 
@@ -53,11 +58,11 @@ Global Instance phomotopy_transitive {A B} : Transitive (@pHomotopy A B)
 Definition phomotopy_inverse {A B : pType} {f g : A ->* B}
 : (f ==* g) -> (g ==* f).
 Proof.
-  intros p; pointed_reduce.
+  intros p; pointed_reduce'.
   simple refine (Build_pHomotopy _ _); cbn.
   - intros x; exact ((p x)^).
-  - apply concat_Vp.
-Qed.
+  - apply concat_V_pp.
+Defined.
 
 (* pointed homotopy is a symmetric relation *)
 Global Instance phomotopy_symmetric {A B} : Symmetric (@pHomotopy A B)

--- a/theories/Pointed/pMap.v
+++ b/theories/Pointed/pMap.v
@@ -41,32 +41,42 @@ Defined.
 Definition pmap_compose_assoc {A B C D : pType} (h : C ->* D)
   (g : B ->* C) (f : A ->* B) : (h o* g) o* f ==* h o* (g o* f).
 Proof.
-  pointed_reduce.
+  pointed_reduce'.
   simple refine (Build_pHomotopy _ _); cbn.
   - intros ?; reflexivity.
   - reflexivity.
-Qed.
+Defined.
 
 Definition pmap_precompose_idmap {A B : pType} (f : A ->* B)
 : f o* pmap_idmap ==* f.
 Proof.
-  pointed_reduce.
+  pointed_reduce_pmap f.
   simple refine (Build_pHomotopy _ _); cbn.
   - intros ?; reflexivity.
   - reflexivity.
-Qed.
+Defined.
 
 Definition pmap_postcompose_idmap {A B : pType} (f : A ->* B)
 : pmap_idmap o* f ==* f.
 Proof.
-  pointed_reduce.
+  pointed_reduce_pmap f.
   simple refine (Build_pHomotopy _ _); cbn.
   - intros ?; reflexivity.
   - reflexivity.
-Qed.
+Defined.
 
 (** ** Trivially pointed maps *)
 
 (** Not infrequently we have a map between two unpointed types and want to consider it as a pointed map that trivially respects some given point in the domain. *)
 Definition pmap_from_point {A B : Type} (f : A -> B) (a : A)
   := Build_pMap (Build_pType A a) (Build_pType B (f a)) f 1%path.
+
+(** ** The type of pointed maps is itself pointed *)
+
+Definition constpmap {X Y : pType} : X ->* Y := Build_pMap _ _ (const (point Y)) idpath.
+
+Definition ispointed_pmap {X Y : pType} : IsPointed (X ->* Y) := constpmap.
+
+Definition ppMap (X Y : pType) : pType := Build_pType (X ->* Y) constpmap.
+
+Infix "->**" := ppMap : pointed_scope.

--- a/theories/Pointed/pTrunc.v
+++ b/theories/Pointed/pTrunc.v
@@ -71,7 +71,7 @@ Proof.
   srapply Build_pHomotopy.
   { intro x.
     by strip_truncations. }
-  by pointed_reduce.
+  by pointed_reduce'.
 Defined.
 
 Definition ptr_pequiv {X Y : pType} (n : trunc_index) (f : X <~>* Y)


### PR DESCRIPTION
Make a version of pointed_reduce without the rewrites, and use it in a bunch of places.  Also make a version that just handles a single map, to keep the context clean.  Give shorter default names for some of the destructed things, to make things more readable.

Unrelated, but also define the pointed type of pointed maps.
