### PR TITLE
Removed eisadj_other + some optimizations

### DIFF
--- a/contrib/HoTTBook.v
+++ b/contrib/HoTTBook.v
@@ -532,9 +532,10 @@ Definition Book_4_2_1 := @HoTT.Basics.Overture.IsEquiv.
 (* ================================================== lem:coh-equiv *)
 (** Lemma 4.2.2 *)
 
-Definition Book_4_2_2 := fun A B f isf x =>
+(* The proof of Lemma 4.2.2 is embedded in the proof of isequiv_inverse. *)
+Definition Book_4_2_2 := fun (A B : Type) (f : A -> B) (feq : IsEquiv f) (y : B) =>
   @HoTT.Basics.Overture.eisadj B A f^-1
-    (@HoTT.Basics.Equivalences.isequiv_inverse A B f isf) x.
+    (@HoTT.Basics.Equivalences.isequiv_inverse A B f feq) y.
 
 (* ================================================== thm:equiv-iso-adj *)
 (** Theorem 4.2.3 *)
@@ -2337,4 +2338,3 @@ Definition Book_11_6_17_iv := @HoTT.Spaces.No.Core.lt_le_trans.
 (** Example 11.6.18 *)
 
 Definition Book_11_6_18 := @HoTT.Spaces.No.Addition.plus.
-

--- a/contrib/HoTTBook.v
+++ b/contrib/HoTTBook.v
@@ -532,7 +532,9 @@ Definition Book_4_2_1 := @HoTT.Basics.Overture.IsEquiv.
 (* ================================================== lem:coh-equiv *)
 (** Lemma 4.2.2 *)
 
-Definition Book_4_2_2 := @HoTT.Basics.Equivalences.eisadj_other.
+Definition Book_4_2_2 := fun A B f isf x =>
+  @HoTT.Basics.Overture.eisadj B A f^-1
+    (@HoTT.Basics.Equivalences.isequiv_inverse A B f isf) x.
 
 (* ================================================== thm:equiv-iso-adj *)
 (** Theorem 4.2.3 *)

--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -369,26 +369,21 @@ Definition equiv_inj `(f : A -> B) `{IsEquiv A B f} {x y : A}
   := (ap f)^-1.
 
 (** The inverse of an equivalence is an equivalence. *)
-Section EquivInverse.
-
-  Context {A B : Type} (f : A -> B) {feq : IsEquiv f}.
-
-  Theorem eisadj_other (b : B) : eissect f (f^-1 b) = ap f^-1 (eisretr f b).
-  Proof.
-    apply (equiv_inj (ap f)).
-    (* We will prove the equality as a composite of four paths, working right to left.
-       The LHS remains [ap f (eissect f (f^-1 b))] throughout the process.
-       Both sides of the equation are paths of type [f (f^-1 (f (f^-1 b))) = f (f^-1 b)]. *)
-    refine (_ @ _ @ _ @ _); revgoals.
-    1: apply ap_compose.
-    1: symmetry; apply (ap_homotopic_id (eisretr f)).
-    1: symmetry; apply concat_pp_V.
-    1: symmetry; apply eisadj.
-  Qed.
-
-  Global Instance isequiv_inverse : IsEquiv f^-1 | 10000
-    := Build_IsEquiv B A f^-1 f (eissect f) (eisretr f) eisadj_other.
-End EquivInverse.
+Global Instance isequiv_inverse {A B : Type} (f : A -> B) {feq : IsEquiv f}
+  : IsEquiv f^-1 | 10000.
+Proof.
+  refine (Build_IsEquiv B A f^-1 f (eissect f) (eisretr f) _).
+  intro b.
+  apply (equiv_inj (ap f)).
+(* We will prove the equality as a composite of four paths, working right to left.
+  The LHS remains [ap f (eissect f (f^-1 b))] throughout the process.
+  Both sides of the equation are paths of type [f (f^-1 (f (f^-1 b))) = f (f^-1 b)]. *)
+  refine (_ @ _ @ _ @ _); revgoals.
+  1: apply ap_compose.
+  1: symmetry; apply (ap_homotopic_id (eisretr f)).
+  1: symmetry; apply concat_pp_V.
+  1: symmetry; apply eisadj.
+Defined.
 
 (** If the goal is [IsEquiv _^-1], then use [isequiv_inverse]; otherwise, don't pretend worry about if the goal is an evar and we want to add a [^-1]. *)
 #[export]

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -574,6 +574,9 @@ Arguments eissect {A B}%type_scope f%function_scope {_} _.
 Arguments eisadj {A B}%type_scope f%function_scope {_} _.
 Arguments IsEquiv {A B}%type_scope f%function_scope.
 
+(** We mark [eisadj] as Opaque to deter Coq from unfolding it when simplifying. Since proofs of [eisadj] typically have larger proofs than the rest of the equivalence data, we gain some speed up as a result. *)
+Opaque eisadj.
+
 (** A record that includes all the data of an adjoint equivalence. *)
 Cumulative Record Equiv A B := {
   equiv_fun : A -> B ;

--- a/theories/Homotopy/ClassifyingSpace.v
+++ b/theories/Homotopy/ClassifyingSpace.v
@@ -547,18 +547,14 @@ Proof.
         transitivity (loops (pClassifyingSpace (Pi1 X))).
         1: symmetry; rapply equiv_tr.
         rapply equiv_loops_bg_g. }
-      intro x.
-      strip_truncations.
-      simpl.
-      unfold Trunc_functor.
-      unfold O_functor.
-      unfold O_rec.
-      simpl.
-      revert x.
+      intro x; strip_truncations; revert x.
       snrapply equiv_ind.
       2: apply equiv_loops_bg_g.
       1: exact _.
       intro p.
+      hnf.
+      change (_ = ?R) with (encode (point (ClassifyingSpace (Pi1 X))) (bloop p) = R).
+      unfold Trunc_functor, O_functor, O_rec.
       simpl.
       rewrite ClassifyingSpace_rec_beta_bloop.
       unfold encode.
@@ -570,7 +566,6 @@ Proof.
     snrapply isequiv_contr_contr.
     { nrapply contr_equiv'.
       { apply equiv_tr.
-        Search IsTrunc Contr.
         nrapply trunc_contr.
         apply equiv_istrunc_contr_iterated_loops.
         snrapply trunc_leq.
@@ -583,7 +578,6 @@ Proof.
       induction n; exact _. }
     { nrapply contr_equiv'.
       { apply equiv_tr.
-        Search IsTrunc Contr.
         nrapply trunc_contr.
         apply equiv_istrunc_contr_iterated_loops.
         snrapply trunc_leq.

--- a/theories/Spaces/Card.v
+++ b/theories/Spaces/Card.v
@@ -4,7 +4,8 @@ Require Import HoTT.Basics HoTT.Types HoTT.HSet HoTT.TruncType.
 Require Import HoTT.Classes.interfaces.abstract_algebra.
 Require Import HoTT.Truncations.
 
-Opaque trunc_equiv. (** This speeds things up considerably *)
+(** This speeds things up considerably *)
+Local Opaque equiv_isequiv trunc_equiv.
 
 (** ** Definitions and operations *)
 
@@ -32,7 +33,7 @@ Definition leq_card `{Univalence} : Card -> Card -> HProp.
 Proof.
   refine (Trunc_rec (fun a => _)).
   refine (Trunc_rec (fun b => _)).
-  refine (hexists (fun (i : a -> b) => isinj i)).
+  exact (hexists (fun (i : a -> b) => isinj i)).
 Defined.
 
 (** ** Properties *)
@@ -51,8 +52,9 @@ Section contents.
 
   (* Simplify an equation by unfolding all the definitions apart from
   the actual operations. *)
+  (* Note that this is an expensive thing to do, and will be very slow unless we tell it not to unfold the following. *)
   Local Ltac simpl_ops :=
-    cbv-[plus_card mult_card zero_card one_card].
+    cbv-[plus_card mult_card zero_card one_card exp_card].
 
   (** We only make the instances of upper classes global, since the
   other instances will be project anyway. *)


### PR DESCRIPTION
I've inlined the proof of `eisadj_other` as requested in #1282.

I've also gone ahead and made `eisadj` opaque. This will tell coq to delay unfolding it as long as possible when simplifying. This will stop equivalences from turning into super large terms. Note that marking a term as Opaque is different from being Qed, as Qed will never be unfolded.

Doing this unfortunately caused ClassifiyngSpace.v to blow up. I have therefore replaced a large simplification with a manual one which has saved quite bit of time.

```
   After |  Peak Mem | File Name                                                    |   Before |  Peak Mem ||    Change || Change (mem) | % Change | % Change (mem)
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
5m39.28s | 585436 ko | Total Time / Peak Mem                                        | 6m38.31s | 666804 ko || -0m59.02s ||    -81368 ko |  -14.81% |        -12.20%
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
0m17.77s | 583772 ko | Homotopy/ClassifyingSpace.vo                                 | 0m28.22s | 666804 ko || -0m10.44s ||    -83032 ko |  -37.03% |        -12.45%
```

Finally, in Card.v (where the problems first began) I noticed that the tactic `simpl_ops`, was unfolding the term `exp_card` which was unnecessary and costly. It is much faster now.

closes #1282 