### PR TITLE
Added logical path for contrib

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -1,5 +1,7 @@
 -R theories HoTT
--Q contrib ""
+-Q contrib HoTT.Contrib
+
+#-arg -boot
 -arg -noinit
 -arg -indices-matter
 


### PR DESCRIPTION
We are currently trying to make a coq platform release. In order to do this, we need to give a logical path to the contrib folder or else it gets installed weirdly.