### PR TITLE
Define and characterize projective types

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -111,7 +111,6 @@ theories/Spaces/Card.v
 theories/Spaces/Circle.v
 theories/Spaces/TwoSphere.v
 theories/Spaces/Spheres.v
-theories/Spaces/Projective.v
 
 theories/Spaces/Int.v
 theories/Spaces/Int/Core.v
@@ -244,6 +243,7 @@ theories/HFiber.v
 theories/HProp.v
 theories/Extensions.v
 theories/HSet.v
+theories/Projective.v
 theories/TruncType.v
 theories/DProp.v
 theories/EquivGroupoids.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -111,6 +111,7 @@ theories/Spaces/Card.v
 theories/Spaces/Circle.v
 theories/Spaces/TwoSphere.v
 theories/Spaces/Spheres.v
+theories/Spaces/Projective.v
 
 theories/Spaces/Int.v
 theories/Spaces/Int/Core.v

--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -1619,9 +1619,17 @@ End Book_7_1.
 
 (* ================================================== ex:acnm-surjset *)
 (** Exercise 7.9 *)
-(* Solved for AC_(oo,-1) by projective_cover_AC in Spaces/Projective.v *)
 
+Section Book_7_9.
+  (** Solution for the case (oo,-1). *)
 
+  Axiom AC_oo_neg1 : forall X : hSet, Choice X.
+
+  Definition Book_7_9_oo_neg1 `{Univalence} (A : Type)
+    : merely (exists X : hSet, exists p : X -> A, IsSurjection p)
+    := @HoTT.Projective.projective_cover_AC AC_oo_neg1 _ A.
+
+End Book_7_9.
 
 (* ================================================== ex:acconn *)
 (** Exercise 7.10 *)

--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -1620,16 +1620,10 @@ End Book_7_1.
 (* ================================================== ex:acnm-surjset *)
 (** Exercise 7.9 *)
 
-Section Book_7_9.
-  (** Solution for the case (oo,-1). *)
-
-  Axiom AC_oo_neg1 : forall X : hSet, Choice X.
-
-  Definition Book_7_9_oo_neg1 `{Univalence} (A : Type)
-    : merely (exists X : hSet, exists p : X -> A, IsSurjection p)
-    := @HoTT.Projective.projective_cover_AC AC_oo_neg1 _ A.
-
-End Book_7_9.
+(** Solution for the case (oo,-1). *)
+Definition Book_7_9_oo_neg1 `{Univalence} (AC_oo_neg1 : forall X : hSet, Choice X) (A : Type)
+  : merely (exists X : hSet, exists p : X -> A, IsSurjection p)
+  := @HoTT.Projective.projective_cover_AC AC_oo_neg1 _ A.
 
 (* ================================================== ex:acconn *)
 (** Exercise 7.10 *)

--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -1621,7 +1621,7 @@ End Book_7_1.
 (** Exercise 7.9 *)
 
 (** Solution for the case (oo,-1). *)
-Definition Book_7_9_oo_neg1 `{Univalence} (AC_oo_neg1 : forall X : hSet, Choice X) (A : Type)
+Definition Book_7_9_oo_neg1 `{Univalence} (AC_oo_neg1 : forall X : hSet, IsProjective' X) (A : Type)
   : merely (exists X : hSet, exists p : X -> A, IsSurjection p)
   := @HoTT.Projective.projective_cover_AC AC_oo_neg1 _ A.
 

--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -1619,6 +1619,7 @@ End Book_7_1.
 
 (* ================================================== ex:acnm-surjset *)
 (** Exercise 7.9 *)
+(* Solved for AC_(oo,-1) by projective_cover_AC in Spaces/Projective.v *)
 
 
 

--- a/theories/Basics/Trunc.v
+++ b/theories/Basics/Trunc.v
@@ -400,6 +400,14 @@ Definition equiv_iff_hprop `{IsHProp A} `{IsHProp B}
   : (A -> B) -> (B -> A) -> (A <~> B)
   := fun f g => equiv_iff_hprop_uncurried (f, g).
 
+Corollary equiv_contr_hprop (A : Type) `{Funext} `{IsHProp A}
+  : Contr A <~> A.
+Proof.
+  rapply equiv_iff_hprop.
+  - apply center.
+  - rapply contr_inhabited_hprop.
+Defined.
+
 (** Truncatedness is an hprop. *)
 Global Instance ishprop_istrunc `{Funext} (n : trunc_index) (A : Type)
   : IsHProp (IsTrunc n A) | 0.

--- a/theories/Basics/Trunc.v
+++ b/theories/Basics/Trunc.v
@@ -400,12 +400,18 @@ Definition equiv_iff_hprop `{IsHProp A} `{IsHProp B}
   : (A -> B) -> (B -> A) -> (A <~> B)
   := fun f g => equiv_iff_hprop_uncurried (f, g).
 
+Corollary iff_contr_hprop (A : Type) `{IsHProp A}
+  : Contr A <-> A.
+Proof.
+  split.
+  - apply center.
+  - rapply contr_inhabited_hprop.
+Defined.
+
 Corollary equiv_contr_hprop (A : Type) `{Funext} `{IsHProp A}
   : Contr A <~> A.
 Proof.
-  rapply equiv_iff_hprop.
-  - apply center.
-  - rapply contr_inhabited_hprop.
+  exact (equiv_iff_hprop_uncurried (iff_contr_hprop A)).
 Defined.
 
 (** Truncatedness is an hprop. *)

--- a/theories/HSet.v
+++ b/theories/HSet.v
@@ -121,6 +121,13 @@ Proof.
   exact (ap pr1 q).
 Defined.
 
+Definition isinj_section {A B : Type} {s : A -> B} {r : B -> A}
+      (H : r o s == idmap) : isinj s.
+Proof.
+  intros a a' alpha.
+  exact ((H a)^ @ ap r alpha @ H a').
+Defined.
+
 Lemma isembedding_isinj_hset {A B : Type} `{IsHSet B} (m : A -> B)
 : isinj m -> IsEmbedding m.
 Proof.

--- a/theories/HoTT.v
+++ b/theories/HoTT.v
@@ -12,6 +12,7 @@ Require Export HoTT.Truncations.
 
 Require Export HoTT.HFiber.
 Require Export HoTT.HProp.
+Require Export HoTT.Projective.
 Require Export HoTT.HSet.
 Require Export HoTT.EquivGroupoids.
 

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -94,7 +94,7 @@ Section Subuniverse.
   : MapIn O g.
   Proof.
     intros b.
-    refine (inO_equiv_inO (hfiber f b)
+    exact (inO_equiv_inO (hfiber f b)
                           (equiv_hfiber_homotopic f g p b)).
   Defined.
 

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -51,6 +51,14 @@ Definition inO_equiv_inO' {O : Subuniverse}
   : In O U
   := inO_equiv_inO T f.
 
+Definition inO_equiv_inO'' `{Funext} (O : Subuniverse) {T U : Type} (f : T <~> U)
+  : In O T <~> In O U.
+Proof.
+  apply equiv_iff_hprop.
+  - intro T_inO; exact (inO_equiv_inO' T f).
+  - intro U_inO; exact (inO_equiv_inO' U f^-1%equiv).
+Defined.
+
 (** The universe of types in the subuniverse *)
 Definition Type_@{i j} (O : Subuniverse@{i}) : Type@{j}
   := @sig@{j i} Type@{i} (fun (T : Type@{i}) => In O T).
@@ -69,6 +77,54 @@ Definition equiv_path_TypeO@{i j} {fs : Funext} O (T T' : Type_ O)
 (** Types in [TypeO] are always in [O]. *)
 Global Instance inO_TypeO {O : Subuniverse} (A : Type_ O) : In O A
   := A.2.
+
+(** ** Properties of Subuniverses *)
+
+(** A map is O-local if all its fibers are. *)
+Class MapIn (O : Subuniverse) {A B : Type} (f : A -> B)
+  := inO_hfiber_ino_map : forall (b:B), In O (hfiber f b).
+
+Global Existing Instance inO_hfiber_ino_map.
+
+Section Subuniverse.
+  Context (O : Subuniverse).
+
+  (** Anything homotopic to a local map is local. *)
+  Definition mapinO_homotopic {A B : Type} (f : A -> B) {g : A -> B}
+             (p : f == g) `{MapIn O _ _ f}
+  : MapIn O g.
+  Proof.
+    intros b.
+    refine (inO_equiv_inO (hfiber f b)
+                          (equiv_hfiber_homotopic f g p b)).
+  Defined.
+
+  (** The projection from a family of local types is local. *)
+  Global Instance mapinO_pr1 {A : Type} {B : A -> Type}
+         `{forall a, In O (B a)}
+  : MapIn O (@pr1 A B).
+  Proof.
+    intros a.
+    exact (inO_equiv_inO (B a) (hfiber_fibration a B)).
+  Defined.
+
+  Lemma equiv_forall_inO_mapinO_pr1 `{Funext} {A : Type} (B : A -> Type)
+    : (forall a, In O (B a)) <~> MapIn O (@pr1 A B).
+  Proof.
+    unfold MapIn.
+    apply equiv_functor_forall_id; intro a.
+    apply inO_equiv_inO''.
+    exact (hfiber_fibration a B).
+  Defined.
+
+  (** Being a local map is an hprop *)
+  Global Instance ishprop_mapinO `{Funext} {A B : Type} (f : A -> B)
+  : IsHProp (MapIn O f).
+  Proof.
+    apply trunc_forall.
+  Defined.
+
+End Subuniverse.
 
 (** *** Reflections *)
 
@@ -1210,6 +1266,14 @@ Section ConnectedTypes.
   : IsConnected O A -> IsConnected O B
     := isconnected_equiv A f.
 
+  (** The O-connected types form a subuniverse. *)
+  Definition Conn : Subuniverse.
+  Proof.
+    rapply (Build_Subuniverse (IsConnected O)).
+    simpl; intros T U isconnT f isequivf.
+    exact (isconnected_equiv T f isconnT).
+  Defined.
+
   (** Connectedness of a type [A] can equivalently be characterized by the fact that any map to an [O]-type [C] is nullhomotopic.  Here is one direction of that equivalence. *)
   Definition isconnected_elim {A : Type} `{IsConnected O A} (C : Type) `{In O C} (f : A -> C)
   : NullHomotopy f.
@@ -1310,13 +1374,6 @@ End ConnectedTypes.
 
 (** ** Modally truncated maps *)
 
-(** A map is "in [O]" if each of its fibers is. *)
-
-Class MapIn (O : ReflectiveSubuniverse) {A B : Type} (f : A -> B)
-  := inO_hfiber_ino_map : forall (b:B), In O (hfiber f b).
-
-Global Existing Instance inO_hfiber_ino_map.
-
 Section ModalMaps.
   Context (O : ReflectiveSubuniverse).
 
@@ -1325,25 +1382,6 @@ Section ModalMaps.
   : MapIn O f.
   Proof.
     intros b; exact _.
-  Defined.
-
-  (** Anything homotopic to a modal map is modal. *)
-  Definition mapinO_homotopic {A B : Type} (f : A -> B) {g : A -> B}
-             (p : f == g) `{MapIn O _ _ f}
-  : MapIn O g.
-  Proof.
-    intros b.
-    refine (inO_equiv_inO (hfiber f b)
-                          (equiv_hfiber_homotopic f g p b)).
-  Defined.
-
-  (** The projection from a family of modal types is modal. *)
-  Global Instance mapinO_pr1 {A : Type} {B : A -> Type}
-         `{forall a, In O (B a)}
-  : MapIn O (@pr1 A B).
-  Proof.
-    intros a.
-    refine (inO_equiv_inO (B a) (hfiber_fibration a B)).
   Defined.
 
   (** A slightly specialized result: if [Empty] is modal, then a map with decidable hprop fibers (such as [inl] or [inr]) is modal. *)
@@ -1357,13 +1395,6 @@ Section ModalMaps.
     destruct (equiv_decidable_hprop (hfiber f b)) as [e|e].
     - exact (inO_equiv_inO Unit e^-1).
     - exact (inO_equiv_inO Empty e^-1).
-  Defined.
-
-  (** Being modal is an hprop *)
-  Global Instance ishprop_mapinO `{Funext} {A B : Type} (f : A -> B)
-  : IsHProp (MapIn O f).
-  Proof.
-    apply trunc_forall.
   Defined.
 
   (** Any map between modal types is modal. *)

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -121,8 +121,7 @@ Section Subuniverse.
   Lemma equiv_forall_inO_mapinO_pr1 `{Funext} {A : Type} (B : A -> Type)
     : (forall a, In O (B a)) <~> MapIn O (@pr1 A B).
   Proof.
-    apply equiv_iff_hprop_uncurried.
-    apply iff_forall_inO_mapinO_pr1.
+    exact (equiv_iff_hprop_uncurried (iff_forall_inO_mapinO_pr1 B)).
   Defined.
 
 End Subuniverse.

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -51,14 +51,6 @@ Definition inO_equiv_inO' {O : Subuniverse}
   : In O U
   := inO_equiv_inO T f.
 
-Definition inO_equiv_inO'' `{Funext} (O : Subuniverse) {T U : Type} (f : T <~> U)
-  : In O T <~> In O U.
-Proof.
-  apply equiv_iff_hprop.
-  - intro T_inO; exact (inO_equiv_inO' T f).
-  - intro U_inO; exact (inO_equiv_inO' U f^-1%equiv).
-Defined.
-
 (** The universe of types in the subuniverse *)
 Definition Type_@{i j} (O : Subuniverse@{i}) : Type@{j}
   := @sig@{j i} Type@{i} (fun (T : Type@{i}) => In O T).
@@ -89,6 +81,13 @@ Global Existing Instance inO_hfiber_ino_map.
 Section Subuniverse.
   Context (O : Subuniverse).
 
+  (** Being a local map is an hprop *)
+  Global Instance ishprop_mapinO `{Funext} {A B : Type} (f : A -> B)
+  : IsHProp (MapIn O f).
+  Proof.
+    apply trunc_forall.
+  Defined.
+
   (** Anything homotopic to a local map is local. *)
   Definition mapinO_homotopic {A B : Type} (f : A -> B) {g : A -> B}
              (p : f == g) `{MapIn O _ _ f}
@@ -109,20 +108,21 @@ Section Subuniverse.
   Defined.
 
   (** A family of types is local if and only if the associated projection map is local. *)
+  Lemma iff_forall_inO_mapinO_pr1 {A : Type} (B : A -> Type)
+    : (forall a, In O (B a)) <-> MapIn O (@pr1 A B).
+  Proof.
+    split.
+    - exact _. (* Uses the instance mapinO_pr1 above. *)
+    - rapply functor_forall; intros a x.
+      exact (inO_equiv_inO (hfiber pr1 a)
+                           (hfiber_fibration a B)^-1%equiv).
+  Defined.
+
   Lemma equiv_forall_inO_mapinO_pr1 `{Funext} {A : Type} (B : A -> Type)
     : (forall a, In O (B a)) <~> MapIn O (@pr1 A B).
   Proof.
-    unfold MapIn.
-    apply equiv_functor_forall_id; intro a.
-    apply inO_equiv_inO''.
-    exact (hfiber_fibration a B).
-  Defined.
-
-  (** Being a local map is an hprop *)
-  Global Instance ishprop_mapinO `{Funext} {A B : Type} (f : A -> B)
-  : IsHProp (MapIn O f).
-  Proof.
-    apply trunc_forall.
+    apply equiv_iff_hprop_uncurried.
+    apply iff_forall_inO_mapinO_pr1.
   Defined.
 
 End Subuniverse.

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -108,6 +108,7 @@ Section Subuniverse.
     exact (inO_equiv_inO (B a) (hfiber_fibration a B)).
   Defined.
 
+  (** A family of types is local if and only if the associated projection map is local. *)
   Lemma equiv_forall_inO_mapinO_pr1 `{Funext} {A : Type} (B : A -> Type)
     : (forall a, In O (B a)) <~> MapIn O (@pr1 A B).
   Proof.

--- a/theories/Modalities/Separated.v
+++ b/theories/Modalities/Separated.v
@@ -98,6 +98,13 @@ Proof.
   refine (inO_equiv_inO' _ (equiv_ap_isembedding i x y)^-1).
 Defined.
 
+(* As a special case, if X embeds into an n-type for n >= -1 then X is an n-type. Note that this doesn't hold for n = -2. *)
+Corollary istrunc_embedding_trunc `{Funext} {X Y : Type} {n : trunc_index} `{IsTrunc n.+1 Y}
+      (i : X -> Y) `{IsEmbedding i} : IsTrunc n.+1 X.
+Proof.
+  exact (@in_SepO_embedding (Tr n) _ _ i IsEmbedding0 H0).
+Defined.
+
 Global Instance in_SepO_hprop (O : ReflectiveSubuniverse)
        {A : Type} `{IsHProp A}
   : In (Sep O) A.
@@ -105,6 +112,7 @@ Proof.
   srapply (in_SepO_embedding O (const tt)).
   intros x y; exact _.
 Defined.
+
 
 (** Remark 2.16(4) of CORS *)
 Definition sigma_closed_SepO (O : Modality) {A : Type} (B : A -> Type)

--- a/theories/Projective.v
+++ b/theories/Projective.v
@@ -52,7 +52,7 @@ Proof.
   srapply equiv_iff_hprop.
   - intros splits P S.
     specialize splits with {x : X & P x} pr1.
-    pose proof (splits ((equiv_merely_issurjection P) S)) as M.
+    pose proof (splits (equiv_merely_issurjection P S)) as M.
     clear S splits.
     strip_truncations; apply tr.
     destruct M as [s p].
@@ -67,7 +67,7 @@ Proof.
     exact (fun x => (M x).2).
 Defined.
 
-Proposition isprojective_unit `{Univalence} : IsProjective Unit.
+Proposition isprojective_unit `{Funext} : IsProjective Unit.
 Proof.
   apply (equiv_isprojective_choice Unit)^-1.
   intros P S.

--- a/theories/Projective.v
+++ b/theories/Projective.v
@@ -40,13 +40,14 @@ Proof.
 Defined.
 
 
-(** ** Projectivity and choice *)
+(** ** Projectivity and the axiom of choice *)
 
-Definition Choice (X : Type) : Type := forall P : X -> Type,
+(** In topos theory, an object X is said to be projective if the axiom of choice holds when making choices indexed by X. *)
+Definition IsProjective' (X : Type) : Type := forall P : X -> Type,
     (forall x, merely (P x)) -> merely (forall x, P x).
 
 Proposition iff_isprojective_choice (X : Type)
-  : IsProjective X <-> Choice X.
+  : IsProjective X <-> IsProjective' X.
 Proof.
   refine (iff_compose (iff_isprojective_surjections_split X) _).
   split.
@@ -68,7 +69,7 @@ Proof.
 Defined.
 
 Proposition equiv_isprojective_choice `{Funext} (X : Type)
-  : IsProjective X <~> Choice X.
+  : IsProjective X <~> IsProjective' X.
 Proof.
   exact (equiv_iff_hprop_uncurried (iff_isprojective_choice X)).
 Defined.
@@ -87,7 +88,7 @@ Section AC_oo_neg1.
   (** ** Projectivity and AC_(oo,-1) (defined in HoTT book, Exercise 7.8) *)
   (* TODO: Generalize to n, m. *)
 
-  Context {AC : forall X : hSet, Choice X}.
+  Context {AC : forall X : hSet, IsProjective' X}.
 
   (** (Exercise 7.9) Assuming AC_(oo,-1) every type merely has a projective cover. *)
   Proposition projective_cover_AC `{Univalence} (A : Type)
@@ -98,11 +99,8 @@ Section AC_oo_neg1.
     pose proof (P A X idmap tr _) as F; clear P.
     strip_truncations.
     destruct F as [f p].
-    apply tr; refine (X; (f; _)).
-    unfold IsConnMap, IsConnected.
-    intro a.
-    rapply contr_inhabited_hprop.
-    unfold hfiber.
+    refine (tr (X; (f; BuildIsSurjection f _))).
+    intro a; unfold hfiber.
     apply equiv_O_sigma_O.
     refine (tr (tr a; _)).
     rapply (equiv_path_Tr _ _)^-1%equiv.  (* Uses Univalence. *)

--- a/theories/Projective.v
+++ b/theories/Projective.v
@@ -45,14 +45,14 @@ Defined.
 Definition Choice (X : Type) : Type := forall P : X -> Type,
     (forall x, merely (P x)) -> merely (forall x, P x).
 
-Proposition equiv_isprojective_choice `{Funext} (X : Type)
-  : IsProjective X <~> Choice X.
+Proposition iff_isprojective_choice (X : Type)
+  : IsProjective X <-> Choice X.
 Proof.
-  refine (_ oE equiv_isprojective_surjections_split X).
-  srapply equiv_iff_hprop.
+  refine (iff_compose (iff_isprojective_surjections_split X) _).
+  split.
   - intros splits P S.
     specialize splits with {x : X & P x} pr1.
-    pose proof (splits (equiv_merely_issurjection P S)) as M.
+    pose proof (splits (fst (iff_merely_issurjection P) S)) as M.
     clear S splits.
     strip_truncations; apply tr.
     destruct M as [s p].
@@ -67,9 +67,15 @@ Proof.
     exact (fun x => (M x).2).
 Defined.
 
-Proposition isprojective_unit `{Funext} : IsProjective Unit.
+Proposition equiv_isprojective_choice `{Funext} (X : Type)
+  : IsProjective X <~> Choice X.
 Proof.
-  apply (equiv_isprojective_choice Unit)^-1.
+  exact (equiv_iff_hprop_uncurried (iff_isprojective_choice X)).
+Defined.
+
+Proposition isprojective_unit : IsProjective Unit.
+Proof.
+  apply (iff_isprojective_choice Unit).
   intros P S.
   specialize S with tt.
   strip_truncations; apply tr.

--- a/theories/Spaces/Finite.v
+++ b/theories/Spaces/Finite.v
@@ -10,6 +10,7 @@ Require Import Factorization.
 Require Import Equiv.PathSplit.
 Require Import Truncations.
 Require Import Colimits.Quotient.
+Require Import Projective.
 
 Local Open Scope path_scope.
 Local Open Scope nat_scope.
@@ -566,10 +567,10 @@ Proof.
   - refine (transport (P (Fin n.+1)) (path_ishprop _ _) (fs _ _ IH)).
 Defined.
 
-(** ** The finite axiom of choice *)
+(** ** The finite axiom of choice, and projectivity *)
 
 Definition finite_choice {X} `{Finite X} (P : X -> Type)
-: (forall x, merely (P x)) -> merely (forall x, P x).
+  : (forall x, merely (P x)) -> merely (forall x, P x).
 Proof.
   intros f.
   assert (e := merely_equiv_fin X).
@@ -586,6 +587,12 @@ Proof.
       assert (e := f (inr tt)).
       strip_truncations.
       exact (tr (sum_ind P IH (Unit_ind e))).
+Defined.
+
+Corollary isprojective_fin_n `{Funext} (n : nat) : IsProjective (Fin n).
+Proof.
+  apply (equiv_isprojective_choice (Fin n))^-1.
+  rapply finite_choice.
 Defined.
 
 (** ** Constructions on finite sets *)

--- a/theories/Spaces/Finite.v
+++ b/theories/Spaces/Finite.v
@@ -589,9 +589,9 @@ Proof.
       exact (tr (sum_ind P IH (Unit_ind e))).
 Defined.
 
-Corollary isprojective_fin_n `{Funext} (n : nat) : IsProjective (Fin n).
+Corollary isprojective_fin_n (n : nat) : IsProjective (Fin n).
 Proof.
-  apply (equiv_isprojective_choice (Fin n))^-1.
+  apply (iff_isprojective_choice (Fin n)).
   rapply finite_choice.
 Defined.
 

--- a/theories/Spaces/Projective.v
+++ b/theories/Spaces/Projective.v
@@ -1,0 +1,142 @@
+Require Import Basics Types HProp HSet HFiber Truncations.
+Require Import Modalities.Descent Modalities.Separated.
+Require Import Limits.Pullback Spaces.Finite.
+
+
+(** * Projective types *)
+
+Definition IsProjective (X : Type)
+  := forall A B : Type, forall f : X -> B, forall p : A -> B,
+        IsSurjection p -> merely (exists s : X -> A, p o s == f).
+
+(** A type X is projective if and only if surjections into X merely split. *)
+Proposition equiv_isprojective_surjections_split `{Funext} (X : Type)
+  : IsProjective X <~>
+    (forall (Y:Type), forall (p : Y -> X),
+          IsSurjection p -> merely (exists s : X -> Y, p o s == idmap)).
+Proof.
+  srapply equiv_iff_hprop.
+  - intro isprojX. unfold IsProjective in isprojX.
+    intros Y p S.
+    exact (isprojX Y X idmap p S).
+  - intro splits. unfold IsProjective.
+    intros A B f p S.
+    pose proof (splits (Pullback p f) pullback_pr2 _) as s'.
+    strip_truncations.
+    destruct s' as [s E].
+    refine (tr (pullback_pr1 o s; _)).
+    intro x.
+    refine (pullback_commsq p f (s x) @ _).
+    apply (ap f).
+    apply E.
+Defined.
+
+(** ** Projectivity and choice *)
+
+Definition choice (X : Type) := forall P : X -> Type,
+      (forall x, merely (P x)) -> merely (forall x, P x).
+
+(* The following two lemmas make the proof of equiv_isprojective_choice below easier to follow. *)
+Lemma equiv_contr_hprop `{Funext} (A : Type) `{IsHProp A}
+  : Contr A <~> A.
+Proof.
+  rapply equiv_iff_hprop.
+  - apply center.
+  - rapply contr_inhabited_hprop.
+Defined.
+
+Lemma equiv_isconnmap_merely `{Funext} {X : Type} (P : X -> Type)
+  : IsConnMap (Tr (-1)) (pr1 : {x : X & P x} -> X) <~> forall x : X, merely (P x).
+Proof.
+  apply equiv_functor_forall_id; intro x.
+  unfold IsConnected.
+  refine (_ oE equiv_contr_hprop _).
+  apply Trunc_functor_equiv.
+  symmetry; apply hfiber_fibration.
+Defined.
+
+Proposition equiv_isprojective_choice `{Funext} (X : Type)
+  : IsProjective X <~> choice X.
+Proof.
+  refine (_ oE equiv_isprojective_surjections_split X).
+  srapply equiv_iff_hprop.
+  - intros splits P S.
+    specialize splits with {x : X & P x} pr1.
+    pose proof (splits ((equiv_isconnmap_merely P)^-1%equiv S)) as M.
+    clear S splits.
+    strip_truncations; apply tr.
+    destruct M as [s p].
+    intro x.
+    exact (transport _ (p x) (s x).2).
+  - intros choiceX Y p S.
+    unfold IsConnMap, IsConnected in S.
+    pose proof (fun b => (@center _ (S b))) as S'; clear S.
+    pose proof (choiceX (hfiber p) S') as M; clear S'.
+    strip_truncations; apply tr.
+    exists (fun x => (M x).1).
+    exact (fun x => (M x).2).
+Defined.
+
+(** Finite sets (as in Spaces/Finite.v) are projective. *)
+Theorem isprojective_fin_n `{Funext} (n : nat) : IsProjective (Fin n).
+Proof.
+  apply (equiv_isprojective_choice (Fin n))^-1.
+  rapply finite_choice.
+Defined.
+
+Proposition isprojective_unit `{Funext} : IsProjective Unit.
+Proof.
+  apply (equiv_isprojective_choice Unit)^-1.
+  intros P S.
+  specialize S with tt.
+  strip_truncations; apply tr.
+  apply Unit_ind.
+  exact S.
+Defined.
+
+
+Section AC_oo_neg1.
+  (** ** Projectivity and AC_(oo,-1) (defined in HoTT book, Exercise 7.8) *)
+  (* TODO: Generalize to n, m. *)
+
+  Context {AC : forall X : hSet, choice X}.
+
+  (** (Exercise 7.9) Assuming AC_(oo,-1) every type merely has a projective cover. *)
+  Proposition projective_cover_AC `{Univalence} (A : Type)
+    : merely (exists X:hSet, exists p : X -> A, IsSurjection p).
+  Proof.
+    pose (X := BuildhSet (Tr 0 A)).
+    pose proof ((equiv_isprojective_choice X)^-1 (AC X)) as P.
+    pose proof (P A X idmap tr _) as F; clear P.
+    strip_truncations.
+    destruct F as [f p].
+    apply tr; refine (X; (f; _)).
+    unfold IsConnMap, IsConnected.
+    intro a.
+    rapply contr_inhabited_hprop.
+    unfold hfiber.
+    apply equiv_O_sigma_O.
+    refine (tr (tr a; _)).
+    rapply (equiv_path_Tr _ _)^-1%equiv.  (* Uses Univalence. *)
+    apply p.
+  Defined.
+
+  (** Assuming AC_(oo,-1), projective types are exactly sets. *)
+  Theorem equiv_isprojective_ishset_AC `{Univalence} (X : Type)
+    : IsProjective X <~> IsHSet X.
+  Proof.
+    apply equiv_iff_hprop.
+    - intro isprojX. unfold IsProjective in isprojX.
+      pose proof (projective_cover_AC X) as P; strip_truncations.
+      destruct P as [P [p issurj_p]].
+      pose proof (isprojX P X idmap p issurj_p) as S; strip_truncations.
+      destruct S as [s h].
+      rapply (istrunc_embedding_trunc s).
+      apply isembedding_isinj_hset.
+      exact (isinj_section h).
+    - intro ishsetX.
+      apply (equiv_isprojective_choice X)^-1.
+      rapply AC.
+  Defined.
+
+End AC_oo_neg1.

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -192,12 +192,18 @@ Proof.
 Defined.
 
 (** A family of types is pointwise merely inhabited if and only if the corresponding fibration is surjective. *)
+Lemma iff_merely_issurjection {X : Type} (P : X -> Type)
+  : (forall x, merely (P x)) <-> IsSurjection (pr1 : {x : X & P x} -> X).
+Proof.
+  refine (iff_compose _ (iff_forall_inO_mapinO_pr1 (Conn _) P)).
+  apply iff_functor_forall; intro a.
+  symmetry; apply (iff_contr_hprop (Tr (-1) (P a))).
+Defined.
+
 Lemma equiv_merely_issurjection `{Funext} {X : Type} (P : X -> Type)
   : (forall x, merely (P x)) <~> IsSurjection (pr1 : {x : X & P x} -> X).
-Proof.
-  refine (equiv_forall_inO_mapinO_pr1 (Conn _) _ oE _).
-  apply equiv_functor_forall_id; intro x.
-  exact (equiv_contr_hprop _)^-1%equiv.
+Proof. (* Can also be proved from equiv_forall_inO_mapinO_pr1. *)
+  exact (equiv_iff_hprop_uncurried (iff_merely_issurjection P)).
 Defined.
 
 Definition isequiv_surj_emb {A B} (f : A -> B)

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -191,6 +191,15 @@ Proof.
   apply H.
 Defined.
 
+(** A family of types is pointwise merely inhabited if and only if the corresponding fibration is surjective. *)
+Lemma equiv_merely_issurjection `{Funext} {X : Type} (P : X -> Type)
+  : (forall x, merely (P x)) <~> IsSurjection (pr1 : {x : X & P x} -> X).
+Proof.
+  refine (equiv_forall_inO_mapinO_pr1 (Conn _) _ oE _).
+  apply equiv_functor_forall_id; intro x.
+  exact (equiv_contr_hprop _)^-1%equiv.
+Defined.
+
 Definition isequiv_surj_emb {A B} (f : A -> B)
   `{IsSurjection f} `{IsEmbedding f}
   : IsEquiv f.


### PR DESCRIPTION
Co-authored-by: Dan Christensen <jdc@uwo.ca>

Defines projective types and characterizes them as types for which the axiom of choice holds, or alternatively types into which every epi (merely) splits. Under `AC_oo,-1` (in the sense of the HoTT Book, Exercise 7.8) projective types correspond to sets.

Questions:
- Is `Spaces/Projective.v` a good placement? `Types/Projective.v` didn't work out due to circular imports.
- Should the `AC_oo,neg1` section at the end of `Projectivity.v` be placed elsewhere? An alternative placement would be in `HSet.v`, in which case the definition of `choice` in `Projectivity.v` would need to be factored out into it's own file to avoid circular imports. (In this case, `Spaces/Finite.v` could also import this definition of choice, and `finite_choice` would implement `choice X` for finite `X`.)

Lastly, the proposition `projective_cover_AC` solves exercise 7.8 from the HoTT Book for n = oo, so a comment was added about that. 