### PR TITLE
Predicate subgroups

### DIFF
--- a/theories/Algebra/AbGroups/AbPushout.v
+++ b/theories/Algebra/AbGroups/AbPushout.v
@@ -19,7 +19,7 @@ Theorem ab_pushout_rec {A B C Y : AbGroup} {f : A $-> B} {g : A $-> C}
 Proof.
   srapply grp_quotient_rec.
   - exact (ab_biprod_rec b c).
-  - intros [[x y] q]; strip_truncations; simpl.
+  - intros [x y] q; strip_truncations; simpl.
     destruct q as [a q]. cbn in q.
     refine (ap (uncurry (fun x y => b x + c y)) q^ @ _).
     unfold uncurry; cbn.
@@ -47,13 +47,22 @@ Proof.
   intro a.
   apply qglue.
   pose (bc := grp_image_in (ab_biprod_corec f (g $o ab_homo_negation)) a).
-  exists (-bc); simpl.
+  destruct bc as [[b c] p].
+  strip_truncations.
+  destruct p as [p q].
+  apply equiv_path_prod in q.
+  destruct q as [q r]; cbn in q, r.
+  simpl.
+  apply tr.
+  exists (-a); simpl.
   apply path_prod; simpl.
-  - exact (right_identity (- f a))^.
-  - rewrite (preserves_negate (f:=g)).
-    refine (negate_involutive _ @ _).
+  - rewrite grp_homo_inv.
     symmetry.
-    exact (ap (fun x => x + g a) negate_mon_unit @ left_identity _).
+    apply right_identity.
+  - rewrite negate_involutive.
+    rewrite negate_mon_unit.
+    symmetry.
+    apply left_identity.
 Defined.
 
 Proposition ab_pushout_rec_beta `{Funext} {A B C Y : AbGroup}
@@ -63,13 +72,13 @@ Proposition ab_pushout_rec_beta `{Funext} {A B C Y : AbGroup}
                    (fun a:A => ap phi (ab_pushout_commsq a)) = phi.
 Proof.
   pose (N := grp_image (ab_biprod_corec f (g $o ab_homo_negation))).
-  rapply (equiv_ap' (equiv_grp_quotient_ump (G:=ab_biprod B C) N Y)^-1%equiv _ _)^-1.
+  rapply (equiv_ap' (equiv_quotient_abgroup_ump (G:=ab_biprod B C) N Y)^-1%equiv _ _)^-1.
   srapply path_sigma_hprop.
   change (ab_pushout_rec
             (phi $o ab_pushout_inl) (phi $o ab_pushout_inr)
             (fun a : A => ap phi (ab_pushout_commsq a)) $o grp_quotient_map
           =  phi $o grp_quotient_map).
-  refine (grp_quotient_rec_beta N Y _ _ @ _).
+  refine (grp_quotient_rec_beta _ Y _ _ @ _).
   apply equiv_path_grouphomomorphism; intro bc.
   exact (ab_biprod_rec_beta' (phi $o grp_quotient_map) bc).
 Defined.

--- a/theories/Algebra/AbGroups/AbPushout.v
+++ b/theories/Algebra/AbGroups/AbPushout.v
@@ -51,8 +51,7 @@ Proof.
   strip_truncations.
   destruct p as [p q].
   apply equiv_path_prod in q.
-  destruct q as [q r]; cbn in q, r.
-  simpl.
+  destruct q as [q r]; cbn in q, r; simpl.
   apply tr.
   exists (-a); simpl.
   apply path_prod; simpl.
@@ -61,8 +60,7 @@ Proof.
     apply right_identity.
   - rewrite negate_involutive.
     rewrite negate_mon_unit.
-    symmetry.
-    apply left_identity.
+    exact (left_identity _)^.
 Defined.
 
 Proposition ab_pushout_rec_beta `{Funext} {A B C Y : AbGroup}
@@ -74,10 +72,6 @@ Proof.
   pose (N := grp_image (ab_biprod_corec f (g $o ab_homo_negation))).
   rapply (equiv_ap' (equiv_quotient_abgroup_ump (G:=ab_biprod B C) N Y)^-1%equiv _ _)^-1.
   srapply path_sigma_hprop.
-  change (ab_pushout_rec
-            (phi $o ab_pushout_inl) (phi $o ab_pushout_inr)
-            (fun a : A => ap phi (ab_pushout_commsq a)) $o grp_quotient_map
-          =  phi $o grp_quotient_map).
   refine (grp_quotient_rec_beta _ Y _ _ @ _).
   apply equiv_path_grouphomomorphism; intro bc.
   exact (ab_biprod_rec_beta' (phi $o grp_quotient_map) bc).

--- a/theories/Algebra/AbGroups/AbPushout.v
+++ b/theories/Algebra/AbGroups/AbPushout.v
@@ -63,7 +63,7 @@ Proposition ab_pushout_rec_beta `{Funext} {A B C Y : AbGroup}
                    (fun a:A => ap phi (ab_pushout_commsq a)) = phi.
 Proof.
   pose (N := grp_image (ab_biprod_corec f (g $o ab_homo_negation))).
-  apply (equiv_ap' (equiv_grp_quotient_ump (G:=ab_biprod B C) N Y)^-1%equiv _ _)^-1.
+  rapply (equiv_ap' (equiv_grp_quotient_ump (G:=ab_biprod B C) N Y)^-1%equiv _ _)^-1.
   srapply path_sigma_hprop.
   change (ab_pushout_rec
             (phi $o ab_pushout_inl) (phi $o ab_pushout_inr)

--- a/theories/Algebra/AbGroups/AbelianGroup.v
+++ b/theories/Algebra/AbGroups/AbelianGroup.v
@@ -54,34 +54,29 @@ Proof.
   cbn. apply commutativity.
 Defined.
 
+
 Global Instance isnormal_ab_subgroup (G : AbGroup) (H : Subgroup G)
   : IsNormalSubgroup H.
 Proof.
   intros x y.
   unfold in_cosetL, in_cosetR.
-  refine (equiv_functor_sigma' (Build_Equiv _ _ group_inverse _) _).
-  intros h.
   srapply equiv_iff_hprop.
-  + intros p.
-    rewrite grp_homo_inv.
-    rewrite p.
+  { rewrite <- (negate_involutive (x + -y)).
     rewrite negate_sg_op.
-    rewrite (involutive x).
-    apply commutativity.
-  + intros p.
-    rewrite grp_homo_inv in p.
-    apply moveL_equiv_V in p.
-    rewrite p; cbn.
-    change (- (x + -y) = - x + y).
-    rewrite negate_sg_op.
-    rewrite (involutive y).
-    apply commutativity.
+    rewrite negate_involutive.
+    rewrite (commutativity y (-x)).
+    rapply subgroup_inv. }
+  rewrite <- (negate_involutive (-x + y)).
+  rewrite negate_sg_op.
+  rewrite negate_involutive.
+  rewrite (commutativity x (-y)).
+  rapply subgroup_inv.
 Defined.
 
 (** ** Quotients of abelian groups *)
 
 Global Instance isabgroup_quotient (G : AbGroup) (H : Subgroup G)
-  : IsAbGroup (QuotientGroup G H).
+  : IsAbGroup (QuotientGroup G (Build_NormalSubgroup G H (isnormal_ab_subgroup G H))).
 Proof.
   nrapply Build_IsAbGroup.
   1: exact _.
@@ -94,8 +89,19 @@ Proof.
   apply commutativity.
 Defined.
 
-Definition QuotientAbGroup (G : AbGroup) (H : Subgroup G)
-  : AbGroup := Build_AbGroup (QuotientGroup G H) _ _ _ _.
+Definition QuotientAbGroup (G : AbGroup) (H : Subgroup G) : AbGroup :=
+  Build_AbGroup
+    (QuotientGroup G
+      (Build_NormalSubgroup G H (isnormal_ab_subgroup G H)))
+    _ _ _ _.
+
+Theorem equiv_quotient_abgroup_ump {F : Funext} {G : AbGroup}
+  (N : Subgroup G) (H : Group)
+  : {f : GroupHomomorphism G H & forall (n : G), N n -> f n = mon_unit}
+    <~> (GroupHomomorphism (QuotientAbGroup G N) H).
+Proof.
+  exact (equiv_grp_quotient_ump (Build_NormalSubgroup G N _) _).
+Defined.
 
 (** ** The wild category of abelian groups *)
 

--- a/theories/Algebra/AbGroups/AbelianGroup.v
+++ b/theories/Algebra/AbGroups/AbelianGroup.v
@@ -76,7 +76,7 @@ Defined.
 (** ** Quotients of abelian groups *)
 
 Global Instance isabgroup_quotient (G : AbGroup) (H : Subgroup G)
-  : IsAbGroup (QuotientGroup G (Build_NormalSubgroup G H (isnormal_ab_subgroup G H))).
+  : IsAbGroup (QuotientGroup' G H (isnormal_ab_subgroup G H)).
 Proof.
   nrapply Build_IsAbGroup.
   1: exact _.
@@ -90,10 +90,7 @@ Proof.
 Defined.
 
 Definition QuotientAbGroup (G : AbGroup) (H : Subgroup G) : AbGroup :=
-  Build_AbGroup
-    (QuotientGroup G
-      (Build_NormalSubgroup G H (isnormal_ab_subgroup G H)))
-    _ _ _ _.
+  Build_AbGroup (QuotientGroup' G H (isnormal_ab_subgroup G H)) _ _ _ _.
 
 Theorem equiv_quotient_abgroup_ump {F : Funext} {G : AbGroup}
   (N : Subgroup G) (H : Group)

--- a/theories/Algebra/AbGroups/AbelianGroup.v
+++ b/theories/Algebra/AbGroups/AbelianGroup.v
@@ -54,23 +54,14 @@ Proof.
   cbn. apply commutativity.
 Defined.
 
-
 Global Instance isnormal_ab_subgroup (G : AbGroup) (H : Subgroup G)
   : IsNormalSubgroup H.
 Proof.
-  intros x y.
-  unfold in_cosetL, in_cosetR.
-  srapply equiv_iff_hprop.
-  { rewrite <- (negate_involutive (x + -y)).
-    rewrite negate_sg_op.
-    rewrite negate_involutive.
-    rewrite (commutativity y (-x)).
-    rapply subgroup_inv. }
-  rewrite <- (negate_involutive (-x + y)).
+  intros x y; unfold in_cosetL, in_cosetR.
+  refine (_ oE equiv_subgroup_inverse _ _).
   rewrite negate_sg_op.
   rewrite negate_involutive.
-  rewrite (commutativity x (-y)).
-  rapply subgroup_inv.
+  by rewrite (commutativity (-y) x).
 Defined.
 
 (** ** Quotients of abelian groups *)

--- a/theories/Algebra/AbGroups/AbelianGroup.v
+++ b/theories/Algebra/AbGroups/AbelianGroup.v
@@ -50,10 +50,8 @@ Proof.
   nrapply Build_IsAbGroup.
   1: exact _.
   intros x y.
-  apply (injective issubgroup_incl).
-  refine (_ @ _ @ _^).
-  1,3: apply grp_homo_op.
-  apply commutativity.
+  apply path_sigma_hprop.
+  cbn. apply commutativity.
 Defined.
 
 Global Instance isnormal_ab_subgroup (G : AbGroup) (H : Subgroup G)
@@ -62,7 +60,7 @@ Proof.
   intros x y.
   unfold in_cosetL, in_cosetR.
   refine (equiv_functor_sigma' (Build_Equiv _ _ group_inverse _) _).
-  intros h; simpl.
+  intros h.
   srapply equiv_iff_hprop.
   + intros p.
     rewrite grp_homo_inv.

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -377,19 +377,18 @@ Defined.
 (** Inverses distribute over the group operation *)
 (* Check negate_sg_op. *)
 
-Definition group_cancelR {G : Group} (x y z : G)
-  : y = z <~> y * x = z * x := equiv_ap (fun t => t * x) _ _.
+(** Group elements can be cancelled both on the left and the right. *)
+(* Check group_cancelR. *)
+(* Check group_cancelL. *)
 
-Definition group_cancelL {G : Group} (x y z : G)
-  : y = z <~> x * y = x * z := equiv_ap (fun t => x * t) _ _.
-
+(* TODO make all of these into equivalences *)
 Lemma group_moveR_gV {G : Group} (x y : G)
   : x = y <~> x * -y = mon_unit.
 Proof.
   apply equiv_iff_hprop.
   1: intros []; apply right_inverse.
   intro p.
-  apply (group_cancelR (-y) _ _)^-1%equiv.
+  apply (group_cancelR (-y)).
   exact (p @ (right_inverse y)^).
 Defined.
 
@@ -399,12 +398,10 @@ Proof.
   apply equiv_iff_hprop.
   1: intros []; apply left_inverse.
   intro p.
-  apply (group_cancelL (-y) _ _)^-1%equiv.
+  apply (group_cancelL (-y)).
   exact (p @ (left_inverse y)^).
 Defined.
 
-(* jarlg: TODO make these equivalence, like the ones just above. *)
-(* jarlg: note that moveL_1M is inverse to moveR_gV, and so on *)
 Lemma group_moveL_1M {G : Group} (x y : G)
   : x * (-y) = mon_unit -> x = y.
 Proof.
@@ -473,7 +470,7 @@ Proof.
   exact (ap (fun a => a * y) (left_inverse x) @ left_identity _ @ p).
 Defined.
 
-(** Given a group element a0:A over b:B, multiplication by a establishes an equivalence between the kernel and the fiber over b. *)
+(** Given a group element [a0 : A] over [b : B], multiplication by [a] establishes an equivalence between the kernel and the fiber over [b]. *)
 Lemma equiv_grp_hfiber {A B : Group} (f : GroupHomomorphism A B) (b : B)
   : forall (a0 : hfiber f b), hfiber f b <~> hfiber f mon_unit.
 Proof.

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -60,7 +60,7 @@ Local Definition grp_law_right_inverse {G : Group} (x : G) := right_inverse x.
 #[export] Hint Immediate grp_law_right_inverse : group_db.
 
 (** Given path types in a product we may want to decompose. *)
-#[export] Hint Extern 5 (@paths (_ * _) _ _) => (rapply path_prod) : group_db.
+#[export] Hint Extern 5 (@paths (_ * _) _ _) => (apply path_prod) : group_db.
 (** Given path types in a sigma type of a hprop family (i.e. a subset) we may want to decompose. *)
 #[export] Hint Extern 6 (@paths (sig _) _ _) => (rapply path_sigma_hprop) : group_db.
 
@@ -96,88 +96,6 @@ Proof.
   refine (associativity _ _ _ @ _).
   refine (ap (fun x => x * y) p @ _).
   apply left_identity.
-Defined.
-
-(** ** Working with equations in groups *)
-
-(** Inverses are involutive *)
-(* Check negate_involutive. *)
-
-(** Inverses distribute over the group operation *)
-(* Check negate_sg_op. *)
-
-(** Group elements can be cancelled on the left of an equation *)
-(* Check group_cancelL. *)
-
-(** Group elements can be cancelled on the right of an equation *)
-(* Check group_cancelR. *)
-
-Lemma group_moveL_1M {G : Group} (x y : G)
-  : x * (-y) = mon_unit -> x = y.
-Proof.
-  intro p.
-  apply (group_cancelR (- y)).
-  exact (p @ (right_inverse y)^).
-Defined.
-
-Lemma group_moveL_M1 {G : Group} (x y : G)
-  : -y * x = mon_unit -> x = y.
-Proof.
-  intro p.
-  apply (group_cancelL (- y)).
-  exact (p @ (left_inverse y)^).
-Defined.
-
-Lemma group_moveL_gM {G : Group} (x y z : G)
-  : x * -z = y -> x = y * z.
-Proof.
-  intro p.
-  apply (group_cancelR (- z)).
-  refine (_ @ associativity _ _ _).
-  exact (p @ (right_identity y)^ @ (ap (fun a => y * a) (right_inverse z))^).
-Defined.
-
-Lemma group_moveL_Mg {G : Group} (x y z : G)
-  : -y * x = z -> x = y * z.
-Proof.
-  intro p.
-  apply (group_cancelL (- y)).
-  refine (_ @ (associativity _ _ _)^).
-  exact (p @ (left_identity z)^ @ (ap (fun a => a * z) (left_inverse y))^).
-Defined.
-
-Lemma group_moveR_1M {G : Group} (x y : G)
-  : mon_unit = y * (-x) -> x = y.
-Proof.
-  intro p.
-  apply (group_cancelR (- x)).
-  exact (right_inverse x @ p).
-Defined.
-
-Lemma group_moveR_M1 {G : Group} (x y : G)
-  : mon_unit = -x * y -> x = y.
-Proof.
-  intro p.
-  apply (group_cancelL (- x)).
-  exact (left_inverse x @ p).
-Defined.
-
-Lemma group_moveR_gM {G : Group} (x y z : G)
-  : x = z * -y -> x * y = z.
-Proof.
-  intro p.
-  apply (group_cancelR (- y)).
-  refine ((associativity _ _ _)^ @ _).
-  exact (ap (fun a => x * a) (right_inverse y) @ right_identity _ @ p).
-Defined.
-
-Lemma group_moveR_Mg {G : Group} (x y z : G)
-  : y = -x * z -> x * y = z.
-Proof.
-  intro p.
-  apply (group_cancelL (- x)).
- refine (associativity _ _ _ @ _).
-  exact (ap (fun a => a * y) (left_inverse x) @ left_identity _ @ p).
 Defined.
 
 (** ** Group homomorphisms *)
@@ -449,6 +367,110 @@ Proof.
   srapply isequiv_adjointify.
   1: apply (-).
   all: intro; apply negate_involutive.
+Defined.
+
+(** ** Working with equations in groups *)
+
+(** Inverses are involutive *)
+(* Check negate_involutive. *)
+
+(** Inverses distribute over the group operation *)
+(* Check negate_sg_op. *)
+
+Definition group_cancelR {G : Group} (x y z : G)
+  : y = z <~> y * x = z * x := equiv_ap (fun t => t * x) _ _.
+
+Definition group_cancelL {G : Group} (x y z : G)
+  : y = z <~> x * y = x * z := equiv_ap (fun t => x * t) _ _.
+
+Lemma group_moveR_gV {G : Group} (x y : G)
+  : x = y <~> x * -y = mon_unit.
+Proof.
+  apply equiv_iff_hprop.
+  1: intros []; apply right_inverse.
+  intro p.
+  apply (group_cancelR (-y) _ _)^-1%equiv.
+  exact (p @ (right_inverse y)^).
+Defined.
+
+Lemma group_moveR_Vg {G : Group} (x y : G)
+  : x = y <~> -y * x = mon_unit.
+Proof.
+  apply equiv_iff_hprop.
+  1: intros []; apply left_inverse.
+  intro p.
+  apply (group_cancelL (-y) _ _)^-1%equiv.
+  exact (p @ (left_inverse y)^).
+Defined.
+
+(* jarlg: TODO make these equivalence, like the ones just above. *)
+(* jarlg: note that moveL_1M is inverse to moveR_gV, and so on *)
+Lemma group_moveL_1M {G : Group} (x y : G)
+  : x * (-y) = mon_unit -> x = y.
+Proof.
+  intro p.
+  apply (group_cancelR (- y)).
+  exact (p @ (right_inverse y)^).
+Defined.
+
+Lemma group_moveL_M1 {G : Group} (x y : G)
+  : -y * x = mon_unit -> x = y.
+Proof.
+  intro p.
+  apply (group_cancelL (- y)).
+  exact (p @ (left_inverse y)^).
+Defined.
+
+Lemma group_moveL_gM {G : Group} (x y z : G)
+  : x * -z = y -> x = y * z.
+Proof.
+  intro p.
+  apply (group_cancelR (- z)).
+  refine (_ @ associativity _ _ _).
+  exact (p @ (right_identity y)^ @ (ap (fun a => y * a) (right_inverse z))^).
+Defined.
+
+Lemma group_moveL_Mg {G : Group} (x y z : G)
+  : -y * x = z -> x = y * z.
+Proof.
+  intro p.
+  apply (group_cancelL (- y)).
+  refine (_ @ (associativity _ _ _)^).
+  exact (p @ (left_identity z)^ @ (ap (fun a => a * z) (left_inverse y))^).
+Defined.
+
+Lemma group_moveR_1M {G : Group} (x y : G)
+  : mon_unit = y * (-x) -> x = y.
+Proof.
+  intro p.
+  apply (group_cancelR (- x)).
+  exact (right_inverse x @ p).
+Defined.
+
+Lemma group_moveR_M1 {G : Group} (x y : G)
+  : mon_unit = -x * y -> x = y.
+Proof.
+  intro p.
+  apply (group_cancelL (- x)).
+  exact (left_inverse x @ p).
+Defined.
+
+Lemma group_moveR_gM {G : Group} (x y z : G)
+  : x = z * -y -> x * y = z.
+Proof.
+  intro p.
+  apply (group_cancelR (- y)).
+  refine ((associativity _ _ _)^ @ _).
+  exact (ap (fun a => x * a) (right_inverse y) @ right_identity _ @ p).
+Defined.
+
+Lemma group_moveR_Mg {G : Group} (x y z : G)
+  : y = -x * z -> x * y = z.
+Proof.
+  intro p.
+  apply (group_cancelL (- x)).
+ refine (associativity _ _ _ @ _).
+  exact (ap (fun a => a * y) (left_inverse x) @ left_identity _ @ p).
 Defined.
 
 (** Given a group element a0:A over b:B, multiplication by a establishes an equivalence between the kernel and the fiber over b. *)

--- a/theories/Algebra/Groups/Image.v
+++ b/theories/Algebra/Groups/Image.v
@@ -12,67 +12,20 @@ Local Open Scope mc_add_scope.
 (** The image of a group homomorphisms between groups is a subgroup *)
 Definition grp_image {A B : Group} (f : A $-> B) : Subgroup B.
 Proof.
-  snrapply Build_Subgroup.
-  { (** The underlying type is the (propositional) image of the type *)
-  srapply (Build_Group (image (Tr (-1)) f)); repeat split.
-  + (** Group operation *)
-    intros [a p] [b q].
+  snrapply (Build_Subgroup _ (fun b => hexists (fun a => f a = b))).
+  repeat split.
+  1: exact _.
+  1: apply tr; exists mon_unit; apply grp_homo_unit.
+  { intros x y p q; strip_truncations; apply tr.
+    destruct p as [a []], q as [b []].
     exists (a + b).
-    strip_truncations.
-    apply tr.
-    exists (p.1 + q.1).
-    rewrite grp_homo_op.
-    rewrite p.2, q.2. 
-    reflexivity.
-  + (** Group unit *)
-    exists mon_unit.
-    apply tr.
-    exists mon_unit.
-    apply (grp_homo_unit f).
-  + (** Group inverse *)
-    intros [a p].
-    exists (- a).
-    strip_truncations.
-    apply tr.
-    exists (- p.1).
-    rewrite grp_homo_inv.
-    apply ap, p.2.
-  (** The image is a set *)
-  + exact _.
-  (** Our operation is commutative *)
-  + intros [a p] [b q] [c r].
-    srapply path_sigma_hprop.
-    cbn; apply associativity.
-  (** Left identity *)
-  + intros [a p].
-    srapply path_sigma_hprop.
-    cbn; apply left_identity.
-  (** Right identity *)
-  + intros [a p].
-    srapply path_sigma_hprop.
-    cbn; apply right_identity.
-  (** Left inverse *)
-  + intros [a p].
-    srapply path_sigma_hprop.
-    cbn; apply left_inverse.
-  (** Right inverse *)
-  + intros [a p].
-    srapply path_sigma_hprop.
-    cbn; apply right_inverse. }
-  (** The image is a subgroup *)
-  snrapply Build_IsSubgroup.
-  { snrapply Build_GroupHomomorphism.
-    (** The inclusion map is just the projection *)
-    1: exact pr1.
-    (** This is easily a homomorphism *)
-    intros ??; reflexivity. }
-  hnf; cbn; intros a b.
-  (** We know that the first components of this sigma type are equal and since the second component is a proposition we are done. *)
-  apply path_sigma_hprop.
+    apply grp_homo_op. }
+  intros b p.
+  strip_truncations.
+  destruct p as [a []].
+  apply tr; exists (- a).
+  apply grp_homo_inv.
 Defined.
-
-Global Instance ishset_grp_image {A B : Group} (f : A $-> B)
-  : IsHSet (grp_image f) := _.
 
 Definition grp_image_in {A B : Group} (f : A $-> B) : A $-> grp_image f.
 Proof.
@@ -82,7 +35,5 @@ Proof.
     srapply tr.
     exists x.
     reflexivity. }
-  { intros x y.
-    apply path_sigma_hprop.
-    apply grp_homo_op. }  
+  cbn. grp_auto.
 Defined.

--- a/theories/Algebra/Groups/Kernel.v
+++ b/theories/Algebra/Groups/Kernel.v
@@ -10,50 +10,15 @@ Local Open Scope mc_mult_scope.
 
 Definition grp_kernel {A B : Group} (f : GroupHomomorphism A B) : Subgroup A.
 Proof.
-  snrapply Build_Subgroup.
-  { srapply (Build_Group (hfiber f group_unit)); repeat split.
-    - (** Operation *)
-      intros [a p] [b q].
-      exists (sg_op a b).
-      rewrite grp_homo_op, p, q.
-      apply left_identity.
-    - (** Unit *)
-      exists mon_unit.
-      apply (grp_homo_unit f).
-    - (** Inverse *)
-      intros [a p].
-      exists (-a).
-      rewrite grp_homo_inv, p.
-      exact negate_mon_unit.
-    - (** HSet *)
-      exact _.
-    - (** Associativity *)
-      intros [a p] [b q] [c r].
-      srapply path_sigma_hprop.
-      cbn; apply associativity.
-    - (** Left identity *)
-      intros [a p].
-      srapply path_sigma_hprop.
-      cbn; apply left_identity.
-    - (** Right identity *)
-      intros [a p].
-      srapply path_sigma_hprop.
-      cbn; apply right_identity.
-    - (** Left inverse *)
-      intros [a p].
-      srapply path_sigma_hprop.
-      cbn; apply left_inverse.
-    - (** Right inverse *)
-      intros [a p].
-      srapply path_sigma_hprop.
-      cbn; apply right_inverse. }
-  (** The kernel is a subgroup of the source of the map *)
-  snrapply Build_IsSubgroup.
-  { snrapply Build_GroupHomomorphism.
-    1: exact pr1.
-    intros ??; reflexivity. }
-  hnf; cbn; intros x y p.
-  by apply path_sigma_hprop.
+  snrapply (Build_Subgroup A (fun x => f x = group_unit)).
+  repeat split.
+  1: exact _.
+  1: apply grp_homo_unit.
+  { intros x y p q.
+    refine (_ @ ap011 _ p q @ left_identity mon_unit).
+    apply grp_homo_op. }
+  intros x p.
+  exact (grp_homo_inv f x @ ap _ p @ negate_mon_unit).
 Defined.
 
 Global Instance isnormal_kernel {A B : Group} (f : GroupHomomorphism A B)
@@ -86,7 +51,9 @@ Theorem equiv_grp_kernel_corec `{Funext} {A B G : Group} {f : A $-> B}
   : (G $-> grp_kernel f) <~> (exists g : G $-> A, f $o g == grp_homo_const).
 Proof.
   srapply equiv_adjointify.
-  - intro k. refine (subgrp_incl _ _ $o k; _).
+  - intro k.
+    srefine (_ $o k; _).
+    1: apply subgroup_incl.
     intro x; cbn.
     exact (k x).2.
   - intros [g p].
@@ -101,7 +68,8 @@ Defined.
 
 (** ** Characterisation of group embeddings *)
 
-Local Existing Instance ishprop_path_subgroup.
+(*
+(* Local Existing Instance ishprop_path_subgroup. *)
 
 Proposition equiv_kernel_isembedding `{Univalence} {A B : Group} (f : A $-> B)
   : (grp_kernel f = trivial_subgroup) <~> IsEmbedding f.
@@ -123,4 +91,4 @@ Proof.
     + apply equiv_path_grouphomomorphism; intro x; cbn.
       refine (ap pr1 (y:=(mon_unit; grp_homo_unit f)) _).
       apply path_ishprop.
-Defined.
+Defined.*)

--- a/theories/Algebra/Groups/Kernel.v
+++ b/theories/Algebra/Groups/Kernel.v
@@ -8,31 +8,24 @@ Require Import WildCat.
 Local Open Scope mc_scope.
 Local Open Scope mc_mult_scope.
 
-Definition grp_kernel {A B : Group} (f : GroupHomomorphism A B) : Subgroup A.
+Definition grp_kernel {A B : Group} (f : GroupHomomorphism A B) : NormalSubgroup A.
 Proof.
-  snrapply (Build_Subgroup A (fun x => f x = group_unit)).
-  repeat split.
-  1: exact _.
-  1: apply grp_homo_unit.
-  { intros x y p q.
-    refine (_ @ ap011 _ p q @ left_identity mon_unit).
-    apply grp_homo_op. }
-  intros x p.
-  exact (grp_homo_inv f x @ ap _ p @ negate_mon_unit).
-Defined.
-
-Global Instance isnormal_kernel {A B : Group} (f : GroupHomomorphism A B)
-  : IsNormalSubgroup (grp_kernel f).
-Proof.
-  apply isnormalsubgroup_of_cong_mem.
-  intros g n.
-  srefine ((_ ; _ ); _).
-  3: reflexivity.
-  simpl.
-  rewrite grp_homo_op, grp_homo_op, grp_homo_inv.
-  rewrite (pr2 n), (right_identity (- f g)).
-  rewrite (negate_l _).
-  reflexivity.
+  snrapply Build_NormalSubgroup.
+  - snrapply (Build_Subgroup A (fun x => f x = group_unit)).
+    repeat split.
+    1: exact _.
+    1: apply grp_homo_unit.
+    { intros x y p q.
+      refine (_ @ ap011 _ p q @ left_identity mon_unit).
+      apply grp_homo_op. }
+    intros x p.
+    exact (grp_homo_inv f x @ ap _ p @ negate_mon_unit).
+  - unfold IsNormalSubgroup; cbn.
+    intros x y.
+    rewrite 2 grp_homo_op.
+    rewrite 2 grp_homo_inv.
+    refine (group_moveR_gV _ _ oE equiv_path_inverse _ _ oE _ ); symmetry.
+    apply group_moveR_Vg.
 Defined.
 
 (** ** Corecursion principle for group kernels *)

--- a/theories/Algebra/Groups/Kernel.v
+++ b/theories/Algebra/Groups/Kernel.v
@@ -11,17 +11,13 @@ Local Open Scope mc_mult_scope.
 Definition grp_kernel {A B : Group} (f : GroupHomomorphism A B) : NormalSubgroup A.
 Proof.
   snrapply Build_NormalSubgroup.
-  - snrapply (Build_Subgroup A (fun x => f x = group_unit)).
-    repeat split.
-    1: exact _.
+  - srapply (Build_Subgroup' (fun x => f x = group_unit)).
     1: apply grp_homo_unit.
-    { intros x y p q.
-      refine (_ @ ap011 _ p q @ left_identity mon_unit).
-      apply grp_homo_op. }
-    intros x p.
-    exact (grp_homo_inv f x @ ap _ p @ negate_mon_unit).
-  - unfold IsNormalSubgroup; cbn.
-    intros x y.
+    intros x y p q; cbn in p, q; cbn.
+    refine (grp_homo_op _ _ _ @ ap011 _ p _ @ _).
+    1: apply grp_homo_inv.
+    rewrite q; apply right_inverse.
+  - intros x y; cbn.
     rewrite 2 grp_homo_op.
     rewrite 2 grp_homo_inv.
     refine (group_moveR_gV _ _ oE equiv_path_inverse _ _ oE _ ); symmetry.
@@ -61,9 +57,9 @@ Defined.
 
 (** ** Characterisation of group embeddings *)
 Proposition equiv_kernel_isembedding `{Univalence} {A B : Group} (f : A $-> B)
-  : (grp_kernel f = trivial_subgroup :> Subgroup _) <~> IsEmbedding f.
+  : (grp_kernel f = trivial_subgroup :> Subgroup A) <~> IsEmbedding f.
 Proof.
-  refine (_ oE (equiv_path_subgroup' _ _)^-1).
+  refine (_ oE (equiv_path_subgroup' _ _)^-1%equiv).
   srapply equiv_iff_hprop.
   - cbn; intros h.
     intros b.

--- a/theories/Algebra/Groups/Kernel.v
+++ b/theories/Algebra/Groups/Kernel.v
@@ -1,4 +1,4 @@
-Require Import Basics Types.
+Require Import Basics Types HSet.
 Require Import Algebra.Groups.Group.
 Require Import Algebra.Groups.Subgroup.
 Require Import WildCat.
@@ -60,28 +60,28 @@ Proof.
 Defined.
 
 (** ** Characterisation of group embeddings *)
-
-(*
-(* Local Existing Instance ishprop_path_subgroup. *)
-
 Proposition equiv_kernel_isembedding `{Univalence} {A B : Group} (f : A $-> B)
-  : (grp_kernel f = trivial_subgroup) <~> IsEmbedding f.
+  : (grp_kernel f = trivial_subgroup :> Subgroup _) <~> IsEmbedding f.
 Proof.
+  refine (_ oE (equiv_path_subgroup' _ _)^-1).
   srapply equiv_iff_hprop.
-  - intros phi b.
-    apply hprop_inhabited_contr; intro a.
-    rapply (contr_equiv' _ (equiv_grp_hfiber _ _ a)^-1%equiv).
-    rapply (transport Contr (x:=grp_trivial)).
-    exact (ap (group_type o subgroup_group A) phi^).
-  - intro isemb_f.
-    rapply equiv_path_subgroup.
-    srefine (grp_iso_inverse _; _).
-    + srapply Build_GroupIsomorphism.
-      * exact grp_homo_const.
-      * srapply isequiv_adjointify.
-        1: exact grp_homo_const.
-        all: intro x; apply path_ishprop.
-    + apply equiv_path_grouphomomorphism; intro x; cbn.
-      refine (ap pr1 (y:=(mon_unit; grp_homo_unit f)) _).
-      apply path_ishprop.
-Defined.*)
+  - cbn; intros h.
+    intros b.
+    apply hprop_allpath.
+    intros [x p] [y q].
+    apply path_sigma_hprop; cbn.
+    apply group_moveL_1M.
+    apply h.
+    rewrite grp_homo_op, grp_homo_inv.
+    rewrite p, q.
+    apply right_inverse.
+  - intros isemb_f g.
+    apply isinj_embedding in isemb_f.
+    split.
+    + cbn; intros p.
+      apply isemb_f.
+      refine (p @ _^).
+      apply grp_homo_unit.
+    + cbn; intros p.
+      refine (ap _ p @ grp_homo_unit f).
+Defined.

--- a/theories/Algebra/Groups/QuotientGroup.v
+++ b/theories/Algebra/Groups/QuotientGroup.v
@@ -179,9 +179,11 @@ Proof.
 Defined.
 
 (** The proof of normality is irrelevent up to equivalence. This is unfortunate that it doesn't hold definitionally. *)
-(* Definition grp_iso_quotient_normal (G : Group) (H : Subgroup G)
+Definition grp_iso_quotient_normal (G : Group) (H : Subgroup G)
   {k k' : IsNormalSubgroup H}
-  : GroupIsomorphism (@QuotientGroup G _ k) (@QuotientGroup G _ k').
+  : GroupIsomorphism
+      (@QuotientGroup G (Build_NormalSubgroup G H k))
+      (@QuotientGroup G (Build_NormalSubgroup G H k')).
 Proof.
   snrapply Build_GroupIsomorphism'.
   1: reflexivity.
@@ -189,7 +191,7 @@ Proof.
   srapply Quotient_ind_hprop; intro y; revert x.
   srapply Quotient_ind_hprop; intro x.
   reflexivity.
-Defined. *)
+Defined.
 
 (** The universal mapping property for groups *)
 Theorem equiv_grp_quotient_ump {F : Funext} {G : Group} (N : NormalSubgroup G) (H : Group)

--- a/theories/Algebra/Groups/QuotientGroup.v
+++ b/theories/Algebra/Groups/QuotientGroup.v
@@ -113,7 +113,7 @@ End GroupCongruenceQuotient.
 
 Section QuotientGroup.
 
-  Context (G : Group) (N : Group) `{IsNormalSubgroup N G}.
+  Context (G : Group) (N : Subgroup G) `{!IsNormalSubgroup N}.
 
   Global Instance iscongruence_in_cosetL : IsCongruence (in_cosetL N).
   Proof.
@@ -139,7 +139,7 @@ Section QuotientGroup.
   Defined.
 
   Definition grp_quotient_rec {A : Group} (f : G $-> A)
-    (h : forall n : N, f (issubgroup_incl n) = mon_unit) : QuotientGroup $-> A.
+    (h : forall n : N, f (subgroup_incl _ n) = mon_unit) : QuotientGroup $-> A.
   Proof.
     snrapply Build_GroupHomomorphism.
     { srapply Quotient_rec.
@@ -164,7 +164,7 @@ Section QuotientGroup.
 
 End QuotientGroup.
 
-Arguments grp_quotient_map {_ _ _ _}.
+Arguments grp_quotient_map {_ _ _}.
 
 Notation "G / N" := (QuotientGroup G N) : group_scope.
 
@@ -172,18 +172,18 @@ Local Open Scope group_scope.
 
 (** Computation rule for grp_quotient_rec. *)
 Corollary grp_quotient_rec_beta `{F : Funext} {G : Group}
-          (N : Group) (H : Group) `{IsNormalSubgroup N G}
+          (N : Subgroup G) (H : Group) `{!IsNormalSubgroup N}
           {A : Group} (f : G $-> A)
-          (h : forall n:N, f (issubgroup_incl n) = mon_unit)
+          (h : forall n:N, f (subgroup_incl _ n) = mon_unit)
   : (grp_quotient_rec G N f h) $o grp_quotient_map = f.
 Proof.
   apply equiv_path_grouphomomorphism; reflexivity.
 Defined.
 
 (** The proof of normality is irrelevent up to equivalence. This is unfortunate that it doesn't hold definitionally. *)
-Definition grp_iso_quotient_normal (G : Group) (H : Group) `{IsSubgroup H G}
-  {k k' : @IsNormalSubgroup H G _}
-  : GroupIsomorphism (@QuotientGroup G H _ k) (@QuotientGroup G H _ k').
+Definition grp_iso_quotient_normal (G : Group) (H : Subgroup G)
+  {k k' : IsNormalSubgroup H}
+  : GroupIsomorphism (@QuotientGroup G H k) (@QuotientGroup G H k').
 Proof.
   snrapply Build_GroupIsomorphism'.
   1: reflexivity.
@@ -194,8 +194,9 @@ Proof.
 Defined.
 
 (** The universal mapping property for groups *)
-Theorem equiv_grp_quotient_ump {F : Funext} {G : Group} (N : Subgroup G) (H : Group) `{IsNormalSubgroup N G}
-  : {f : G $-> H & forall (n : N), f (issubgroup_incl n) = mon_unit} <~> (G / N $-> H).
+Theorem equiv_grp_quotient_ump {F : Funext} {G : Group} (N : Subgroup G) (H : Group)
+  `{!IsNormalSubgroup N}
+  : {f : G $-> H & forall (n : N), f (subgroup_incl _ n) = mon_unit} <~> (G / N $-> H).
 Proof.
   srapply equiv_adjointify.
   { intros [f p].
@@ -252,7 +253,7 @@ Section FirstIso.
     srefine (_;_).
     { exists (-x * y).
       apply (equiv_path_sigma_hprop _ _)^-1%equiv in h; cbn in h.
-      rewrite grp_homo_op, grp_homo_inv, h.
+      cbn. rewrite grp_homo_op, grp_homo_inv, h.
       srapply negate_l. }
     reflexivity.
   Defined.

--- a/theories/Algebra/Groups/QuotientGroup.v
+++ b/theories/Algebra/Groups/QuotientGroup.v
@@ -155,8 +155,7 @@ Section QuotientGroup.
       refine (Quotient_ind_hprop _ _ _).
       intro y. revert x.
       refine (Quotient_ind_hprop _ _ _).
-      intro x.
-      simpl.
+      intro x; simpl.
       apply grp_homo_op.
   Defined.
 
@@ -200,24 +199,22 @@ Theorem equiv_grp_quotient_ump {F : Funext} {G : Group} (N : NormalSubgroup G) (
   : {f : G $-> H & forall (n : G), N n -> f n = mon_unit} <~> (G / N $-> H).
 Proof.
   srapply equiv_adjointify.
-  { intros [f p].
-    exact (grp_quotient_rec _ _ f p). }
-  { intro f.
+  - intros [f p].
+    exact (grp_quotient_rec _ _ f p).
+  - intro f.
     exists (f $o grp_quotient_map).
     intros n h; cbn.
     refine (_ @ grp_homo_unit f).
     apply ap.
     apply qglue; cbn.
     rewrite right_identity;
-      by apply issubgroup_inv. }
-  { intros f.
+      by apply issubgroup_inverse.
+  - intros f.
     rapply equiv_path_grouphomomorphism.
-    srapply Quotient_ind_hprop.
-    intro x.
-    reflexivity. }
-  { intros [f p].
+      by srapply Quotient_ind_hprop.
+  - intros [f p].
     srapply path_sigma_hprop; simpl.
-    exact (grp_quotient_rec_beta N H f p). }
+    exact (grp_quotient_rec_beta N H f p).
 Defined.
 
 Section FirstIso.

--- a/theories/Algebra/Groups/QuotientGroup.v
+++ b/theories/Algebra/Groups/QuotientGroup.v
@@ -166,7 +166,7 @@ Arguments grp_quotient_map {_ _}.
 
 Notation "G / N" := (QuotientGroup G N) : group_scope.
 
-(** Rephrasing that let's you specify the normality proof *)
+(** Rephrasing that lets you specify the normality proof *)
 Definition QuotientGroup' (G : Group) (N : Subgroup G) (H : IsNormalSubgroup N)
   := QuotientGroup G (Build_NormalSubgroup G N H).
 

--- a/theories/Algebra/Groups/QuotientGroup.v
+++ b/theories/Algebra/Groups/QuotientGroup.v
@@ -166,6 +166,10 @@ Arguments grp_quotient_map {_ _}.
 
 Notation "G / N" := (QuotientGroup G N) : group_scope.
 
+(** Rephrasing that let's you specify the normality proof *)
+Definition QuotientGroup' (G : Group) (N : Subgroup G) (H : IsNormalSubgroup N)
+  := QuotientGroup G (Build_NormalSubgroup G N H).
+
 Local Open Scope group_scope.
 
 (** Computation rule for grp_quotient_rec. *)
@@ -181,9 +185,7 @@ Defined.
 (** The proof of normality is irrelevent up to equivalence. This is unfortunate that it doesn't hold definitionally. *)
 Definition grp_iso_quotient_normal (G : Group) (H : Subgroup G)
   {k k' : IsNormalSubgroup H}
-  : GroupIsomorphism
-      (@QuotientGroup G (Build_NormalSubgroup G H k))
-      (@QuotientGroup G (Build_NormalSubgroup G H k')).
+  : GroupIsomorphism (QuotientGroup' G H k) (QuotientGroup' G H k').
 Proof.
   snrapply Build_GroupIsomorphism'.
   1: reflexivity.

--- a/theories/Algebra/Groups/ShortExactSequence.v
+++ b/theories/Algebra/Groups/ShortExactSequence.v
@@ -46,6 +46,7 @@ Proof.
     exists tt; apply path_ishprop.
 Defined.
 
+(*
 (** A complex 0 -> A -> B is purely exact if and only if the kernel of the map A -> B is trivial. *)
 Corollary equiv_grp_isexact_kernel `{Univalence} {A B : Group} (f : A $-> B)
   : IsExact purely (@grp_homo_const grp_trivial A) f
@@ -53,3 +54,4 @@ Corollary equiv_grp_isexact_kernel `{Univalence} {A B : Group} (f : A $-> B)
 Proof.
   exact ((equiv_kernel_isembedding f)^-1%equiv oE equiv_grp_isexact_isembedding f).
 Defined.
+*)

--- a/theories/Algebra/Groups/ShortExactSequence.v
+++ b/theories/Algebra/Groups/ShortExactSequence.v
@@ -46,12 +46,11 @@ Proof.
     exists tt; apply path_ishprop.
 Defined.
 
-(*
+
 (** A complex 0 -> A -> B is purely exact if and only if the kernel of the map A -> B is trivial. *)
 Corollary equiv_grp_isexact_kernel `{Univalence} {A B : Group} (f : A $-> B)
   : IsExact purely (@grp_homo_const grp_trivial A) f
-            <~> (grp_kernel f = trivial_subgroup).
+            <~> (grp_kernel f = trivial_subgroup :> Subgroup _).
 Proof.
   exact ((equiv_kernel_isembedding f)^-1%equiv oE equiv_grp_isexact_isembedding f).
 Defined.
-*)

--- a/theories/Algebra/Groups/Subgroup.v
+++ b/theories/Algebra/Groups/Subgroup.v
@@ -336,22 +336,3 @@ Proof.
   by apply isnormal, symmetric_in_cosetR.
 Defined.
 
-(* jarlg: needed for abelian groups *)
-(* Definition isnormalsubgroup_of_cong_mem  {G : Group} {N : Subgroup G}
-  (h : forall (g : G) (n : N), exists m : N,
-    - g * subgroup_incl N n * g = subgroup_incl N m)
-  : IsNormalSubgroup N.
-Proof.
-  intros x y.
-  apply equiv_iff_hprop; intros [m p].
-  1: specialize (h (-y) (-m)).
-  2: specialize (h y (-m)).
-  1-2: destruct h as [m' p'].
-  1-2: exists m'.
-  1-2: rewrite <- p'.
-  1-2: f_ap.
-  1-2: rewrite grp_homo_inv, p, negate_sg_op, involutive. 
-  1: rewrite associativity, involutive, (negate_r G y).
-  2: rewrite (associativity (-y)), (negate_l G y).
-  1-2: rewrite (left_identity _); reflexivity.
-Defined. *)

--- a/theories/Algebra/Groups/Subgroup.v
+++ b/theories/Algebra/Groups/Subgroup.v
@@ -12,7 +12,7 @@ Class IsSubgroup {G : Group} (H : G -> Type) := {
   issubgroup_predicate : forall x, IsHProp (H x) ;
   issubgroup_unit : H mon_unit ;
   issubgroup_op : forall x y, H x -> H y -> H (x * y) ;
-  issubgroup_inv : forall x, H x -> H (- x) ;
+  issubgroup_inverse : forall x, H x -> H (- x) ;
 }.
 
 Global Existing Instance issubgroup_predicate.
@@ -71,9 +71,21 @@ Proof.
 Defined.
 
 Definition subgroup_unit `(H : Subgroup G) : H mon_unit := issubgroup_unit.
-Definition subgroup_inv `(H : Subgroup G) x : H x -> H (- x) := issubgroup_inv x.
+Definition subgroup_inverse `(H : Subgroup G) x : H x -> H (- x) := issubgroup_inverse x.
 Definition subgroup_op `(H : Subgroup G) x y : H x -> H y -> H (x * y)
 := issubgroup_op x y.
+
+Global Instance isequiv_subgroup_inverse `(H : Subgroup G) (x : G)
+  : IsEquiv (subgroup_inverse H x).
+Proof.
+  srapply isequiv_iff_hprop.
+  intro h.
+  rewrite <- negate_involutive.
+    by apply subgroup_inverse.
+Defined.
+
+Definition equiv_subgroup_inverse {G : Group} (H : Subgroup G) (x : G)
+  : H x <~> H (-x) := Build_Equiv _ _ (subgroup_inverse H x) _.
 
 (** The group given by a subgroup *)
 Definition subgroup_group (G : Group) (H : Subgroup G) : Group.
@@ -86,7 +98,7 @@ Proof.
       (** The unit *)
       (mon_unit ; issubgroup_unit)
       (** Inverse *)
-      (fun '(x ; p) => (- x ; issubgroup_inv _ p))).
+      (fun '(x ; p) => (- x ; issubgroup_inverse _ p))).
   (** Finally we need to prove our group laws. *)
   repeat split.
   1: exact _.
@@ -199,7 +211,7 @@ Section Cosets.
     intros x y h; cbn; cbn in h.
     rewrite <- (negate_involutive x).
     rewrite <- negate_sg_op.
-    apply issubgroup_inv; assumption.
+    apply issubgroup_inverse; assumption.
   Defined.
 
   Global Instance symmetric_in_cosetR : Symmetric in_cosetR.
@@ -207,7 +219,7 @@ Section Cosets.
     intros x y h; cbn; cbn in h.
     rewrite <- (negate_involutive y).
     rewrite <- negate_sg_op.
-    apply issubgroup_inv; assumption.
+    apply issubgroup_inverse; assumption.
   Defined.
 
   Global Instance transitive_in_cosetL : Transitive in_cosetL.
@@ -283,7 +295,7 @@ Coercion normalsubgroup_subgroup : NormalSubgroup >-> Subgroup.
 Global Existing Instance normalsubgroup_isnormal.
 
 (* Inverses are then respected *)
-Definition in_cosetL_inv {G : Group} {N : NormalSubgroup G}
+Definition in_cosetL_inverse {G : Group} {N : NormalSubgroup G}
   : forall x y : G, in_cosetL N (-x) (-y) <~> in_cosetL N x y.
 Proof.
   intros x y.
@@ -292,7 +304,7 @@ Proof.
   symmetry; apply isnormal.
 Defined.
 
-Definition in_cosetR_inv {G : Group} {N : NormalSubgroup G}
+Definition in_cosetR_inverse {G : Group} {N : NormalSubgroup G}
   : forall x y : G, in_cosetR N (-x) (-y) <~> in_cosetR N x y.
 Proof.
   intros x y.
@@ -303,7 +315,7 @@ Proof.
   by rewrite negate_involutive.
 Defined.
 
-(* This lets us prove that left and right coset relations are congruences. *)
+(** This lets us prove that left and right coset relations are congruences. *)
 Definition in_cosetL_cong {G : Group} {N : NormalSubgroup G}
   (x x' y y' : G)
   : in_cosetL N x y -> in_cosetL N x' y' -> in_cosetL N (x * x') (y * y').

--- a/theories/Algebra/Groups/Subgroup.v
+++ b/theories/Algebra/Groups/Subgroup.v
@@ -1,41 +1,57 @@
+
 Require Import Basics Types HProp HSet HFiber PathAny WildCat.
-Require Import Algebra.Groups.Group.
+Require Import Algebra.Groups.Group TruncType.
 
 Local Open Scope mc_mult_scope.
 Generalizable Variables G H A B C N f g.
 
 (** * Subgroups *)
 
-(** The property of being a subgroup *)
+(** A subgroup H of a group G is a predicate (i.e. an hProp-valued type family) on G which is closed under the group operations. The group underlying H is given by the total space { g : G & H g }, defined in [subgroup_group] below. *)
 Class IsSubgroup {G : Group} (H : G -> Type) := {
-  ishprop_issubgroup : forall x, IsHProp (H x) ;
+  issubgroup_predicate : forall x, IsHProp (H x) ;
   issubgroup_unit : H mon_unit ;
   issubgroup_op : forall x y, H x -> H y -> H (x * y) ;
   issubgroup_inv : forall x, H x -> H (- x) ;
-(*   issubgroup_incl : GroupHomomorphism G H; *)
-(*   isinj_issubgroup_incl : IsInjective issubgroup_incl; *)
 }.
 
-Global Existing Instance ishprop_issubgroup.
-(* Global Existing Instance isinj_issubgroup_incl. *)
-(*
-(* Subgroup inclusion is an embedding. *)
-Global Instance isembedding_issubgroup_incl `{!IsSubgroup G H}
-  : IsEmbedding (@issubgroup_incl G H _).
+Global Existing Instance issubgroup_predicate.
+
+(** Smart constructor for subgroups.  *)
+Definition Build_IsSubgroup' { G : Group } (H : G -> Type)
+           `{forall x, IsHProp (H x)}
+           (unit : H mon_unit)
+           (c : forall x y, H x -> H y -> H (x * -y))
+  : IsSubgroup H.
 Proof.
-  apply isembedding_isinj_hset.
-  apply isinj_issubgroup_incl.
-Defined. *)
+  refine (Build_IsSubgroup G H _ unit _ _).
+  - intros x y.
+    intros hx hy.
+    pose (c' := c mon_unit y).
+    specialize (c' unit).
+    specialize (c x (-y)).
+    rewrite (negate_involutive y) in c.
+    rewrite left_identity in c'.
+    apply c.
+    1: assumption.
+    exact (c' hy).
+  - intro g.
+    specialize (c _ g unit).
+    rewrite left_identity in c.
+    assumption.
+Defined.
 
 Definition issig_issubgroup {G : Group} (H : G -> Type) : _ <~> IsSubgroup H
   := ltac:(issig).
 
-Global Instance ishset_issubgroup `{F : Funext} {G : Group} {H : G -> Type}
+(** Given a predicate H on a group G, being a subgroup is a property. *)
+Global Instance ishprop_issubgroup `{F : Funext} {G : Group} {H : G -> Type}
   : IsHProp (IsSubgroup H).
 Proof.
   exact (trunc_equiv' _ (issig_issubgroup H)).
 Defined.
 
+(** The type (set) of subgroups of a group G. *)
 Record Subgroup (G : Group) := {
   subgroup_pred : G -> Type ;
   subgroup_issubgroup : IsSubgroup subgroup_pred ;
@@ -43,6 +59,16 @@ Record Subgroup (G : Group) := {
 
 Coercion subgroup_pred : Subgroup >-> Funclass.
 Global Existing Instance subgroup_issubgroup.
+
+Definition Build_Subgroup' {G : Group} (H : G -> Type)
+           `{forall x, IsHProp (H x)}
+           (unit : H mon_unit)
+           (c : forall x y, H x -> H y -> H (x * -y))
+  : Subgroup G.
+Proof.
+  refine (Build_Subgroup G H _).
+  rapply Build_IsSubgroup'; assumption.
+Defined.
 
 Definition subgroup_unit `(H : Subgroup G) : H mon_unit := issubgroup_unit.
 Definition subgroup_inv `(H : Subgroup G) x : H x -> H (- x) := issubgroup_inv x.
@@ -52,8 +78,7 @@ Definition subgroup_op `(H : Subgroup G) x y : H x -> H y -> H (x * y)
 (** The group given by a subgroup *)
 Definition subgroup_group (G : Group) (H : Subgroup G) : Group.
 Proof.
-  snrefine (
-    Build_Group
+  apply (Build_Group
       (** The underlying type is the sigma type of the predicate. *)
       (sig H)
       (** The operation is the group operation on the first projection with the proof  of being in the subgroup given by the subgroup data. *)
@@ -61,10 +86,7 @@ Proof.
       (** The unit *)
       (mon_unit ; issubgroup_unit)
       (** Inverse *)
-      (fun '(x ; p) => (- x ; issubgroup_inv _ p))
-      _).
- (** Why isn't typeclasses able to pick these up earlier (without snrefine ofc)?? *)
-  1-3: exact _.
+      (fun '(x ; p) => (- x ; issubgroup_inv _ p))).
   (** Finally we need to prove our group laws. *)
   repeat split.
   1: exact _.
@@ -88,103 +110,54 @@ Global Instance isembedding_subgroup_incl {G : Group} (H : Subgroup G)
 Definition issig_subgroup {G : Group} : _ <~> Subgroup G
   := ltac:(issig).
 
-(* Definition issig_subgroup' `{Univalence} {G : Group}
-  : {h : G -> hProp & IsSubgroup h} <~> Subgroup G.
-Proof.
-  snrapply equiv_adjointify.
-  { intros [h p].
-    exact (Build_Subgroup G h p). }
-  { intros [h p].
-    exists (fun g => BuildTruncType (-1) (h g)).
-    exact _. }
-  1: intro x; reflexivity.
-  simpl.
-  hnf.
-  intros [h p].
-  srapply path_sigma.
-  1: funext x; rapply TruncType.path_iff_hprop; trivial.
-  rewrite trans *)
-  
-
-
 (** Trivial subgroup *)
 Definition trivial_subgroup {G} : Subgroup G.
 Proof.
-  rapply (Build_Subgroup G (fun x => x = mon_unit)).
-  rapply Build_IsSubgroup.
+  rapply (Build_Subgroup' (fun x => x = mon_unit)).
   1: reflexivity.
-  { intros x y p q.
-    rewrite p, q.
-    apply left_identity. }
-  intros x p.
-  rewrite p.
+  intros x y p q.
+  rewrite p, q.
+  rewrite left_identity.
   apply negate_mon_unit.
 Defined.
 
-(** Every group is a subgroup of itself *)
-(**  The maximal subgroup *)
+(** Every group is a (maximal) subgroup of itself *)
 Definition maximal_subgroup {G} : Subgroup G.
 Proof.
   rapply (Build_Subgroup G (fun x => Unit)).
   split; auto; exact _.
 Defined.
 
-(* (** Paths between subgroups correspond to isomorphisms respecting the inclusions. *)
+(** Paths between subgroups correspond to homotopies between the underlying predicates. *) 
 Proposition equiv_path_subgroup `{F : Funext} {G : Group} (H K : Subgroup G)
-  : (exists p : GroupIsomorphism H K, subgrp_incl H G = (subgrp_incl K G) $o p)
-      <~> H = K.
+  : (H == K) <~> (H = K).
 Proof.
-  refine (equiv_ap_inv (@issig_subgroup' G) H K oE _).
-  refine ((equiv_path_sigma _ _ _) oE _); cbn.
-  refine (equiv_functor_sigma' equiv_path_group _).
-  intro phi.
-  refine (equiv_concat_l (transport_sigma _ _) _ oE _).
-  refine (equiv_path_sigma_hprop _ _ oE _); unfold pr1.
-  refine (equiv_concat_l (transport_lemma _ _) _ oE _).
-  rewrite (eissect equiv_path_group phi).
-  refine ((equiv_ap' (equiv_precompose_cat_equiv phi) _ _)^-1%equiv oE _); cbn.
-  apply equiv_concat_l.
-  apply equiv_path_grouphomomorphism; intro x; cbn.
-  rewrite (eissect phi x).
-  reflexivity.
-Defined. *)
-
-Global Instance ishset_subgroup `{Funext} {G : Group} : IsHSet (Subgroup G).
-Proof.
-  refine (trunc_equiv' _ issig_subgroup).
-  rapply trunc_sigma.
-  
-
-(*   refine (trunc_equiv' _ (equiv_ap' issig_subgroup^-1 _ _)^-1). *)
-Admitted.
-(*
-Corollary ishprop_path_subgroup `{U : Univalence} {G : Group} {H K : Subgroup G}
-  : IsHProp (H = K).
-Proof.
-  refine (trunc_equiv' _ (equiv_ap' issig_subgroup^-1%equiv _ _)^-1%equiv).
-  
-  apply istrunc_paths.
-  
-  exact _.
-  rapply (equiv_transport IsHProp _ _).
-  - apply equiv_path_universe.
-    exact (equiv_path_subgroup H K).
-  - apply equiv_hprop_allpath.
-    intros [f p] [g q].
-    apply path_sigma_hprop; cbn.
-    apply equiv_path_groupisomorphism.
-    apply ap10.
-    rapply (ismono_isinj (subgrp_incl K G) (isinj_issubgroup_incl)); cbn.
-    exact (ap (grp_homo_map H G) (p^ @ q)).
+  refine ((equiv_ap' issig_subgroup^-1%equiv _ _)^-1%equiv oE _); cbn.
+  refine (equiv_path_sigma_hprop _ _ oE _); cbn.
+  apply equiv_path_arrow.
 Defined.
 
-(** Any group has as set of subgroups. *)
-Corollary ishset_subgroup `{U: Univalence} {G : Group}
-  : IsHSet (Subgroup G).
+Proposition equiv_path_subgroup' `{U : Univalence} {G : Group} (H K : Subgroup G)
+  : (forall g:G, H g <-> K g) <~> (H = K).
 Proof.
-  intros H K; apply ishprop_path_subgroup.
+  refine (equiv_path_subgroup _ _ oE _).
+  apply equiv_functor_forall_id; intro g.
+  exact equiv_path_iff_ishprop.
 Defined.
-*)
+
+Global Instance ishset_subgroup `{Univalence} {G : Group} : IsHSet (Subgroup G).
+Proof.
+  nrefine (trunc_equiv' _ issig_subgroup).
+  nrefine (trunc_equiv' _ (equiv_functor_sigma_id _)).
+  - intro P; apply issig_issubgroup.
+  - nrefine (trunc_equiv' _ (equiv_sigma_assoc' _ _)^-1%equiv).
+    nrapply trunc_sigma.
+    2: intros []; apply trunc_hprop.
+    nrefine (trunc_equiv'
+               _ (equiv_sig_coind (fun g:G => Type) (fun g x => IsHProp x))^-1%equiv).
+    apply trunc_forall.
+Defined.
+
 Section Cosets.
 
   (** Left and right cosets give equivalence relations. *)
@@ -192,85 +165,69 @@ Section Cosets.
   Context {G : Group} (H : Subgroup G).
 
   (** The relation of being in a left coset represented by an element. *)
-  Definition in_cosetL : Relation G := fun x y => hfiber (subgroup_incl H) (-x * y).
+  Definition in_cosetL : Relation G := fun x y => H (-x * y).
   (** The relation of being in a right coset represented by an element. *)
-  Definition in_cosetR : Relation G := fun x y => hfiber (subgroup_incl H) (x * -y).
+  Definition in_cosetR : Relation G := fun x y => H (x * -y).
+
+  Hint Unfold in_cosetL : typeclass_instances.
+  Hint Unfold in_cosetR : typeclass_instances.
+
+  Global Arguments in_cosetL /.
+  Global Arguments in_cosetR /.
+
   (** These are props *)
   Global Instance ishprop_in_cosetL : is_mere_relation G in_cosetL := _.
   Global Instance ishprop_in_cosetR : is_mere_relation G in_cosetR := _.
+
   (** In fact, they are both equivalence relations. *)
   Global Instance reflexive_in_cosetL : Reflexive in_cosetL.
   Proof.
     intro x; hnf.
-    exists mon_unit.
-    refine (_ @ _).
-    2: apply symmetry, left_inverse.
-    apply grp_homo_unit.
+    rewrite left_inverse.
+    apply issubgroup_unit.
   Defined.
 
   Global Instance reflexive_in_cosetR : Reflexive in_cosetR.
   Proof.
     intro x; hnf.
-    exists mon_unit.
-    refine (_ @ _).
-    2: apply symmetry, right_inverse.
-    apply grp_homo_unit.
+    rewrite right_inverse.
+    apply issubgroup_unit.
   Defined.
 
   Global Instance symmetric_in_cosetL : Symmetric in_cosetL.
   Proof.
-    intros x y [h p]; hnf.
-    exists (-h).
-    refine (_ @ _).
-    1: apply grp_homo_inv.
-    apply moveR_equiv_M.
-    refine (p @ _).
-    symmetry.
-    refine (negate_sg_op _ _ @ _).
-    refine (ap (-x *.) _).
-    apply negate_involutive.
+    intros x y h; cbn; cbn in h.
+    rewrite <- (negate_involutive x).
+    rewrite <- negate_sg_op.
+    apply issubgroup_inv; assumption.
   Defined.
 
   Global Instance symmetric_in_cosetR : Symmetric in_cosetR.
   Proof.
-    intros x y [h p]; hnf.
-    exists (-h).
-    refine (_ @ _).
-    1: apply grp_homo_inv.
-    apply moveR_equiv_M.
-    refine (p @ _).
-    symmetry.
-    refine (negate_sg_op _ _ @ _).
-    refine (ap (fun x => x *  -y) _).
-    apply negate_involutive.
+    intros x y h; cbn; cbn in h.
+    rewrite <- (negate_involutive y).
+    rewrite <- negate_sg_op.
+    apply issubgroup_inv; assumption.
   Defined.
 
   Global Instance transitive_in_cosetL : Transitive in_cosetL.
   Proof.
-    intros x y z [h p] [h' q].
-    exists (h * h').
-    refine (grp_homo_op _ _ _ @ _).
-    destruct p^, q^.
+    intros x y z h k; cbn; cbn in h; cbn in k.
+    rewrite <- (right_identity (-x)).
+    rewrite <- (right_inverse y : y * -y = mon_unit).
+    rewrite (associativity (-x) _ _).
     rewrite <- simple_associativity.
-    apply ap.
-    rewrite simple_associativity.
-    refine (ap (fun x => x *  -z) _ @ _).
-    1: apply right_inverse.
-    apply left_identity.
+    apply issubgroup_op; assumption.
   Defined.
 
   Global Instance transitive_in_cosetR : Transitive in_cosetR.
   Proof.
-    intros x y z [h p] [h' q].
-    exists (h * h').
-    refine (grp_homo_op _ _ _ @ _).
-    destruct p^, q^.
-    rewrite <- simple_associativity.
-    apply ap.
-    rewrite simple_associativity.
-    refine (ap (fun x => x *  -z) _ @ _).
-    1: apply left_inverse.
-    apply left_identity.
+    intros x y z h k; cbn; cbn in h; cbn in k.
+    rewrite <- (right_identity x).
+    rewrite <- (left_inverse y : -y * y = mon_unit).
+    rewrite (simple_associativity x).
+    rewrite <- (associativity _ _ (-z)).
+    apply issubgroup_op; assumption.
   Defined.
 
 End Cosets.
@@ -280,21 +237,17 @@ End Cosets.
 Definition in_cosetL_unit {G : Group} {N : Subgroup G}
   : forall x y, in_cosetL N (-x * y) mon_unit <~> in_cosetL N x y.
 Proof.
-  intros x y.
-  unfold in_cosetL.
-  rewrite negate_sg_op.
-  rewrite negate_involutive.
-  rewrite (right_identity (-y * x)).
-  change (in_cosetL N y x <~> in_cosetL N x y).
-  srapply equiv_iff_hprop;
-  by intro; symmetry.
+  intros x y; cbn.
+  rewrite (right_identity (- _)).
+  rewrite (negate_sg_op _).
+  rewrite (negate_involutive _).
+  apply equiv_iff_hprop; apply symmetric_in_cosetL.
 Defined.
 
 Definition in_cosetR_unit {G : Group} {N : Subgroup G}
   : forall x y, in_cosetR N (x * -y) mon_unit <~> in_cosetR N x y.
 Proof.
-  intros x y.
-  unfold in_cosetR.
+  intros x y; cbn.
   rewrite negate_mon_unit.
   rewrite (right_identity (x * -y)).
   reflexivity.
@@ -317,7 +270,7 @@ Proof.
   all: by intro.
 Defined.
 
-(* A subgroup is normal if being in a left coset is equivalent to being in a right coset represented by the same element. *)
+(** A subgroup is normal if being in a left coset is equivalent to being in a right coset represented by the same element. *)
 Class IsNormalSubgroup {G : Group} (N : Subgroup G)
   := isnormal : forall {x y}, in_cosetL N x y <~> in_cosetR N x y.
 
@@ -330,18 +283,16 @@ Coercion normalsubgroup_subgroup : NormalSubgroup >-> Subgroup.
 Global Existing Instance normalsubgroup_isnormal.
 
 (* Inverses are then respected *)
-Definition in_cosetL_inv {G : Group} {N : Subgroup G} `{!IsNormalSubgroup N}
+Definition in_cosetL_inv {G : Group} {N : NormalSubgroup G}
   : forall x y : G, in_cosetL N (-x) (-y) <~> in_cosetL N x y.
 Proof.
   intros x y.
-  refine (_ oE (in_cosetL_unit _ _)^-1).
-  refine (_ oE isnormal).
-  refine (_ oE in_cosetR_unit _ _).
-  refine (_ oE isnormal^-1).
-  by rewrite negate_involutive.
+  unfold in_cosetL.
+  rewrite negate_involutive.
+  symmetry; apply isnormal.
 Defined.
 
-Definition in_cosetR_inv {G : Group} {N : Subgroup G} `{!IsNormalSubgroup N}
+Definition in_cosetR_inv {G : Group} {N : NormalSubgroup G}
   : forall x y : G, in_cosetR N (-x) (-y) <~> in_cosetR N x y.
 Proof.
   intros x y.
@@ -352,69 +303,41 @@ Proof.
   by rewrite negate_involutive.
 Defined.
 
-(** There is always another element of the normal subgroup allowing us to commute with an element of the group. *)
-Definition normal_subgroup_swap {G : Group} {N : Subgroup G} `{!IsNormalSubgroup N}
-  (x : G) (h : N)
-  : exists h' : N, x * subgroup_incl N h = subgroup_incl N h' * x.
-Proof.
-  assert (X : in_cosetL N x (x * subgroup_incl _ h)).
-  { exists h.
-    rewrite simple_associativity.
-    rewrite left_inverse.
-    symmetry.
-    apply left_identity. }
-  apply isnormal in X.
-  destruct X as [a p].
-  rewrite negate_sg_op in p.
-  rewrite simple_associativity in p.
-  eexists (-a).
-  symmetry.
-  rewrite grp_homo_inv.
-  apply (moveR_equiv_M (f := (- _ *.))).
-  cbn; rewrite negate_involutive.
-  rewrite simple_associativity.
-  apply (moveL_equiv_M (f := (fun x => x * _))).
-  apply (moveL_equiv_M (f := (fun x => x * _))).
-  symmetry.
-  assumption.
-Defined.
-
 (* This lets us prove that left and right coset relations are congruences. *)
-Definition in_cosetL_cong {G : Group} {N : Subgroup G} `{!IsNormalSubgroup N}
+Definition in_cosetL_cong {G : Group} {N : NormalSubgroup G}
   (x x' y y' : G)
   : in_cosetL N x y -> in_cosetL N x' y' -> in_cosetL N (x * x') (y * y').
 Proof.
-  intros [a p] [b q].
-  eexists ?[c].
-  rewrite negate_sg_op.
-  rewrite <- simple_associativity.
-  rewrite (simple_associativity (-x) y).
-  rewrite <- p.
+  cbn; intros p q.
+  (** rewrite goal before applying subgroup_op *)
+  rewrite negate_sg_op, <- simple_associativity.
+  apply symmetric_in_cosetL; cbn.
   rewrite simple_associativity.
-  rewrite (normal_subgroup_swap _ a).2.
+  apply isnormal; cbn.
   rewrite <- simple_associativity.
-  rewrite <- q.
-  apply grp_homo_op.
+  apply subgroup_op.
+  1: assumption.
+  by apply isnormal, symmetric_in_cosetL.
 Defined.
 
-Definition in_cosetR_cong  {G : Group} {N : Subgroup G} `{!IsNormalSubgroup N}
+Definition in_cosetR_cong  {G : Group} {N : NormalSubgroup G}
   (x x' y y' : G)
   : in_cosetR N x y -> in_cosetR N x' y' -> in_cosetR N (x * x') (y * y').
 Proof.
-  intros [a p] [b q].
-  eexists ?[c].
-  rewrite negate_sg_op.
+  cbn; intros p q.
+  (** rewrite goal before applying subgroup_op *)
+  rewrite negate_sg_op, simple_associativity.
+  apply symmetric_in_cosetR; cbn.
   rewrite <- simple_associativity.
-  rewrite (simple_associativity x' (-y')).
-  rewrite <- q.
+  apply isnormal; cbn.
   rewrite simple_associativity.
-  rewrite (normal_subgroup_swap _ b).2.
-  rewrite <- simple_associativity.
-  rewrite <- p.
-  apply grp_homo_op.
+  apply subgroup_op.
+  2: assumption.
+  by apply isnormal, symmetric_in_cosetR.
 Defined.
 
-Definition isnormalsubgroup_of_cong_mem  {G : Group} {N : Subgroup G}
+(* jarlg: needed for abelian groups *)
+(* Definition isnormalsubgroup_of_cong_mem  {G : Group} {N : Subgroup G}
   (h : forall (g : G) (n : N), exists m : N,
     - g * subgroup_incl N n * g = subgroup_incl N m)
   : IsNormalSubgroup N.
@@ -431,4 +354,4 @@ Proof.
   1: rewrite associativity, involutive, (negate_r G y).
   2: rewrite (associativity (-y)), (negate_l G y).
   1-2: rewrite (left_identity _); reflexivity.
-Defined.
+Defined. *)

--- a/theories/Algebra/Rings/Ideal.v
+++ b/theories/Algebra/Rings/Ideal.v
@@ -12,7 +12,7 @@ Local Open Scope mc_scope.
 Class IsIdeal {R : CRing} (I : Subgroup R) := {
   (** Forall r : R and x : I, there exists an a : I, such that a = r * x inside R *)
   isideal (r : R) (x : I)
-    : exists (a : I), issubgroup_incl a = r * issubgroup_incl x;
+    : exists (a : I), subgroup_incl _ a = r * subgroup_incl _ x;
 }.
 
 Record Ideal (R : CRing) := {
@@ -32,11 +32,10 @@ Section Examples.
     : IsIdeal (R:=R) trivial_subgroup.
   Proof.
     split.
-    intros r [].
-    exists tt.
-    refine (_ @ _^ @ ap _ _^).
-    1,3: rapply grp_homo_unit.
-    apply rng_mult_zero_r.
+    intros r [x p].
+    srefine ((cring_zero; idpath);_).
+    refine ((rng_mult_zero_r r)^ @ _^).
+    f_ap.
   Defined.
 
   (** Zero ideal *)
@@ -48,8 +47,8 @@ Section Examples.
     : IsIdeal (R:=R) maximal_subgroup.
   Proof.
     split.
-    cbn; intros r r'.
-    exists (r * r').
+    cbn; intros r [r'].
+    srefine ((r * r'; tt); _).
     reflexivity.
   Defined.
 

--- a/theories/Algebra/Rings/Ideal.v
+++ b/theories/Algebra/Rings/Ideal.v
@@ -9,11 +9,8 @@ Local Open Scope mc_scope.
 (** TODO: In the future it might be useful to define ideals as submodules when we go about defining R-modules. *)
 
 (** An additive subgroup I of a ring R is an ideal when: *)
-Class IsIdeal {R : CRing} (I : Subgroup R) := {
-  (** Forall r : R and x : I, there exists an a : I, such that a = r * x inside R *)
-  isideal (r : R) (x : I)
-    : exists (a : I), subgroup_incl _ a = r * subgroup_incl _ x;
-}.
+Class IsIdeal {R : CRing} (I : Subgroup R) :=
+  isideal (r x : R) : I x -> I (r * x).
 
 Record Ideal (R : CRing) := {
   ideal_subgroup : Subgroup R;
@@ -31,10 +28,8 @@ Section Examples.
   Global Instance isideal_trivial_subgroup
     : IsIdeal (R:=R) trivial_subgroup.
   Proof.
-    split.
-    intros r [x p].
-    srefine ((cring_zero; idpath);_).
-    refine ((rng_mult_zero_r r)^ @ _^).
+    hnf; cbn. intros r x p.
+    refine (_ @ rng_mult_zero_r r).
     f_ap.
   Defined.
 
@@ -47,9 +42,6 @@ Section Examples.
     : IsIdeal (R:=R) maximal_subgroup.
   Proof.
     split.
-    cbn; intros r [r'].
-    srefine ((r * r'; tt); _).
-    reflexivity.
   Defined.
 
   (** Unit ideal *)
@@ -66,16 +58,11 @@ Definition ideal_kernel {R S : CRing} (f : CRingHomomorphism R S) : Ideal R.
 Proof.
   snrapply Build_Ideal.
   1: exact (grp_kernel f).
-  snrapply Build_IsIdeal.
-  intros r x.
-  simpl in x.
-  unfold hfiber in x.
-  srefine (_;_).
-  { exists (r * x.1).
-    refine (rng_homo_mult f _ _ @ _).
-    refine (ap _ _ @ rng_mult_zero_r (f r)).
-    exact x.2. }
-  reflexivity.
+  intros r x p; cbn in p.
+  simpl.
+  refine (rng_homo_mult _ _ _ @ _).
+  refine (_ @ rng_mult_zero_r (f r)).
+  f_ap.
 Defined.
 
 (** Properties of ideals *)

--- a/theories/Algebra/Rings/QuotientRing.v
+++ b/theories/Algebra/Rings/QuotientRing.v
@@ -13,14 +13,14 @@ Section QuotientRing.
   Instance plus_quotient_group : Plus (QuotientGroup R I) := group_sgop.
 
   Instance iscong_mult_incosetL
-    : @IsCongruence R cring_mult (@in_cosetL R I _).
+    : @IsCongruence R cring_mult (in_cosetL I).
   Proof.
     snrapply Build_IsCongruence.
     intros x x' y y' [i p] [j q].
-    change (issubgroup_incl (H:=R) i = (- x) + x') in p.
-    change (issubgroup_incl (H:=R) j = (- y) + y') in q.
+    change (subgroup_incl I i = (- x) + x') in p.
+    change (subgroup_incl I j = (- y) + y') in q.
     unfold in_cosetL, hfiber.
-    change {m : I & issubgroup_incl (H:=R) m = - (x * y) + (x' * y')}.
+    change {m : I & subgroup_incl I m = - (x * y) + (x' * y')}.
     rewrite <- (left_identity (op:=(+)) (x' * y') : 0 + (x' * y') = x' * y').
     rewrite <- (right_inverse (op:=(+)) (x' * y) : (x' * y) - (x' * y) = 0).
     rewrite 2 simple_associativity.

--- a/theories/Algebra/Rings/QuotientRing.v
+++ b/theories/Algebra/Rings/QuotientRing.v
@@ -10,17 +10,16 @@ Section QuotientRing.
 
   Context (R : CRing) (I : Ideal R).
 
-  Instance plus_quotient_group : Plus (QuotientGroup R I) := group_sgop.
+  Instance plus_quotient_group : Plus (QuotientAbGroup R I) := group_sgop.
 
   Instance iscong_mult_incosetL
     : @IsCongruence R cring_mult (in_cosetL I).
   Proof.
     snrapply Build_IsCongruence.
-    intros x x' y y' [i p] [j q].
-    change (subgroup_incl I i = (- x) + x') in p.
-    change (subgroup_incl I j = (- y) + y') in q.
-    unfold in_cosetL, hfiber.
-    change {m : I & subgroup_incl I m = - (x * y) + (x' * y')}.
+    intros x x' y y' p q.
+    change (I ( - (x * y) + (x' * y'))).
+    change (I (-x + x')) in p.
+    change (I (-y + y')) in q.
     rewrite <- (left_identity (op:=(+)) (x' * y') : 0 + (x' * y') = x' * y').
     rewrite <- (right_inverse (op:=(+)) (x' * y) : (x' * y) - (x' * y) = 0).
     rewrite 2 simple_associativity.
@@ -29,16 +28,12 @@ Section QuotientRing.
     rewrite <- simple_associativity.
     rewrite negate_mult_distr_r.
     rewrite <- simple_distribute_l.
-    rewrite <- p, <- q.
-    pose (isideal x' j) as s; destruct s as [s s'].
-    pose (isideal y i) as t; destruct t as [t t'].
-    rewrite (commutativity _ y).
-    rewrite <- s', <- t'.
-    exists (sg_op t s).
-    rapply grp_homo_op.
+    rapply subgroup_op.
+    1: rewrite (commutativity _ y).
+    all: by rapply isideal.
   Defined.
 
-  Instance mult_quotient_group : Mult (QuotientGroup R I).
+  Instance mult_quotient_group : Mult (QuotientAbGroup R I).
   Proof.
     intro x.
     srapply Quotient_rec.
@@ -59,10 +54,10 @@ Section QuotientRing.
     by rapply iscong.
   Defined.
 
-  Instance zero_quotient_abgroup : Zero (QuotientGroup R I) := class_of _ zero.
-  Instance one_quotient_abgroup : One (QuotientGroup R I) := class_of _ one.
+  Instance zero_quotient_abgroup : Zero (QuotientAbGroup R I) := class_of _ zero.
+  Instance one_quotient_abgroup : One (QuotientAbGroup R I) := class_of _ one.
 
-  Instance isring_quotient_abgroup : IsRing (QuotientGroup R I).
+  Instance isring_quotient_abgroup : IsRing (QuotientAbGroup R I).
   Proof.
     split.
     1: exact _.
@@ -101,7 +96,7 @@ Section QuotientRing.
   Defined.
 
   Definition QuotientRing : CRing 
-    := Build_CRing (QuotientGroup R I) _ _ _ _ _ _.
+    := Build_CRing (QuotientAbGroup R I) _ _ _ _ _ _.
 
 End QuotientRing.
 

--- a/theories/TruncType.v
+++ b/theories/TruncType.v
@@ -183,4 +183,10 @@ Definition path_iff_hprop {A B : hProp}
 : (A -> B) -> (B -> A) -> A = B :> hProp
   := fun f g => path_iff_hprop_uncurried (f,g).
 
+Lemma equiv_path_iff_ishprop `{Univalence} {A B : Type} `{IsHProp A, IsHProp B}
+  : (A <-> B) <~> (A = B).
+Proof.
+  exact (Build_Equiv _ _ path_iff_ishprop_uncurried _).
+Defined.
+
 End TruncType.

--- a/theories/TruncType.v
+++ b/theories/TruncType.v
@@ -183,7 +183,7 @@ Definition path_iff_hprop {A B : hProp}
 : (A -> B) -> (B -> A) -> A = B :> hProp
   := fun f g => path_iff_hprop_uncurried (f,g).
 
-Lemma equiv_path_iff_ishprop `{Univalence} {A B : Type} `{IsHProp A, IsHProp B}
+Lemma equiv_path_iff_ishprop {A B : Type} `{IsHProp A, IsHProp B}
   : (A <-> B) <~> (A = B).
 Proof.
   exact (Build_Equiv _ _ path_iff_ishprop_uncurried _).


### PR DESCRIPTION
This is a WIP attempt at switching to predicates for subgroups as discussed in #1387.

This should have a few advantages when it comes to formalization.

I've also implemented a basic hint database for groups, which can automate a lot of routine arguments that we had. With some more careful design we can make this a powerful and useful tool.

This should also resolve issues we were having with #1369 though I haven't been able to confirm this yet.

When it comes to actually constructing subgroups, the predicate approach is far more efficient. There is no need to construct another group and check that the inclusion map is a homomorphism, etc.