### PR TITLE
modified _CoqProject so that it works with coq_makefile

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -1,6 +1,7 @@
 -R theories HoTT
 -Q contrib ""
-COQC = hoqc
+-arg -noinit
+-arg -indices-matter
 
 #
 #   Table of contents:


### PR DESCRIPTION
This let's us build the library by doing the following:
```
coq_makefile -f _CoqProject -o CoqMakefile
make -f CoqMakefile
```
I've allowed for this since there are people in the coq platform who are interested in getting this to work this way.

Eventually we should replace our current makefile set up with this way, but our current makefile targets are super intertwined and the makefile does a lot more than build the library.

---

This also means that `coqide` should just work without needing any `./hoqide` etc.