### PR TITLE
Use pointed_reduce' and remove Funext hyp where possible

### DIFF
--- a/theories/Algebra/ooGroup.v
+++ b/theories/Algebra/ooGroup.v
@@ -172,14 +172,14 @@ Defined.
 
 (** *** Homomorphic properties *)
 
-(** The following tactic often allows us to "pretend" that phi preserves basepoints strictly.  This is basically a simple extension of [pointed_reduce] (see Pointed.v). *)
+(** The following tactic often allows us to "pretend" that phi preserves basepoints strictly.  This is basically a simple extension of [pointed_reduce_rewrite] (see Pointed.v). *)
 Ltac grouphom_reduce :=
   unfold grouphom_fun; cbn;
   repeat match goal with
            | [ G : ooGroup |- _ ] => destruct G as [G ?]
            | [ phi : ooGroupHom ?G ?H |- _ ] => destruct phi as [phi ?]
          end;
-  pointed_reduce.
+  pointed_reduce_rewrite.
 
 Definition compose_grouphom {G H K : ooGroup}
            (psi : ooGroupHom H K) (phi : ooGroupHom G H)

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -495,7 +495,7 @@ Proof.
   revert p' r. srapply phomotopy_ind.
   revert h q. srapply phomotopy_ind.
   revert g p. srapply phomotopy_ind.
-  pointed_reduce. reflexivity.
+  pointed_reduce'. reflexivity.
 Defined.
 
 Definition phomotopy_prewhisker `{Funext} {A : pType} {P : pFam A}
@@ -507,7 +507,7 @@ Proof.
   revert q' s. srapply phomotopy_ind.
   revert h q. srapply phomotopy_ind.
   revert g p. srapply phomotopy_ind.
-  pointed_reduce. reflexivity.
+  pointed_reduce'. reflexivity.
 Defined.
 
 Definition phomotopy_compose_assoc `{Funext} {A : pType} {P : pFam A}
@@ -519,7 +519,7 @@ Proof.
   revert k r. srapply phomotopy_ind.
   revert h q. srapply phomotopy_ind.
   revert g p. srapply phomotopy_ind.
-  pointed_reduce. reflexivity.
+  pointed_reduce'. reflexivity.
 Defined.
 
 Definition phomotopy_compose_p1 {A : pType} {P : pFam A} {f g : pForall A P}
@@ -527,7 +527,7 @@ Definition phomotopy_compose_p1 {A : pType} {P : pFam A} {f g : pForall A P}
 Proof.
   srapply Build_pHomotopy.
   1: intro; apply concat_p1.
-  pointed_reduce.
+  pointed_reduce'.
   rewrite (concat_pp_V H (concat_p1 _))^. generalize (H @ concat_p1 _).
   clear H. intros H. destruct H.
   generalize (p point); generalize (g point).
@@ -539,7 +539,7 @@ Definition phomotopy_compose_1p {A : pType} {P : pFam A} {f g : pForall A P}
 Proof.
   srapply Build_pHomotopy.
   + intro x. apply concat_1p.
-  + pointed_reduce.
+  + pointed_reduce'.
     rewrite (concat_pp_V H (concat_p1 _))^. generalize (H @ concat_p1 _).
     clear H. intros H. destruct H.
     generalize (p point). generalize (g point).
@@ -552,7 +552,7 @@ Proof.
   srapply Build_pHomotopy.
   + intro x. apply concat_pV.
   + revert g p. srapply phomotopy_ind.
-    pointed_reduce. reflexivity.
+    pointed_reduce'. reflexivity.
 Defined.
 
 Definition phomotopy_compose_Vp `{Funext} {A : pType} {P : pFam A} {f g : pForall A P}
@@ -561,7 +561,7 @@ Proof.
   srapply Build_pHomotopy.
   + intro x. apply concat_Vp.
   + revert g p. srapply phomotopy_ind.
-    pointed_reduce. reflexivity.
+    pointed_reduce'. reflexivity.
 Defined.
 
 (** ** The pointed category structure of [pType] *)

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -145,7 +145,7 @@ Definition pproduct {A : Type} (F : A -> pType) : pType
 (** The following tactics often allow us to "pretend" that pointed maps and homotopies preserve basepoints strictly. *)
 
 (** First a version with no rewrites, which leaves some cleanup to be done but which can be used in transparent proofs. *)
-Ltac pointed_reduce' :=
+Ltac pointed_reduce :=
   (*TODO: are these correct? *)
   unfold pointed_fun, pointed_htpy;
   cbn in *;
@@ -160,8 +160,8 @@ Ltac pointed_reduce' :=
   path_induction; cbn.
 
 (** Next a version that uses [rewrite], and should only be used in opaque proofs. *)
-Ltac pointed_reduce :=
-  pointed_reduce';
+Ltac pointed_reduce_rewrite :=
+  pointed_reduce;
   rewrite ?concat_p1, ?concat_1p.
 
 (** Finally, a version that just strictifies a single map or equivalence.  This has the advantage that it leaves the context more readable. *)
@@ -408,7 +408,7 @@ Proof.
   srefine (Build_pHomotopy _ _).
   1: apply (eissect f). 
   simpl. unfold moveR_equiv_V.
-  pointed_reduce'.
+  pointed_reduce.
   symmetry.
   refine (concat_p1 _ @ concat_1p _ @ concat_1p _).
 Defined.
@@ -418,7 +418,7 @@ Definition peisretr {A B : pType} (f : A <~>* B) : pSect (pequiv_inverse f) f.
 Proof.
   srefine (Build_pHomotopy _ _).
   1: apply (eisretr f).
-  pointed_reduce'.
+  pointed_reduce.
   unfold moveR_equiv_V.
   refine (eisadj f _ @ _).
   symmetry.
@@ -495,7 +495,7 @@ Proof.
   revert p' r. srapply phomotopy_ind.
   revert h q. srapply phomotopy_ind.
   revert g p. srapply phomotopy_ind.
-  pointed_reduce'. reflexivity.
+  pointed_reduce. reflexivity.
 Defined.
 
 Definition phomotopy_prewhisker `{Funext} {A : pType} {P : pFam A}
@@ -507,7 +507,7 @@ Proof.
   revert q' s. srapply phomotopy_ind.
   revert h q. srapply phomotopy_ind.
   revert g p. srapply phomotopy_ind.
-  pointed_reduce'. reflexivity.
+  pointed_reduce. reflexivity.
 Defined.
 
 Definition phomotopy_compose_assoc `{Funext} {A : pType} {P : pFam A}
@@ -519,7 +519,7 @@ Proof.
   revert k r. srapply phomotopy_ind.
   revert h q. srapply phomotopy_ind.
   revert g p. srapply phomotopy_ind.
-  pointed_reduce'. reflexivity.
+  pointed_reduce. reflexivity.
 Defined.
 
 Definition phomotopy_compose_p1 {A : pType} {P : pFam A} {f g : pForall A P}
@@ -527,7 +527,7 @@ Definition phomotopy_compose_p1 {A : pType} {P : pFam A} {f g : pForall A P}
 Proof.
   srapply Build_pHomotopy.
   1: intro; apply concat_p1.
-  pointed_reduce'.
+  pointed_reduce.
   rewrite (concat_pp_V H (concat_p1 _))^. generalize (H @ concat_p1 _).
   clear H. intros H. destruct H.
   generalize (p point); generalize (g point).
@@ -539,7 +539,7 @@ Definition phomotopy_compose_1p {A : pType} {P : pFam A} {f g : pForall A P}
 Proof.
   srapply Build_pHomotopy.
   + intro x. apply concat_1p.
-  + pointed_reduce'.
+  + pointed_reduce.
     rewrite (concat_pp_V H (concat_p1 _))^. generalize (H @ concat_p1 _).
     clear H. intros H. destruct H.
     generalize (p point). generalize (g point).
@@ -552,7 +552,7 @@ Proof.
   srapply Build_pHomotopy.
   + intro x. apply concat_pV.
   + revert g p. srapply phomotopy_ind.
-    pointed_reduce'. reflexivity.
+    pointed_reduce. reflexivity.
 Defined.
 
 Definition phomotopy_compose_Vp `{Funext} {A : pType} {P : pFam A} {f g : pForall A P}
@@ -561,7 +561,7 @@ Proof.
   srapply Build_pHomotopy.
   + intro x. apply concat_Vp.
   + revert g p. srapply phomotopy_ind.
-    pointed_reduce'. reflexivity.
+    pointed_reduce. reflexivity.
 Defined.
 
 (** ** The pointed category structure of [pType] *)

--- a/theories/Pointed/Loops.v
+++ b/theories/Pointed/Loops.v
@@ -73,7 +73,7 @@ Proof.
     refine (_ @ concat_p_pp _ _ _ @ ((ap_pp _ _ _)^ @@ 1)).
     apply whiskerR.
     apply ap_compose. }
-  by pointed_reduce'.
+  by pointed_reduce.
 Defined.
 
 (* Loops functor respects identity *)
@@ -90,7 +90,7 @@ Defined.
 Lemma loops_functor_pp {X Y : pType} (f : X ->* Y) (x y : loops X)
   : loops_functor f (x @ y) = loops_functor f x @ loops_functor f y.
 Proof.
-  pointed_reduce.
+  pointed_reduce_rewrite.
   apply ap_pp.
 Defined.
 
@@ -105,7 +105,7 @@ Defined.
 Definition loops_2functor {A B : pType} {f g : A ->* B} (p : f ==* g)
   : (loops_functor f) ==* (loops_functor g).
 Proof.
-  pointed_reduce'.
+  pointed_reduce.
   srapply Build_pHomotopy; cbn.
   { intro q.
     refine (_ @ (concat_p1 _)^ @ (concat_1p _)^).
@@ -478,7 +478,7 @@ Proof.
   srapply Build_pHomotopy.
   + intros p. refine (inv_Vp _ _ @ whiskerR _ (point_eq f) @ concat_pp_p _ _ _).
     refine (inv_pp _ _ @ whiskerL (point_eq f)^ (ap_V f p)^).
-  + pointed_reduce'. reflexivity.
+  + pointed_reduce. reflexivity.
 Defined.
 
 (** Loops on the pointed type of dependent pointed maps correspond to

--- a/theories/Pointed/Loops.v
+++ b/theories/Pointed/Loops.v
@@ -73,7 +73,7 @@ Proof.
     refine (_ @ concat_p_pp _ _ _ @ ((ap_pp _ _ _)^ @@ 1)).
     apply whiskerR.
     apply ap_compose. }
-  by pointed_reduce.
+  by pointed_reduce'.
 Defined.
 
 (* Loops functor respects identity *)
@@ -105,11 +105,12 @@ Defined.
 Definition loops_2functor {A B : pType} {f g : A ->* B} (p : f ==* g)
   : (loops_functor f) ==* (loops_functor g).
 Proof.
-  pointed_reduce.
+  pointed_reduce'.
   srapply Build_pHomotopy; cbn.
   { intro q.
     refine (_ @ (concat_p1 _)^ @ (concat_1p _)^).
-    apply moveR_Vp, concat_Ap. }
+    apply moveR_Vp.
+    apply (concat_Ap (fun x => p x @ 1)). }
   simpl. generalize (p point0). generalize (g point0).
   intros _ []. reflexivity.
 Defined.
@@ -477,7 +478,7 @@ Proof.
   srapply Build_pHomotopy.
   + intros p. refine (inv_Vp _ _ @ whiskerR _ (point_eq f) @ concat_pp_p _ _ _).
     refine (inv_pp _ _ @ whiskerL (point_eq f)^ (ap_V f p)^).
-  + pointed_reduce. pointed_reduce. reflexivity.
+  + pointed_reduce'. reflexivity.
 Defined.
 
 (** Loops on the pointed type of dependent pointed maps correspond to

--- a/theories/Pointed/pEquiv.v
+++ b/theories/Pointed/pEquiv.v
@@ -1,6 +1,5 @@
 Require Import Basics.
 Require Import Types.
-Require Import UnivalenceImpliesFunext.
 Require Import WildCat.
 Require Import Pointed.Core Pointed.pMap Pointed.pHomotopy.
 

--- a/theories/Pointed/pFiber.v
+++ b/theories/Pointed/pFiber.v
@@ -46,7 +46,7 @@ Proof.
     refine (_ oE equiv_path_inverse _ _).
     apply equiv_concat_l.
     apply transport_paths_Fl. }
-  by pointed_reduce'.
+  by pointed_reduce.
 Defined.
 
 Definition pr1_pfiber_loops_functor {A B} (f : A ->* B)
@@ -57,7 +57,7 @@ Proof.
   - intros [u v].
     refine (concat_1p _ @ concat_p1 _ @ _).
     exact (@ap_pr1_path_sigma _ _ (point A; point_eq f) (point A;point_eq f) _ _).
-  - abstract (pointed_reduce; reflexivity).
+  - abstract (pointed_reduce_rewrite; reflexivity).
 Defined.
 
 Definition pfiber_iterated_loops_functor {A B : pType} (n : nat) (f : A ->* B)
@@ -110,7 +110,7 @@ Definition pfiber2_loops_functor {A B : pType} (f : A ->* B)
 : loops_inv _ o* pfiber2_loops f o* pfib (pfib (pfib f))
   ==* loops_functor f o* pfiber2_loops (pfib f).
 Proof.
-  pointed_reduce'.
+  pointed_reduce.
   simple refine (Build_pHomotopy _ _).
   - intros [[[x p] q] r]. simpl in *.
     (** Apparently [destruct q] isn't smart enough to generalize over [p]. *)

--- a/theories/Pointed/pFiber.v
+++ b/theories/Pointed/pFiber.v
@@ -46,7 +46,7 @@ Proof.
     refine (_ oE equiv_path_inverse _ _).
     apply equiv_concat_l.
     apply transport_paths_Fl. }
-  by pointed_reduce.
+  by pointed_reduce'.
 Defined.
 
 Definition pr1_pfiber_loops_functor {A B} (f : A ->* B)
@@ -110,7 +110,7 @@ Definition pfiber2_loops_functor {A B : pType} (f : A ->* B)
 : loops_inv _ o* pfiber2_loops f o* pfib (pfib (pfib f))
   ==* loops_functor f o* pfiber2_loops (pfib f).
 Proof.
-  pointed_reduce.
+  pointed_reduce'.
   simple refine (Build_pHomotopy _ _).
   - intros [[[x p] q] r]. simpl in *.
     (** Apparently [destruct q] isn't smart enough to generalize over [p]. *)

--- a/theories/Pointed/pHomotopy.v
+++ b/theories/Pointed/pHomotopy.v
@@ -12,7 +12,7 @@ Definition phomotopy_inverse_1 {A : pType} {P : pFam A} {f : pForall A P}
 Proof.
   srapply Build_pHomotopy.
   + reflexivity.
-  + pointed_reduce'. reflexivity.
+  + pointed_reduce. reflexivity.
 Defined.
 
 (** [phomotopy_path] sends concatenation to composition of pointed homotopies.*)
@@ -30,7 +30,7 @@ Definition pmap_postwhisker {A B C : pType} {f g : A ->* B}
 Proof.
   snrapply Build_pHomotopy; cbn.
   1: intros a; apply ap, p.
-  pointed_reduce'.
+  pointed_reduce.
   symmetry.
   simpl.
   refine (concat_p1 _ @ concat_p1 _ @ ap _ _).
@@ -42,7 +42,7 @@ Definition pmap_prewhisker {A B C : pType} (f : A ->* B)
 Proof.
   snrapply Build_pHomotopy; cbn.
   1: intros a; apply p.
-  pointed_reduce'.
+  pointed_reduce.
   symmetry.
   refine (concat_p1 _ @ concat_1p _ @ concat_p1 _).
 Defined.

--- a/theories/Pointed/pHomotopy.v
+++ b/theories/Pointed/pHomotopy.v
@@ -5,8 +5,6 @@ Require Import WildCat.
 
 Local Open Scope pointed_scope.
 
-(** TODO: in various places we use pointed_reduce. We should avoid doing so. *)
-
 (** Some higher homotopies *)
 
 Definition phomotopy_inverse_1 {A : pType} {P : pFam A} {f : pForall A P}
@@ -14,11 +12,11 @@ Definition phomotopy_inverse_1 {A : pType} {P : pFam A} {f : pForall A P}
 Proof.
   srapply Build_pHomotopy.
   + reflexivity.
-  + pointed_reduce. reflexivity.
+  + pointed_reduce'. reflexivity.
 Defined.
 
 (** [phomotopy_path] sends concatenation to composition of pointed homotopies.*)
-Definition phomotopy_path_pp `{Funext} {A : pType} {P : pFam A}
+Definition phomotopy_path_pp {A : pType} {P : pFam A}
   {f g h : pForall A P} (p : f = g) (q : g = h)
   : phomotopy_path (p @ q) ==* phomotopy_path p @* phomotopy_path q.
 Proof.
@@ -50,7 +48,7 @@ Proof.
 Defined.
 
 (** ** Composition of pointed homotopies *)
-Definition phomotopy_path2 `{Funext} {A : pType} {P : pFam A}
+Definition phomotopy_path2 {A : pType} {P : pFam A}
   {f g : pForall A P} {p p' : f = g} (q : p = p')
   : phomotopy_path p ==* phomotopy_path p'.
 Proof.
@@ -58,13 +56,14 @@ Proof.
 Defined.
 
 (** [phomotopy_path] sends inverses to inverses.*)
-Definition phomotopy_path_V `{Funext} {A : pType} {P : pFam A}
+Definition phomotopy_path_V {A : pType} {P : pFam A}
   {f g : pForall A P} (p : f = g)
   : phomotopy_path (p^) ==* (phomotopy_path p)^*.
 Proof.
   induction p. simpl. symmetry. apply phomotopy_inverse_1.
 Defined.
 
+(* TODO: Remove [Funext] when whiskering is reproven without it. *)
 Definition phomotopy_hcompose `{Funext} {A : pType} {P : pFam A} {f g h : pForall A P}
  {p p' : f ==* g} {q q' : g ==* h} (r : p ==* p') (s : q ==* q') :
   p @* q ==* p' @* q'.

--- a/theories/Pointed/pMap.v
+++ b/theories/Pointed/pMap.v
@@ -125,7 +125,7 @@ Definition functor2_pforall_right_refl {A : pType} {B C : pFam A}
       (concat_1p _)
     ==* phomotopy_reflexive (functor_pforall_right g g₀ f).
 Proof.
-  pointed_reduce. reflexivity.
+  pointed_reduce'. reflexivity.
 Defined.
 
 (* functorial action of [pForall A (pointed_fam B)] in [B]. *)
@@ -183,7 +183,6 @@ Definition pmap_compose_ppforall2_refl `{Funext} {A : pType} {P Q : A -> pType}
   : pmap_compose_ppforall2 (fun a => phomotopy_reflexive (g a)) (phomotopy_reflexive f)
     ==* phomotopy_reflexive _.
 Proof.
-  simpl.
   unfold pmap_compose_ppforall2.
   revert Q g. refine (fiberwise_pointed_map_rec _ _). intros Q g.
   srapply functor2_pforall_right_refl.

--- a/theories/Pointed/pMap.v
+++ b/theories/Pointed/pMap.v
@@ -115,7 +115,7 @@ Definition functor2_pforall_right {A : pType} {B C : pFam A}
 Proof.
   srapply Build_pHomotopy.
   1: { intro a. refine (p a (f a) @ ap (g' a) (q a)). }
-  pointed_reduce. symmetry. apply concat_Ap.
+  pointed_reduce_rewrite. symmetry. apply concat_Ap.
 Defined.
 
 Definition functor2_pforall_right_refl {A : pType} {B C : pFam A}
@@ -125,7 +125,7 @@ Definition functor2_pforall_right_refl {A : pType} {B C : pFam A}
       (concat_1p _)
     ==* phomotopy_reflexive (functor_pforall_right g g₀ f).
 Proof.
-  pointed_reduce'. reflexivity.
+  pointed_reduce. reflexivity.
 Defined.
 
 (* functorial action of [pForall A (pointed_fam B)] in [B]. *)

--- a/theories/Pointed/pSusp.v
+++ b/theories/Pointed/pSusp.v
@@ -64,7 +64,7 @@ Qed.
 Definition psusp_2functor {X Y} {f g : X ->* Y} (p : f ==* g)
   : psusp_functor f ==* psusp_functor g.
 Proof.
-  pointed_reduce.
+  pointed_reduce'.
   srapply Build_pHomotopy.
   { simpl.
     srapply Susp_ind.
@@ -168,7 +168,7 @@ Definition loop_susp_unit_natural {X Y : pType} (f : X ->* Y)
   : loop_susp_unit Y o* f
   ==* loops_functor (psusp_functor f) o* loop_susp_unit X.
 Proof.
-  pointed_reduce.
+  pointed_reduce'.
   simple refine (Build_pHomotopy _ _); cbn.
   - intros x; symmetry.
     refine (concat_1p _@ (concat_p1 _ @ _)).
@@ -201,7 +201,7 @@ Definition loop_susp_counit_natural {X Y : pType} (f : X ->* Y)
   : f o* loop_susp_counit X
   ==* loop_susp_counit Y o* psusp_functor (loops_functor f).
 Proof.
-  pointed_reduce.
+  pointed_reduce'.
   simple refine (Build_pHomotopy _ _); simpl.
   - simple refine (Susp_ind _ _ _ _); cbn; try reflexivity; intros p.
     rewrite transport_paths_FlFr, ap_compose, concat_p1.

--- a/theories/Pointed/pSusp.v
+++ b/theories/Pointed/pSusp.v
@@ -39,7 +39,7 @@ Definition psusp_functor {X Y : pType} (f : X ->* Y) : psusp X ->* psusp Y
 Definition psusp_functor_compose {X Y Z : pType} (g : Y ->* Z) (f : X ->* Y)
   : psusp_functor (g o* f) ==* psusp_functor g o* psusp_functor f.
 Proof.
-  pointed_reduce; srefine (Build_pHomotopy _ _); cbn.
+  pointed_reduce_rewrite; srefine (Build_pHomotopy _ _); cbn.
   { srapply Susp_ind; try reflexivity; cbn.
     intros x.
     refine (transport_paths_FlFr _ _ @ _).
@@ -64,7 +64,7 @@ Qed.
 Definition psusp_2functor {X Y} {f g : X ->* Y} (p : f ==* g)
   : psusp_functor f ==* psusp_functor g.
 Proof.
-  pointed_reduce'.
+  pointed_reduce.
   srapply Build_pHomotopy.
   { simpl.
     srapply Susp_ind.
@@ -122,7 +122,7 @@ Module Book_Loop_Susp_Adjunction.
   : loop_susp_adjoint A B' (g o* f)
     ==* loops_functor g o* loop_susp_adjoint A B f.
   Proof.
-    pointed_reduce.
+    pointed_reduce_rewrite.
     srefine (Build_pHomotopy _ _).
     - intros a. simpl.
       refine (_ @ (concat_1p _)^).
@@ -168,7 +168,7 @@ Definition loop_susp_unit_natural {X Y : pType} (f : X ->* Y)
   : loop_susp_unit Y o* f
   ==* loops_functor (psusp_functor f) o* loop_susp_unit X.
 Proof.
-  pointed_reduce'.
+  pointed_reduce.
   simple refine (Build_pHomotopy _ _); cbn.
   - intros x; symmetry.
     refine (concat_1p _@ (concat_p1 _ @ _)).
@@ -201,7 +201,7 @@ Definition loop_susp_counit_natural {X Y : pType} (f : X ->* Y)
   : f o* loop_susp_counit X
   ==* loop_susp_counit Y o* psusp_functor (loops_functor f).
 Proof.
-  pointed_reduce'.
+  pointed_reduce.
   simple refine (Build_pHomotopy _ _); simpl.
   - simple refine (Susp_ind _ _ _ _); cbn; try reflexivity; intros p.
     rewrite transport_paths_FlFr, ap_compose, concat_p1.

--- a/theories/Pointed/pTrunc.v
+++ b/theories/Pointed/pTrunc.v
@@ -80,7 +80,7 @@ Proof.
   srapply Build_pHomotopy.
   { intro x.
     by strip_truncations. }
-  by pointed_reduce'.
+  by pointed_reduce.
 Defined.
 
 Definition ptr_functor_homotopy {X Y : pType} (n : trunc_index)


### PR DESCRIPTION
The pointed_reduce' tactic avoids rewrites, and in many cases works in place of pointed_reduce with little or no change.  Also, several results had unnecessary Funext hypotheses.