### PR TITLE
Characterise paths of subgroups, relate to trivial kernels and exactness

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -359,6 +359,7 @@ theories/Algebra/Groups/GrpPullback.v
 theories/Algebra/Groups/FreeProduct.v
 theories/Algebra/Groups/GroupCoeq.v
 theories/Algebra/Groups/Presentation.v
+theories/Algebra/Groups/ShortExactSequence.v
 
 theories/Algebra/Groups/FreeGroup.v
 

--- a/theories/Algebra/Groups.v
+++ b/theories/Algebra/Groups.v
@@ -7,6 +7,7 @@ Require Export HoTT.Algebra.Groups.Image.
 Require Export HoTT.Algebra.Groups.Kernel.
 Require Export HoTT.Algebra.Groups.GrpPullback.
 Require Export HoTT.Algebra.Groups.FreeGroup.
+Require Export HoTT.Algebra.Groups.ShortExactSequence.
 
 (** Examples *)
 

--- a/theories/Algebra/Groups/Kernel.v
+++ b/theories/Algebra/Groups/Kernel.v
@@ -70,7 +70,6 @@ Proof.
   reflexivity.
 Defined.
 
-
 (** ** Corecursion principle for group kernels *)
 
 Proposition grp_kernel_corec {A B G : Group} {f : A $-> B} {g : G $-> A}
@@ -100,7 +99,6 @@ Proof.
     apply path_sigma_hprop; reflexivity.
 Defined.
 
-
 (** ** Characterisation of group embeddings *)
 
 Local Existing Instance ishprop_path_subgroup.
@@ -109,22 +107,12 @@ Proposition equiv_kernel_isembedding `{Univalence} {A B : Group} (f : A $-> B)
   : (grp_kernel f = trivial_subgroup) <~> IsEmbedding f.
 Proof.
   srapply equiv_iff_hprop.
-  - intros phi b; unfold hfiber.
-    apply ishprop_sigma_disjoint.
-    intros a a' p q.
-    apply group_moveL_1M.
-    change mon_unit with (pr1 ((mon_unit; grp_homo_unit f) : grp_kernel f)).
-    pose proof (ap (fun g => g *  -(f a')) (p @ q^)) as P; cbn in P.
-    rewrite right_inverse in P.
-    rewrite <- (grp_homo_inv f) in P.
-    rewrite <- (grp_homo_op f) in P.
-    change (a * -a') with (pr1 ((a * -a'; P) : grp_kernel f)).
-    apply (ap pr1).
-    pose (phi' := ap (@group_type o (subgroup_group A)) phi); cbn in phi'.
-    apply (equiv_ap' (equiv_path _ _ phi')).
-    apply path_ishprop.
-  - unfold IsEmbedding.
-    intro isemb_f.
+  - intros phi b.
+    apply hprop_inhabited_contr; intro a.
+    rapply (contr_equiv' _ (equiv_grp_hfiber _ _ a)^-1%equiv).
+    rapply (transport Contr (x:=grp_trivial)).
+    exact (ap (group_type o subgroup_group A) phi^).
+  - intro isemb_f.
     rapply equiv_path_subgroup.
     srefine (grp_iso_inverse _; _).
     + srapply Build_GroupIsomorphism.

--- a/theories/Algebra/Groups/ShortExactSequence.v
+++ b/theories/Algebra/Groups/ShortExactSequence.v
@@ -25,7 +25,6 @@ Proof.
 Defined.
 
 Local Existing Instance ishprop_phomotopy_hset.
-Local Existing Instance isequiv_purely_conn.
 Local Existing Instance ishprop_isexact_hset.
 
 (** A complex 0 -> A -> B of groups is purely exact if and only if the map A -> B is an embedding. *)
@@ -41,6 +40,8 @@ Proof.
     + rapply (transport IsHProp (x:= grp_trivial)).
       apply path_universe_uncurried.
       rapply Build_Equiv.
+      apply isequiv_contr_map.
+      exact conn.
   - intro isemb_f.
     exists (grp_iscomplex_trivial f).
     intros y; rapply contr_inhabited_hprop.

--- a/theories/Algebra/Groups/ShortExactSequence.v
+++ b/theories/Algebra/Groups/ShortExactSequence.v
@@ -1,0 +1,56 @@
+Require Import Basics Types WildCat Pointed.
+Require Import Groups.Group Groups.Subgroup Groups.Kernel.
+Require Import Homotopy.ExactSequence Modalities.Identity.
+
+Local Open Scope mc_scope.
+Local Open Scope mc_add_scope.
+Local Open Scope path_scope.
+
+(** * Complexes of groups *)
+
+Proposition grp_homo_cxfib {A B C : Group} {i : A $-> B} {f : B $-> C} (cx : IsComplex i f)
+  : GroupHomomorphism A (grp_kernel f).
+Proof.
+  destruct cx as [phi eq]; simpl in phi, eq.
+  exact (@grp_kernel_corec _ _ _ f i phi).
+Defined.
+
+Definition grp_iscomplex_trivial {X Y : Group} (f : X $-> Y)
+  : IsComplex (@grp_homo_const grp_trivial X) f.
+Proof.
+  srapply Build_pHomotopy.
+  - intro x; cbn.
+    exact (grp_homo_unit f).
+  - apply path_ishprop.
+Defined.
+
+Local Existing Instance ishprop_phomotopy_hset.
+Local Existing Instance isequiv_purely_conn.
+Local Existing Instance ishprop_isexact_hset.
+
+(** A complex 0 -> A -> B of groups is purely exact if and only if the map A -> B is an embedding. *)
+Lemma equiv_grp_isexact_isembedding `{Univalence} {A B : Group} (f : A $-> B)
+  : IsExact purely (@grp_homo_const grp_trivial A) f <~> IsEmbedding f.
+Proof.
+  srapply equiv_iff_hprop.
+  - intros [cx conn] b a.
+    rapply (transport IsHProp (x:= hfiber f 0)).
+    + apply path_universe_uncurried; symmetry.
+      apply equiv_grp_hfiber.
+      exact a.
+    + rapply (transport IsHProp (x:= grp_trivial)).
+      apply path_universe_uncurried.
+      rapply Build_Equiv.
+  - intro isemb_f.
+    exists (grp_iscomplex_trivial f).
+    intros y; rapply contr_inhabited_hprop.
+    exists tt; apply path_ishprop.
+Defined.
+
+(** A complex 0 -> A -> B is purely exact if and only if the kernel of the map A -> B is trivial. *)
+Corollary equiv_grp_isexact_kernel `{Univalence} {A B : Group} (f : A $-> B)
+  : IsExact purely (@grp_homo_const grp_trivial A) f
+            <~> (grp_kernel f = trivial_subgroup).
+Proof.
+  exact ((equiv_kernel_isembedding f)^-1%equiv oE equiv_grp_isexact_isembedding f).
+Defined.

--- a/theories/Algebra/Groups/Subgroup.v
+++ b/theories/Algebra/Groups/Subgroup.v
@@ -82,18 +82,11 @@ Definition maximal_subgroup {G} : Subgroup G
 
 (** ** Characterization of paths between subgroups *)
 
-(* jdc: It takes too long for Coq to process the *statement* of this Lemma.
-I think you need to supply some implicit arguments to fix this. 
-I think the lemma might be ok here, since it is used twice below. *)
-(* jarlg: The processing of the statement is instant on my
-computer. What am I missing? Making the lemma local as the name isn't
-appropriate to be exported, and is only used here currently. *)
 Local Lemma transport_lemma `{U : Univalence} {G H K : Group} (f : H $-> G) (p : H = K)
   : transport (fun x : Group => x $-> G) p f
     = grp_homo_compose f (grp_iso_inverse (equiv_path_group^-1 p)).
 Proof.
   induction p.
-  (* jarlg: "cbn." is slow, just giving the proof is fast: *)
   exact (cat_idr_strong f)^.
 Defined.
 

--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -417,6 +417,14 @@ Proof.
   apply ap, eisretr.
 Defined.
 
+Definition equiv_ap_inv `(f : A -> B) `{IsEquiv A B f} (x y : B)
+  : (f^-1 x = f^-1 y) <~> (x = y)
+  := (@equiv_ap B A f^-1 _ x y)^-1%equiv.
+
+Definition equiv_ap_inv' `(f : A <~> B) (x y : B)
+  : (f^-1 x = f^-1 y) <~> (x = y)
+  := (equiv_ap' f^-1%equiv x y)^-1%equiv.
+
 (** If [g \o f] and [f] are equivalences, so is [g].  This is not an Instance because it would require Coq to guess [f]. *)
 Definition cancelR_isequiv {A B C} (f : A -> B) {g : B -> C}
   `{IsEquiv A B f} `{IsEquiv A C (g o f)}

--- a/theories/Classes/interfaces/abstract_algebra.v
+++ b/theories/Classes/interfaces/abstract_algebra.v
@@ -281,6 +281,8 @@ End jections.
 Global Instance isinj_idmap A : @IsInjective A A idmap
   := fun x y => idmap.
 
+Hint Unfold IsInjective : typeclass_instances.
+
 Section strong_injective.
   Context {A B} {Aap : Apart A} {Bap : Apart B} (f : A -> B) .
   Class IsStrongInjective :=

--- a/theories/Homotopy/ExactSequence.v
+++ b/theories/Homotopy/ExactSequence.v
@@ -106,6 +106,23 @@ Proof.
   apply postcompose_pconst.
 Defined.
 
+(** Any pointed map induces a trivial complex. *)
+Definition iscomplex_trivial {X Y : pType} (f : X ->* Y)
+  : IsComplex (@pconst pUnit X) f.
+Proof.
+  srapply Build_pHomotopy.
+  - intro x; cbn.
+    exact (point_eq f).
+  - cbn; symmetry.
+    exact (concat_p1 _ @ concat_1p _).
+Defined.
+
+Local Existing Instance ishprop_phomotopy_hset.
+
+(** If Y is a set, then IsComplex is an HProp. *)
+Instance ishprop_iscomplex_hset `{Univalence} {F X Y : pType} `{IsHSet Y} (i : F ->* X) (f : X ->* Y)
+  : IsHProp (IsComplex i f) := {}.
+
 
 (** ** Very short exact sequences and fiber sequences *)
 
@@ -117,6 +134,17 @@ Class IsExact (n : Modality) {F X Y : pType} (i : F ->* X) (f : X ->* Y) :=
 }.
 
 Global Existing Instance conn_map_isexact.
+
+Definition issig_isexact (n : Modality) {F X Y : pType} (i : F ->* X) (f : X ->* Y)
+  : _ <~> IsExact n i f := ltac:(issig).
+
+(** If Y is a set, then IsExact is an HProp. *)
+Instance ishprop_isexact_hset `{Univalence} {F X Y : pType} `{IsHSet Y} (n : Modality) (i : F ->* X) (f : X ->* Y)
+  : IsHProp (IsExact n i f).
+Proof.
+  rapply (transport IsHProp (x := { cx : IsComplex i f & IsConnMap n (cxfib cx) })).
+  apply path_universe_uncurried; issig.
+Defined.
 
 (** Passage across homotopies preserves exactness. *)
 Definition isexact_homotopic_i n  {F X Y : pType}

--- a/theories/Homotopy/ExactSequence.v
+++ b/theories/Homotopy/ExactSequence.v
@@ -120,7 +120,7 @@ Defined.
 Local Existing Instance ishprop_phomotopy_hset.
 
 (** If Y is a set, then IsComplex is an HProp. *)
-Instance ishprop_iscomplex_hset `{Univalence} {F X Y : pType} `{IsHSet Y} (i : F ->* X) (f : X ->* Y)
+Global Instance ishprop_iscomplex_hset `{Univalence} {F X Y : pType} `{IsHSet Y} (i : F ->* X) (f : X ->* Y)
   : IsHProp (IsComplex i f) := {}.
 
 
@@ -139,7 +139,7 @@ Definition issig_isexact (n : Modality) {F X Y : pType} (i : F ->* X) (f : X ->*
   : _ <~> IsExact n i f := ltac:(issig).
 
 (** If Y is a set, then IsExact is an HProp. *)
-Instance ishprop_isexact_hset `{Univalence} {F X Y : pType} `{IsHSet Y} (n : Modality) (i : F ->* X) (f : X ->* Y)
+Global Instance ishprop_isexact_hset `{Univalence} {F X Y : pType} `{IsHSet Y} (n : Modality) (i : F ->* X) (f : X ->* Y)
   : IsHProp (IsExact n i f).
 Proof.
   rapply (transport IsHProp (x := { cx : IsComplex i f & IsConnMap n (cxfib cx) })).

--- a/theories/Modalities/Identity.v
+++ b/theories/Modalities/Identity.v
@@ -1,5 +1,5 @@
 (* -*- mode: coq; mode: visual-line -*- *)
-Require Import HoTT.Basics HoTT.Types.
+Require Import HoTT.Basics HoTT.Types HoTT.Truncations.
 Require Import Modality Accessible.
 
 Local Open Scope path_scope.
@@ -26,4 +26,11 @@ Proof.
   - intros X; split.
     + intros _ [].
     + intros; exact tt.
+Defined.
+
+(** A purely connected map is an equivalence. *)
+Instance isequiv_purely_conn `{Funext} {A B : Type} (f : A -> B) {conn : IsConnMap purely f}
+  : IsEquiv f.
+Proof.
+  rapply equiv_contr_map_isequiv.
 Defined.

--- a/theories/Modalities/Identity.v
+++ b/theories/Modalities/Identity.v
@@ -1,5 +1,5 @@
 (* -*- mode: coq; mode: visual-line -*- *)
-Require Import HoTT.Basics HoTT.Types HoTT.Truncations.
+Require Import HoTT.Basics HoTT.Types.
 Require Import Modality Accessible.
 
 Local Open Scope path_scope.
@@ -26,11 +26,4 @@ Proof.
   - intros X; split.
     + intros _ [].
     + intros; exact tt.
-Defined.
-
-(** A purely connected map is an equivalence. *)
-Global Instance isequiv_purely_conn `{Funext} {A B : Type} (f : A -> B) {conn : IsConnMap purely f}
-  : IsEquiv f.
-Proof.
-  rapply equiv_contr_map_isequiv.
 Defined.

--- a/theories/Modalities/Identity.v
+++ b/theories/Modalities/Identity.v
@@ -29,7 +29,7 @@ Proof.
 Defined.
 
 (** A purely connected map is an equivalence. *)
-Instance isequiv_purely_conn `{Funext} {A B : Type} (f : A -> B) {conn : IsConnMap purely f}
+Global Instance isequiv_purely_conn `{Funext} {A B : Type} (f : A -> B) {conn : IsConnMap purely f}
   : IsEquiv f.
 Proof.
   rapply equiv_contr_map_isequiv.

--- a/theories/Pointed/pHomotopy.v
+++ b/theories/Pointed/pHomotopy.v
@@ -72,3 +72,11 @@ Proof.
 Defined.
 
 Notation "p @@* q" := (phomotopy_hcompose p q).
+
+(** Pointed homotopies in a set form an HProp. *)
+Instance ishprop_phomotopy_hset `{Univalence} {X Y : pType} `{IsHSet Y} (f g : X ->* Y)
+  : IsHProp (f ==* g).
+Proof.
+  rapply (transport IsHProp (x := {p : f == g & p (point X) = dpoint_eq f @ (dpoint_eq g)^})).
+  apply path_universe_uncurried; issig.
+Defined.

--- a/theories/Pointed/pHomotopy.v
+++ b/theories/Pointed/pHomotopy.v
@@ -74,7 +74,7 @@ Defined.
 Notation "p @@* q" := (phomotopy_hcompose p q).
 
 (** Pointed homotopies in a set form an HProp. *)
-Instance ishprop_phomotopy_hset `{Univalence} {X Y : pType} `{IsHSet Y} (f g : X ->* Y)
+Global Instance ishprop_phomotopy_hset `{Univalence} {X Y : pType} `{IsHSet Y} (f g : X ->* Y)
   : IsHProp (f ==* g).
 Proof.
   rapply (transport IsHProp (x := {p : f == g & p (point X) = dpoint_eq f @ (dpoint_eq g)^})).

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -2,7 +2,7 @@
 
 Require Import Basics Types.
 Require Import TruncType HProp.
-Require Import Modalities.Modality Modalities.Identity Modalities.Descent.
+Require Import Modalities.Modality Modalities.Descent.
 
 (** * Truncations of types, in all dimensions. *)
 


### PR DESCRIPTION
The first commit characterises paths of subgroups as isomorphisms respecting the inclusions, and proves that the kernel of a group homomorphism is trivial if and only if it's an embedding. There was some related discussion at #1387, and I've opted to stick with the existing formalization of subgroups instead of developing a version using predicates. If there's an argument for switching, I'd like to know.

The second commit relates the above to (pure) exactness of a complex `0 -> A -> B` of groups in `equiv_grp_isexact_isembedding`.
