### PR TITLE
fixed typo in reflexivity tactic causing universe increase

### DIFF
--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -24,6 +24,8 @@ Notation "1" := equiv_idmap : equiv_scope.
 
 Global Instance reflexive_equiv : Reflexive Equiv | 0 := @equiv_idmap.
 
+Arguments reflexive_equiv /.
+
 (** The composition of equivalences is an equivalence. *)
 Global Instance isequiv_compose `{IsEquiv A B f} `{IsEquiv B C g}
   : IsEquiv (compose g f) | 1000

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -70,7 +70,7 @@ Ltac reflexivity :=
       let R := match goal with |- ?R ?x ?y => constr:(R) end in
       let pre_proof_term_head := constr:(@reflexivity _ R _) in
       let proof_term_head := (eval cbn in pre_proof_term_head) in
-      apply (pre_proof_term_head : forall x, R x x)).
+      apply (proof_term_head : forall x, R x x)).
 
 (** Even if we weren't using [cbn], we would have to redefine symmetry, since the built-in Coq version is sometimes too smart for its own good, and will occasionally fail when it should not. *)
 Ltac symmetry :=

--- a/theories/Tests.v
+++ b/theories/Tests.v
@@ -56,3 +56,21 @@ Module Issue754_1.
     assumption.
   Qed.
 End Issue754_1.
+
+Module Issue_1358.
+
+  Axiom A@{i} : Type@{i}.
+
+  Axiom foo@{i} : A@{i} <~> A@{i}.
+
+  Definition bar@{i} : A@{i} <~> A@{i}.
+  Proof.
+    reflexivity.
+  Defined.
+
+  Definition bar'@{i} : A@{i} <~> A@{i}.
+  Proof.
+    exact equiv_idmap.
+  Defined.
+
+End Issue_1358.


### PR DESCRIPTION
There was a typo in the `reflexivity` tactic which caused universes to increase when proving an `Equiv` goal. Now `reflexivity` applies the reduced term just like `symmetry` and `transitivity` do.


closes #1356 