### PR TITLE
Define ab_biprod, ab_pushout and prove recursion principles

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -334,6 +334,7 @@ theories/Algebra/AbGroups.v
 theories/Algebra/AbGroups/AbelianGroup.v
 theories/Algebra/AbGroups/Abelianization.v
 theories/Algebra/AbGroups/AbPullback.v
+theories/Algebra/AbGroups/AbPushout.v
 theories/Algebra/AbGroups/Z.v
 
 theories/Algebra/Groups.v

--- a/theories/Algebra/AbGroups.v
+++ b/theories/Algebra/AbGroups.v
@@ -3,6 +3,7 @@
 Require Export HoTT.Algebra.AbGroups.AbelianGroup.
 Require Export HoTT.Algebra.AbGroups.Abelianization.
 Require Export HoTT.Algebra.AbGroups.AbPullback.
+Require Export HoTT.Algebra.AbGroups.AbPushout.
 
 (** Examples *)
 

--- a/theories/Algebra/AbGroups/AbPushout.v
+++ b/theories/Algebra/AbGroups/AbPushout.v
@@ -1,0 +1,104 @@
+Require Import Basics Types WildCat.
+Require Import Algebra.Groups Algebra.AbGroups.AbelianGroup.
+
+Local Open Scope mc_scope.
+Local Open Scope mc_add_scope.
+
+(** * Pushouts of abelian groups. *)
+
+Definition ab_pushout {A B C : AbGroup}
+           (f : A $-> B) (g : A $-> C) : AbGroup
+  := QuotientAbGroup
+       (ab_biprod B C)
+       (grp_image (ab_biprod_corec f (g $o ab_homo_negation))).
+
+(** Recursion principle. *)
+Theorem ab_pushout_rec {A B C Y : AbGroup} {f : A $-> B} {g : A $-> C}
+        (b : B $-> Y) (c : C $-> Y) (p : b o f == c o g)
+  : ab_pushout f g $-> Y.
+Proof.
+  srapply grp_quotient_rec.
+  - exact (ab_biprod_rec b c).
+  - intros [[x y] q]; strip_truncations; simpl.
+    destruct q as [a q]. cbn in q.
+    refine (ap (uncurry (fun x y => b x + c y)) q^ @ _).
+    unfold uncurry; cbn.
+    refine (ap011 sg_op (p a) (preserves_negate (f:=c $o g) _) @ _).
+    exact (right_inverse _).
+Defined.
+
+Corollary ab_pushout_rec_uncurried {A B C Y : AbGroup} {f : A $-> B} {g : A $-> C}
+  : {b : B $-> Y & {c : C $-> Y & b o f == c o g}}
+      -> (ab_pushout f g $-> Y).
+Proof.
+  intros [b [c p]]; exact (ab_pushout_rec b c p).
+Defined.
+
+Definition ab_pushout_i1 {A B C : AbGroup} {f : A $-> B} {g : A $-> C}
+  : B $-> ab_pushout f g := grp_quotient_map $o grp_prod_i1.
+
+Definition ab_pushout_i2 {A B C : AbGroup} {f : A $-> B} {g : A $-> C}
+  : C $-> ab_pushout f g := grp_quotient_map $o grp_prod_i2.
+
+Proposition ab_pushout_commsq {A B C : AbGroup} {f : A $-> B} {g : A $-> C}
+  : (@ab_pushout_i1 A B C f g) $o f == ab_pushout_i2 $o g.
+Proof.
+  intro a.
+  apply qglue.
+  pose (bc := grp_image_in (ab_biprod_corec f (g $o ab_homo_negation)) a).
+  exists (-bc); simpl.
+  apply path_prod; simpl.
+  - exact (right_identity (- f a))^.
+  - rewrite (preserves_negate (f:=g)).
+    refine (negate_involutive _ @ _).
+    symmetry.
+    exact (ap (fun x => x + g a) negate_mon_unit @ left_identity _).
+Defined.
+
+Proposition ab_pushout_rec_beta `{Funext} {A B C Y : AbGroup}
+            {f : A $-> B} {g : A $-> C}
+            (phi : ab_pushout f g $-> Y)
+  : ab_pushout_rec (phi $o ab_pushout_i1) (phi $o ab_pushout_i2)
+                   (fun a:A => ap phi (ab_pushout_commsq a)) = phi.
+Proof.
+  pose (N := grp_image (ab_biprod_corec f (g $o ab_homo_negation))).
+  apply (equiv_ap' (equiv_grp_quotient_ump (G:=ab_biprod B C) N Y)^-1%equiv _ _)^-1.
+  srapply path_sigma_hprop.
+  (* The goal is definitionally equivalent to:
+
+    ab_pushout_rec
+       (phi $o ab_pushout_i1) (phi $o ab_pushout_i2)
+       (fun a : A => ap phi (ab_pushout_commsq a)) $o grp_quotient_map
+       =  phi $o grp_quotient_map
+
+  However, Coq struggles to do this simplification. *)
+  refine (grp_quotient_rec_beta N Y _ _ @ _).
+  apply equiv_path_grouphomomorphism; intro bc.
+  exact (ab_biprod_rec_beta' (phi $o grp_quotient_map) bc).
+Defined.
+
+Theorem isequiv_ab_pushout_rec `{Funext} {A B C Y : AbGroup}
+        {f : A $-> B} {g : A $-> C}
+  : IsEquiv (@ab_pushout_rec_uncurried A B C Y f g).
+Proof.
+  srapply isequiv_adjointify.
+  - intro phi.
+    refine (phi $o ab_pushout_i1; phi $o ab_pushout_i2; _).
+    intro a.
+    apply (ap phi).
+    exact (ab_pushout_commsq a).
+  - intro phi.
+    exact (ab_pushout_rec_beta phi).
+  - intros [b [c p]].
+    srapply path_sigma.
+    + apply equiv_path_grouphomomorphism.
+      intro x; simpl.
+      refine (ap (fun k => b x + k) (grp_homo_unit c) @ _).
+      apply right_identity.
+    + refine (transport_sigma' _ _ @ _).
+      apply path_sigma_hprop; simpl.
+      apply equiv_path_grouphomomorphism.
+      intro y; simpl.
+      refine (ap (fun k => k + c y) (grp_homo_unit b) @ _).
+      apply left_identity.
+Defined.

--- a/theories/Algebra/AbGroups/AbPushout.v
+++ b/theories/Algebra/AbGroups/AbPushout.v
@@ -27,7 +27,8 @@ Proof.
     exact (right_inverse _).
 Defined.
 
-Corollary ab_pushout_rec_uncurried {A B C Y : AbGroup} {f : A $-> B} {g : A $-> C}
+Corollary ab_pushout_rec_uncurried {A B C : AbGroup}
+          (f : A $-> B) (g : A $-> C) (Y : AbGroup)
   : {b : B $-> Y & {c : C $-> Y & b o f == c o g}}
       -> (ab_pushout f g $-> Y).
 Proof.
@@ -64,14 +65,10 @@ Proof.
   pose (N := grp_image (ab_biprod_corec f (g $o ab_homo_negation))).
   apply (equiv_ap' (equiv_grp_quotient_ump (G:=ab_biprod B C) N Y)^-1%equiv _ _)^-1.
   srapply path_sigma_hprop.
-  (* The goal is definitionally equivalent to:
-
-    ab_pushout_rec
-       (phi $o ab_pushout_inl) (phi $o ab_pushout_inr)
-       (fun a : A => ap phi (ab_pushout_commsq a)) $o grp_quotient_map
-       =  phi $o grp_quotient_map
-
-  However, Coq struggles to do this simplification. *)
+  change (ab_pushout_rec
+            (phi $o ab_pushout_inl) (phi $o ab_pushout_inr)
+            (fun a : A => ap phi (ab_pushout_commsq a)) $o grp_quotient_map
+          =  phi $o grp_quotient_map).
   refine (grp_quotient_rec_beta N Y _ _ @ _).
   apply equiv_path_grouphomomorphism; intro bc.
   exact (ab_biprod_rec_beta' (phi $o grp_quotient_map) bc).
@@ -79,7 +76,7 @@ Defined.
 
 Theorem isequiv_ab_pushout_rec `{Funext} {A B C Y : AbGroup}
         {f : A $-> B} {g : A $-> C}
-  : IsEquiv (@ab_pushout_rec_uncurried A B C Y f g).
+  : IsEquiv (ab_pushout_rec_uncurried f g Y).
 Proof.
   srapply isequiv_adjointify.
   - intro phi.

--- a/theories/Algebra/AbGroups/AbPushout.v
+++ b/theories/Algebra/AbGroups/AbPushout.v
@@ -34,14 +34,14 @@ Proof.
   intros [b [c p]]; exact (ab_pushout_rec b c p).
 Defined.
 
-Definition ab_pushout_i1 {A B C : AbGroup} {f : A $-> B} {g : A $-> C}
-  : B $-> ab_pushout f g := grp_quotient_map $o grp_prod_i1.
+Definition ab_pushout_inl {A B C : AbGroup} {f : A $-> B} {g : A $-> C}
+  : B $-> ab_pushout f g := grp_quotient_map $o grp_prod_inl.
 
-Definition ab_pushout_i2 {A B C : AbGroup} {f : A $-> B} {g : A $-> C}
-  : C $-> ab_pushout f g := grp_quotient_map $o grp_prod_i2.
+Definition ab_pushout_inr {A B C : AbGroup} {f : A $-> B} {g : A $-> C}
+  : C $-> ab_pushout f g := grp_quotient_map $o grp_prod_inr.
 
 Proposition ab_pushout_commsq {A B C : AbGroup} {f : A $-> B} {g : A $-> C}
-  : (@ab_pushout_i1 A B C f g) $o f == ab_pushout_i2 $o g.
+  : (@ab_pushout_inl A B C f g) $o f == ab_pushout_inr $o g.
 Proof.
   intro a.
   apply qglue.
@@ -58,7 +58,7 @@ Defined.
 Proposition ab_pushout_rec_beta `{Funext} {A B C Y : AbGroup}
             {f : A $-> B} {g : A $-> C}
             (phi : ab_pushout f g $-> Y)
-  : ab_pushout_rec (phi $o ab_pushout_i1) (phi $o ab_pushout_i2)
+  : ab_pushout_rec (phi $o ab_pushout_inl) (phi $o ab_pushout_inr)
                    (fun a:A => ap phi (ab_pushout_commsq a)) = phi.
 Proof.
   pose (N := grp_image (ab_biprod_corec f (g $o ab_homo_negation))).
@@ -67,7 +67,7 @@ Proof.
   (* The goal is definitionally equivalent to:
 
     ab_pushout_rec
-       (phi $o ab_pushout_i1) (phi $o ab_pushout_i2)
+       (phi $o ab_pushout_inl) (phi $o ab_pushout_inr)
        (fun a : A => ap phi (ab_pushout_commsq a)) $o grp_quotient_map
        =  phi $o grp_quotient_map
 
@@ -83,7 +83,7 @@ Theorem isequiv_ab_pushout_rec `{Funext} {A B C Y : AbGroup}
 Proof.
   srapply isequiv_adjointify.
   - intro phi.
-    refine (phi $o ab_pushout_i1; phi $o ab_pushout_i2; _).
+    refine (phi $o ab_pushout_inl; phi $o ab_pushout_inr; _).
     intro a.
     apply (ap phi).
     exact (ab_pushout_commsq a).

--- a/theories/Algebra/AbGroups/AbelianGroup.v
+++ b/theories/Algebra/AbGroups/AbelianGroup.v
@@ -5,7 +5,7 @@ Require Export Algebra.Groups.
 Require Import Cubical.
 Require Import WildCat.
 
-Local Open Scope mc_mult_scope.
+Local Open Scope mc_add_scope.
 
 (** * Abelian groups *)
 
@@ -74,13 +74,13 @@ Proof.
     rewrite grp_homo_inv in p.
     apply moveL_equiv_V in p.
     rewrite p; cbn.
-    change (- (x * -y) = - x * y).
+    change (- (x + -y) = - x + y).
     rewrite negate_sg_op.
     rewrite (involutive y).
     apply commutativity.
 Defined.
 
-(** Quotients of abelian groups *)
+(** ** Quotients of abelian groups *)
 
 Global Instance isabgroup_quotient (G : AbGroup) (H : Subgroup G)
   : IsAbGroup (QuotientGroup G H).
@@ -99,7 +99,7 @@ Defined.
 Definition QuotientAbGroup (G : AbGroup) (H : Subgroup G)
   : AbGroup := Build_AbGroup (QuotientGroup G H) _ _ _ _.
 
-(** The wild category of abelian groups *)
+(** ** The wild category of abelian groups *)
 
 Global Instance isgraph_abgroup : IsGraph AbGroup
   := induced_graph group_abgroup.
@@ -166,3 +166,116 @@ Proof.
   apply grp_iso_quotient_normal.
 Defined.
 
+(** ** Biproducts of abelian groups *)
+
+Definition ab_biprod (A B : AbGroup) : AbGroup.
+Proof.
+  apply (Build_AbGroup (grp_prod A B) _ _ _).
+  srapply Build_IsAbGroup.
+  intros [a b] [a' b'].
+  apply path_prod; simpl; apply commutativity.
+Defined.
+
+Definition ab_biprod_i1 {A B : AbGroup} : A $-> ab_biprod A B := grp_prod_i1.
+Definition ab_biprod_i2 {A B : AbGroup} : B $-> ab_biprod A B := grp_prod_i2.
+
+(** Recursion principle *)
+Proposition ab_biprod_rec {A B Y : AbGroup}
+            (f : A $-> Y) (g : B $-> Y)
+  : (ab_biprod A B) $-> Y.
+Proof.
+  snrapply Build_GroupHomomorphism.
+  - intros [a b]; exact (f a + g b).
+  - intros [a b] [a' b']; simpl.
+    rewrite (grp_homo_op f).
+    rewrite (grp_homo_op g).
+    rewrite (associativity _ (g b) _).
+    rewrite <- (associativity _ (f a') _).
+    rewrite (commutativity (f a') _).
+    rewrite (associativity _ (g b) _).
+    exact (associativity _ (f a') _)^.
+Defined.
+
+Definition ab_biprod_p1 {A B : AbGroup} : ab_biprod A B $-> A
+  := ab_biprod_rec grp_homo_id grp_homo_const.
+
+Definition ab_biprod_p2 {A B : AbGroup} : ab_biprod A B $-> B
+  := ab_biprod_rec grp_homo_const grp_homo_id.
+
+Corollary ab_biprod_rec_uncurried {A B Y : AbGroup}
+  : (A $-> Y) * (B $-> Y)
+    -> (ab_biprod A B) $-> Y.
+Proof.
+  intros [f g]. exact (ab_biprod_rec f g).
+Defined.
+
+Proposition ab_biprod_rec_beta' {A B Y : AbGroup}
+            (u : ab_biprod A B $-> Y)
+  : ab_biprod_rec (u $o ab_biprod_i1) (u $o ab_biprod_i2) == u.
+Proof.
+  intros [a b]; simpl.
+  refine ((grp_homo_op u _ _)^ @ _).
+  apply (ap u).
+  apply path_prod.
+  - exact (right_identity a).
+  - exact (left_identity b).
+Defined.
+
+Proposition ab_biprod_rec_beta `{Funext} {A B Y : AbGroup}
+            (u : ab_biprod A B $-> Y)
+  : ab_biprod_rec (u $o ab_biprod_i1) (u $o ab_biprod_i2) = u.
+Proof.
+  apply equiv_path_grouphomomorphism.
+  exact (ab_biprod_rec_beta' u).
+Defined.
+
+Proposition ab_biprod_rec_i1_beta `{Funext} {A B Y : AbGroup}
+            (a : A $-> Y) (b : B $-> Y)
+  : (ab_biprod_rec a b) $o ab_biprod_i1 = a.
+Proof.
+  apply equiv_path_grouphomomorphism.
+  intro x; simpl.
+  rewrite (grp_homo_unit b).
+  exact (right_identity (a x)).
+Defined.
+
+Proposition ab_biprod_rec_i2_beta `{Funext} {A B Y : AbGroup}
+            (a : A $-> Y) (b : B $-> Y)
+  : (ab_biprod_rec a b) $o ab_biprod_i2 = b.
+Proof.
+  apply equiv_path_grouphomomorphism.
+  intro y; simpl.
+  rewrite (grp_homo_unit a).
+  exact (left_identity (b y)).
+Defined.
+
+Theorem isequiv_ab_biprod_rec `{Funext} {A B Y : AbGroup}
+  : IsEquiv (@ab_biprod_rec_uncurried A B Y).
+Proof.
+  srapply isequiv_adjointify.
+  - intro phi.
+    exact (phi $o ab_biprod_i1, phi $o ab_biprod_i2).
+  - intro phi.
+    exact (ab_biprod_rec_beta phi).
+  - intros [a b].
+    apply path_prod.
+    + apply ab_biprod_rec_i1_beta.
+    + apply ab_biprod_rec_i2_beta.
+Defined.
+
+(** Corecursion principle, inherited from Groups/Group.v. *)
+Definition ab_biprod_corec {A B X : AbGroup}
+           (f : X $-> A) (g : X $-> B)
+  : X $-> ab_biprod A B := grp_prod_corec f g.
+
+(** The negation automorphism of an abelian group *)
+Definition ab_homo_negation { A : AbGroup } : GroupIsomorphism A A.
+Proof.
+  snrapply Build_GroupIsomorphism.
+  - snrapply Build_GroupHomomorphism.
+    + exact (fun a => -a).
+    + exact negate_sg_op_distr.
+  - srapply isequiv_adjointify.
+    1: exact (fun a => -a).
+    1-2: exact negate_involutive.
+Defined.

--- a/theories/Algebra/AbGroups/AbelianGroup.v
+++ b/theories/Algebra/AbGroups/AbelianGroup.v
@@ -170,14 +170,13 @@ Defined.
 
 Definition ab_biprod (A B : AbGroup) : AbGroup.
 Proof.
-  apply (Build_AbGroup (grp_prod A B) _ _ _).
-  srapply Build_IsAbGroup.
+  rapply (Build_AbGroup' (grp_prod A B)).
   intros [a b] [a' b'].
   apply path_prod; simpl; apply commutativity.
 Defined.
 
-Definition ab_biprod_i1 {A B : AbGroup} : A $-> ab_biprod A B := grp_prod_i1.
-Definition ab_biprod_i2 {A B : AbGroup} : B $-> ab_biprod A B := grp_prod_i2.
+Definition ab_biprod_inl {A B : AbGroup} : A $-> ab_biprod A B := grp_prod_inl.
+Definition ab_biprod_inr {A B : AbGroup} : B $-> ab_biprod A B := grp_prod_inr.
 
 (** Recursion principle *)
 Proposition ab_biprod_rec {A B Y : AbGroup}
@@ -196,10 +195,10 @@ Proof.
     exact (associativity _ (f a') _)^.
 Defined.
 
-Definition ab_biprod_p1 {A B : AbGroup} : ab_biprod A B $-> A
+Definition ab_biprod_pr1 {A B : AbGroup} : ab_biprod A B $-> A
   := ab_biprod_rec grp_homo_id grp_homo_const.
 
-Definition ab_biprod_p2 {A B : AbGroup} : ab_biprod A B $-> B
+Definition ab_biprod_pr2 {A B : AbGroup} : ab_biprod A B $-> B
   := ab_biprod_rec grp_homo_const grp_homo_id.
 
 Corollary ab_biprod_rec_uncurried {A B Y : AbGroup}
@@ -211,7 +210,7 @@ Defined.
 
 Proposition ab_biprod_rec_beta' {A B Y : AbGroup}
             (u : ab_biprod A B $-> Y)
-  : ab_biprod_rec (u $o ab_biprod_i1) (u $o ab_biprod_i2) == u.
+  : ab_biprod_rec (u $o ab_biprod_inl) (u $o ab_biprod_inr) == u.
 Proof.
   intros [a b]; simpl.
   refine ((grp_homo_op u _ _)^ @ _).
@@ -223,15 +222,15 @@ Defined.
 
 Proposition ab_biprod_rec_beta `{Funext} {A B Y : AbGroup}
             (u : ab_biprod A B $-> Y)
-  : ab_biprod_rec (u $o ab_biprod_i1) (u $o ab_biprod_i2) = u.
+  : ab_biprod_rec (u $o ab_biprod_inl) (u $o ab_biprod_inr) = u.
 Proof.
   apply equiv_path_grouphomomorphism.
   exact (ab_biprod_rec_beta' u).
 Defined.
 
-Proposition ab_biprod_rec_i1_beta `{Funext} {A B Y : AbGroup}
+Proposition ab_biprod_rec_inl_beta `{Funext} {A B Y : AbGroup}
             (a : A $-> Y) (b : B $-> Y)
-  : (ab_biprod_rec a b) $o ab_biprod_i1 = a.
+  : (ab_biprod_rec a b) $o ab_biprod_inl = a.
 Proof.
   apply equiv_path_grouphomomorphism.
   intro x; simpl.
@@ -239,9 +238,9 @@ Proof.
   exact (right_identity (a x)).
 Defined.
 
-Proposition ab_biprod_rec_i2_beta `{Funext} {A B Y : AbGroup}
+Proposition ab_biprod_rec_inr_beta `{Funext} {A B Y : AbGroup}
             (a : A $-> Y) (b : B $-> Y)
-  : (ab_biprod_rec a b) $o ab_biprod_i2 = b.
+  : (ab_biprod_rec a b) $o ab_biprod_inr = b.
 Proof.
   apply equiv_path_grouphomomorphism.
   intro y; simpl.
@@ -254,13 +253,13 @@ Theorem isequiv_ab_biprod_rec `{Funext} {A B Y : AbGroup}
 Proof.
   srapply isequiv_adjointify.
   - intro phi.
-    exact (phi $o ab_biprod_i1, phi $o ab_biprod_i2).
+    exact (phi $o ab_biprod_inl, phi $o ab_biprod_inr).
   - intro phi.
     exact (ab_biprod_rec_beta phi).
   - intros [a b].
     apply path_prod.
-    + apply ab_biprod_rec_i1_beta.
-    + apply ab_biprod_rec_i2_beta.
+    + apply ab_biprod_rec_inl_beta.
+    + apply ab_biprod_rec_inr_beta.
 Defined.
 
 (** Corecursion principle, inherited from Groups/Group.v. *)

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -409,11 +409,11 @@ Proof.
     refine (path_prod' _ _ ); try apply grp_homo_op.
 Defined.
 
-Definition grp_prod_i1 {H K : Group}
+Definition grp_prod_inl {H K : Group}
   : GroupHomomorphism H (grp_prod H K)
   := grp_prod_corec grp_homo_id grp_homo_const.
 
-Definition grp_prod_i2 {H K : Group}
+Definition grp_prod_inr {H K : Group}
   : GroupHomomorphism K (grp_prod H K)
   := grp_prod_corec grp_homo_const grp_homo_id.
 

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -173,6 +173,14 @@ Proof.
   srapply (Build_GroupHomomorphism idmap).
 Defined.
 
+Definition grp_homo_const {G H : Group} : GroupHomomorphism G H.
+Proof.
+  snrapply Build_GroupHomomorphism.
+  - exact (fun _ => mon_unit).
+  - intros x y.
+    exact (left_identity mon_unit)^.
+Defined.
+
 (* An isomorphism of groups is a group homomorphism that is an equivalence. *)
 Record GroupIsomorphism (G H : Group) := Build_GroupIsomorphism {
   grp_iso_homo : GroupHomomorphism G H;
@@ -389,6 +397,25 @@ Proof.
     apply path_prod; cbn.
     1,2: apply right_inverse. }
 Defined.
+
+Proposition grp_prod_corec {G H K : Group}
+            (f : GroupHomomorphism K G)
+            (g : GroupHomomorphism K H)
+  : GroupHomomorphism K (grp_prod G H).
+Proof.
+  snrapply Build_GroupHomomorphism.
+  - exact (fun x:K => (f x, g x)).
+  - intros x y.
+    refine (path_prod' _ _ ); try apply grp_homo_op.
+Defined.
+
+Definition grp_prod_i1 {H K : Group}
+  : GroupHomomorphism H (grp_prod H K)
+  := grp_prod_corec grp_homo_id grp_homo_const.
+
+Definition grp_prod_i2 {H K : Group}
+  : GroupHomomorphism K (grp_prod H K)
+  := grp_prod_corec grp_homo_const grp_homo_id.
 
 Definition grp_iso_prod {A B C D : Group}
   : GroupIsomorphism A B -> GroupIsomorphism C D

--- a/theories/Algebra/Groups/QuotientGroup.v
+++ b/theories/Algebra/Groups/QuotientGroup.v
@@ -170,6 +170,16 @@ Notation "G / N" := (QuotientGroup G N) : group_scope.
 
 Local Open Scope group_scope.
 
+(** Computation rule for grp_quotient_rec. *)
+Corollary grp_quotient_rec_beta `{F : Funext} {G : Group}
+          (N : Group) (H : Group) `{IsNormalSubgroup N G}
+          {A : Group} (f : G $-> A)
+          (h : forall n:N, f (issubgroup_incl n) = mon_unit)
+  : (grp_quotient_rec G N f h) $o grp_quotient_map = f.
+Proof.
+  apply equiv_path_grouphomomorphism; reflexivity.
+Defined.
+
 (** The proof of normality is irrelevent up to equivalence. This is unfortunate that it doesn't hold definitionally. *)
 Definition grp_iso_quotient_normal (G : Group) (H : Group) `{IsSubgroup H G}
   {k k' : @IsNormalSubgroup H G _}
@@ -199,7 +209,6 @@ Proof.
     apply ap.
     apply qglue.
     unfold in_cosetL.
-    unfold class_of.
     exists (-n).
     symmetry.
     etransitivity.
@@ -212,9 +221,8 @@ Proof.
     intro x.
     reflexivity. }
   { intros [f p].
-    srapply path_sigma_hprop.
-    rapply equiv_path_grouphomomorphism.
-    reflexivity. }
+    srapply path_sigma_hprop; simpl.
+    exact (grp_quotient_rec_beta N H f p). }
 Defined.
 
 Section FirstIso.


### PR DESCRIPTION
Implements pushouts of abelian groups as quotients of the (bi)product in AbGroups/AbPushout.v. In order to do this, biproducts of abelian groups were added to AbGroups/AbelianGroup.v along with their recursion principle. The corecursion principle for `ab_biprod` is that of coproducts of groups (`grp_prod`), so this was added to Groups/Group.v.

Other minor things:
- Add the constant group homomorphism as `grp_homo_const` in Groups/Group.v.
- Add the negation automorphism of an abelian group as `ab_homo_negation` in AbGroups/AbelianGroup.v.
- The computation rule `grp_quotient_rec_beta` proved useful, so it was factored out of `equiv_grp_quotient_ump`.