### PR TITLE
Free groups

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -351,6 +351,7 @@ theories/Algebra/Groups/GrpPullback.v
 theories/Algebra/Groups/FreeGroup.v
 
 theories/Algebra/Groups/FreeGroup/KrausAltenkirch.v
+theories/Algebra/Groups/FreeGroup/LoopSusp.v
 
 #
 #   Tactics

--- a/_CoqProject
+++ b/_CoqProject
@@ -350,7 +350,7 @@ theories/Algebra/Groups/Kernel.v
 theories/Algebra/Groups/GrpPullback.v
 theories/Algebra/Groups/FreeGroup.v
 
-theories/Algebra/Groups/FreeGroup/KrausAltenkirch.v
+theories/Algebra/Groups/FreeGroup/ListQuotient.v
 theories/Algebra/Groups/FreeGroup/LoopSusp.v
 
 #

--- a/_CoqProject
+++ b/_CoqProject
@@ -348,6 +348,9 @@ theories/Algebra/Groups/QuotientGroup.v
 theories/Algebra/Groups/Image.v
 theories/Algebra/Groups/Kernel.v
 theories/Algebra/Groups/GrpPullback.v
+theories/Algebra/Groups/FreeGroup.v
+
+theories/Algebra/Groups/FreeGroup/KrausAltenkirch.v
 
 #
 #   Tactics

--- a/theories/Algebra/Groups.v
+++ b/theories/Algebra/Groups.v
@@ -6,6 +6,7 @@ Require Export HoTT.Algebra.Groups.QuotientGroup.
 Require Export HoTT.Algebra.Groups.Image.
 Require Export HoTT.Algebra.Groups.Kernel.
 Require Export HoTT.Algebra.Groups.GrpPullback.
+Require Export HoTT.Algebra.Groups.FreeGroup.
 
 (** Examples *)
 

--- a/theories/Algebra/Groups/FreeGroup.v
+++ b/theories/Algebra/Groups/FreeGroup.v
@@ -1,0 +1,45 @@
+Require Import Basics Types.
+Require Import Groups.Group.
+Require Import WildCat.
+
+(** Free groups are defined in Group.v. In this file we prove properties of free groups. There are various constructions of free groups to choose from, all of which can be found in the FreeGroup folder. *)
+
+(** In this file, and in the rest of the library we choose a modified version of the free group which can be found in Kraus-Altenkirch 2018 arXiv:1805.02069. This is a very simple HIT in a similar manner to the abelianization HIT used in Algebra.AbGroup.Abelianization. *)
+Require Export Algebra.Groups.FreeGroup.KrausAltenkirch.
+
+(** Properties of free groups *)
+
+(** We can state the universal property of free groups as an equivalence: (F(A) $-> G) <~> (A -> G) *)
+Theorem equiv_isfreegroup_rec `{Funext} (G F : Group) (A : Type) (i : A -> F)
+  `{IsFreeGroupOn A F i}
+  : (F $-> G) <~> (A -> G).
+Proof.
+  snrapply Build_Equiv.
+  { intros f.
+    exact (f o i). }
+  nrapply isequiv_contr_map.
+  intro f.
+  unfold hfiber.
+  snrapply contr_equiv'.
+  1: exact (FactorsThroughFreeGroup A F i G f).
+  { rapply equiv_functor_sigma_id.
+    intro g.
+    apply equiv_path_forall. }
+  exact _.
+Defined.
+
+(** The above theorem is true regardless of the implementation of free groups. This let's us state the more specific theorem about the free groups themselves. This can be read as [FreeGroup] is left adjoint to the forgetful functor [group_type]. *)
+Theorem equiv_freegroup_rec `{Funext} (G : Group) (A : Type)
+  : (FreeGroup A $-> G) <~> (A -> G).
+Proof.
+  rapply equiv_isfreegroup_rec.
+Defined.
+
+(** TODO: Nielsen-Schreier theorem: Subgroups of free groups are free. Proofs of this statement are non-trivial. We can prove it using covering spaces which haven't yet been considered in this library. In fact, every known proof requires the axiom of choice in some crucical way. *)
+
+(** Here is a sketch of such a proof. If F is a free group on a type X, then it is the fundamental group of the suspension of (X + 1) (This coule be by definition). A subgroup is then the fundamental group of a covering space of Susp (X + 1). This space is a connected 1-type and using choice we can show it has a spanning tree (since it is a topological graph). By shrinking the spanning tree we get that this cover is also the suspension of some non-empty type, hence is a free group. This "proof" is however a sketch and there may be serious problems when allowing groups to be free over arbitrary types. *)
+
+(** TODO: If F(A) $<~> F(B) then the cardinalities of [A] and [B] are the same. *)
+
+(** A proof might go like this: If F(A) $<~> F(B) then so are their abelianizations F(A)^ab $<~> F(B)^ab. It can be shown that F(A)^ab = Z^A hence we need only compare ranks of free abelian groups. It is not clear to me at the time of writing that this is now easier to prove however. *)
+

--- a/theories/Algebra/Groups/FreeGroup.v
+++ b/theories/Algebra/Groups/FreeGroup.v
@@ -28,7 +28,7 @@ Proof.
   exact _.
 Defined.
 
-(** The above theorem is true regardless of the implementation of free groups. This let's us state the more specific theorem about the free groups themselves. This can be read as [FreeGroup] is left adjoint to the forgetful functor [group_type]. *)
+(** The above theorem is true regardless of the implementation of free groups. This lets us state the more specific theorem about the canonical free groups. This can be read as [FreeGroup] is left adjoint to the forgetful functor [group_type]. *)
 Theorem equiv_freegroup_rec `{Funext} (G : Group) (A : Type)
   : (FreeGroup A $-> G) <~> (A -> G).
 Proof.
@@ -57,4 +57,3 @@ Proof.
     apply equiv_path_forall. }
   exact _.
 Defined.
-

--- a/theories/Algebra/Groups/FreeGroup.v
+++ b/theories/Algebra/Groups/FreeGroup.v
@@ -35,11 +35,26 @@ Proof.
   rapply equiv_isfreegroup_rec.
 Defined.
 
-(** TODO: Nielsen-Schreier theorem: Subgroups of free groups are free. Proofs of this statement are non-trivial. We can prove it using covering spaces which haven't yet been considered in this library. In fact, every known proof requires the axiom of choice in some crucical way. *)
+Global Instance ishprop_isfreegroupon `{Funext} (F : Group) (A : Type) (i : A -> F)
+  : IsHProp (IsFreeGroupOn A F i).
+Proof.
+  unfold IsFreeGroupOn.
+  apply trunc_forall.
+Defined.
 
-(** Here is a sketch of such a proof. If F is a free group on a type X, then it is the fundamental group of the suspension of (X + 1) (This coule be by definition). A subgroup is then the fundamental group of a covering space of Susp (X + 1). This space is a connected 1-type and using choice we can show it has a spanning tree (since it is a topological graph). By shrinking the spanning tree we get that this cover is also the suspension of some non-empty type, hence is a free group. This "proof" is however a sketch and there may be serious problems when allowing groups to be free over arbitrary types. *)
-
-(** TODO: If F(A) $<~> F(B) then the cardinalities of [A] and [B] are the same. *)
-
-(** A proof might go like this: If F(A) $<~> F(B) then so are their abelianizations F(A)^ab $<~> F(B)^ab. It can be shown that F(A)^ab = Z^A hence we need only compare ranks of free abelian groups. It is not clear to me at the time of writing that this is now easier to prove however. *)
+(** Both ways of stating the universal property are equivalent. *)
+Definition equiv_isfregroupon_isequiv_precomp `{Funext} (F : Group) (A : Type) (i : A -> F)
+  : IsFreeGroupOn A F i <~> forall G, IsEquiv (fun f : F $-> G => f o i).
+Proof.
+  srapply equiv_iff_hprop.
+  1: intros k G; rapply (equiv_isequiv (equiv_isfreegroup_rec G F A i)).
+  intros k G g.
+  specialize (k G).
+  snrapply contr_equiv'.
+  1: exact (hfiber (fun f x => grp_homo_map F G f (i x)) g).
+  { rapply equiv_functor_sigma_id.
+    intro y; symmetry.
+    apply equiv_path_forall. }
+  exact _.
+Defined.
 

--- a/theories/Algebra/Groups/FreeGroup.v
+++ b/theories/Algebra/Groups/FreeGroup.v
@@ -2,10 +2,10 @@ Require Import Basics Types.
 Require Import Groups.Group.
 Require Import WildCat.
 
-(** Free groups are defined in Group.v. In this file we prove properties of free groups. There are various constructions of free groups to choose from, all of which can be found in the FreeGroup folder. *)
+(** Free groups are defined in Group.v. In this file we prove properties of free groups. There are various constructions of free groups to choose from, all of which can be found in the FreeGroup folder. Though, this is a bit of a lie since currently there is only one full implmentation. O:-) *)
 
 (** In this file, and in the rest of the library we choose a modified version of the free group which can be found in Kraus-Altenkirch 2018 arXiv:1805.02069. This is a very simple HIT in a similar manner to the abelianization HIT used in Algebra.AbGroup.Abelianization. *)
-Require Export Algebra.Groups.FreeGroup.KrausAltenkirch.
+Require Export Algebra.Groups.FreeGroup.ListQuotient.
 
 (** Properties of free groups *)
 

--- a/theories/Algebra/Groups/FreeGroup/KrausAltenkirch.v
+++ b/theories/Algebra/Groups/FreeGroup/KrausAltenkirch.v
@@ -1,0 +1,361 @@
+Require Import Basics Types.
+Require Import Groups.Group.
+Require Import Truncations.
+Require Import HIT.Coeq.
+
+Local Open Scope mc_scope.
+Local Open Scope mc_mult_scope.
+
+(** In this file we construct the free abelian group on a type [A] as a higher inductive type. This construction is due to Kraus and Altenkirch. Their construction is actually more general, but we set truncate it to suit our needs which is the free group as a set. *)
+
+Section Reduction.
+
+  Context (A : Type).
+
+  (** We define words (with inverses) on A to be lists of marked elements of A *)
+  Definition Words : Type := list (A + A).
+
+  (** Given a marked element of A we can change its mark *)
+  Definition change_sign : A + A -> A + A
+    := fun x => match x with
+                | inl a => inr a
+                | inr a => inl a
+                end.
+
+  (** We introduce a local notation for [change_sign]. It is only defined in this section however. *)
+  Notation "x ^" := (change_sign x).
+
+  (** Changing sign is an involution *)
+  Definition change_sign_inv a : a^^ = a.
+  Proof.
+    by destruct a.
+  Defined.
+
+  (** We can concatenate words using list concatenation *)
+  Definition word_concat : Words -> Words -> Words := @app _.
+
+  (** We introduce a local notation for word_concat. *)
+  Infix "@" := word_concat.
+
+  Definition word_concat_w_nil x : x @ nil = x.
+  Proof.
+    induction x; trivial.
+    cbn; f_ap.
+  Defined.
+
+  Definition word_concat_w_ww x y z : x @ (y @ z) = (x @ y) @ z.
+  Proof.
+    revert x z.
+    induction y; intros x z.
+    { f_ap; symmetry.
+      apply word_concat_w_nil. }
+    simpl; revert z y IHy.
+    induction x; trivial.
+    intros z y IHy.
+    simpl; f_ap.
+    apply IHx, IHy.
+  Defined.
+
+  (** Singleton word *)
+  Definition word_sing (x : A + A) : Words := (cons x nil).
+
+  Notation "[ x ]" := (word_sing x).
+
+  (** We define an inductive family [Red] on [Words] which expresses whether a given word can be reduced to the empty list *)
+  Inductive Red : Words -> Type :=
+    | red_zero : Red nil
+    | red_step (y z : Words) (a : A + A)
+      : Red (y @ z) -> Red (y @ [a] @ [a^] @ z).
+
+  (** Now we wish to define the free group on A as the following HIT: 
+
+    HIT N(A) : hSet
+     | eta : Words -> N(A)
+     | tau (x : Words) (a : A + A) (y : Words)
+         : eta (x @ [a] @ [a^] @ y) = eta (x @ y).
+
+    Since we cannot write our HITs directly like this (without resorting to private inductive types), we will construct this HIT out of HITs we know. In fact, we can define N(A) as a coequalizer. *)
+
+  Definition map1 : Words * (A + A) * Words -> Words.
+  Proof.
+    intros [[x a] y].
+    exact (x @ [a] @ [a^] @ y).
+  Defined.
+
+  Definition map2 : Words * (A + A) * Words -> Words.
+  Proof.
+    intros [[x a] y].
+    exact (x @ y).
+  Defined.
+
+  (** Now we can define the underlying type of the free group as the 0-truncated coequalizer of these two maps *)
+  Definition freegroup_type : Type := Tr 0 (Coeq map1 map2).
+
+  (** This is the point constructor *)
+  Definition freegroup_eta : Words -> freegroup_type := tr o coeq.
+
+  (** This is the path constructor *)
+  Definition freegroup_tau (x : Words) (a : A + A) (y : Words)
+    : freegroup_eta (x @ [a] @ [a^] @ y) = freegroup_eta (x @ y).
+  Proof.
+    apply path_Tr, tr.
+    exact ((cglue (x, a, y))).
+  Defined.
+
+  (** The group operation *)
+  Global Instance sgop_freegroup : SgOp freegroup_type.
+  Proof.
+    intros x y.
+    strip_truncations.
+(*      apply tr. *)
+    revert x; snrapply Coeq_rec.
+    { intros x; revert y.
+      snrapply Coeq_rec.
+      { intros y.
+        exact (freegroup_eta (x @ y)). }
+      intros [[y a] z]; cbn.
+      refine (concat (ap _ _) _).
+      { refine (concat (word_concat_w_ww _ _ _) _).
+        rapply (ap (fun t => t @ _)).
+        refine (concat (word_concat_w_ww _ _ _) _).
+        rapply (ap (fun t => t @ _)).
+        refine (word_concat_w_ww _ _ _). }
+      refine (concat _ (ap _ _^)).
+      2: apply word_concat_w_ww.
+      apply freegroup_tau. }
+    intros [[c b] d].
+    simpl.
+    revert y.
+    snrapply Coeq_ind.
+    { simpl.
+      intro a.
+      rewrite <- word_concat_w_ww.
+      rewrite <- (word_concat_w_ww _ _ a).
+      rapply (freegroup_tau c b (d @ a)). }
+    intro; rapply path_ishprop.
+  Defined.
+
+  (** The unit of the free group is the empty word *)
+  Global Instance monunit_freegroup_type : MonUnit freegroup_type.
+  Proof.
+    apply freegroup_eta.
+    exact nil.
+  Defined.
+
+  (** We can change the sign of all the elements in a word and reverse the order. This will be the inversion in the group *)
+  Fixpoint word_change_sign (x : Words) : Words.
+  Proof.
+    destruct x as [|x xs].
+    1: exact nil.
+    exact (word_change_sign xs @ [change_sign x]).
+  Defined.
+
+  (** Changing the sign changes the order of word concatenation *)
+  Definition word_change_sign_ww (x y : Words)
+    : word_change_sign (x @ y) = word_change_sign y @ word_change_sign x.
+  Proof.
+    induction x.
+    { symmetry.
+      apply word_concat_w_nil. }
+    simpl.
+    refine (concat _ (inverse (word_concat_w_ww _ _ _))).
+    f_ap.
+  Defined.
+
+  (** This is also involutive *)
+  Lemma word_change_sign_inv x : word_change_sign (word_change_sign x) = x.
+  Proof.
+    induction x.
+    1: reflexivity.
+    simpl.
+    rewrite word_change_sign_ww.
+    cbn; f_ap.
+    apply change_sign_inv.
+  Defined.
+
+  (** Changing the sign gives us left inverses *)
+  Lemma word_concat_Vw x : freegroup_eta (word_change_sign x @ x) = mon_unit.
+  Proof.
+    induction x.
+    1: reflexivity.
+    cbn.
+    set (a' := a^).
+    rewrite <- (change_sign_inv a).
+    change a^ with a'.
+    change (freegroup_eta ((word_change_sign x @ [a']) @ ([a'^] @ x)) = mon_unit).
+    rewrite word_concat_w_ww.
+    rewrite freegroup_tau.
+    apply IHx.
+  Defined.
+
+  (** And since changing the sign is involutive we get right inverses from left inverses *)
+  Lemma word_concat_wV x : freegroup_eta (x @ word_change_sign x) = mon_unit.
+  Proof.
+    set (x' := word_change_sign x).
+    rewrite <- (word_change_sign_inv x).
+    change (freegroup_eta (word_change_sign x' @ x') = mon_unit).
+    apply word_concat_Vw.
+  Defined.
+
+  (** Negation is defined by changing the order of a word that appears in eta. Most of the work here is checking that it is agreeable with the path constructor. *)
+  Global Instance negate_freegroup_type : Negate freegroup_type.
+  Proof.
+    intro x.
+    strip_truncations.
+    revert x; srapply Coeq_rec.
+    { intro x.
+      apply freegroup_eta.
+      exact (word_change_sign x). }
+    intros [[b a] c].
+    unfold map1, map2.
+    refine (concat _ (ap _ (inverse _))).
+    2: apply word_change_sign_ww.
+    refine (concat (ap _ _) _).
+    { refine (concat (word_change_sign_ww _ _) _).
+      apply ap.
+      refine (concat (ap _ (inverse (word_concat_w_ww _ _ _))) _).
+      refine (concat (word_change_sign_ww _ _) _).
+      rapply (ap (fun t => t @ word_change_sign b)).
+      apply word_change_sign_ww. }
+    refine (concat _ (freegroup_tau _ a _)).
+    apply ap.
+    refine (concat (word_concat_w_ww _ _ _) _); f_ap.
+    refine (concat (word_concat_w_ww _ _ _) _); f_ap.
+    f_ap; cbn; f_ap.
+    apply change_sign_inv.
+  Defined.
+
+  (** Now we can start to prove the group laws. Since these are hprops we can ignore what happens with the path constructor. *)
+
+  (** Our operation is associative *)
+  Global Instance associative_freegroup_type : Associative sg_op.
+  Proof.
+    intros x y z.
+    strip_truncations.
+    revert x; snrapply Coeq_ind; intro x; [ | apply path_ishprop].
+    revert y; snrapply Coeq_ind; intro y; [ | apply path_ishprop].
+    revert z; snrapply Coeq_ind; intro z; [ | apply path_ishprop].
+    cbn; apply ap.
+    apply word_concat_w_ww.
+  Defined.
+
+  (** Left identity *)
+  Global Instance leftidentity_freegroup_type : LeftIdentity sg_op mon_unit.
+  Proof.
+    rapply Trunc_ind.
+    srapply Coeq_ind; intro x; [ | apply path_ishprop].
+    reflexivity.
+  Defined.
+
+  (** Right identity *)
+  Global Instance rightidentity_freegroup_type : RightIdentity sg_op mon_unit.
+  Proof.
+    rapply Trunc_ind.
+    srapply Coeq_ind; intro x; [ | apply path_ishprop].
+    apply (ap tr), ap.
+    apply word_concat_w_nil.
+  Defined.
+
+  (** Left inverse *)
+  Global Instance leftinverse_freegroup_type : LeftInverse sg_op negate mon_unit.
+  Proof.
+    rapply Trunc_ind.
+    srapply Coeq_ind; intro x; [ | apply path_ishprop].
+    apply word_concat_Vw.
+  Defined.
+
+  (** Right inverse *)
+  Global Instance rightinverse_freegroup_type : RightInverse sg_op negate mon_unit.
+  Proof.
+    rapply Trunc_ind.
+    srapply Coeq_ind; intro x; [ | apply path_ishprop].
+    apply word_concat_wV.
+  Defined.
+
+  (** Finally we have defined the free group on [A] *)
+  Definition FreeGroup : Group.
+  Proof.
+    snrapply (Build_Group freegroup_type); repeat split; exact _.
+  Defined.
+
+  Definition words_rec (G : Group) (s : A -> G) : Words -> G.
+  Proof.
+    intro x.
+    induction x as [|x xs].
+    1: exact mon_unit.
+    refine (_ * IHxs).
+    destruct x as [x|x].
+    1: exact (s x).
+    exact (- s x).
+  Defined.
+
+  Lemma words_rec_coh (G : Group) (s : A -> G) (a : A + A) (b c : Words)
+    : words_rec G s (map1 (b, a, c)) = words_rec G s (map2 (b, a, c)).
+  Proof.
+    
+  Admitted.
+
+  Lemma words_rec_pp  (G : Group) (s : A -> G)  (x y : Words)
+    : words_rec G s (x @ y) = words_rec G s x * words_rec G s y.
+  Proof.
+    induction x.
+    1: symmetry; apply left_identity.
+    cbn; rewrite <- simple_associativity.
+    f_ap.
+  Defined.
+
+  (** Given a group [G] we can construct a group homomorphism [FreeGroup A -> G] if we have a map [A -> G] *)
+  Definition FreeGroup_rec (G : Group) (s : A -> G)
+    : GroupHomomorphism FreeGroup G.
+  Proof.
+    snrapply Build_GroupHomomorphism.
+    { rapply Trunc_rec.
+      srapply Coeq_rec.
+      1: apply words_rec, s.
+      intros [[b a] c].
+      apply words_rec_coh. }
+    intros x y; strip_truncations.
+    revert x; snrapply Coeq_ind; hnf; intro x; [ | apply path_ishprop ].
+    revert y; snrapply Coeq_ind; hnf; intro y; [ | apply path_ishprop ].
+    simpl.
+    apply words_rec_pp.
+  Defined.
+
+  (** Now we need to prove that the free group satisifes the unviersal property of the free group. *)
+  (** TODO: remove funext from here and universal property of free group *)
+  Global Instance isfreegroupon_freegroup `{Funext}
+    : IsFreeGroupOn A FreeGroup (freegroup_eta o word_sing o inl).
+  Proof.
+    intros G f.
+    snrapply Build_Contr.
+    { srefine (_;_); simpl.
+      1: apply FreeGroup_rec, f.
+      intro x; simpl.
+      apply right_identity. }
+    intros [g h].
+    nrapply path_sigma_hprop; [ exact _ |].
+    simpl.
+    apply equiv_path_grouphomomorphism.
+    intro x.
+    rewrite <- (path_forall _ _ h).
+    strip_truncations; revert x.
+    snrapply Coeq_ind; intro x; [|apply path_ishprop].
+    hnf; symmetry.
+    induction x.
+    1: apply (grp_homo_unit g).
+    refine (concat (grp_homo_op g (freegroup_eta [a]) (freegroup_eta x)) _).
+    simpl.
+    f_ap.
+    destruct a.
+    1: reflexivity.
+    exact (grp_homo_inv g (freegroup_eta [inl a])).
+  Defined.
+
+  (** Typeclass search can already find this but we leave it here as a definition for reference. *)
+  Definition isfreegroup_freegrup `{Funext} : IsFreeGroup FreeGroup := _.
+
+End Reduction.
+
+
+
+

--- a/theories/Algebra/Groups/FreeGroup/KrausAltenkirch.v
+++ b/theories/Algebra/Groups/FreeGroup/KrausAltenkirch.v
@@ -355,7 +355,3 @@ Section Reduction.
   Definition isfreegroup_freegrup `{Funext} : IsFreeGroup FreeGroup := _.
 
 End Reduction.
-
-
-
-

--- a/theories/Algebra/Groups/FreeGroup/ListQuotient.v
+++ b/theories/Algebra/Groups/FreeGroup/ListQuotient.v
@@ -6,7 +6,7 @@ Require Import HIT.Coeq.
 Local Open Scope mc_scope.
 Local Open Scope mc_mult_scope.
 
-(** In this file we construct the free abelian group on a type [A] as a higher inductive type. This construction is due to Kraus and Altenkirch. Their construction is actually more general, but we set truncate it to suit our needs which is the free group as a set. *)
+(** In this file we construct the free abelian group on a type [A] as a higher inductive type. This construction is due to Kraus-Altenkirch 2018 arXiv:1805.02069. Their construction is actually more general, but we set truncate it to suit our needs which is the free group as a set. *)
 
 Section Reduction.
 

--- a/theories/Algebra/Groups/FreeGroup/LoopSusp.v
+++ b/theories/Algebra/Groups/FreeGroup/LoopSusp.v
@@ -1,0 +1,128 @@
+Require Import Basics Types.
+Require Import Groups.Group.
+Require Import Pointed.
+Require Import WildCat.
+Require Import Truncations.
+Require Import Homotopy.Suspension.
+Require Import Homotopy.ClassifyingSpace.
+Require Import Homotopy.HomotopyGroup.
+
+Local Open Scope pointed_scope.
+Import ClassifyingSpaceNotation.
+
+(** In this file we experiment with defining the free group on [A] to be the fundamental group of the suspension of [A + Unit]. *)
+
+(** Note that this is NOT the definition of a free group that is used in the library. The definition in use will be exported in the file Algebra.Groups.FreeGroup. This file merely exists to serve as a demonstration that the free group *could* be defined this way.
+
+This is not a very practical definition because we cannot even show that it is free at the time of writing, and univalence is used in a crucial way which seems overkill for a definition of freegroup. *)
+
+
+(** TODO: Perhaps move this to the Pointed directory? *)
+(** The free base point added to a type. This is in fact a functor and left adjoint to the forgetful functor pType to Type. *)
+Definition pointify (S : Type) : pType := Build_pType (S + Unit) (inr tt).
+
+(** pointify is left adjoint to forgetting the basepoint in the following sense *)
+Theorem equiv_pointify_map `{Funext} (A : Type) (X : pType)
+  : (pointify A ->* X) <~> (A -> X).
+Proof.
+  snrapply equiv_adjointify.
+  1: exact (fun f => f o inl).
+  { intros f.
+    snrapply Build_pMap.
+    { intros [a|].
+      1: exact (f a).
+      exact (point _). }
+    reflexivity. }
+  1: intro x; reflexivity.
+  intros f.
+  cbv.
+  pointed_reduce.
+  rapply equiv_path_pforall.
+  snrapply Build_pHomotopy.
+  1: by intros [a|[]].
+  reflexivity.
+Defined.
+
+(** We can rephrase the universal property of the free group as a certain precomposition being an equivalence. *)
+Definition isfreegroupon_isequiv_postcomp `{Funext} (F : Group) (A : Type) (i : A -> F)
+  : (forall G, IsEquiv (fun f : F $-> G => f o i)) -> IsFreeGroupOn A F i.
+Proof.
+  intros k G g.
+  specialize (k G).
+  snrapply contr_equiv'.
+  1: exact (hfiber (fun f x => grp_homo_map F G f (i x)) g).
+  { rapply equiv_functor_sigma_id.
+    intro y; symmetry.
+    apply equiv_path_forall. }
+  exact _.
+Defined.
+
+Section AssumeUnivalence.
+
+  Context `{Univalence}.
+
+  (** We define the free group as the 0-truncation of the loop space of the suspension of S + 1. Or in other words the fundamental group of the suspension of S + 1. *)
+  Definition FreeGroup (S : Type) : Group
+    := Pi1 (psusp (pointify S)).
+
+  (** We can directly prove that it satisfies the desired equivalence. *)
+  Theorem equiv_freegroup_rec (S : Type) (G : Group)
+    : (FreeGroup S $-> G) <~> (S -> G).
+  Proof.
+    unfold FreeGroup.
+    (** The first step is to swap the fundemantal group for the fundemantal group of a truncation. This will be important later. *)
+    etransitivity.
+    { srapply equiv_precompose_cat_equiv.
+      1: exact (Pi1 (pTr 1 (psusp (pointify S)))).
+      apply grp_iso_pi1_Tr. }
+    (** Now we use the equivalence of group homomorphisms and pointed maps between their deloopings. *)
+    etransitivity.
+    1: rapply equiv_grp_homo_pmap_bg.
+    (** Now since we have the classifying space of a fundamental group, we can change it into the original type. This lemma only works since the truncation is 1-truncated. *)
+    etransitivity.
+    { rapply equiv_pequiv_precompose.
+      symmetry.
+      nrapply pequiv_pclassifyingspace_pi1.
+      1,3: exact _.
+      apply isconnected_trunc.
+      rapply isconnected_susp.
+      rapply contr_inhabited_hprop.
+      apply tr; exact (point _). }
+    (** We can now get rid of the truncation by the universal property of trucation since BG is 1-truncated. *)
+    etransitivity.
+    1: rapply equiv_ptr_rec.
+    (** Applying the loop-susp adjunction *)
+    etransitivity.
+    1: apply loop_susp_adjoint.
+    (** Now we use the pointed equivalence between a group and the loop space of its delooping *)
+    etransitivity.
+    { rapply equiv_pequiv_postcompose.
+      apply pequiv_loops_bg_g. }
+    (** Finally we use the pointify adjunction. *)
+    apply equiv_pointify_map.
+  Defined.
+
+  (** We can define the inclusion map by using the previous equivalence on the identity group homomorphism. *)
+  Definition freegroup_incl (S : Type) : S -> FreeGroup S.
+  Proof.
+    rapply equiv_freegroup_rec.
+    apply grp_homo_id.
+  Defined.
+
+  (** This in theory would allow us to prove that this definition of a free group is in fact a free group. We however run into trouble. We have to use [isequiv_homotopic'] since we are not using the specific map that the property of being a free group uses. However showing that these two maps are homotopic seems to be nontrivial. Coq struggles a lot working with the extreme amount of data needed to be unfolded here as well. Therefore we leave this instance as aborted. *)
+  Global Instance isfreegroupon_freegroup (S : Type)
+    : IsFreeGroupOn S (FreeGroup S) (freegroup_incl S).
+  Proof.
+    apply isfreegroupon_isequiv_postcomp.
+    intro G.
+    snrapply isequiv_homotopic'.
+    1: apply equiv_freegroup_rec.
+    intro f.
+    unfold equiv_freegroup_rec.
+    unfold transitive_equiv.
+    unfold equiv_compose.
+    unfold equiv_isequiv.
+    (** It's not obvious how this can be finished. *)
+  Abort.
+
+End AssumeUnivalence.

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -26,7 +26,7 @@ Record Group := {
   group_isgroup : IsGroup group_type;
 }.
 
-Arguments group_type {_}.
+(* Arguments group_type {_}. *)
 Arguments group_sgop {_}.
 Arguments group_unit {_}.
 Arguments group_inverse {_}.

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -561,5 +561,3 @@ Global Instance isfreegroup_isfreegroupon (S : Type) (F_S : Group) (i : S -> F_S
   {H : IsFreeGroupOn S F_S i}
   : IsFreeGroup F_S
   := (S; i; H).
-
-

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -554,7 +554,7 @@ Global Existing Instance contr_isfreegroupon.
 
 (** A group is free if there exists a generating type on which it is a free group *)
 Class IsFreeGroup (F_S : Group)
-  := isfreegroup : exists S i, IsFreeGroupOn S F_S i.
+  := isfreegroup : {S : _ & {i : _ & IsFreeGroupOn S F_S i}}.
 
 Global Instance isfreegroup_isfreegroupon (S : Type) (F_S : Group) (i : S -> F_S)
   {H : IsFreeGroupOn S F_S i}

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -26,7 +26,6 @@ Record Group := {
   group_isgroup : IsGroup group_type;
 }.
 
-(* Arguments group_type {_}. *)
 Arguments group_sgop {_}.
 Arguments group_unit {_}.
 Arguments group_inverse {_}.

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -31,6 +31,8 @@ Arguments group_sgop {_}.
 Arguments group_unit {_}.
 Arguments group_inverse {_}.
 Arguments group_isgroup {_}.
+(** We never need to unfold the proof that something is a group *)
+Opaque group_isgroup.
 
 (** We coerce groups back to types. *)
 Coercion group_type : Group >-> Sortclass.
@@ -538,3 +540,26 @@ Proof.
   intros x.
   apply path_contr.
 Defined.
+
+(** ** Free groups *)
+
+Definition FactorsThroughFreeGroup (S : Type) (F_S : Group)
+  (i : S -> F_S) (A : Group) (g : S -> A) : Type
+  := {f : F_S $-> A & f o i == g}.
+
+(** Universal property of a free group on a set (type). *)
+Class IsFreeGroupOn (S : Type) (F_S : Group) (i : S -> F_S)
+  := contr_isfreegroupon : forall (A : Group) (g : S -> A),
+      Contr (FactorsThroughFreeGroup S F_S i A g).
+Global Existing Instance contr_isfreegroupon.
+
+(** A group is free if there exists a generating type on which it is a free group *)
+Class IsFreeGroup (F_S : Group)
+  := isfreegroup : exists S i, IsFreeGroupOn S F_S i.
+
+Global Instance isfreegroup_isfreegroupon (S : Type) (F_S : Group) (i : S -> F_S)
+  {H : IsFreeGroupOn S F_S i}
+  : IsFreeGroup F_S
+  := (S; i; H).
+
+

--- a/theories/Algebra/ooGroup.v
+++ b/theories/Algebra/ooGroup.v
@@ -1,9 +1,11 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
-Require Import Basics.
-Require Import Types.
+Require Import Basics Types.
 Require Import Pointed.
 Require Import Truncations.
 Require Import Colimits.Quotient.
+Require Import Homotopy.ClassifyingSpace.
+Require Import Algebra.Groups.
+Require Import WildCat.
 
 Local Open Scope path_scope.
 Local Open Scope pointed_scope.
@@ -37,7 +39,7 @@ Coercion group_type : ooGroup >-> Sortclass.
 
 (** Every pointed type has a loop space that is an oo-group. *)
 Definition group_loops (X : pType)
-: ooGroup.
+  : ooGroup.
 Proof.
   (* Work around https://coq.inria.fr/bugs/show_bug.cgi?id=4256 *)
   pose (x0 := point X);
@@ -57,7 +59,7 @@ Defined.
 
 (** Unfortunately, the underlying type of that oo-group is not *definitionally* the same as the ordinary loop space, but it is equivalent to it. *)
 Definition loops_group (X : pType)
-: loops X <~> group_loops X.
+  : loops X <~> group_loops X.
 Proof.
   unfold loops, group_type. simpl.
   exact (equiv_path_sigma_hprop (point X ; tr 1) (point X ; tr 1)).
@@ -283,3 +285,34 @@ Section Subgroups.
   Definition cosets := Quotient in_coset.
 
 End Subgroups.
+
+(** The wild category of oo-groups is induced by the wild category of pTypes *)
+
+Global Instance isgraph_oogroup : IsGraph ooGroup := Build_IsGraph _ ooGroupHom.
+Global Instance is01cat_oogroup : Is01Cat ooGroup := Build_Is01Cat _ _ grouphom_idmap (@grouphom_compose).
+Global Instance is1cat_oogroup : Is1Cat ooGroup := induced_1cat classifying_space.
+
+(** ** 1-groups as oo-groups *)
+
+Definition group_to_oogroup : Group -> ooGroup
+  := fun G => Build_ooGroup (pClassifyingSpace G) _.
+
+Global Instance is0functor_group_to_oogroup : Is0Functor group_to_oogroup.
+Proof.
+  snrapply Build_Is0Functor.
+  intros G H f.
+  by rapply functor_pclassifyingspace.
+Defined.
+
+Global Instance is1functor_group_to_oogroup : Is1Functor group_to_oogroup.
+Proof.
+  snrapply Build_Is1Functor.
+  1: exact @functor2_pclassifyingspace.
+  1: exact functor_pclassifyingspace_idmap.
+  exact functor_pclassifyingspace_compose.
+Defined.
+
+
+
+
+

--- a/theories/Algebra/ooGroup.v
+++ b/theories/Algebra/ooGroup.v
@@ -311,8 +311,3 @@ Proof.
   1: exact functor_pclassifyingspace_idmap.
   exact functor_pclassifyingspace_compose.
 Defined.
-
-
-
-
-

--- a/theories/Homotopy/ClassifyingSpace.v
+++ b/theories/Homotopy/ClassifyingSpace.v
@@ -278,9 +278,29 @@ Section EncodeDecode.
 
 End EncodeDecode.
 
+(** We also have that the equivalence is a group isomorphism. *)
+
+(** First we show that the loop space of a pointed 1-type is a group *)
+Definition LoopGroup (X : pType) `{IsTrunc 1 X} : Group
+  := Build_Group (loops X) concat idpath inverse
+    (Build_IsGroup _ _ _ _
+      (Build_IsMonoid _ _ _
+        (Build_IsSemiGroup _ _ _ concat_p_pp) concat_1p concat_p1)
+      concat_Vp concat_pV).
+
+Definition grp_iso_loopgroup_bg `{Univalence} (G : Group)
+  : GroupIsomorphism (LoopGroup (B G)) G.
+Proof.
+  snrapply Build_GroupIsomorphism'.
+  1: exact equiv_loops_bg_g.
+  intros x y.
+  apply encode_pp.
+Defined.
+
 (** When G is an abelian group, BG is a H-space. *)
 Section HSpace_bg.
 
+  (** TODO: funext can probably be avoided here *)
   Context `{Funext} {G : AbGroup}.
 
   Definition bg_mul : B G -> B G -> B G.

--- a/theories/Homotopy/ClassifyingSpace.v
+++ b/theories/Homotopy/ClassifyingSpace.v
@@ -185,7 +185,7 @@ Section EncodeDecode.
 
   Context `{Univalence} {G : Group}.
 
-  Local Definition codes : B G -> 0 -Type.
+  Local Definition codes : B G -> 0-Type.
   Proof.
     srapply ClassifyingSpace_rec.
     + srapply (BuildhSet G).
@@ -256,6 +256,24 @@ Section EncodeDecode.
     srapply Build_pEquiv'.
     1: apply equiv_loops_bg_g.
     reflexivity.
+  Defined.
+
+  Local Lemma encode_pp' (x : B G) (p q : bbase = x)
+    : encode _ (p @ q^) = transport (fun x : B G => codes x) q^ (encode x p).
+  Proof.
+    destruct q; cbn.
+    f_ap; apply concat_p1.
+  Defined.
+
+  Local Lemma encode_pp (p q : bbase = bbase)
+    : encode _ (p @ q) = encode _ p * encode _ q.
+  Proof.
+    refine (_ @ codes_transport _ _).
+    refine (_ @ transport2 codes _^ (encode bbase p)).
+    2: rapply decode_encode.
+    rewrite <- (inv_V q).
+    generalize q^; intro q'; clear q.
+    apply encode_pp'.
   Defined.
 
 End EncodeDecode.

--- a/theories/Homotopy/ClassifyingSpace.v
+++ b/theories/Homotopy/ClassifyingSpace.v
@@ -3,6 +3,8 @@ Require Import Algebra.AbGroups.
 Require Import Homotopy.HSpace.
 Require Import TruncType.
 Require Import Truncations.
+Require Import Homotopy.HomotopyGroup.
+Require Import Homotopy.WhiteheadsPrinciple.
 
 Local Open Scope pointed_scope.
 Local Open Scope trunc_scope.
@@ -387,3 +389,211 @@ Section HSpace_bg.
           bg_mul_right_id.
 
 End HSpace_bg.
+
+(** Functoriality of B(-) *)
+
+Definition functor_pclassifyingspace {G H : Group} (f : GroupHomomorphism G H)
+  : B G ->* B H.
+Proof.
+  snrapply Build_pMap.
+  { srapply ClassifyingSpace_rec.
+    1: exact (point _).
+    1: exact (bloop o f).
+    intros x y.
+    refine (ap bloop (grp_homo_op f x y) @ _).
+    apply bloop_pp. }
+  reflexivity.
+Defined.
+
+Definition functor2_pclassifyingspace {G H : Group} {f g : GroupHomomorphism G H}
+  : f == g -> functor_pclassifyingspace f ==* functor_pclassifyingspace g.
+Proof.
+  intro p.
+  snrapply Build_pHomotopy.
+  { srapply ClassifyingSpace_ind_hset.
+    1: reflexivity.
+    intro x.
+    unfold functor_pclassifyingspace.
+    rapply equiv_sq_dp^-1.
+    simpl.
+    rewrite 2 ClassifyingSpace_rec_beta_bloop.
+    apply sq_1G.
+    apply ap.
+    exact (p x). }
+  reflexivity.
+Defined.
+
+Definition functor_pclassifyingspace_idmap (G : Group)
+  : functor_pclassifyingspace (@grp_homo_id G) ==* pmap_idmap.
+Proof.
+  snrapply Build_pHomotopy.
+  { srapply ClassifyingSpace_ind_hset.
+    1: reflexivity.
+    intro x.
+    rapply equiv_sq_dp^-1.
+    simpl.
+    rewrite ClassifyingSpace_rec_beta_bloop.
+    apply sq_1G.
+    symmetry.
+    apply ap_idmap. }
+  reflexivity.
+Defined.
+
+Definition functor_pclassifyingspace_compose (A B C : Group)
+  (g : GroupHomomorphism A B) (f : GroupHomomorphism B C)
+  : functor_pclassifyingspace (grp_homo_compose f g)
+  ==* functor_pclassifyingspace f o* functor_pclassifyingspace g.
+Proof.
+  snrapply Build_pHomotopy.
+  { srapply ClassifyingSpace_ind_hset.
+    1: reflexivity.
+    intro x.
+    rapply equiv_sq_dp^-1.
+    simpl.
+    rapply sq_ccGG.
+    1,2: symmetry.
+    2: refine (ap_compose (ClassifyingSpace_rec _ _ _ (fun x y =>
+      ap bloop (grp_homo_op g x y) @ bloop_pp (g x) (g y))) _ (bloop x)
+      @ ap _ _ @ _).
+    1-3: nrapply ClassifyingSpace_rec_beta_bloop.
+    apply sq_1G.
+    reflexivity. }
+  reflexivity.
+Defined.
+
+(** Interestingly, [functor_pclassifyingspace] is an equivalence *)
+Global Instance isequiv_functor_pclassifyingspace `{U : Univalence} (G H : Group)
+  : IsEquiv (@functor_pclassifyingspace G H).
+Proof.
+  snrapply isequiv_adjointify.
+  { intros f.
+    refine (grp_homo_compose _ (grp_homo_compose _ (grp_iso_inverse _))).
+    1,3: rapply grp_iso_loopgroup_bg.
+    snrapply Build_GroupHomomorphism.
+    1: by nrapply loops_functor.
+    intros x y.
+    apply loops_functor_pp. }
+  { intros f.
+    rapply equiv_path_pforall.
+    snrapply Build_pHomotopy.
+    { srapply ClassifyingSpace_ind_hset.
+      { cbn; symmetry.
+        rapply (point_eq f). }
+      { intro g.
+        rapply equiv_sq_dp^-1.
+        unfold functor_pclassifyingspace.
+        unfold Build_pMap.
+        unfold pointed_fun.
+        rewrite ClassifyingSpace_rec_beta_bloop.
+        simpl.
+        rapply sq_ccGc.
+        1: symmetry; rapply decode_encode.
+        apply equiv_sq_path.
+        hott_simpl. } }
+      symmetry; apply concat_1p. }
+  intros f.
+  rapply equiv_path_grouphomomorphism.
+  simpl; intro g.
+  rapply (moveR_equiv_M' equiv_loops_bg_g).
+  rewrite concat_1p, concat_p1.
+  rewrite ClassifyingSpace_rec_beta_bloop.
+  reflexivity.
+Defined.
+
+(** Hence we have that group homomorphisms are equivalent to pointed maps between their deloopings. *)
+Theorem equiv_grp_homo_pmap_bg `{U : Univalence} (G H : Group)
+  : (GroupHomomorphism G H) <~> (B G ->* B H).
+Proof.
+  snrapply Build_Equiv.
+  2: apply isequiv_functor_pclassifyingspace.
+Defined.
+
+(** TODO: clean up and speed up *)
+(** Using Whitehead's principle we can prove that B(Pi 1 X) = X for a 0-connected 1-truncated X. *)
+Theorem pequiv_pclassifyingspace_pi1 `{Univalence}
+  (X : pType) `{IsConnected 0 X} `{IsTrunc 1 X}
+  : B (Pi1 X) <~>* X.
+Proof.
+  snrapply Build_pEquiv'.
+  { snrapply Build_Equiv.
+    (** First we give the map inducing equivalences between homotopy groups. *)
+    { srapply ClassifyingSpace_rec.
+      1: exact (point _).
+      { apply Trunc_rec.
+        exact idmap. }
+      intros x y.
+      strip_truncations.
+      reflexivity. }
+    (** Now we apply Whitehead's principle *)
+    snrapply whiteheads_principle.
+    1: exact _.
+    1: exact 1.
+    1,2: exact _.
+    1: apply isequiv_contr_contr.
+    (** We need to show that this map induces equivalences for all homotopy groups *)
+    intros x n.
+    revert x.
+    snrapply ClassifyingSpace_ind_hset.
+    1: exact _.
+    2: intro x; apply equiv_dp_path_transport, path_ishprop.
+    hnf.
+    unfold pmap_from_point.
+    unfold Build_pMap.
+    (** The case for n = 1 follows from the universal property of BG *)
+    destruct n.
+    { simpl.
+      snrapply isequiv_homotopic'.
+      { simpl.
+        transitivity (loops (pClassifyingSpace (Pi1 X))).
+        1: symmetry; rapply equiv_tr.
+        rapply equiv_loops_bg_g. }
+      intro x.
+      strip_truncations.
+      simpl.
+      unfold Trunc_functor.
+      unfold O_functor.
+      unfold O_rec.
+      simpl.
+      revert x.
+      snrapply equiv_ind.
+      2: apply equiv_loops_bg_g.
+      1: exact _.
+      intro p.
+      simpl.
+      rewrite ClassifyingSpace_rec_beta_bloop.
+      unfold encode.
+      rewrite codes_transport.
+      strip_truncations.
+      apply path_Tr, tr.
+      hott_simpl. }
+    (** The case for n > 1 follows since higher homotopy groups are trivial *)
+    snrapply isequiv_contr_contr.
+    { nrapply contr_equiv'.
+      { apply equiv_tr.
+        Search IsTrunc Contr.
+        nrapply trunc_contr.
+        apply equiv_istrunc_contr_iterated_loops.
+        snrapply trunc_leq.
+        1: exact 1.
+        { induction n.
+          1: exact tt.
+          rapply trunc_index_leq_transitive. }
+        exact _. }
+      apply equiv_istrunc_contr_iterated_loops.
+      induction n; exact _. }
+    { nrapply contr_equiv'.
+      { apply equiv_tr.
+        Search IsTrunc Contr.
+        nrapply trunc_contr.
+        apply equiv_istrunc_contr_iterated_loops.
+        snrapply trunc_leq.
+        1: exact 1.
+        { induction n.
+          1: exact tt.
+          rapply trunc_index_leq_transitive. }
+        exact _. }
+      apply equiv_istrunc_contr_iterated_loops.
+      induction n; exact _. } }
+  (** Finally we need to show that this equivalence is pointed *)
+  reflexivity.
+Defined.

--- a/theories/Homotopy/ClassifyingSpace.v
+++ b/theories/Homotopy/ClassifyingSpace.v
@@ -149,12 +149,12 @@ Defined.
 (** Now we focus on the classifying space of a group. *)
 
 (** The classifying space of a group is the following pointed type. *)
-Definition pClassifingSpace (G : Group)
+Definition pClassifyingSpace (G : Group)
   := Build_pType (ClassifyingSpace G) bbase.
 
 (** To use the B G notation for pClassifyingSpace import this module. *)
 Module Import ClassifyingSpaceNotation.
-  Definition B G := pClassifingSpace G.
+  Definition B G := pClassifyingSpace G.
 End ClassifyingSpaceNotation.
 
 Import ClassifyingSpaceNotation.

--- a/theories/Homotopy/EMSpace.v
+++ b/theories/Homotopy/EMSpace.v
@@ -199,7 +199,7 @@ Section EilenbergMacLane.
   Fixpoint EilenbergMacLane (G : Group) (n : nat) : pType
     := match n with
         | 0    => Build_pType G _
-        | 1    => pClassifingSpace G
+        | 1    => pClassifyingSpace G
         | m.+1 => pTr m.+1 (psusp (EilenbergMacLane G m))
        end.
 

--- a/theories/Homotopy/HomotopyGroup.v
+++ b/theories/Homotopy/HomotopyGroup.v
@@ -264,3 +264,23 @@ Lemma pmap_pi_functor {X Y : pType} (f : X ->* Y) (n : nat)
 Proof.
   srapply Build_pHomotopy. 1: reflexivity. apply path_ishprop.
 Defined.
+
+(** Homotopy groups of truncations *)
+
+(** The fundamental group 1st truncation of X is isomorphic to the fundamental group of X *) 
+Theorem grp_iso_pi1_Tr `{Univalence} (X : pType)
+  : GroupIsomorphism (Pi1 (pTr 1 X)) (Pi1 X).
+Proof.
+  symmetry.
+  snrapply Build_GroupIsomorphism'.
+  { unfold Pi1.
+    unfold group_type.
+    refine ((Trunc_functor_equiv _ _ )^-1%equiv oE _).
+    1: symmetry; rapply ptr_loops.
+    rapply equiv_tr. }
+  intros x y.
+  strip_truncations.
+  apply path_Tr, tr.
+  exact (ap_pp tr x y).
+Defined.
+

--- a/theories/Pointed/pEquiv.v
+++ b/theories/Pointed/pEquiv.v
@@ -108,3 +108,54 @@ Proof.
   apply pmap_postwhisker.
   symmetry; apply peisretr.
 Defined.
+
+Definition equiv_pequiv_precompose `{Funext} {A B C : pType} (f : A <~>* B)
+  : (B ->* C) <~> (A ->* C).
+Proof.
+  snrapply equiv_adjointify.
+  1: exact (fun g => g o* f).
+  1: exact (fun h => h o* f^-1*).
+  { intros g.
+    rapply equiv_path_pforall.
+    snrapply Build_pHomotopy.
+    { intro x; cbn.
+      apply ap, eissect. }
+    pointed_reduce.
+    unfold moveR_equiv_V.
+    hott_simpl. }
+  intros h.
+  rapply equiv_path_pforall.
+  snrapply Build_pHomotopy.
+  { intro x; cbn.
+    apply ap, eisretr. }
+  pointed_reduce.
+  unfold moveR_equiv_V.
+  hott_simpl.
+  refine (ap _ _ @ (ap_compose _ h _)^).
+  rapply eisadj.
+Defined.
+
+Definition equiv_pequiv_postcompose `{Funext} {A B C : pType} (f : B <~>* C)
+  : (A ->* B) <~> (A ->* C).
+Proof.
+  snrapply equiv_adjointify.
+  1: exact (fun g => f o* g).
+  1: exact (fun h => f^-1* o* h).
+  { intros g.
+    rapply equiv_path_pforall.
+    snrapply Build_pHomotopy.
+    { intro x; cbn.
+      apply eisretr. }
+    pointed_reduce.
+    unfold moveR_equiv_V.
+    hott_simpl.
+    apply eisadj. }
+  intros h.
+  rapply equiv_path_pforall.
+  snrapply Build_pHomotopy.
+  { intro x; cbn.
+    apply eissect. }
+  pointed_reduce.
+  unfold moveR_equiv_V.
+  hott_simpl.
+Defined.

--- a/theories/Pointed/pEquiv.v
+++ b/theories/Pointed/pEquiv.v
@@ -110,52 +110,9 @@ Proof.
 Defined.
 
 Definition equiv_pequiv_precompose `{Funext} {A B C : pType} (f : A <~>* B)
-  : (B ->* C) <~> (A ->* C).
-Proof.
-  snrapply equiv_adjointify.
-  1: exact (fun g => g o* f).
-  1: exact (fun h => h o* f^-1*).
-  { intros g.
-    rapply equiv_path_pforall.
-    snrapply Build_pHomotopy.
-    { intro x; cbn.
-      apply ap, eissect. }
-    pointed_reduce.
-    unfold moveR_equiv_V.
-    hott_simpl. }
-  intros h.
-  rapply equiv_path_pforall.
-  snrapply Build_pHomotopy.
-  { intro x; cbn.
-    apply ap, eisretr. }
-  pointed_reduce.
-  unfold moveR_equiv_V.
-  hott_simpl.
-  refine (ap _ _ @ (ap_compose _ h _)^).
-  rapply eisadj.
-Defined.
+  : (B ->* C) <~> (A ->* C)
+  := equiv_precompose_cat_equiv f.
 
 Definition equiv_pequiv_postcompose `{Funext} {A B C : pType} (f : B <~>* C)
-  : (A ->* B) <~> (A ->* C).
-Proof.
-  snrapply equiv_adjointify.
-  1: exact (fun g => f o* g).
-  1: exact (fun h => f^-1* o* h).
-  { intros g.
-    rapply equiv_path_pforall.
-    snrapply Build_pHomotopy.
-    { intro x; cbn.
-      apply eisretr. }
-    pointed_reduce.
-    unfold moveR_equiv_V.
-    hott_simpl.
-    apply eisadj. }
-  intros h.
-  rapply equiv_path_pforall.
-  snrapply Build_pHomotopy.
-  { intro x; cbn.
-    apply eissect. }
-  pointed_reduce.
-  unfold moveR_equiv_V.
-  hott_simpl.
-Defined.
+  : (A ->* B) <~> (A ->* C)
+  := equiv_postcompose_cat_equiv f.

--- a/theories/WildCat/Equiv.v
+++ b/theories/WildCat/Equiv.v
@@ -323,3 +323,29 @@ Proof.
   - apply cate_issect.
   - apply cate_isretr.
 Defined.
+
+(** ** Pre/post-composition with equivalences *)
+
+(** Precompositon with a cat_equiv is an equivalence between the homs *)
+Definition equiv_precompose_cat_equiv {A : Type} `{HasEquivs A} `{!HasMorExt A}
+  {x y z : A} (f : x $<~> y)
+  : (y $-> z) <~> (x $-> z).
+Proof.
+  snrapply equiv_adjointify.
+  1: exact (fun g => g $o f).
+  1: exact (fun h => h $o f^-1$).
+  { intros h.
+    apply path_hom.
+    refine (cat_assoc _ _ _ $@ _).
+    refine (_ $@ _).
+    { rapply cat_postwhisker.
+      apply cate_issect. }
+    apply cat_idr. }
+  intros g.
+  apply path_hom.
+  refine (cat_assoc _ _ _ $@ _).
+  refine (_ $@ _).
+  { rapply cat_postwhisker.
+    apply cate_isretr. }
+  apply cat_idr.
+Defined.

--- a/theories/WildCat/Equiv.v
+++ b/theories/WildCat/Equiv.v
@@ -349,3 +349,28 @@ Proof.
     apply cate_isretr. }
   apply cat_idr.
 Defined.
+
+(** Postcompositon with a cat_equiv is an equivalence between the homs *)
+Definition equiv_postcompose_cat_equiv {A : Type} `{HasEquivs A} `{!HasMorExt A}
+  {x y z : A} (f : y $<~> z)
+  : (x $-> y) <~> (x $-> z).
+Proof.
+  snrapply equiv_adjointify.
+  1: exact (fun g => f $o g).
+  1: exact (fun h => f^-1$ $o h).
+  { intros h.
+    apply path_hom.
+    refine ((cat_assoc _ _ _)^$ $@ _).
+    refine (_ $@ _).
+    { rapply cat_prewhisker.
+      apply cate_isretr. }
+    apply cat_idl. }
+  intros g.
+  apply path_hom.
+  refine ((cat_assoc _ _ _)^$ $@ _).
+  refine (_ $@ _).
+  { rapply cat_prewhisker.
+    apply cate_issect. }
+  apply cat_idl.
+Defined.
+


### PR DESCRIPTION
Here is a beginning on free groups. We add a new folder to Algebra/Groups called `FreeGroup`. This includes two files `KrausAltenkirch.v` and `LoopSusp.v`. These are two separate constructions of free groups which are defined in Group.v. The file Algebra/Groups/FreeGroup.v contains properties of free groups and exports KrausAltenkirch.v as the main implementation.

Here is a quick summary of the main file changes:

* `theories/Algebra/FreeGroup.v` contains properties of free groups (UP). Anybody wanting material on free groups would import this file or just Group.v which imports all group theory.
* `theories/Algebra/FreeGroup/KrausAltenkirch.v` contains a clever HIT for the free group on a type X. It is basically a quotient of the usual list construction, but with minimal constructors. This is a truncated version of a HIT found in Kraus-Altenkirch's "Free Higher Groups in Homotopy Type Theory". It is shown that this HIT satisfies the correct UP. This is also how we define the free group on X.
* `theories/Algebra/FreeGroup/LoopSusp.v` contains a definition of the free group on X as the fundamental group of the suspension of X with a basepoint attached. I wasn't able to finish the proof that this is the free group, but I kept this around anyway in case anybody else want's to finish it.
* In `ClassifyingSpace.v` we prove that the delooping of the fundamental group of a 0-connected 1-truncated type is equivalent to the original type.
* In `ooGroup.v` we show that ooGroup is a wildcat and that there is an inclusion (at least) 1-functor from Group to ooGroup.

Closes #1139