### PR TITLE
added _build/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ contrib/*.bak.*
 
 *.crashcoqide
 .vscode/
+
+# ignore dune _build directory
+_build/


### PR DESCRIPTION
The `_build` directory is where dune puts built things, this can generate many files so it's good to ignore it