### PR TITLE
Reinstate EquivGroupoids in export list HoTT.v

### DIFF
--- a/theories/HoTT.v
+++ b/theories/HoTT.v
@@ -13,6 +13,7 @@ Require Export HoTT.Truncations.
 Require Export HoTT.HFiber.
 Require Export HoTT.HProp.
 Require Export HoTT.HSet.
+Require Export HoTT.EquivGroupoids.
 
 Require Export HoTT.Equiv.BiInv.
 Require Export HoTT.Equiv.PathSplit.


### PR DESCRIPTION
Cf. #1345. This reverts fdedfe6, but was missed when restoring `EquivGroupoids` in #1344 .