### PR TITLE
Adapt w.r.t. coq/coq#12572.

### DIFF
--- a/theories/Homotopy/EMSpace.v
+++ b/theories/Homotopy/EMSpace.v
@@ -125,11 +125,9 @@ Section LicataFinsterLemma.
     set (Q := fun a b => tr (n:=1) (merid (a * b))
       = tr (merid b @ (merid mon_unit)^ @ merid a)).
     srapply (@wedge_incl_elim_uncurried _ (-1) (-1) _
-      mon_unit _ _ mon_unit _ Q _ _ x y).
-    { intros a b.
-      cbn; unfold Q.
-      apply istrunc_paths.
-      exact _. }
+      mon_unit _ _ mon_unit _ Q _ _ x y);
+    (* The try clause below is only needed for Coq <= 8.11 *)
+    try (intros a b; cbn; unfold Q; apply istrunc_paths; exact _).
     unfold Q.
     srefine (_;_;_).
     { intro b.

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -793,7 +793,8 @@ Section Reflective_Subuniverse.
     Proof.
       refine (inO_equiv_inO _ (hfiber_fibration x B)^-1).
       (** TODO: Why doesn't Coq find this instance? *)
-      refine (inO_hfiber pr1 x); assumption.
+      (* This is #12571 and it is only needed for Coq <= 8.11 *)
+      all: refine (inO_hfiber pr1 x); assumption.
     Defined.
 
     Hint Immediate inO_unsigma : typeclass_instances.

--- a/theories/PropResizing/Nat.v
+++ b/theories/PropResizing/Nat.v
@@ -372,8 +372,8 @@ Section AssumeStuff.
   Proof.
     intros [n nrec].
     pose (Q := fun m:Graph => forall (mrec : in_N m), P (m;mrec)).
-    refine (resize_nrec n nrec Q _ _ _ nrec);clear n nrec.
-    - intros A; apply trunc_forall.
+    (* The try clause below is only needed for Coq <= 8.11 *)
+    refine (resize_nrec n nrec Q _ _ _ nrec);clear n nrec; try (intros A; apply trunc_forall).
     - intros zrec.
       refine (transport P _ P0).
       apply ap.

--- a/theories/Spaces/Finite.v
+++ b/theories/Spaces/Finite.v
@@ -875,8 +875,8 @@ Definition detachable_finite_subset {X} `{Finite X}
 Proof.
   intros x.
   refine (decidable_equiv _ (hfiber_fibration x P)^-1 _).
-  refine (detachable_image_finite pr1 x).
-  - assumption.                 (** Why doesn't Coq find this? *)
+  (* The try clause below is only needed for Coq <= 8.11 *)
+  refine (detachable_image_finite pr1 x); try assumption.
   - apply (mapinO_pr1 (Tr (-1))).  (** Why doesn't Coq find this? *)
 Defined.
 


### PR DESCRIPTION
The Coq PR fixes #12571 which was observed in HoTT, according to some puzzled comments in the code. This PR should be backwards compatible.