### PR TITLE
Pasting for pullbacks

### DIFF
--- a/theories/Diagrams/CommutativeSquares.v
+++ b/theories/Diagrams/CommutativeSquares.v
@@ -2,7 +2,7 @@ Require Import Basics.
 
 (** * Comutative squares *)
 
-(** Commutative squares compose.
+(** Commutative squares compose vertically.
 
       A --f--> B
       |    //  |
@@ -24,6 +24,28 @@ Proof.
   intros x.
   path_via (g' (f' (h x))).
   apply ap, comm.
+Defined.
+
+(** Commutative squares compose horizontally.
+
+      A --k--> B --l--> C
+      |    //  |    //  |
+      f  comm  g  comm  h
+      |  //    |  //    |
+      V //     V //     V
+      X --i--> Y --j--> Z
+*)
+
+Lemma comm_square_comp' {A B C X Y Z : Type}
+    {k : A -> B} {l : B -> C}
+    {f : A -> X} {g : B -> Y} {h : C -> Z}
+    {i : X -> Y} {j : Y -> Z}
+    (H : i o f == g o k) (K : j o g == h o l)
+  : (j o i) o f == h o (l o k).
+Proof.
+  intros x.
+  path_via (j (g (k x))).
+  apply ap, H.
 Defined.
 
 (** Given any commutative square from [f] to [f'] whose verticals

--- a/theories/HFiber.v
+++ b/theories/HFiber.v
@@ -1,5 +1,5 @@
 (* -*- mode: coq; mode: visual-line -*- *)
-Require Import Basics Types.
+Require Import Basics Types Diagrams.CommutativeSquares.
 
 Local Open Scope equiv_scope.
 Local Open Scope path_scope.
@@ -105,6 +105,20 @@ Definition equiv_functor_hfiber2 {A B C D}
   : hfiber f b <~> hfiber g b'
   := Build_Equiv _ _ (functor_hfiber2 p q) _.
 
+Definition functor_hfiber_compose {A B C X Y Z : Type} {k : A -> B} {l : B -> C}
+    {f : A -> X} {g : B -> Y} {h : C -> Z} {i : X -> Y} {j : Y -> Z}
+    (H : i o f == g o k) (K : j o g == h o l)
+  : forall x, functor_hfiber (comm_square_comp' H K) x
+    == (functor_hfiber K (i x)) o (functor_hfiber H x : hfiber f x -> _).
+Proof.
+  intros x [y p].
+  destruct p.
+  apply (path_sigma' _ idpath).
+  refine (concat_p1 _ @ _).
+  refine (inv_pp _ _ @ ap _ _).
+  refine ((ap_V _ _)^ @ ap _ _^).
+  apply concat_p1.
+Defined.
 
 (** ** The 3x3 lemma for fibrations *)
 Definition hfiber_functor_hfiber {A B C D}

--- a/theories/Limits/Pullback.v
+++ b/theories/Limits/Pullback.v
@@ -353,7 +353,7 @@ Section Pasting.
     pose (e2' := isequiv_functor_hfiber_ispullback _ e2 b).
     snrapply isequiv_commsq'.
     7: apply isequiv_idmap.
-    4: apply (functor_hfiber_compose b).
+    4: apply (functor_hfiber_compose H K b).
     1,2: exact _.
   Defined.
 
@@ -367,7 +367,7 @@ Section Pasting.
     pose (e2' := isequiv_functor_hfiber_ispullback _ e2 b).
     snrapply isequiv_commsq'.
     9: apply isequiv_idmap.
-    4: symmetry; apply (functor_hfiber_compose b).
+    4: symmetry; apply (functor_hfiber_compose H K b).
     1,2: exact _.
   Defined.
 

--- a/theories/Limits/Pullback.v
+++ b/theories/Limits/Pullback.v
@@ -1,6 +1,7 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 Require Import HoTT.Basics HoTT.Types.
 Require Import HFiber PathAny Cubical.PathSquare.
+Require Import Diagrams.CommutativeSquares.
 
 Local Open Scope path_scope.
 
@@ -112,8 +113,8 @@ Proof.
   symmetry; apply inv_V.
 Defined.
 
-(** If the induced map on fibers is an equivalence, then a square is a pullback. *)
-Definition ispullback_isequiv_functor_hfiber {A B C D}
+(** If the induced maps on fibers is an equivalence, then a square is a pullback. *)
+Definition ispullback_isequiv_functor_hfiber {A B C D : Type}
            {f : A -> B} {g : C -> D} {h : A -> C} {k : B -> D}
            (p : k o f == g o h)
            (e : forall b:B, IsEquiv (functor_hfiber p b))
@@ -323,3 +324,51 @@ Section Pullback3x3.
   Defined.
 
 End Pullback3x3.
+
+(** Pasting for pullbacks (or 2-pullbacks lemma) *)
+
+Section Pasting.
+
+  (** Given the following diagram where the right square is a pullback square, then the outer square is a pullback square if and only if the left square is a pullback. *)
+  (* A --k--> B --l--> C
+     |    //  |    //  |
+     f  comm  g  comm  h
+     |  //    |  //    |
+     V //     V //     V
+     X --i--> Y --j--> Z *)
+  Context
+    {A B C X Y Z : Type}
+    {k : A -> B} {l : B -> C}
+    {f : A -> X} {g : B -> Y} {h : C -> Z}
+    {i : X -> Y} {j : Y -> Z}
+    (H : i o f == g o k) (K : j o g == h o l) {e1 : IsPullback K}.
+
+  Definition ispullback_pasting_left
+    : IsPullback (comm_square_comp' H K) -> IsPullback H.
+  Proof.
+    intro e2.
+    apply ispullback_isequiv_functor_hfiber.
+    intro b.
+    pose (e1' := isequiv_functor_hfiber_ispullback _ e1 (i b)).
+    pose (e2' := isequiv_functor_hfiber_ispullback _ e2 b).
+    snrapply isequiv_commsq'.
+    7: apply isequiv_idmap.
+    4: apply (functor_hfiber_compose b).
+    1,2: exact _.
+  Defined.
+
+  Definition ispullback_pasting_outer
+    : IsPullback H -> IsPullback (comm_square_comp' H K).
+  Proof.
+    intro e2.
+    apply ispullback_isequiv_functor_hfiber.
+    intro b.
+    pose (e1' := isequiv_functor_hfiber_ispullback _ e1 (i b)).
+    pose (e2' := isequiv_functor_hfiber_ispullback _ e2 b).
+    snrapply isequiv_commsq'.
+    9: apply isequiv_idmap.
+    4: symmetry; apply (functor_hfiber_compose b).
+    1,2: exact _.
+  Defined.
+
+End Pasting.

--- a/theories/Limits/Pullback.v
+++ b/theories/Limits/Pullback.v
@@ -113,7 +113,7 @@ Proof.
   symmetry; apply inv_V.
 Defined.
 
-(** If the induced maps on fibers is an equivalence, then a square is a pullback. *)
+(** If the induced maps on fibers are equivalences, then a square is a pullback. *)
 Definition ispullback_isequiv_functor_hfiber {A B C D : Type}
            {f : A -> B} {g : C -> D} {h : A -> C} {k : B -> D}
            (p : k o f == g o h)

--- a/theories/Limits/Pullback.v
+++ b/theories/Limits/Pullback.v
@@ -126,6 +126,32 @@ Proof.
   - exact _.
 Defined.
 
+(** Conversely, if the square is a pullback then the induced maps on fibers are equivalences. *)
+Definition isequiv_functor_hfiber_ispullback {A B C D : Type}
+           {f : A -> B} {g : C -> D} {h : A -> C} {k : B -> D}
+           (p : k o f == g o h)
+           (e : IsPullback p)
+  : forall b:B, IsEquiv (functor_hfiber p b).
+Proof.
+  apply isequiv_from_functor_sigma.
+  unfold IsPullback in e.
+  snrapply isequiv_commsq'.
+  4: exact (equiv_fibration_replacement f)^-1%equiv.
+  1: exact (Pullback k g).
+  1: exact (pullback_corec p).
+  { apply (functor_sigma idmap); intro b.
+    apply (functor_sigma idmap); intro c.
+    apply inverse. }
+  { intros [x [y q]].
+    destruct q.
+    apply (path_sigma' _ idpath).
+    apply (path_sigma' _ idpath).
+    simpl.
+    refine (_^ @ (inv_Vp _ _)^).
+    apply concat_1p. }
+  all: exact _.
+Defined.
+
 (** The pullback of a map along another one *)
 Definition pullback_along {A B C} (f : B -> A) (g : C -> A)
 : Pullback f g -> B


### PR DESCRIPTION
In this PR we prove the pasting lemma for pullbacks in both directions. We also show that a commutative square is a pullback if and only if `functor_hfiber` is an equivalence.

closes #1012 