### PR TITLE
With Coq PR #13513, "intros []" uses "destruct" rather than "case" and becomes "smarter".

### DIFF
--- a/theories/PropResizing/Nat.v
+++ b/theories/PropResizing/Nat.v
@@ -263,7 +263,7 @@ Section AssumeStuff.
       apply equiv_ap; try exact _.
       apply path_sigma_hprop, path_equiv@{s s s u}, path_arrow.
       intros [].
-    - clear B;intros B BC.
+    - try clear B;intros B BC.
       refine (contr_equiv (B = B) (graph_succ_path_equiv B B)).
   Qed.
 


### PR DESCRIPTION
As a consequence, a clear on a residual dependent argument of an inductive type becomes useless. We leave a try so as to be backwards-compatible. You may prefer a clean non-compatible script though.

cf coq/coq#13513