### PR TITLE
Define GrpPullback, AbPullback and prove corecursion principle

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -333,6 +333,7 @@ theories/Algebra/Congruence.v
 theories/Algebra/AbGroups.v
 theories/Algebra/AbGroups/AbelianGroup.v
 theories/Algebra/AbGroups/Abelianization.v
+theories/Algebra/AbGroups/AbPullback.v
 theories/Algebra/AbGroups/Z.v
 
 theories/Algebra/Groups.v
@@ -341,6 +342,7 @@ theories/Algebra/Groups/Subgroup.v
 theories/Algebra/Groups/QuotientGroup.v
 theories/Algebra/Groups/Image.v
 theories/Algebra/Groups/Kernel.v
+theories/Algebra/Groups/GrpPullback.v
 
 #
 #   Tactics

--- a/theories/Algebra/AbGroups.v
+++ b/theories/Algebra/AbGroups.v
@@ -2,6 +2,7 @@
 
 Require Export HoTT.Algebra.AbGroups.AbelianGroup.
 Require Export HoTT.Algebra.AbGroups.Abelianization.
+Require Export HoTT.Algebra.AbGroups.AbPullback.
 
 (** Examples *)
 

--- a/theories/Algebra/AbGroups/AbPullback.v
+++ b/theories/Algebra/AbGroups/AbPullback.v
@@ -1,0 +1,49 @@
+Require Import Basics Types Limits.Pullback Cubical.PathSquare.
+Require Import Algebra.Groups Algebra.AbGroups.AbelianGroup.
+Require Import WildCat.
+
+(** Pullbacks of abelian groups. *)
+
+Section AbPullback.
+  (* Variables are named to correspond with Limits.Pullback. *)
+  Context {A B C : AbGroup} (f : B $-> A) (g : C $-> A).
+
+  Global Instance ab_pullback_commutative
+    : Commutative (@group_sgop (GrpPullback f g)).
+  Proof.
+    unfold Commutative.
+    intros [b [c p]] [d [e q]].
+    apply equiv_path_pullback; simpl.
+    refine (commutativity _ _; commutativity _ _; _).
+    apply equiv_sq_path.
+    apply path_ishprop.
+  Defined.
+
+  Global Instance isabgroup_ab_pullback
+    : IsAbGroup (GrpPullback f g) := {}.
+
+  Definition AbPullback
+    : AbGroup := Build_AbGroup (GrpPullback f g) _ _ _ _.
+
+  Proposition ab_pullback_corec {X : AbGroup}
+              (b : X $-> B) (c : X $-> C)
+              (p : f o b == g o c)
+    : X $-> AbPullback.
+  Proof.
+    exact ((@grp_pullback_corec A B C f g X) b c p).
+  Defined.
+
+  Corollary ab_pullback_corec' {X : AbGroup}
+    : {b : X $-> B & {c : X $-> C & f o b == g o c}}
+      -> (X $-> AbPullback).
+  Proof.
+    intros [b [c p]]; exact (ab_pullback_corec b c p).
+  Defined.
+
+  Theorem isequiv_ab_pullback_corec {X : AbGroup} `{Funext}
+    : IsEquiv (@ab_pullback_corec' X).
+  Proof.
+    srapply isequiv_grp_pullback_corec.
+  Defined.
+
+End AbPullback.

--- a/theories/Algebra/AbGroups/AbPullback.v
+++ b/theories/Algebra/AbGroups/AbPullback.v
@@ -25,26 +25,7 @@ Section AbPullback.
   Definition AbPullback
     : AbGroup := Build_AbGroup (GrpPullback f g) _ _ _ _.
 
-  Proposition ab_pullback_corec {X : AbGroup}
-              (b : X $-> B) (c : X $-> C)
-              (p : f o b == g o c)
-    : X $-> AbPullback.
-  Proof.
-    exact ((grp_pullback_corec f g) b c p).
-  Defined.
-
-  Corollary ab_pullback_corec' (X : AbGroup)
-    : {b : X $-> B & {c : X $-> C & f o b == g o c}}
-      -> (X $-> AbPullback).
-  Proof.
-    exact ((grp_pullback_corec' f g) X).
-  Defined.
+  (** The corecursion principle is inherited from Groups; use grp_pullback_corec and friends from Groups/GrpPullback.v. *)
 
 End AbPullback.
-
-Theorem isequiv_ab_pullback_corec `{Funext} {A B C X : AbGroup}
-        (f : B $-> A) (g : C $-> A)
-  : IsEquiv (ab_pullback_corec' f g X).
-Proof.
-  exact ((isequiv_grp_pullback_corec f g) X).
-Defined.
+  

--- a/theories/Algebra/AbGroups/AbPullback.v
+++ b/theories/Algebra/AbGroups/AbPullback.v
@@ -9,7 +9,7 @@ Section AbPullback.
   Context {A B C : AbGroup} (f : B $-> A) (g : C $-> A).
 
   Global Instance ab_pullback_commutative
-    : Commutative (@group_sgop (GrpPullback f g)).
+    : Commutative (@group_sgop (grp_pullback f g)).
   Proof.
     unfold Commutative.
     intros [b [c p]] [d [e q]].
@@ -20,12 +20,11 @@ Section AbPullback.
   Defined.
 
   Global Instance isabgroup_ab_pullback
-    : IsAbGroup (GrpPullback f g) := {}.
+    : IsAbGroup (grp_pullback f g) := {}.
 
-  Definition AbPullback
-    : AbGroup := Build_AbGroup (GrpPullback f g) _ _ _ _.
+  Definition ab_pullback
+    : AbGroup := Build_AbGroup (grp_pullback f g) _ _ _ _.
 
   (** The corecursion principle is inherited from Groups; use grp_pullback_corec and friends from Groups/GrpPullback.v. *)
 
 End AbPullback.
-  

--- a/theories/Algebra/AbGroups/AbPullback.v
+++ b/theories/Algebra/AbGroups/AbPullback.v
@@ -30,20 +30,21 @@ Section AbPullback.
               (p : f o b == g o c)
     : X $-> AbPullback.
   Proof.
-    exact ((grp_pullback_corec f g) b c p).
+    apply ((grp_pullback_corec f g) b c p).
   Defined.
 
-  Corollary ab_pullback_corec' {X : AbGroup}
+  Corollary ab_pullback_corec' (X : AbGroup)
     : {b : X $-> B & {c : X $-> C & f o b == g o c}}
       -> (X $-> AbPullback).
   Proof.
-    exact (grp_pullback_corec' f g).
-  Defined.
-
-  Theorem isequiv_ab_pullback_corec {X : AbGroup} `{Funext}
-    : IsEquiv (@ab_pullback_corec' X).
-  Proof.
-    exact (isequiv_grp_pullback_corec f g).
+    apply (grp_pullback_corec' f g).
   Defined.
 
 End AbPullback.
+
+Theorem isequiv_ab_pullback_corec `{Funext} {A B C X : AbGroup}
+        (f : B $-> A) (g : C $-> A)
+  : IsEquiv (ab_pullback_corec' f g X).
+Proof.
+  apply (isequiv_grp_pullback_corec f g).
+Defined.

--- a/theories/Algebra/AbGroups/AbPullback.v
+++ b/theories/Algebra/AbGroups/AbPullback.v
@@ -30,20 +30,20 @@ Section AbPullback.
               (p : f o b == g o c)
     : X $-> AbPullback.
   Proof.
-    exact ((@grp_pullback_corec A B C f g X) b c p).
+    exact ((grp_pullback_corec f g) b c p).
   Defined.
 
   Corollary ab_pullback_corec' {X : AbGroup}
     : {b : X $-> B & {c : X $-> C & f o b == g o c}}
       -> (X $-> AbPullback).
   Proof.
-    intros [b [c p]]; exact (ab_pullback_corec b c p).
+    exact (grp_pullback_corec' f g).
   Defined.
 
   Theorem isequiv_ab_pullback_corec {X : AbGroup} `{Funext}
     : IsEquiv (@ab_pullback_corec' X).
   Proof.
-    srapply isequiv_grp_pullback_corec.
+    exact (isequiv_grp_pullback_corec f g).
   Defined.
 
 End AbPullback.

--- a/theories/Algebra/AbGroups/AbPullback.v
+++ b/theories/Algebra/AbGroups/AbPullback.v
@@ -30,14 +30,14 @@ Section AbPullback.
               (p : f o b == g o c)
     : X $-> AbPullback.
   Proof.
-    apply ((grp_pullback_corec f g) b c p).
+    exact ((grp_pullback_corec f g) b c p).
   Defined.
 
   Corollary ab_pullback_corec' (X : AbGroup)
     : {b : X $-> B & {c : X $-> C & f o b == g o c}}
       -> (X $-> AbPullback).
   Proof.
-    apply (grp_pullback_corec' f g).
+    exact ((grp_pullback_corec' f g) X).
   Defined.
 
 End AbPullback.
@@ -46,5 +46,5 @@ Theorem isequiv_ab_pullback_corec `{Funext} {A B C X : AbGroup}
         (f : B $-> A) (g : C $-> A)
   : IsEquiv (ab_pullback_corec' f g X).
 Proof.
-  apply (isequiv_grp_pullback_corec f g).
+  exact ((isequiv_grp_pullback_corec f g) X).
 Defined.

--- a/theories/Algebra/Groups.v
+++ b/theories/Algebra/Groups.v
@@ -5,6 +5,7 @@ Require Export HoTT.Algebra.Groups.Subgroup.
 Require Export HoTT.Algebra.Groups.QuotientGroup.
 Require Export HoTT.Algebra.Groups.Image.
 Require Export HoTT.Algebra.Groups.Kernel.
+Require Export HoTT.Algebra.Groups.GrpPullback.
 
 (** Examples *)
 

--- a/theories/Algebra/Groups/GrpPullback.v
+++ b/theories/Algebra/Groups/GrpPullback.v
@@ -90,17 +90,17 @@ Section GrpPullback.
 
   Global Instance isgroup_grp_pullback : IsGroup (Pullback f g) := {}.
 
-  Definition GrpPullback : Group
+  Definition grp_pullback : Group
     := Build_Group (Pullback f g) _ _ _ _.
 
-  Definition grp_pullback_pr1 : GrpPullback $-> B.
+  Definition grp_pullback_pr1 : grp_pullback $-> B.
   Proof.
     snrapply Build_GroupHomomorphism.
     - apply pullback_pr1.
     - intros x y. reflexivity.
   Defined.
 
-  Definition grp_pullback_pr2 : GrpPullback $-> C.
+  Definition grp_pullback_pr2 : grp_pullback $-> C.
   Proof.
     snrapply Build_GroupHomomorphism.
     - apply pullback_pr2.
@@ -110,7 +110,7 @@ Section GrpPullback.
   Proposition grp_pullback_corec {X : Group}
               (b : X $-> B) (c : X $-> C)
               (p : f o b == g o c)
-    : X $-> GrpPullback.
+    : X $-> grp_pullback.
   Proof.
     snrapply Build_GroupHomomorphism.
     - exact (fun x => (b x; c x; p x)).
@@ -127,7 +127,7 @@ Section GrpPullback.
 
   Corollary grp_pullback_corec' (X : Group)
     : {b : X $-> B & { c : X $-> C & f o b == g o c}}
-      -> (X $-> GrpPullback).
+      -> (X $-> grp_pullback).
   Proof.
     intros [b [c p]]; exact (grp_pullback_corec b c p).
   Defined.

--- a/theories/Algebra/Groups/GrpPullback.v
+++ b/theories/Algebra/Groups/GrpPullback.v
@@ -1,0 +1,175 @@
+Require Import Basics Types Limits.Pullback Cubical.PathSquare.
+Require Import Algebra.Groups.Group.
+Require Import WildCat.
+
+(** Pullbacks of groups are formalized by equipping the set-pullback with the desired group structure. The universal property in the category of groups is proved by saying that the corecursion principle (grp_pullback_corec) is an equivalence. *) 
+
+Local Open Scope mc_scope.
+Local Open Scope mc_mult_scope.
+
+Section GrpPullback.
+
+  (* Variables are named to correspond with Limits.Pullback. *)
+  Context {A B C : Group} (f : B $-> A) (g : C $-> A).
+
+  Local Instance grp_pullback_sgop : SgOp (Pullback f g).
+  Proof.
+    intros [b [c p]] [d [e q]].
+    refine (b * d; c * e; _).
+    refine (grp_homo_op f b d @ (_ @ _) @ (grp_homo_op g c e)^).
+    - exact (ap (fun y:A => f b * y) q).
+    - exact (ap (fun x:A => x * g e) p).
+  Defined.
+
+  Local Instance grp_pullback_sgop_associative
+    : Associative grp_pullback_sgop.
+  Proof.
+    intros [x1 [x2 p]] [y1 [y2 q]] [z1 [z2 u]].
+    apply equiv_path_pullback; simpl.
+    refine (associativity _ _ _; associativity _ _ _; _).
+    apply equiv_sq_path.
+    apply path_ishprop.
+  Defined.
+
+  Local Instance grp_pullback_issemigroup : IsSemiGroup (Pullback f g) := {}.
+  
+  Local Instance grp_pullback_mon_unit : MonUnit (Pullback f g)
+    := (1; 1; grp_homo_unit f @ (grp_homo_unit g)^).
+
+  Local Instance grp_pullback_leftidentity
+    : LeftIdentity grp_pullback_sgop grp_pullback_mon_unit.
+  Proof.
+    intros [b [c p]]; simpl.
+    apply equiv_path_pullback; simpl.
+    refine (left_identity _; left_identity _; _).
+    apply equiv_sq_path.
+    apply path_ishprop.
+  Defined.
+
+  Local Instance grp_pullback_rightidentity
+    : RightIdentity grp_pullback_sgop grp_pullback_mon_unit.
+  Proof.
+    intros [b [c p]]; simpl.
+    apply equiv_path_pullback; simpl.
+    refine (right_identity _; right_identity _; _).
+    apply equiv_sq_path.
+    apply path_ishprop.
+  Defined.
+
+  Local Instance ismonoid_grp_pullback : IsMonoid (Pullback f g) := {}.
+
+  Local Instance grp_pullback_negate : Negate (Pullback f g).
+  Proof.
+    intros [b [c p]].
+    refine (-b; -c; grp_homo_inv f b @ _ @ (grp_homo_inv g c)^).
+    exact (ap (fun a => -a) p).
+  Defined.
+
+  Local Instance grp_pullback_leftinverse
+    : LeftInverse grp_pullback_sgop grp_pullback_negate grp_pullback_mon_unit.
+  Proof.
+    unfold LeftInverse.
+    intros [b [c p]].
+    unfold grp_pullback_sgop; simpl.
+    apply equiv_path_pullback; simpl.
+    refine (left_inverse _; left_inverse _; _).
+    apply equiv_sq_path.
+    apply path_ishprop.
+  Defined.
+
+  Local Instance grp_pullback_rightinverse
+    : RightInverse grp_pullback_sgop grp_pullback_negate grp_pullback_mon_unit.
+  Proof.
+    intros [b [c p]].
+    unfold grp_pullback_sgop; simpl.
+    apply equiv_path_pullback; simpl.
+    refine (right_inverse _; right_inverse _; _).
+    apply equiv_sq_path.
+    apply path_ishprop.
+  Defined.
+
+  Global Instance isgroup_grp_pullback : IsGroup (Pullback f g) := {}.
+
+  Definition GrpPullback : Group
+    := Build_Group (Pullback f g) _ _ _ _.
+
+  Definition grp_pullback_pr1 : GrpPullback $-> B.
+  Proof.
+    snrapply Build_GroupHomomorphism.
+    - apply pullback_pr1.
+    - intros x y. reflexivity.
+  Defined.
+
+  Definition grp_pullback_pr2 : GrpPullback $-> C.
+  Proof.
+    snrapply Build_GroupHomomorphism.
+    - apply pullback_pr2.
+    - intros x y. reflexivity.
+  Defined.
+
+  Proposition grp_pullback_corec {X : Group}
+              (b : X $-> B) (c : X $-> C)
+              (p : f o b == g o c)
+    : X $-> GrpPullback.
+  Proof.
+    snrapply Build_GroupHomomorphism.
+    - exact (fun x => (b x; c x; p x)).
+    - intros x y.
+      srapply path_sigma.
+      + simpl.
+        apply (grp_homo_op b).
+      + unfold pr2.
+        refine (transport_sigma' _ _ @ _). unfold pr1.
+        apply path_sigma_hprop.
+        simpl.
+        apply (grp_homo_op c).
+  Defined.
+
+  Corollary grp_pullback_corec' (X : Group)
+    : {b : X $-> B & { c : X $-> C & f o b == g o c}}
+      -> (X $-> GrpPullback).
+  Proof.
+    intros [b [c p]]; exact (grp_pullback_corec b c p).
+  Defined.
+
+End GrpPullback.
+
+Section IsEquivGrpPullbackCorec.
+
+  (* New section with Funext at the start of the Context. *)
+  Context `{Funext} {A B C : Group} (f : B $-> A) (g : C $-> A).
+
+  Lemma grp_pullback_corec_pr1 {X : Group}
+        (b : X $-> B) (c : X $-> C)
+        (p : f o b == g o c)
+    : grp_pullback_pr1 f g $o grp_pullback_corec f g b c p = b.
+  Proof.
+    apply equiv_path_grouphomomorphism; reflexivity.
+  Defined.
+
+  Lemma grp_pullback_corec_pr2 {X : Group}
+        (b : X $-> B) (c : X $-> C)
+        (p : f o b == g o c)
+    : grp_pullback_pr2 f g $o grp_pullback_corec f g b c p = c.
+  Proof.
+    apply equiv_path_grouphomomorphism; reflexivity.
+  Defined.
+
+  Theorem isequiv_grp_pullback_corec `{Funext} (X : Group)
+    : IsEquiv (grp_pullback_corec' f g X).
+  Proof.
+    snrapply isequiv_adjointify.
+    - intro phi.
+      refine (grp_pullback_pr1 f g $o phi; grp_pullback_pr2 f g $o phi; _).
+      intro x; exact (pullback_commsq f g (phi x)).
+    - intro phi.
+      apply equiv_path_grouphomomorphism; reflexivity.
+    - intro bcp; simpl.
+      srapply path_sigma.
+      + simpl. apply grp_pullback_corec_pr1.
+      + refine (transport_sigma' _ _ @ _).
+        apply path_sigma_hprop; simpl pr1.
+        simpl. apply grp_pullback_corec_pr2.
+  Defined.
+
+End IsEquivGrpPullbackCorec.

--- a/theories/Algebra/Groups/GrpPullback.v
+++ b/theories/Algebra/Groups/GrpPullback.v
@@ -155,7 +155,7 @@ Section IsEquivGrpPullbackCorec.
     apply equiv_path_grouphomomorphism; reflexivity.
   Defined.
 
-  Theorem isequiv_grp_pullback_corec `{Funext} (X : Group)
+  Theorem isequiv_grp_pullback_corec (X : Group)
     : IsEquiv (grp_pullback_corec' f g X).
   Proof.
     snrapply isequiv_adjointify.


### PR DESCRIPTION
Implements pullbacks of groups in [Groups/GrpPullback.v](https://github.com/jarlg/HoTT/blob/GrpPullback/theories/Algebra/Groups/GrpPullback.v) by equipping `Pullback f g` (from Limits/Pullback.v) with a group structure whenever `f`, `g` are group homomorphisms. If the groups involved are abelian, so is the pullback -- this is what [AbGroups/AbPullback.v](https://github.com/jarlg/HoTT/blob/GrpPullback/theories/Algebra/AbGroups/AbPullback.v) amounts to.

I'm unsure about which instances should be Global vs Local. Currently only the [Group instance for `Pullback f g`](https://github.com/jarlg/HoTT/blob/3eeee0b774f59343a14cd970ca7865f9d590e25f/theories/Algebra/Groups/GrpPullback.v#L91) is Global and the [two instances in AbPullback.v](https://github.com/jarlg/HoTT/blob/3eeee0b774f59343a14cd970ca7865f9d590e25f/theories/Algebra/AbGroups/AbPullback.v#L11) as well.

Should [`isequiv_grp_pullback_corec`](https://github.com/jarlg/HoTT/blob/3eeee0b774f59343a14cd970ca7865f9d590e25f/theories/Algebra/Groups/GrpPullback.v#L158) and [`isequiv_ab_pullback_corec`](https://github.com/jarlg/HoTT/blob/3eeee0b774f59343a14cd970ca7865f9d590e25f/theories/Algebra/AbGroups/AbPullback.v#L43) be instances?