### PR TITLE
removed unused folders in coq

### DIFF
--- a/coq/theories/Arith/README.txt
+++ b/coq/theories/Arith/README.txt
@@ -1,5 +1,0 @@
-This directory exists because Coq expects it. At present there are no files
-in it, but we may add some from the Coq standard library in the future.
-When this happens, please remove this README.txt. It is here only because
-git does not want to put empty directories in a repository.
-

--- a/coq/theories/Bool/README.txt
+++ b/coq/theories/Bool/README.txt
@@ -1,5 +1,0 @@
-This directory exists because Coq expects it. At present there are no files
-in it, but we may add some from the Coq standard library in the future.
-When this happens, please remove this README.txt. It is here only because
-git does not want to put empty directories in a repository.
-

--- a/coq/theories/Classes/README.txt
+++ b/coq/theories/Classes/README.txt
@@ -1,5 +1,0 @@
-This directory exists because Coq expects it. At present there are no files
-in it, but we may add some from the Coq standard library in the future.
-When this happens, please remove this README.txt. It is here only because
-git does not want to put empty directories in a repository.
-

--- a/coq/theories/FSets/README.txt
+++ b/coq/theories/FSets/README.txt
@@ -1,5 +1,0 @@
-This directory exists because Coq expects it. At present there are no files
-in it, but we may add some from the Coq standard library in the future.
-When this happens, please remove this README.txt. It is here only because
-git does not want to put empty directories in a repository.
-

--- a/coq/theories/Lists/README.txt
+++ b/coq/theories/Lists/README.txt
@@ -1,5 +1,0 @@
-This directory exists because Coq expects it. At present there are no files
-in it, but we may add some from the Coq standard library in the future.
-When this happens, please remove this README.txt. It is here only because
-git does not want to put empty directories in a repository.
-

--- a/coq/theories/Logic/README.txt
+++ b/coq/theories/Logic/README.txt
@@ -1,5 +1,0 @@
-This directory exists because Coq expects it. At present there are no files
-in it, but we may add some from the Coq standard library in the future.
-When this happens, please remove this README.txt. It is here only because
-git does not want to put empty directories in a repository.
-

--- a/coq/theories/MSets/README.txt
+++ b/coq/theories/MSets/README.txt
@@ -1,5 +1,0 @@
-This directory exists because Coq expects it. At present there are no files
-in it, but we may add some from the Coq standard library in the future.
-When this happens, please remove this README.txt. It is here only because
-git does not want to put empty directories in a repository.
-

--- a/coq/theories/NArith/README.txt
+++ b/coq/theories/NArith/README.txt
@@ -1,5 +1,0 @@
-This directory exists because Coq expects it. At present there are no files
-in it, but we may add some from the Coq standard library in the future.
-When this happens, please remove this README.txt. It is here only because
-git does not want to put empty directories in a repository.
-

--- a/coq/theories/Numbers/README.txt
+++ b/coq/theories/Numbers/README.txt
@@ -1,5 +1,0 @@
-This directory exists because Coq expects it. At present there are no files
-in it, but we may add some from the Coq standard library in the future.
-When this happens, please remove this README.txt. It is here only because
-git does not want to put empty directories in a repository.
-

--- a/coq/theories/PArith/README.txt
+++ b/coq/theories/PArith/README.txt
@@ -1,5 +1,0 @@
-This directory exists because Coq expects it. At present there are no files
-in it, but we may add some from the Coq standard library in the future.
-When this happens, please remove this README.txt. It is here only because
-git does not want to put empty directories in a repository.
-

--- a/coq/theories/QArith/README.txt
+++ b/coq/theories/QArith/README.txt
@@ -1,5 +1,0 @@
-This directory exists because Coq expects it. At present there are no files
-in it, but we may add some from the Coq standard library in the future.
-When this happens, please remove this README.txt. It is here only because
-git does not want to put empty directories in a repository.
-

--- a/coq/theories/Reals/README.txt
+++ b/coq/theories/Reals/README.txt
@@ -1,5 +1,0 @@
-This directory exists because Coq expects it. At present there are no files
-in it, but we may add some from the Coq standard library in the future.
-When this happens, please remove this README.txt. It is here only because
-git does not want to put empty directories in a repository.
-

--- a/coq/theories/Relations/README.txt
+++ b/coq/theories/Relations/README.txt
@@ -1,5 +1,0 @@
-This directory exists because Coq expects it. At present there are no files
-in it, but we may add some from the Coq standard library in the future.
-When this happens, please remove this README.txt. It is here only because
-git does not want to put empty directories in a repository.
-

--- a/coq/theories/Setoids/README.txt
+++ b/coq/theories/Setoids/README.txt
@@ -1,5 +1,0 @@
-This directory exists because Coq expects it. At present there are no files
-in it, but we may add some from the Coq standard library in the future.
-When this happens, please remove this README.txt. It is here only because
-git does not want to put empty directories in a repository.
-

--- a/coq/theories/Sets/README.txt
+++ b/coq/theories/Sets/README.txt
@@ -1,5 +1,0 @@
-This directory exists because Coq expects it. At present there are no files
-in it, but we may add some from the Coq standard library in the future.
-When this happens, please remove this README.txt. It is here only because
-git does not want to put empty directories in a repository.
-

--- a/coq/theories/Sorting/README.txt
+++ b/coq/theories/Sorting/README.txt
@@ -1,5 +1,0 @@
-This directory exists because Coq expects it. At present there are no files
-in it, but we may add some from the Coq standard library in the future.
-When this happens, please remove this README.txt. It is here only because
-git does not want to put empty directories in a repository.
-

--- a/coq/theories/Strings/README.txt
+++ b/coq/theories/Strings/README.txt
@@ -1,5 +1,0 @@
-This directory exists because Coq expects it. At present there are no files
-in it, but we may add some from the Coq standard library in the future.
-When this happens, please remove this README.txt. It is here only because
-git does not want to put empty directories in a repository.
-

--- a/coq/theories/Structures/README.txt
+++ b/coq/theories/Structures/README.txt
@@ -1,5 +1,0 @@
-This directory exists because Coq expects it. At present there are no files
-in it, but we may add some from the Coq standard library in the future.
-When this happens, please remove this README.txt. It is here only because
-git does not want to put empty directories in a repository.
-

--- a/coq/theories/Vectors/README.txt
+++ b/coq/theories/Vectors/README.txt
@@ -1,5 +1,0 @@
-This directory exists because Coq expects it. At present there are no files
-in it, but we may add some from the Coq standard library in the future.
-When this happens, please remove this README.txt. It is here only because
-git does not want to put empty directories in a repository.
-

--- a/coq/theories/Wellfounded/README.txt
+++ b/coq/theories/Wellfounded/README.txt
@@ -1,5 +1,0 @@
-This directory exists because Coq expects it. At present there are no files
-in it, but we may add some from the Coq standard library in the future.
-When this happens, please remove this README.txt. It is here only because
-git does not want to put empty directories in a repository.
-

--- a/coq/theories/ZArith/README.txt
+++ b/coq/theories/ZArith/README.txt
@@ -1,5 +1,0 @@
-This directory exists because Coq expects it. At present there are no files
-in it, but we may add some from the Coq standard library in the future.
-When this happens, please remove this README.txt. It is here only because
-git does not want to put empty directories in a repository.
-


### PR DESCRIPTION
These folders were kept since historically coq complained without them. This doesn't seem to be the case anymore.