### PR TITLE
Using Hint Cut to avoid infinite loops with bidirectional Instances

### DIFF
--- a/theories/Algebra/Groups/Kernel.v
+++ b/theories/Algebra/Groups/Kernel.v
@@ -106,14 +106,14 @@ Local Existing Instance ishprop_path_subgroup.
 Proposition equiv_kernel_isembedding `{Univalence} {A B : Group} (f : A $-> B)
   : (grp_kernel f = trivial_subgroup) <~> IsEmbedding f.
 Proof.
-  srapply equiv_iff_hprop.
+  apply equiv_iff_hprop.
   - intros phi b.
     apply hprop_inhabited_contr; intro a.
     rapply (contr_equiv' _ (equiv_grp_hfiber _ _ a)^-1%equiv).
     rapply (transport Contr (x:=grp_trivial)).
     exact (ap (group_type o subgroup_group A) phi^).
   - intro isemb_f.
-    rapply equiv_path_subgroup.
+    apply equiv_path_subgroup.
     srefine (grp_iso_inverse _; _).
     + srapply Build_GroupIsomorphism.
       * exact grp_homo_const.

--- a/theories/Algebra/Groups/Subgroup.v
+++ b/theories/Algebra/Groups/Subgroup.v
@@ -113,7 +113,8 @@ Defined.
 Corollary ishprop_path_subgroup `{U : Univalence} {G : Group} {H K : Subgroup G}
   : IsHProp (H = K).
 Proof.
-  rapply (equiv_transport IsHProp _ _).
+  (** jarlg: Without "n" here, it unifies (IsHProp ?x) with (IsHprop Unit). Can that be avoided? *)
+  nrapply (transport IsHProp).
   - apply equiv_path_universe.
     exact (equiv_path_subgroup H K).
   - apply equiv_hprop_allpath.

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -712,8 +712,6 @@ Register tt as core.True.I.
 (** A space is pointed if that space has a point. *)
 Class IsPointed (A : Type) := point : A.
 
-Typeclasses Transparent IsPointed.
-
 Arguments point A {_}.
 
 Record pType :=

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -712,6 +712,8 @@ Register tt as core.True.I.
 (** A space is pointed if that space has a point. *)
 Class IsPointed (A : Type) := point : A.
 
+Typeclasses Transparent IsPointed.
+
 Arguments point A {_}.
 
 Record pType :=

--- a/theories/HIT/FreeIntQuotient.v
+++ b/theories/HIT/FreeIntQuotient.v
@@ -74,7 +74,8 @@ Section FreeIntAction.
       unfold loop.
       exact (Coeq_rec_beta_cglue _ _ _ _).
     - intros xu yv.
-      refine (trunc_equiv' (n := -1) _ (equiv_path_sigma _ xu yv)).
+      (** jarlg: This one finishes but takes a while without "n". *)
+      nrefine (trunc_equiv' (n := -1) _ (equiv_path_sigma _ xu yv)).
       destruct xu as [x u], yv as [y v]; cbn.
       apply hprop_allpath.
       intros [p r] [q s].

--- a/theories/Pointed/Loops.v
+++ b/theories/Pointed/Loops.v
@@ -180,7 +180,8 @@ Proof.
   intros p; eapply isconnected_equiv'.
   - refine (hfiber_loops_functor f p oE _).
     symmetry; apply hfiber_ap.
-  - exact _.
+    (** jarlg: "exact _." works here but is a bit slow. *)
+  - apply isconnected_paths.
 Defined.
 
 Definition isconnected_iterated_loops_functor `{Univalence}

--- a/theories/Spaces/Finite.v
+++ b/theories/Spaces/Finite.v
@@ -884,7 +884,6 @@ Proof.
   refine (decidable_equiv _ (hfiber_fibration x P)^-1 _).
   (* The try clause below is only needed for Coq <= 8.11 *)
   refine (detachable_image_finite pr1 x); try assumption.
-  - apply (mapinO_pr1 (Tr (-1))).  (** Why doesn't Coq find this? *)
 Defined.
 
 (** ** Quotients *)

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -128,7 +128,7 @@ Definition merely_path_is0connected `{Univalence}
 : merely (x = y).
 Proof.
   refine ((equiv_path_Tr x y)^-1 (path_contr (tr x) (tr y))).
-  exact H0.
+  assumption.
 Defined.
 
 Definition is0connected_merely_allpath `{Univalence}

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -128,6 +128,7 @@ Definition merely_path_is0connected `{Univalence}
 : merely (x = y).
 Proof.
   refine ((equiv_path_Tr x y)^-1 (path_contr (tr x) (tr y))).
+  exact H0.
 Defined.
 
 Definition is0connected_merely_allpath `{Univalence}

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -133,9 +133,11 @@ Proof.
   assumption.
 Defined.
 
-(** To avoid infinite loops we cut proofs which apply any of the above Instances twice. Note that the cuts match arbitrary applications of the Instances, so this disallows proofs that would non-circularly use the Instances with different hypotheses. In practice this rarely happens however. *)
-Hint Cut [( _* ) inO_tr_istrunc ( _* ) inO_tr_istrunc] : typeclass_instances.
+(** To avoid infinite loops we cut proofs which apply second Instance twice. Note that the cuts match arbitrary applications of the Instances, so this disallows proofs that would non-circularly use this Instance with different hypotheses. In practice this rarely happens. It turns out to slightly slow down compilation of the library to add the same cut rule for inO_tr_istrunc. *)
 Hint Cut [( _* ) istrunc_inO_tr ( _* ) istrunc_inO_tr] : typeclass_instances.
+(** The next two cuts are purely for efficiency, eliminating immediate round-trips between the two inverse Instances. *)
+Hint Cut [( _* ) inO_tr_istrunc istrunc_inO_tr] : typeclass_instances.
+Hint Cut [( _* ) istrunc_inO_tr inO_tr_istrunc] : typeclass_instances.
 
 (** We do the same for [IsTruncMap n] and [MapIn (Tr n)]. *)
 Global Instance mapinO_tr_istruncmap {n : trunc_index} {A B : Type}
@@ -153,8 +155,9 @@ Proof.
 Defined.
 
 (** See comment for the 'Hint Cut's above. *)
-Hint Cut [( _* ) mapinO_tr_istruncmap ( _* ) mapinO_tr_istruncmap] : typeclass_instances.
 Hint Cut [( _* ) istruncmap_mapinO_tr ( _* ) istruncmap_mapinO_tr] : typeclass_instances.
+Hint Cut [( _* ) mapinO_tr_istruncmap istruncmap_mapinO_tr] : typeclass_instances.
+Hint Cut [( _* ) istruncmap_mapinO_tr mapinO_tr_istruncmap] : typeclass_instances.
 
 (** jarlg: An example of what we gain by having the Instance istruncmap_mapinO_tr. *)
 Lemma isembedding_pr1_hset `{Funext} {X : Type} {Y : hSet} (f : X -> Y) (y : Y)


### PR DESCRIPTION
Using `Hint Cut` it's possible to avoid infinite loops induced by having for example both directions of an equivalence be instances. In the library, the usual solution is to make one direction a `Hint Immediate` (or a `Hint Extern` that either fails or succeeds). That may be more efficient, but it's less expressive. This is a draft to discuss the feasibility of using `Hint Cut` like this, and there are some comments inline explaining the changes.

Here `Hint Cut` is just tested out for the equvalences `inO_tr_istrunc` / `istrunc_inO_tr` and `mapinO_tr_istruncmap` / `istruncmap_mapinO_tr`. The main changes are to `Truncations.Core`, and the rest are minor changes either required or to save a few seconds. The new instances open new "proof branches" which aren't always productive, but I think it's possible to clean up. The killer app is `isembedding_pr1_hset`, which Coq is now able to solve by itself.

With these changes, my build time is (on `hint-cut`):
```sh
real    4m57.762s
user    11m11.561s
sys     1m21.895s
```
versus on `master`
```sh
real    3m57.741s
user    9m23.791s
sys     1m21.934s
```

I haven't looked into profiling in Coq, but I think with some cleaning up the gap could be reduced substantially.

The benefit of the proposal should be clear. A possible concern is that these `Hint Cut`s disallow *any* repeated application of a Hint (or Instance), even with different hypotheses. In theory this rules out some valid proofs, but I haven't observed this in practice (and of course, those proofs can still be carried out manually).
