### PR TITLE
Rename hProp and hSet to HProp and HSet + TruncType cleanup

### DIFF
--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -713,10 +713,10 @@ Defined.
 
 Definition LEM := forall (A : Type), IsHProp A -> A + ~A.
 
-Definition LEM_hProp_Bool (lem : LEM) (hprop : hProp) : Bool
+Definition LEM_hProp_Bool (lem : LEM) (hprop : HProp) : Bool
   := match (lem hprop _) with inl _ => true | inr _ => false end.
 
-Lemma Book_3_9_solution_1 `{Univalence} : LEM -> hProp <~> Bool.
+Lemma Book_3_9_solution_1 `{Univalence} : LEM -> HProp <~> Bool.
 Proof.
   intro lem.
   apply (equiv_adjointify (LEM_hProp_Bool lem) is_true).
@@ -1641,8 +1641,8 @@ End Book_7_1.
 (** Exercise 7.9 *)
 
 (** Solution for the case (oo,-1). *)
-Definition Book_7_9_oo_neg1 `{Univalence} (AC_oo_neg1 : forall X : hSet, IsProjective' X) (A : Type)
-  : merely (exists X : hSet, exists p : X -> A, IsSurjection p)
+Definition Book_7_9_oo_neg1 `{Univalence} (AC_oo_neg1 : forall X : HSet, IsProjective' X) (A : Type)
+  : merely (exists X : HSet, exists p : X -> A, IsSurjection p)
   := @HoTT.Projective.projective_cover_AC AC_oo_neg1 _ A.
 
 (* ================================================== ex:acconn *)

--- a/theories/Analysis/Locator.v
+++ b/theories/Analysis/Locator.v
@@ -78,7 +78,7 @@ Section locator.
   Arguments locates_right_false [x] _ [q] [r] _.
 
   Definition locates_left {x : F} (l : locator' x) {q r : Q} : q < r -> DHProp :=
-    fun nu => Build_DHProp (BuildhProp (~ (locates_right l nu))) _.
+    fun nu => Build_DHProp (Build_HProp (~ (locates_right l nu))) _.
 
   Section classical.
     Context `{ExcludedMiddle}.
@@ -128,7 +128,7 @@ Section locator.
     Definition locator_locator' : locator x -> locator' x.
     Proof.
       intros l.
-      refine (Build_locator' x (fun q r nu => Build_DHProp (BuildhProp (is_inl (l q r nu))) _) _ _).
+      refine (Build_locator' x (fun q r nu => Build_DHProp (Build_HProp (is_inl (l q r nu))) _) _ _).
       - intros q r nu. simpl. apply un_inl.
       - intros q r nu. simpl. destruct (l q r nu) as [ltqx|].
         + simpl; intros f; destruct (f tt).

--- a/theories/Basics/Trunc.v
+++ b/theories/Basics/Trunc.v
@@ -338,28 +338,27 @@ Notation IsEmbedding := (IsTruncMap (-1)).
 
 (** It is convenient for some purposes to consider the universe of all n-truncated types (within a given universe of types).  In particular, this allows us to state the important fact that each such universe is itself (n+1)-truncated. *)
 
-Record TruncType (n : trunc_index) := BuildTruncType {
+Record TruncType (n : trunc_index) := {
   trunctype_type : Type ;
-  istrunc_trunctype_type : IsTrunc n trunctype_type
+  trunctype_istrunc : IsTrunc n trunctype_type
 }.
-(* Note: the naming of the second constructor is more than a little clunky.  However, the more obvious [istrunc_trunctype] is taken by the theorem below, that [IsTrunc n.+1 (TruncType n)], which seems to have an even better claim to it. *)
 
-Arguments BuildTruncType _ _ {_}.
+Arguments Build_TruncType _ _ {_}.
 Arguments trunctype_type {_} _.
-Arguments istrunc_trunctype_type [_] _.
+Arguments trunctype_istrunc [_] _.
 
 Coercion trunctype_type : TruncType >-> Sortclass.
-Global Existing Instance istrunc_trunctype_type.
+Global Existing Instance trunctype_istrunc.
 
 Notation "n -Type" := (TruncType n) : type_scope.
-Notation hProp := (-1)-Type.
-Notation hSet := 0-Type.
+Notation HProp := (-1)-Type.
+Notation HSet := 0-Type.
 
-Notation BuildhProp := (BuildTruncType (-1)).
-Notation BuildhSet := (BuildTruncType 0).
+Notation Build_HProp := (Build_TruncType (-1)).
+Notation Build_HSet := (Build_TruncType 0).
 
 (** This is (as of October 2014) the only [Canonical Structure] in the library.  It would be nice to do without it, in the interests of minimizing the number of fancy Coq features that the reader needs to know about. *)
-Canonical Structure default_TruncType := fun n T P => (@BuildTruncType n T P).
+Canonical Structure default_TruncType := fun n T P => (@Build_TruncType n T P).
 
 (** ** Facts about hprops *)
 

--- a/theories/Categories/Functor/Attributes.v
+++ b/theories/Categories/Functor/Attributes.v
@@ -84,7 +84,7 @@ End full_faithful.
 
 Section fully_faithful_helpers.
   Context `{ua : Univalence}.
-  Variables x y : hSet.
+  Variables x y : HSet.
   Variable m : x -> y.
 
   Lemma isisomorphism_isequiv_set_cat

--- a/theories/Categories/HomFunctor.v
+++ b/theories/Categories/HomFunctor.v
@@ -17,7 +17,7 @@ Section hom_functor.
   Variable C : PreCategory.
 
   Local Notation obj_of c'c :=
-    (BuildhSet
+    (Build_HSet
        (morphism
           C
           (fst (c'c : object (C^op * C)))

--- a/theories/Categories/SetCategory/Core.v
+++ b/theories/Categories/SetCategory/Core.v
@@ -20,8 +20,8 @@ Notation cat_of obj :=
 (** There is a category [Set], where the objects are sets and the
     morphisms are set morphisms *)
 
-Definition prop_cat `{Funext} : PreCategory := cat_of hProp.
-Definition set_cat `{Funext} : PreCategory := cat_of hSet.
+Definition prop_cat `{Funext} : PreCategory := cat_of HProp.
+Definition set_cat `{Funext} : PreCategory := cat_of HSet.
 
 (** ** [Prop] is a strict category *)
 Global Instance isstrict_prop_cat `{Univalence}

--- a/theories/Categories/SetCategory/Functors/SetProp.v
+++ b/theories/Categories/SetCategory/Functors/SetProp.v
@@ -32,7 +32,7 @@ Section set_coercions.
   (** ** Functors to [prop_cat] give rise to functors to [set_cat] *)
   Definition to_prop2set (F : to_prop C) : to_set C :=
     Build_Functor C set_cat
-                  (fun x => BuildhSet (F x))
+                  (fun x => Build_HSet (F x))
                   (fun s d m => (F _1 m)%morphism)
                   (fun s d d' m m' => composition_of F s d d' m m')
                   (fun x => identity_of F x).
@@ -40,16 +40,16 @@ Section set_coercions.
   (** ** Functors from [set_cat] give rise to functors to [prop_cat] *)
   Definition from_set2prop (F : from_set C) : from_prop C
     := Build_Functor prop_cat C
-                     (fun x => F (BuildhSet x))
+                     (fun x => F (Build_HSet x))
                      (fun s d m => (F _1 (m : morphism
                                                 set_cat
-                                                (BuildhSet s)
-                                                (BuildhSet d)))%morphism)
+                                                (Build_HSet s)
+                                                (Build_HSet d)))%morphism)
                      (fun s d d' m m' => composition_of F
-                                                        (BuildhSet s)
-                                                        (BuildhSet d)
-                                                        (BuildhSet d')
+                                                        (Build_HSet s)
+                                                        (Build_HSet d)
+                                                        (Build_HSet d')
                                                         m
                                                         m')
-                     (fun x => identity_of F (BuildhSet x)).
+                     (fun x => identity_of F (Build_HSet x)).
 End set_coercions.

--- a/theories/Categories/SetCategory/Morphisms.v
+++ b/theories/Categories/SetCategory/Morphisms.v
@@ -17,7 +17,7 @@ Local Open Scope category_scope.
 
 Lemma isisomorphism_set_cat_natural_transformation_paths
       `{fs : Funext} (X : set_cat) C D F G
-      (T1 T2 : morphism set_cat X (BuildhSet (@NaturalTransformation C D F G)))
+      (T1 T2 : morphism set_cat X (Build_HSet (@NaturalTransformation C D F G)))
       (H : forall x y, T1 x y = T2 x y)
       `{@IsIsomorphism set_cat _ _ T1}
 : @IsIsomorphism set_cat _ _ T2.

--- a/theories/Classes/implementations/field_of_fractions.v
+++ b/theories/Classes/implementations/field_of_fractions.v
@@ -306,7 +306,7 @@ Definition F_rec2@{i j} {T:Type@{i} } {sT : IsHSet T}
   (dequiv : forall x1 x2, equiv x1 x2 -> forall y1 y2, equiv y1 y2 ->
     dclass x1 y1 = dclass x2 y2),
   F -> F -> T
-  := @quotient_rec2@{UR UR j i} _ _ _ _ _ (BuildhSet _).
+  := @quotient_rec2@{UR UR j i} _ _ _ _ _ (Build_HSet _).
 
 Definition F_rec2_compute {T sT} dclass dequiv x y
   : @F_rec2 T sT dclass dequiv (' x) (' y) = dclass x y
@@ -405,7 +405,7 @@ Defined.
 
 Lemma classes_eq_related@{} : forall q r, ' q = ' r -> equiv q r.
 Proof.
-apply classes_eq_related@{UR UR Ularge Ularge Uhuge};apply _.
+apply classes_eq_related@{UR UR Ularge Uhuge};apply _.
 Qed.
 
 Lemma class_neq@{} : forall q r, ~ (equiv q r) -> ' q <> ' r.

--- a/theories/Classes/implementations/hprop_lattice.v
+++ b/theories/Classes/implementations/hprop_lattice.v
@@ -3,19 +3,19 @@ Require Import
   HoTT.HProp HoTT.TruncType
   HoTT.Types.Universe HoTT.Types.Prod.
 
-(** Demonstrate the [hProp] is a (bounded) lattice w.r.t. the logical
+(** Demonstrate the [HProp] is a (bounded) lattice w.r.t. the logical
 operations. This requires Univalence. *)
-Instance join_hor : Join hProp := hor.
-Definition hand (X Y : hProp) : hProp := BuildhProp (X * Y).
-Instance meet_hprop : Meet hProp := hand.
-Instance bottom_hprop : Bottom hProp := False_hp.
-Instance top_hprop : Top hProp := Unit_hp.
+Instance join_hor : Join HProp := hor.
+Definition hand (X Y : HProp) : HProp := Build_HProp (X * Y).
+Instance meet_hprop : Meet HProp := hand.
+Instance bottom_hprop : Bottom HProp := False_hp.
+Instance top_hprop : Top HProp := Unit_hp.
 
 Section contents.
   Context `{Univalence}.
 
   (* We use this notation because [hor] can accept arguments of type [Type], which leads to minor confusion in the instances below *)
-  Notation lor := (hor : hProp -> hProp -> hProp).
+  Notation lor := (hor : HProp -> HProp -> HProp).
 
   (* This tactic attempts to destruct a truncated sum (disjunction) *)
   Local Ltac hor_intros :=
@@ -112,6 +112,6 @@ Section contents.
       * by apply tr, inl.
   Defined.
 
-  Global Instance boundedlattice_hprop : IsBoundedLattice hProp.
+  Global Instance boundedlattice_hprop : IsBoundedLattice HProp.
   Proof. repeat split; apply _. Defined.
 End contents.

--- a/theories/Classes/implementations/natpair_integers.v
+++ b/theories/Classes/implementations/natpair_integers.v
@@ -321,7 +321,7 @@ Definition Z_path {x y} : PairT.equiv x y -> Z_of_pair x = Z_of_pair y
   := related_classes_eq _.
 
 Definition related_path {x y} : Z_of_pair x = Z_of_pair y -> PairT.equiv x y
-  := classes_eq_related@{UN UN Ularge Ularge Uhuge} _ _ _.
+  := classes_eq_related@{UN UN Ularge Uhuge} _ _ _.
 
 Definition Z_rect@{i} (P : Z -> Type@{i}) {sP : forall x, IsHSet (P x)}
   (dclass : forall x : PairT.T N, P (' x))
@@ -377,7 +377,7 @@ Definition Z_rec2@{i j} {T:Type@{i} } {sT : IsHSet T}
   (dequiv : forall x1 x2, PairT.equiv x1 x2 -> forall y1 y2, PairT.equiv y1 y2 ->
     dclass x1 y1 = dclass x2 y2),
   Z -> Z -> T
-  := @quotient_rec2@{UN UN j i} _ _ _ _ _ (BuildhSet _).
+  := @quotient_rec2@{UN UN j i} _ _ _ _ _ (Build_HSet _).
 
 Definition Z_rec2_compute {T sT} dclass dequiv x y
   : @Z_rec2 T sT dclass dequiv (' x) (' y) = dclass x y
@@ -496,15 +496,15 @@ apply Z_path;red;simpl.
 ring_with_nat.
 Qed.
 
-Definition Zle_hProp@{} : Z -> Z -> hProp@{UN}.
+Definition Zle_HProp@{} : Z -> Z -> HProp@{UN}.
 Proof.
-apply (@Z_rec2@{Ularge Ularge} _ (@istrunc_trunctype@{UN Ularge Uhuge} _ _)
-  (fun q r => BuildhProp (PairT.Tle q r))).
-intros. apply path_hprop@{UN Ularge Uhuge}. simpl.
+apply (@Z_rec2@{Ularge Ularge} _ (@trunctype_istrunc@{Ularge} _ _)
+  (fun q r => Build_HProp (PairT.Tle q r))).
+intros. apply path_hprop. simpl.
 apply (PairT.le_respects _);trivial.
 Defined.
 
-Global Instance Zle@{} : Le Z := fun x y => Zle_hProp x y.
+Global Instance Zle@{} : Le Z := fun x y => Zle_HProp x y.
 
 Global Instance ishprop_Zle : is_mere_relation _ Zle.
 Proof. unfold Zle;exact _. Qed.
@@ -605,15 +605,15 @@ intros a b. change (Decidable (PairT.Tle a b)).
 unfold PairT.Tle. apply _.
 Qed.
 
-Definition Zlt_hProp@{} : Z -> Z -> hProp@{UN}.
+Definition Zlt_HProp@{} : Z -> Z -> HProp@{UN}.
 Proof.
-apply (@Z_rec2@{Ularge Ularge} _ (@istrunc_trunctype@{UN Ularge Uhuge} _ _)
-  (fun q r => BuildhProp (PairT.Tlt q r))).
-intros. apply path_hprop@{UN Ularge Uhuge}. simpl.
+apply (@Z_rec2@{Ularge Ularge} _ (@trunctype_istrunc@{Ularge} _ _)
+  (fun q r => Build_HProp (PairT.Tlt q r))).
+intros. apply path_hprop. simpl.
 apply (PairT.lt_respects _);trivial.
 Defined.
 
-Global Instance Zlt@{} : Lt Z := fun x y => Zlt_hProp x y.
+Global Instance Zlt@{} : Lt Z := fun x y => Zlt_HProp x y.
 
 Global Instance ishprop_Zlt : is_mere_relation _ Zlt.
 Proof. unfold Zlt;exact _. Qed.
@@ -701,15 +701,15 @@ Qed.
 
 Local Existing Instance pseudo_order_apart.
 
-Definition Zapart_hProp@{} : Z -> Z -> hProp@{UN}.
+Definition Zapart_HProp@{} : Z -> Z -> HProp@{UN}.
 Proof.
-apply (@Z_rec2@{Ularge Ularge} _ (@istrunc_trunctype@{UN Ularge Uhuge} _ _)
-  (fun q r => BuildhProp (PairT.Tapart q r))).
-intros. apply path_hprop@{UN Ularge Uhuge}. simpl.
+apply (@Z_rec2@{Ularge Ularge} _ _
+  (fun q r => Build_HProp (PairT.Tapart q r))).
+intros. apply path_hprop. simpl.
 apply (PairT.apart_respects _);trivial.
 Defined.
 
-Global Instance Zapart@{} : Apart Z := fun x y => Zapart_hProp x y.
+Global Instance Zapart@{} : Apart Z := fun x y => Zapart_HProp x y.
 
 Lemma Zapart_def' : forall a b, apart (' a) (' b) = PairT.Tapart a b.
 Proof. reflexivity. Qed.

--- a/theories/Classes/interfaces/ua_algebra.v
+++ b/theories/Classes/interfaces/ua_algebra.v
@@ -102,7 +102,7 @@ Global Instance trunc_operation `{Funext} {σ : Signature}
   (A : Carriers σ) {n} `{!∀ s, IsTrunc n (A s)} (w : SymbolType σ)
   : IsTrunc n (Operation A w).
 Proof.
-  induction w; apply (istrunc_trunctype_type (BuildTruncType n _)).
+  induction w; exact _.
 Defined.
 
 (** Uncurry of an [f : Operation A w], such that

--- a/theories/Classes/orders/archimedean.v
+++ b/theories/Classes/orders/archimedean.v
@@ -37,7 +37,7 @@ Section strict_field_order.
       x + y < ' r <-> hexists (fun t : Q => (x < ' t) /\ (y < ' (r - t))).
   Proof. Abort.
 
-  Definition hexists4 {X Y Z W} (f : X -> Y -> Z -> W -> Type) : hProp
+  Definition hexists4 {X Y Z W} (f : X -> Y -> Z -> W -> Type) : HProp
     := hexists (fun xyzw => match xyzw with
                             | ((x , y) , (z , w)) => f x y z w
                             end).

--- a/theories/Classes/theory/ua_first_isomorphism.v
+++ b/theories/Classes/theory/ua_first_isomorphism.v
@@ -76,7 +76,7 @@ Section in_image_hom.
     `{Funext} {σ : Signature} {A B : Algebra σ}
     (f : ∀ s, A s → B s) {hom : IsHomomorphism f}.
 
-  Definition in_image_hom (s : Sort σ) (y : B s) : hProp
+  Definition in_image_hom (s : Sort σ) (y : B s) : HProp
     := merely (hfiber (f s) y).
 
   Lemma closed_under_op_in_image_hom {w : SymbolType σ}

--- a/theories/Classes/theory/ua_quotient_algebra.v
+++ b/theories/Classes/theory/ua_quotient_algebra.v
@@ -266,7 +266,7 @@ Section ump_quotient_algebra.
 
     Definition def_hom_quotient_algebra_mapout
       : ∀ (s : Sort σ), (A/Φ) s → B s
-      := λ s, (quotient_ump (Φ s) (BuildhSet (B s)))^-1 (f s; R s).
+      := λ s, (quotient_ump (Φ s) (Build_HSet (B s)))^-1 (f s; R s).
 
     Lemma oppreserving_quotient_algebra_mapout {w : SymbolType σ}
       (g : Operation (A/Φ) w) (α : Operation A w) (β : Operation B w)

--- a/theories/Classes/theory/ua_second_isomorphism.v
+++ b/theories/Classes/theory/ua_second_isomorphism.v
@@ -80,7 +80,7 @@ Section is_subalgebra_class.
     (P : ∀ s, A s → Type) `{!IsSubalgebraPredicate A P}
     (Φ : ∀ s, Relation (A s)) `{!IsCongruence A Φ}.
 
-  Definition is_subalgebra_class (s : Sort σ) (x : (A/Φ) s) : hProp
+  Definition is_subalgebra_class (s : Sort σ) (x : (A/Φ) s) : HProp
     := hexists (λ (y : (A&&P) s), in_class (Φ s) x (i s y)).
 
   Lemma op_closed_subalgebra_is_subalgebra_class {w : SymbolType σ}

--- a/theories/Colimits/Quotient.v
+++ b/theories/Colimits/Quotient.v
@@ -102,11 +102,11 @@ Section Equiv.
     `{Transitive _ R} `{Symmetric _ R} `{Reflexive _ R}.
 
   (* The proposition of being in a given class in a quotient. *)
-  Definition in_class : A / R -> A -> hProp.
+  Definition in_class : A / R -> A -> HProp.
   Proof.
     srapply Quotient_ind.
     { intros a b.
-      exact (BuildhProp (R a b)). }
+      exact (Build_HProp (R a b)). }
     intros x y p.
     refine (transport_const _ _ @ _).
     funext z.
@@ -164,7 +164,7 @@ Section Equiv.
     - apply related_quotient_paths.
   Defined.
 
-  Definition Quotient_rec2 `{Funext} {B : hSet} {dclass : A -> A -> B}
+  Definition Quotient_rec2 `{Funext} {B : HSet} {dclass : A -> A -> B}
     {dequiv : forall x x', R x x' -> forall y y',
       R y y' -> dclass x y = dclass x' y'}
     : A / R -> A / R -> B.
@@ -207,7 +207,7 @@ Section Equiv.
 
   (* Universal property of quotient *)
   (* Lemma 6.10.3 *)
-  Theorem equiv_quotient_ump (B : hSet)
+  Theorem equiv_quotient_ump (B : HSet)
     : (A / R -> B) <~> {f : A -> B & forall x y, R x y -> f x = f y}.
   Proof.
     srapply equiv_adjointify.

--- a/theories/DProp.v
+++ b/theories/DProp.v
@@ -10,13 +10,13 @@ Local Open Scope path_scope.
 
 (** ** Definitions *)
 
-(** A decidable proposition is, morally speaking, an hprop that is decidable.  However, we only require that it be an hprop under the additional assumption of [Funext]; this enables decidable propositions to usually be used without [Funext] hypotheses. *)
+(** A decidable proposition is, morally speaking, an HProp that is decidable.  However, we only require that it be an HProp under the additional assumption of [Funext]; this enables decidable propositions to usually be used without [Funext] hypotheses. *)
 
-Record DProp :=
-  { dprop_type : Type ;
-    ishprop_dprop : Funext -> IsHProp dprop_type ;
-    dec_dprop : Decidable dprop_type
-  }.
+Record DProp := {
+  dprop_type : Type ;
+  ishprop_dprop : Funext -> IsHProp dprop_type ;
+  dec_dprop : Decidable dprop_type
+}.
 
 (** A fancier definition, which would have the property that negation is judgmentally involutive, would be
 
@@ -41,11 +41,11 @@ Global Existing Instance dec_dprop.
 (** Sometimes, however, we have decidable props that are hprops without funext, and we want to remember that. *)
 
 Record DHProp :=
-  { dhprop_hprop : hProp ;
+  { dhprop_hprop : HProp ;
     dec_dhprop : Decidable dhprop_hprop
   }.
 
-Coercion dhprop_hprop : DHProp >-> hProp.
+Coercion dhprop_hprop : DHProp >-> HProp.
 Global Existing Instance dec_dhprop.
 
 Definition dhprop_to_dprop : DHProp -> DProp
@@ -99,13 +99,13 @@ Definition path_dprop `{Funext} {P Q : DProp}
   := equiv_path_dprop P Q.
 
 Definition issig_dhprop
-  : { X : hProp & Decidable X } <~> DHProp.
+  : { X : HProp & Decidable X } <~> DHProp.
 Proof.
   issig.
 Defined.
 
 Definition equiv_path_dhprop' `{Funext} (P Q : DHProp)
-: (P = Q :> hProp) <~> (P = Q :> DHProp).
+: (P = Q :> HProp) <~> (P = Q :> DHProp).
 Proof.
   destruct P as [P dP]. destruct Q as [Q dQ].
   refine (((equiv_ap' issig_dhprop^-1 _ _)^-1)
@@ -116,8 +116,8 @@ Defined.
 Definition equiv_path_dhprop `{Univalence} (P Q : DHProp)
 : (P = Q :> Type) <~> (P = Q :> DHProp).
 Proof.
-  assert (eq_type_hprop : (P = Q :> Type) <~> (P = Q :> hProp)) by apply equiv_path_trunctype'.
-  assert (eq_hprop_dhprop : (P = Q :> hProp) <~> (P = Q :> DHProp)) by apply equiv_path_dhprop'.
+  assert (eq_type_hprop : (P = Q :> Type) <~> (P = Q :> HProp)) by apply equiv_path_trunctype'.
+  assert (eq_hprop_dhprop : (P = Q :> HProp) <~> (P = Q :> DHProp)) by apply equiv_path_dhprop'.
   refine (eq_hprop_dhprop oE eq_type_hprop).
 Defined.
 
@@ -154,13 +154,13 @@ Definition dand (b1 b2 : DProp) : DProp
   := Build_DProp (b1 * b2) _ _.
 
 Definition dhand (b1 b2 : DHProp) : DHProp
-  := Build_DHProp (BuildhProp (b1 * b2)) _.
+  := Build_DHProp (Build_HProp (b1 * b2)) _.
 
 Definition dor (b1 b2 : DProp) : DProp
   := Build_DProp (hor b1 b2) _ _.
 
 Definition dhor (b1 b2 : DHProp) : DHProp
-  := Build_DHProp (BuildhProp (hor b1 b2)) _.
+  := Build_DHProp (Build_HProp (hor b1 b2)) _.
 
 Definition dneg (b : DProp) : DProp
   := Build_DProp (~b) _ _.

--- a/theories/HIT/SetCone.v
+++ b/theories/HIT/SetCone.v
@@ -5,10 +5,10 @@ Require Import HSet TruncType.
 Require Import Colimits.Pushout.
 Require Import HoTT.Truncations.
 
-(** * Cones of hsets *)
+(** * Cones of HSets *)
 
 Section SetCone.
-  Context {A B : hSet} (f : A -> B).
+  Context {A B : HSet} (f : A -> B).
 
   Definition setcone := Trunc 0 (Pushout f (const tt)).
 

--- a/theories/HIT/V.v
+++ b/theories/HIT/V.v
@@ -11,7 +11,7 @@ Local Open Scope path_scope.
 
 (** Bitotal relation *)
 
-Definition bitotal {A B : Type} (R : A -> B -> hProp) :=
+Definition bitotal {A B : Type} (R : A -> B -> HProp) :=
    (forall a : A, hexists (fun (b : B) => R a b))
  * (forall b : B, hexists (fun (a : A) => R a b)).
 
@@ -22,7 +22,7 @@ Module Export CumulativeHierarchy.
 Private Inductive V : Type@{U'} :=
 | set {A : Type@{U}} (f : A -> V) : V.
 
-Axiom setext : forall {A B : Type} (R : A -> B -> hProp)
+Axiom setext : forall {A B : Type} (R : A -> B -> HProp)
   (bitot_R : bitotal R) (h : SPushout R -> V),
 set (h o (spushl R)) = set (h o (spushr R)).
 
@@ -32,7 +32,7 @@ Existing Instance is0trunc_V.
 Fixpoint V_ind (P : V -> Type)
   (H_0trunc : forall v : V, IsTrunc 0 (P v))
   (H_set : forall (A : Type) (f : A -> V) (H_f : forall a : A, P (f a)), P (set f))
-  (H_setext : forall (A B : Type) (R : A -> B -> hProp) (bitot_R : bitotal R)
+  (H_setext : forall (A B : Type) (R : A -> B -> HProp) (bitot_R : bitotal R)
     (h : SPushout R -> V) (H_h : forall x : SPushout R, P (h x)),
     (setext R bitot_R h) # (H_set A (h o spushl R) (H_h oD spushl R))
       = H_set B (h o spushr R) (H_h oD spushr R) )
@@ -49,11 +49,11 @@ End CumulativeHierarchy.
 Definition V_comp_setext (P : V -> Type)
   (H_0trunc : forall v : V, IsTrunc 0 (P v))
   (H_set : forall (A : Type) (f : A -> V) (H_f : forall a : A, P (f a)), P (set f))
-  (H_setext : forall (A B : Type) (R : A -> B -> hProp) (bitot_R : bitotal R)
+  (H_setext : forall (A B : Type) (R : A -> B -> HProp) (bitot_R : bitotal R)
     (h : SPushout R -> V) (H_h : forall x : SPushout R, P (h x)),
     (setext R bitot_R h) # (H_set A (h o spushl R) (H_h oD spushl R))
       = H_set B (h o spushr R) (H_h oD spushr R) )
-  (A B : Type) (R : A -> B -> hProp) (bitot_R : bitotal R) (h : SPushout R -> V)
+  (A B : Type) (R : A -> B -> HProp) (bitot_R : bitotal R) (h : SPushout R -> V)
 : apD (V_ind P H_0trunc H_set H_setext) (setext R bitot_R h)
   = H_setext A B R bitot_R h ((V_ind P H_0trunc H_set H_setext) oD h).
 Proof.
@@ -65,7 +65,7 @@ Defined.
 Definition V_rec (P : Type)
   (H_0trunc : IsTrunc 0 P)
   (H_set : forall (A : Type), (A -> V) -> (A -> P) -> P)
-  (H_setext : forall (A B : Type) (R : A -> B -> hProp) (bitot_R : bitotal R)
+  (H_setext : forall (A B : Type) (R : A -> B -> HProp) (bitot_R : bitotal R)
     (h : SPushout R -> V) (H_h : SPushout R -> P),
     H_set A (h o spushl R) (H_h o spushl R) = H_set B (h o spushr R) (H_h o spushr R) )
 : V -> P.
@@ -77,10 +77,10 @@ Defined.
 Definition V_comp_nd_setext (P : Type)
   (H_0trunc : IsTrunc 0 P)
   (H_set : forall (A : Type), (A -> V) -> (A -> P) -> P)
-  (H_setext : forall (A B : Type) (R : A -> B -> hProp) (bitot_R : bitotal R)
+  (H_setext : forall (A B : Type) (R : A -> B -> HProp) (bitot_R : bitotal R)
     (h : SPushout R -> V) (H_h : SPushout R -> P),
     H_set A (h o spushl R) (H_h o spushl R) = H_set B (h o spushr R) (H_h o spushr R) )
-  (A B : Type) (R : A -> B -> hProp) (bitot_R : bitotal R) (h : SPushout R -> V)
+  (A B : Type) (R : A -> B -> HProp) (bitot_R : bitotal R) (h : SPushout R -> V)
 : ap (V_rec P H_0trunc H_set H_setext) (setext R bitot_R h)
   = H_setext A B R bitot_R h ((V_rec P H_0trunc H_set H_setext) o h).
 Proof.
@@ -97,7 +97,7 @@ Definition equal_img {A B C : Type} (f : A -> C) (g : B -> C) :=
 Definition setext' {A B : Type} (f : A -> V) (g : B -> V) (eq_img : equal_img f g)
 : set f = set g.
 Proof.
-  pose (R := fun a b => BuildhProp (f a = g b)).
+  pose (R := fun a b => Build_HProp (f a = g b)).
   pose (h := SPushout_rec R V f g (fun _ _ r => r)).
   exact (setext R eq_img h).
 Defined.
@@ -193,7 +193,7 @@ Context `{ua : Univalence}.
 
 (** ** Membership relation *)
 
-Definition mem (x : V) : V -> hProp.
+Definition mem (x : V) : V -> HProp.
 Proof.
   simple refine (V_rec' _ _ _ _).
   - intros A f _.
@@ -215,20 +215,20 @@ Open Scope set_scope.
 
 (** ** Subset relation *)
 
-Definition subset (x : V) (y : V) : hProp
-:= BuildhProp (forall z : V, z ∈ x -> z ∈ y).
+Definition subset (x : V) (y : V) : HProp
+:= Build_HProp (forall z : V, z ∈ x -> z ∈ y).
 
 Notation "x ⊆ y" := (subset x y) : set_scope.
 
 
 (** ** Bisimulation relation *)
-(** The equality in V lives in Type@{U'}. We define the bisimulation relation which is a U-small resizing of the equality in V: it must live in hProp_U : Type{U'}, hence the codomain is hProp@{U}. We then prove that bisimulation is equality (bisim_equals_id), then use it to prove the key lemma monic_set_present. *)
+(** The equality in V lives in Type@{U'}. We define the bisimulation relation which is a U-small resizing of the equality in V: it must live in HProp_U : Type{U'}, hence the codomain is HProp@{U}. We then prove that bisimulation is equality (bisim_equals_id), then use it to prove the key lemma monic_set_present. *)
 
-(* We define bisimulation by double induction on V. We first fix the first argument as set(A,f) and define bisim_aux : V -> hProp, by induction. This is the inner of the two inductions. *)
-Local Definition bisim_aux (A : Type) (f : A -> V) (H_f : A -> V -> hProp) : V -> hProp.
+(* We define bisimulation by double induction on V. We first fix the first argument as set(A,f) and define bisim_aux : V -> HProp, by induction. This is the inner of the two inductions. *)
+Local Definition bisim_aux (A : Type) (f : A -> V) (H_f : A -> V -> HProp) : V -> HProp.
 Proof.
   apply V_rec' with
-    (fun B g _ => BuildhProp ( (forall a, hexists (fun b => H_f a (g b)))
+    (fun B g _ => Build_HProp ( (forall a, hexists (fun b => H_f a (g b)))
                                * forall b, hexists (fun a => H_f a (g b)) )
     ).
   - exact _.
@@ -251,10 +251,10 @@ Proof.
         intros [a H3]. exists a. exact (transport (fun x => H_f a x) p^ H3).
 Defined.
 
-(* Then we define bisim : V -> (V -> hProp) by induction again *)
-Definition bisimulation : V@{U' U} -> V@{U' U} -> hProp@{U}.
+(* Then we define bisim : V -> (V -> HProp) by induction again *)
+Definition bisimulation : V@{U' U} -> V@{U' U} -> HProp@{U}.
 Proof.
-  refine (V_rec' (V -> hProp) _ bisim_aux _).
+  refine (V_rec' (V -> HProp) _ bisim_aux _).
   intros A B f g eq_img H_f H_g H_img.
   apply path_forall.
   refine (V_ind_hprop _ _ _).
@@ -432,7 +432,7 @@ Proof.
     + intros z Hz. apply (transport (fun x => z ∈ x) p^ Hz).
 Qed.
 
-Lemma mem_induction (C : V -> hProp)
+Lemma mem_induction (C : V -> HProp)
 : (forall v, (forall x, x ∈ v -> C x) -> C v) -> forall v, C v.
 Proof.
   intro H.
@@ -450,7 +450,7 @@ Proof.
   { intro.
     unfold complement.
     exact _. }
-  refine (mem_induction (fun x => BuildhProp (~ x ∈ x)) _); simpl in *.
+  refine (mem_induction (fun x => Build_HProp (~ x ∈ x)) _); simpl in *.
   intros v H. intro Hv.
   exact (H v Hv Hv).
 Defined.
@@ -706,7 +706,7 @@ Proof.
     intros [a p']. exists a. transitivity (r z); auto with path_hints. exact (ap r p').
 Qed.
 
-Lemma separation (C : V -> hProp) : forall a : V,
+Lemma separation (C : V -> HProp) : forall a : V,
   hexists (fun w => forall x, x ∈ w <-> x ∈ a * (C x)).
 Proof.
   refine (V_ind_hprop _ _ _).

--- a/theories/HIT/epi.v
+++ b/theories/HIT/epi.v
@@ -11,11 +11,11 @@ Section AssumingUA.
 Context `{ua:Univalence}.
 
 (** We will now prove that for sets, epis and surjections are equivalent.*)
-Definition isepi {X Y} `(f:X->Y) := forall Z: hSet,
+Definition isepi {X Y} `(f:X->Y) := forall Z: HSet,
   forall g h: Y -> Z, g o f = h o f -> g = h.
 
 Definition isepi' {X Y} `(f : X -> Y) :=
-  forall (Z : hSet) (g : Y -> Z), Contr { h : Y -> Z | g o f = h o f }.
+  forall (Z : HSet) (g : Y -> Z), Contr { h : Y -> Z | g o f = h o f }.
 
 Lemma equiv_isepi_isepi' {X Y} f : @isepi X Y f <~> @isepi' X Y f.
 Proof.
@@ -37,7 +37,7 @@ Proof.
 Defined.
 
 Section cones.
-  Lemma isepi'_contr_cone `{Funext} {A B : hSet} (f : A -> B) : isepi' f -> Contr (setcone f).
+  Lemma isepi'_contr_cone `{Funext} {A B : HSet} (f : A -> B) : isepi' f -> Contr (setcone f).
   Proof.
     intros hepi.
     exists (setcone_point _).
@@ -50,7 +50,7 @@ Section cones.
     pose (r := (@const B (setcone f) (setcone_point _); (ap (fun f => @tr 0 _ o f) (path_forall _ _ alpha1))) : tot).
     subst tot.
     assert (X : l = r).
-      { let lem := constr:(fun X push' => hepi (BuildhSet (setcone f)) (tr o push' o @inl _ X)) in
+      { let lem := constr:(fun X push' => hepi (Build_HSet (setcone f)) (tr o push' o @inl _ X)) in
         pose (lem _ push).
         refine (path_contr l r). }
     subst l r.
@@ -94,7 +94,7 @@ transitivity (g (f x)).
 Qed.
 
 (** Old-style proof using polymorphic Omega. Needs resizing for the isepi proof to live in the
- same universe as X and Y (the Z quantifier is instantiated with an hSet at a level higher)
+ same universe as X and Y (the Z quantifier is instantiated with an HSet at a level higher)
 <<
 Lemma isepi_issurj {X Y} (f:X->Y): isepi f -> issurj f.
 Proof.
@@ -116,13 +116,13 @@ Defined.
 >> *)
 
 Section isepi_issurj.
-  Context {X Y : hSet} (f : X -> Y) (Hisepi : isepi f).
+  Context {X Y : HSet} (f : X -> Y) (Hisepi : isepi f).
   Definition epif := equiv_isepi_isepi' _ Hisepi.
-  Definition fam (c : setcone f) : hProp.
+  Definition fam (c : setcone f) : HProp.
   Proof.
     pose (fib y := hexists (fun x : X => f x = y)).
-    apply (fun f => @Trunc_rec _ _ hProp _ f c).
-    refine (Pushout_rec hProp fib (fun _ => Unit_hp) (fun x => _)).
+    apply (fun f => @Trunc_rec _ _ HProp _ f c).
+    refine (Pushout_rec HProp fib (fun _ => Unit_hp) (fun x => _)).
     (** Prove that the truncated sigma is equivalent to Unit *)
     pose (contr_inhabited_hprop (fib (f x)) (tr (x; idpath))) as i.
     apply path_hprop. simpl. simpl in i.

--- a/theories/HIT/iso.v
+++ b/theories/HIT/iso.v
@@ -8,7 +8,7 @@ Local Open Scope path_scope.
 (** We prove that [epi + mono <-> IsEquiv] *)
 Section iso.
   Context `{Univalence}.
-  Variables X Y : hSet.
+  Variables X Y : HSet.
   Variable f : X -> Y.
 
   Lemma atmost1P_isinj (injf : isinj f)

--- a/theories/HIT/quotient.v
+++ b/theories/HIT/quotient.v
@@ -78,9 +78,9 @@ Section Equiv.
     apply @hset_path2. apply _.
   Defined.
 
-  Definition in_class : quotient R -> A -> hProp.
+  Definition in_class : quotient R -> A -> HProp.
   Proof.
-    refine (quotient_ind R (fun _ => A -> hProp) (fun a b => BuildhProp (R a b)) _).
+    refine (quotient_ind R (fun _ => A -> HProp) (fun a b => Build_HProp (R a b)) _).
     intros. eapply concat;[apply transport_const|].
     apply path_forall. intro z. apply path_hprop; simpl.
     apply @equiv_iff_hprop; eauto.
@@ -147,7 +147,7 @@ Section Equiv.
     intros ?? H'. destruct (related_classes_eq R H'). by apply dequiv.
   Defined.
 
-  Definition quotient_rec2 {B : hSet} {dclass : (A -> A -> B)}:
+  Definition quotient_rec2 {B : HSet} {dclass : (A -> A -> B)}:
     forall dequiv : (forall x x', R x x' -> forall y y',  R y y' ->
                                                           dclass x y = dclass x' y'),
       quotient R -> quotient R -> B.
@@ -188,19 +188,19 @@ Section Equiv.
   Defined.
 
   (** From Ch10 *)
-  Definition quotient_ump' (B:hSet): (quotient R -> B) ->
+  Definition quotient_ump' (B:HSet): (quotient R -> B) ->
                                      (sig (fun f : A-> B => (forall a a0:A, R a a0 -> f a =f a0))).
     intro f. exists (compose f (class_of R) ).
     intros. f_ap. by apply related_classes_eq.
   Defined.
 
-  Definition quotient_ump'' (B:hSet): (sig (fun f : A-> B => (forall a a0:A, R a a0 -> f a =f a0)))
+  Definition quotient_ump'' (B:HSet): (sig (fun f : A-> B => (forall a a0:A, R a a0 -> f a =f a0)))
                                       -> quotient R -> B.
     intros [f H'].
     apply (quotient_rec _ H').
   Defined.
 
-  Theorem quotient_ump (B:hSet): (quotient R -> B) <~>
+  Theorem quotient_ump (B:HSet): (quotient R -> B) <~>
                                                    (sig (fun f : A-> B => (forall a a0:A, R a a0 -> f a =f a0))).
   Proof.
     refine (equiv_adjointify (quotient_ump' B) (quotient_ump'' B) _ _).

--- a/theories/HSet.v
+++ b/theories/HSet.v
@@ -1,10 +1,8 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
-(** * H-Sets *)
-
-Require Import Basics.
-Require Import Types.
+Require Import Basics Types.
 Require Import HProp.
 
+(** * H-Sets *)
 
 Local Open Scope path_scope.
 
@@ -106,7 +104,7 @@ Defined.
 
 (** We will now prove that for sets, monos and injections are equivalent.*)
 Definition ismono {X Y} (f : X -> Y)
-  := forall (Z : hSet),
+  := forall (Z : HSet),
      forall g h : Z -> X, f o g = f o h -> g = h.
 
 Definition isinj {X Y} (f : X -> Y)
@@ -150,7 +148,7 @@ Definition isinj_ismono {X Y} (f : X -> Y)
            (H : ismono f)
 : isinj f
   := fun x0 x1 H' =>
-       ap10 (H (BuildhSet Unit)
+       ap10 (H (Build_HSet Unit)
                (fun _ => x0)
                (fun _ => x1)
                (ap (fun x => unit_name x) H'))

--- a/theories/Homotopy/ClassifyingSpace.v
+++ b/theories/Homotopy/ClassifyingSpace.v
@@ -187,10 +187,10 @@ Section EncodeDecode.
 
   Context `{Univalence} {G : Group}.
 
-  Local Definition codes : B G -> 0-Type.
+  Local Definition codes : B G -> HSet.
   Proof.
     srapply ClassifyingSpace_rec.
-    + srapply (BuildhSet G).
+    + srapply (Build_HSet G).
     + intro x.
       apply path_trunctype.
       apply (right_mult_equiv x).

--- a/theories/Homotopy/EMSpace.v
+++ b/theories/Homotopy/EMSpace.v
@@ -38,8 +38,8 @@ Section LicataFinsterLemma.
   Local Definition codes : Susp X -> 1 -Type.
   Proof.
     srapply Susp_rec.
-    1: refine (BuildTruncType _ X).
-    1: refine (BuildTruncType _ X).
+    1: refine (Build_TruncType _ X).
+    1: refine (Build_TruncType _ X).
     intro x.
     apply path_trunctype.
     apply (equiv_hspace_left_op x).

--- a/theories/Modalities/Closed.v
+++ b/theories/Modalities/Closed.v
@@ -13,7 +13,7 @@ Local Open Scope path_scope.
 
 (** We begin by characterizing the modal types. *)
 Section ClosedModalTypes.
-  Context (U : hProp).
+  Context (U : HProp).
 
   Definition equiv_inO_closed (A : Type)
   : (U -> Contr A) <-> IsEquiv (fun a:A => push (inr a) : Join U A).
@@ -44,7 +44,7 @@ Section ClosedModalTypes.
 End ClosedModalTypes.
 
 (** Exercise 7.13(ii): Closed modalities *)
-Definition Cl (U : hProp) : Modality.
+Definition Cl (U : HProp) : Modality.
 Proof.
   snrapply Build_Modality.
   - intros X; exact (U -> Contr X).
@@ -72,7 +72,7 @@ Proof.
 Defined.
 
 (** The closed modality is accessible. *)
-Global Instance accmodality_closed (U : hProp)
+Global Instance accmodality_closed (U : HProp)
   : IsAccModality (Cl U).
 Proof.
   unshelve econstructor.
@@ -90,16 +90,16 @@ Proof.
 Defined.
 
 (** In fact, it is topological, and therefore (assuming univalence) lex.  As for topological modalities generally, we don't need to declare these as global instances, but we prove them here as local instances for exposition. *)
-Local Instance topological_closed (U : hProp)
+Local Instance topological_closed (U : HProp)
   : Topological (Cl U)
   := _.
 
-Global Instance lex_closed `{Univalence} (U : hProp)
+Global Instance lex_closed `{Univalence} (U : HProp)
   : Lex (Cl U).
 Proof.
   rapply lex_topological.
 Defined.
 
 (** Thus, it also has the following alternative version. *)
-Definition Cl' (U : hProp) : Modality
+Definition Cl' (U : HProp) : Modality
   := Nul (Build_NullGenerators U (fun _ => Empty)).

--- a/theories/Modalities/CoreflectiveSubuniverse.v
+++ b/theories/Modalities/CoreflectiveSubuniverse.v
@@ -11,7 +11,7 @@ Local Open Scope path_scope.
 In particular, since we do not foresee many applications of this file, we don't bother introducing modules to make the definitions more universe polymorphic the way we did for reflective subuniverses. *)
 
 Record CoreflectiveSubuniverse :=
-  { inF : Type -> hProp ;
+  { inF : Type -> HProp ;
     F_coreflector : Type -> Type ;
     F_inF : forall X, inF (F_coreflector X) ;
     fromF : forall X, F_coreflector X -> X ;
@@ -95,12 +95,12 @@ End CoreflectiveSubuniverse.
 (** Conversely, we will now show that for any hprop [U], the types [X] such that [X -> U] are a coreflective subuniverse, which we call "co-open" since it is dual to the open modality. *)
 
 Section CoOpen.
-  Context `{Funext} (U : hProp).
+  Context `{Funext} (U : HProp).
 
   Definition coOp : CoreflectiveSubuniverse.
   Proof.
     simple refine (Build_CoreflectiveSubuniverse
-              (fun X => BuildhProp (X -> U))
+              (fun X => Build_HProp (X -> U))
               (fun X => X * U)
               (fun X => @snd X U)
               (fun X => @fst X U) _); try exact _.

--- a/theories/Modalities/Fracture.v
+++ b/theories/Modalities/Fracture.v
@@ -157,7 +157,7 @@ It may sometimes happen that in addition, the "intersection" of [O1] and [O2] is
 
 (** An easy example of the lex-modal fracture theorem is supplied by the open and closed modalities for an hprop [U]. *)
 
-Definition gluable_open_closed `{Funext} (U : hProp)
+Definition gluable_open_closed `{Funext} (U : HProp)
 : Gluable (Op U) (Cl U).
 Proof.
   intros A.
@@ -166,7 +166,7 @@ Proof.
   exact (ap10 (path_contr _ (fun _ => a)) u).
 Defined.
 
-Definition disjoint_open_closed `{Funext} (U : hProp)
+Definition disjoint_open_closed `{Funext} (U : HProp)
 : Disjoint (Op U) (Cl U).
 Proof.
   intros A.
@@ -178,7 +178,7 @@ Defined.
 
 (** We can also prove the same thing without funext if we use the nullification versions of these modalities. *)
 
-Definition gluable_open_closed' (U : hProp)
+Definition gluable_open_closed' (U : HProp)
 : Gluable (Op' U) (Cl' U).
 Proof.
   intros A ? u; simpl in *.
@@ -196,7 +196,7 @@ Proof.
   apply ooextendable_contr; exact _.
 Defined.
 
-Definition disjoint_open_closed' (U : hProp)
+Definition disjoint_open_closed' (U : HProp)
 : Disjoint (Op' U) (Cl' U).
 Proof.
   intros A An.

--- a/theories/Modalities/Open.v
+++ b/theories/Modalities/Open.v
@@ -11,7 +11,7 @@ Local Open Scope path_scope.
 
 (** ** Definition *)
 
-Definition Op `{Funext} (U : hProp) : Modality.
+Definition Op `{Funext} (U : HProp) : Modality.
 Proof.
   snrapply easy_modality.
   - intros X; exact (U -> X).
@@ -50,7 +50,7 @@ Defined.
 (** ** The open modality is lex *)
 
 (** Note that unlike most other cases, we can prove this without univalence (though we do of course need funext). *)
-Global Instance lex_open `{Funext} (U : hProp)
+Global Instance lex_open `{Funext} (U : HProp)
   : Lex (Op U).
 Proof.
   apply lex_from_isconnected_paths.
@@ -68,7 +68,7 @@ Defined.
 
 (** ** The open modality is accessible. *)
 
-Global Instance acc_open `{Funext} (U : hProp)
+Global Instance acc_open `{Funext} (U : HProp)
   : IsAccModality (Op U).
 Proof.
   unshelve econstructor.
@@ -86,5 +86,5 @@ Proof.
 Defined.
 
 (** Thus, arguably a better definition of [Op] would be as a nullification modality, as it would not require [Funext] and would have a judgmental computation rule.  However, the above definition is also nice to know, as it doesn't use HITs.  We name the other version [Op']. *)
-Definition Op' (U : hProp) : Modality
+Definition Op' (U : HProp) : Modality
   := Nul (Build_NullGenerators Unit (fun _ => U)).

--- a/theories/Projective.v
+++ b/theories/Projective.v
@@ -88,13 +88,13 @@ Section AC_oo_neg1.
   (** ** Projectivity and AC_(oo,-1) (defined in HoTT book, Exercise 7.8) *)
   (* TODO: Generalize to n, m. *)
 
-  Context {AC : forall X : hSet, IsProjective' X}.
+  Context {AC : forall X : HSet, IsProjective' X}.
 
   (** (Exercise 7.9) Assuming AC_(oo,-1) every type merely has a projective cover. *)
   Proposition projective_cover_AC `{Univalence} (A : Type)
-    : merely (exists X:hSet, exists p : X -> A, IsSurjection p).
+    : merely (exists X:HSet, exists p : X -> A, IsSurjection p).
   Proof.
-    pose (X := BuildhSet (Tr 0 A)).
+    pose (X := Build_HSet (Tr 0 A)).
     pose proof ((equiv_isprojective_choice X)^-1 (AC X)) as P.
     pose proof (P A X idmap tr _) as F; clear P.
     strip_truncations.

--- a/theories/Spaces/Card.v
+++ b/theories/Spaces/Card.v
@@ -8,27 +8,27 @@ Opaque trunc_equiv. (** This speeds things up considerably *)
 
 (** ** Definitions and operations *)
 
-Definition Card := Trunc 0 hSet.
+Definition Card := Trunc 0 HSet.
 
 Definition sum_card (a b : Card) : Card.
 Proof.
   strip_truncations.
-  refine (tr (BuildhSet (a + b))).
+  refine (tr (Build_HSet (a + b))).
 Defined.
 
 Definition prod_card (a b : Card) : Card.
 Proof.
   strip_truncations.
-  refine (tr (BuildhSet (a * b))).
+  refine (tr (Build_HSet (a * b))).
 Defined.
 
 Definition exp_card `{Funext} (b a : Card) : Card.
 Proof.
   strip_truncations.
-  refine (tr (BuildhSet (b -> a))).
+  refine (tr (Build_HSet (b -> a))).
 Defined.
 
-Definition leq_card `{Univalence} : Card -> Card -> hProp.
+Definition leq_card `{Univalence} : Card -> Card -> HProp.
 Proof.
   refine (Trunc_rec (fun a => _)).
   refine (Trunc_rec (fun b => _)).
@@ -41,8 +41,8 @@ Section contents.
 
   Global Instance plus_card : Plus Card := sum_card.
   Global Instance mult_card : Mult Card := prod_card.
-  Global Instance zero_card : Zero Card := tr (BuildhSet Empty).
-  Global Instance one_card : One Card := tr (BuildhSet Unit).
+  Global Instance zero_card : Zero Card := tr (Build_HSet Empty).
+  Global Instance one_card : One Card := tr (Build_HSet Unit).
   Global Instance le_card : Le Card := leq_card.
 
   (* Reduce an algebraic equation to an equivalence *)

--- a/theories/Spaces/No/Core.v
+++ b/theories/Spaces/No/Core.v
@@ -596,8 +596,8 @@ Section NoCodes.
   Context {S : OptionSort@{i}}.
   Let No := GenNo S.
 
-  Let A := {le'_x : No -> hProp &
-           {lt'_x : No -> hProp &
+  Let A := {le'_x : No -> HProp &
+           {lt'_x : No -> HProp &
            (forall y : No, lt'_x y -> le'_x y) *
            (forall y z : No, le'_x y -> y <= z -> le'_x z) *
            (forall y z : No, le'_x y -> y < z -> lt'_x z) *
@@ -613,7 +613,7 @@ Section NoCodes.
                          (xR_let r).1 y -> ((xL_let l).2).1 y).
 
     Let A' (y : No) : Type
-    := { lelt'_x_y : hProp * hProp &
+    := { lelt'_x_y : HProp * HProp &
          (snd lelt'_x_y -> fst lelt'_x_y) *
          (forall l : L, fst lelt'_x_y -> ((xL_let l).2).1 y) *
          (forall r : R, (xR_let r).1 y -> snd lelt'_x_y) }.
@@ -633,7 +633,7 @@ Section NoCodes.
       unfold A', A'le, A'lt; try exact _.
       - intros L' R' ? yL yR ycut x_let_yL x_let_yR y_lt_le.
         set (y := {{ yL | yR // ycut }}).
-        exists (BuildhProp
+        exists (Build_HProp
                   ((forall l, (xL_let l).2.1 y) *
                    (forall r', snd (x_let_yR r').1)) ,
                 (hor {l':L' & fst (x_let_yL l').1}
@@ -709,7 +709,7 @@ Section NoCodes.
                (yL : L' -> No) (yR : R' -> No)
                (ycut : forall (l:L') (r:R'), (yL l) < (yR r))
     : fst (inner {{ yL | yR // ycut }}).1 =
-      (BuildhProp ((forall l, (xL_let l).2.1 {{ yL | yR // ycut }}) *
+      (Build_HProp ((forall l, (xL_let l).2.1 {{ yL | yR // ycut }}) *
                    (forall r', snd (inner (yR r')).1)))
       := 1.
 
@@ -811,10 +811,10 @@ Section NoCodes.
           refine (fst (zH {{ zL | zR // zcut }}) y_le_z) ).
   Defined.
 
-  Definition le' (x y : No) : hProp
+  Definition le' (x y : No) : HProp
     := (No_codes_package.1 x).1 y.
 
-  Definition lt' (x y : No) : hProp
+  Definition lt' (x y : No) : HProp
     := (No_codes_package.1 x).2.1 y.
 
   Definition lt'_le' x y
@@ -856,7 +856,7 @@ Section NoCodes.
   : le' {{xL | xR // xcut}} {{yL | yR // ycut}}
     = ((forall l, lt' (xL l) {{ yL | yR // ycut }}) *
        (forall r', lt' {{ xL | xR // xcut }} (yR r')))
-        (** For some reason, Coq has a really hard time checking the version of this that asserts an equality in [hProp].  But fortunately, we only ever really need the equality of types. *)
+        (** For some reason, Coq has a really hard time checking the version of this that asserts an equality in [HProp].  But fortunately, we only ever really need the equality of types. *)
         :> Type
     := 1.
 

--- a/theories/TruncType.v
+++ b/theories/TruncType.v
@@ -1,9 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
-(** * Universes of truncated types. *)
-
 Require Import HoTT.Basics HoTT.Types.
 Require Import HProp.
-
 
 Generalizable Variables A B n f.
 
@@ -14,179 +11,156 @@ Now that we have the univalence axiom (from [types/Universe]), we study further 
 (** ** Paths in [TruncType] *)
 
 Section TruncType.
-Context `{Univalence}.
+  Context `{Univalence}.
 
-Definition issig_trunctype {n : trunc_index}
-  : { X : Type & IsTrunc n X } <~> TruncType n.
-Proof.
-  issig.
-Defined.
+  Definition issig_trunctype {n : trunc_index}
+    : { X : Type & IsTrunc n X } <~> TruncType n.
+  Proof.
+    issig.
+  Defined.
 
-Global Instance isequiv_ap_trunctype {n : trunc_index} (A B : n-Type)
-: IsEquiv (@ap _ _ (@trunctype_type n) A B).
-Proof.
-  (* It seems to be easier to construct its inverse directly as an equivalence. *)
-  transparent assert (e : ((A = B :> Type) <~> (A = B :> n-Type))).
-  { equiv_via ((issig_trunctype ^-1 A) = (issig_trunctype ^-1 B)).
-    - simpl. apply (equiv_path_sigma_hprop
-                      (trunctype_type A; istrunc_trunctype_type A)
-                      (trunctype_type B; istrunc_trunctype_type B)).
-    - symmetry. apply equiv_ap. refine _. }
-  (* Apparently writing [e^-1%equiv] here instead of [e^-1%function] is much faster. *)
-  refine (isequiv_homotopic e^-1%equiv _).
-  intros p; destruct p; reflexivity.
-Defined.
+  Definition equiv_path_trunctype' {n : trunc_index} (A B : TruncType n)
+    : (A = B :> Type) <~> (A = B :> TruncType n).
+  Proof.
+    refine ((equiv_ap' issig_trunctype^-1 _ _)^-1 oE _).
+    exact (equiv_path_sigma_hprop (_;_) (_;_)).
+  Defined.
 
-Definition equiv_path_trunctype' {n : trunc_index} (A B : TruncType n)
-  : (A = B :> Type) <~> (A = B :> TruncType n).
-Proof.
-  exact ((Build_Equiv _ _ (@ap _ _ (@trunctype_type n) A B) _)^-1)%equiv.
-Defined.
+  Global Instance isequiv_ap_trunctype {n : trunc_index} (A B : n-Type)
+    : IsEquiv (@ap _ _ (@trunctype_type n) A B).
+  Proof.
+    srefine (isequiv_homotopic _^-1%equiv _).
+    1: apply equiv_path_trunctype'.
+    intros []; reflexivity.
+  Defined.
 
-Definition equiv_path_trunctype {n : trunc_index} (A B : TruncType n)
-  : (A <~> B) <~> (A = B :> TruncType n).
-Proof.
-  equiv_via (A = B :> Type).
-  - apply equiv_path_universe.
-  - exact ((Build_Equiv _ _ (@ap _ _ (@trunctype_type n) A B) _)^-1)%equiv.
-Defined.
+  Definition equiv_path_trunctype {n : trunc_index} (A B : TruncType n)
+    : (A <~> B) <~> (A = B :> TruncType n)
+    := equiv_path_trunctype' _ _ oE equiv_path_universe _ _.
 
-Definition path_trunctype@{a b c} {n : trunc_index} {A B : TruncType n}
-  : A <~> B -> (A = B :> TruncType n)
-:= equiv_path_trunctype@{a b c} A B.
+  Definition path_trunctype@{a b} {n : trunc_index} {A B : TruncType n}
+    : A <~> B -> (A = B :> TruncType n)
+  := equiv_path_trunctype@{a b} A B.
 
-Global Instance isequiv_path_trunctype
-       {n : trunc_index} {A B : TruncType n}
-: IsEquiv (@path_trunctype n A B).
-Proof.
-  exact _.
-Defined.
+  Global Instance isequiv_path_trunctype {n : trunc_index} {A B : TruncType n}
+    : IsEquiv (@path_trunctype n A B) := _.
 
-(** [path_trunctype] is functorial *)
-Definition path_trunctype_1 {n : trunc_index} {A : TruncType n}
-: path_trunctype (equiv_idmap A) = idpath.
-Proof.
-  unfold path_trunctype; simpl.
-  rewrite (eta_path_universe_uncurried 1).
-  rewrite path_sigma_hprop_1.
-  reflexivity.
-Qed.
+  (** [path_trunctype] is functorial *)
+  Definition path_trunctype_1 {n : trunc_index} {A : TruncType n}
+  : path_trunctype (equiv_idmap A) = idpath.
+  Proof.
+    unfold path_trunctype; simpl.
+    rewrite (eta_path_universe_uncurried 1).
+    rewrite path_sigma_hprop_1.
+    reflexivity.
+  Qed.
 
-Definition path_trunctype_V {n : trunc_index} {A B : TruncType n}
-           (f : A <~> B)
-  : path_trunctype f^-1 = (path_trunctype f)^.
-Proof.
-  unfold path_trunctype; simpl.
-  rewrite path_universe_V_uncurried.
-  rewrite (path_sigma_hprop_V (path_universe_uncurried f)).
-  refine (concat_p1 _ @ concat_1p _ @ _).
-  refine (_ @ (ap inverse (concat_1p _))^ @ (ap inverse (concat_p1 _))^).
-  refine (ap_V _ _).
-Qed.
+  Definition path_trunctype_V {n : trunc_index} {A B : TruncType n}
+             (f : A <~> B)
+    : path_trunctype f^-1 = (path_trunctype f)^.
+  Proof.
+    unfold path_trunctype; simpl.
+    rewrite path_universe_V_uncurried.
+    rewrite (path_sigma_hprop_V (path_universe_uncurried f)).
+    refine (concat_p1 _ @ concat_1p _ @ _).
+    refine (_ @ (ap inverse (concat_1p _))^ @ (ap inverse (concat_p1 _))^).
+    refine (ap_V _ _).
+  Qed.
 
-Definition path_trunctype_pp {n : trunc_index} {A B C : TruncType n}
-           (f : A <~> B) (g : B <~> C)
-  : path_trunctype (g oE f) = path_trunctype f @ path_trunctype g.
-Proof.
-  unfold path_trunctype; simpl.
-  rewrite path_universe_compose_uncurried.
-  rewrite (path_sigma_hprop_pp _ _ _ (istrunc_trunctype_type B)).
-  refine (concat_p1 _ @ concat_1p _ @ _).
-  refine (_ @ (ap _ (concat_1p _))^ @ (ap _ (concat_p1 _))^).
-  refine (_ @ (ap (fun z => z @ _) (concat_1p _))^ @ (ap (fun z => z @ _) (concat_p1 _))^).
-  refine (ap_pp _ _ _).
-Qed.
+  Definition path_trunctype_pp {n : trunc_index} {A B C : TruncType n}
+             (f : A <~> B) (g : B <~> C)
+    : path_trunctype (g oE f) = path_trunctype f @ path_trunctype g.
+  Proof.
+    unfold path_trunctype; simpl.
+    rewrite path_universe_compose_uncurried.
+    rewrite (path_sigma_hprop_pp _ _ _ (trunctype_istrunc B)).
+    refine (concat_p1 _ @ concat_1p _ @ _).
+    refine (_ @ (ap _ (concat_1p _))^ @ (ap _ (concat_p1 _))^).
+    refine (_ @ (ap (fun z => z @ _) (concat_1p _))^ @ (ap (fun z => z @ _) (concat_p1 _))^).
+    refine (ap_pp _ _ _).
+  Qed.
 
-Definition ap_trunctype {n : trunc_index} {A B : TruncType n} {f : A <~> B}
-  : ap trunctype_type (path_trunctype f) = path_universe_uncurried f.
-Proof.
-  destruct A, B.
-  cbn in *.
-  cbn; destruct (path_universe_uncurried f).
-  rewrite concat_1p, concat_p1.
-  rewrite <- 2 ap_compose.
-  apply ap_const.
-Qed.
+  Definition ap_trunctype {n : trunc_index} {A B : TruncType n} {f : A <~> B}
+    : ap trunctype_type (path_trunctype f) = path_universe_uncurried f.
+  Proof.
+    destruct A, B.
+    cbn in *.
+    cbn; destruct (path_universe_uncurried f).
+    rewrite concat_1p, concat_p1.
+    rewrite <- 2 ap_compose.
+    apply ap_const.
+  Qed.
 
-Definition path_hset {A B} := @path_trunctype 0 A B.
-Definition path_hprop {A B} := @path_trunctype (-1) A B.
+  Definition path_hset {A B} := @path_trunctype 0 A B.
+  Definition path_hprop {A B} := @path_trunctype (-1) A B.
 
-Global Instance istrunc_trunctype@{i j k | i < j, j < k} {n : trunc_index}
-  : IsTrunc@{j} n.+1 (TruncType@{i} n) | 0.
-Proof.
-  intros A B.
-  refine (trunc_equiv _ (equiv_path_trunctype@{i j k} A B)).
-  case n as [ | n'].
-  - apply contr_equiv_contr_contr. (* The reason is different in this case. *)
-  - apply istrunc_equiv.
-Defined.
+  Global Instance istrunc_trunctype {n : trunc_index}
+    : IsTrunc n.+1 (TruncType n) | 0.
+  Proof.
+    intros A B.
+    refine (trunc_equiv _ (equiv_path_trunctype@{i j} A B)).
+    case n as [ | n'].
+    - apply contr_equiv_contr_contr. (* The reason is different in this case. *)
+    - apply istrunc_equiv.
+  Defined.
 
-Global Instance isset_hProp : IsHSet hProp.
-Proof.
-  exact _.
-Defined.
+  Global Instance isset_HProp : IsHSet HProp := _.
 
-Global Instance Sn_trunctype: forall n, IsTrunc n.+1 (sig (IsTrunc n)) |0.
-Proof.
-  intro n.
-  apply (trunc_equiv' _ issig_trunctype^-1).
-Defined.
+  Global Instance istrunc_sig_istrunc : forall n, IsTrunc n.+1 (sig (IsTrunc n)) | 0.
+  Proof.
+    intro n.
+    apply (trunc_equiv' _ issig_trunctype^-1).
+  Defined.
 
-(** ** Some standard inhabitants *)
+  (** ** Some standard inhabitants *)
 
-Definition Unit_hp : hProp := (BuildhProp Unit).
-Definition False_hp : hProp := (BuildhProp Empty).
-Definition Negation_hp `{Funext} (hprop : hProp) : hProp := BuildhProp (~hprop).
-(** We could continue with products etc *)
+  Definition Unit_hp : HProp := (Build_HProp Unit).
+  Definition False_hp : HProp := (Build_HProp Empty).
+  Definition Negation_hp `{Funext} (hprop : HProp) : HProp := Build_HProp (~hprop).
+  (** We could continue with products etc *)
 
-(** ** The canonical map from Bool to hProp *)
-Definition is_true (b : Bool) : hProp
-  := if b then Unit_hp else False_hp.
+  (** ** The canonical map from Bool to hProp *)
+  Definition is_true (b : Bool) : HProp
+    := if b then Unit_hp else False_hp.
 
-(** ** Facts about HProps using univalence *)
+  (** ** Facts about HProps using univalence *)
 
-Global Instance trunc_path_IsHProp X Y `{IsHProp Y}
-: IsHProp (X = Y).
-Proof.
-  apply hprop_allpath.
-  intros pf1 pf2.
-  apply (equiv_inj (equiv_path X Y)).
-  apply path_equiv, path_arrow.
-  intros x; by apply path_ishprop.
-Qed.
+  Global Instance trunc_path_IsHProp X Y `{IsHProp Y}
+  : IsHProp (X = Y).
+  Proof.
+    apply hprop_allpath.
+    intros pf1 pf2.
+    apply (equiv_inj (equiv_path X Y)).
+    apply path_equiv, path_arrow.
+    intros x; by apply path_ishprop.
+  Qed.
 
-Definition path_iff_ishprop_uncurried `{IsHProp A, IsHProp B}
-: (A <-> B) -> A = B :> Type
-  := @path_universe_uncurried _ A B o equiv_iff_hprop_uncurried.
+  Definition path_iff_ishprop_uncurried `{IsHProp A, IsHProp B}
+  : (A <-> B) -> A = B :> Type
+    := @path_universe_uncurried _ A B o equiv_iff_hprop_uncurried.
 
-Definition path_iff_hprop_uncurried {A B : hProp}
-: (A <-> B) -> A = B :> hProp
-  := (@path_hprop A B) o (@equiv_iff_hprop_uncurried A _ B _).
+  Definition path_iff_hprop_uncurried {A B : HProp}
+  : (A <-> B) -> A = B :> HProp
+    := (@path_hprop A B) o (@equiv_iff_hprop_uncurried A _ B _).
 
-Global Instance isequiv_path_iff_ishprop_uncurried `{IsHProp A, IsHProp B}
-: IsEquiv (@path_iff_ishprop_uncurried A _ B _).
-Proof.
-  exact _.
-Defined.
+  Global Instance isequiv_path_iff_ishprop_uncurried `{IsHProp A, IsHProp B}
+  : IsEquiv (@path_iff_ishprop_uncurried A _ B _) := _.
 
-Global Instance isequiv_path_iff_hprop_uncurried {A B : hProp}
-: IsEquiv (@path_iff_hprop_uncurried A B).
-Proof.
-  exact _.
-Defined.
+  Global Instance isequiv_path_iff_hprop_uncurried {A B : HProp}
+  : IsEquiv (@path_iff_hprop_uncurried A B) := _.
 
-Definition path_iff_ishprop `{IsHProp A, IsHProp B}
-: (A -> B) -> (B -> A) -> A = B :> Type
-  := fun f g => path_iff_ishprop_uncurried (f,g).
+  Definition path_iff_ishprop `{IsHProp A, IsHProp B}
+  : (A -> B) -> (B -> A) -> A = B :> Type
+    := fun f g => path_iff_ishprop_uncurried (f,g).
 
-Definition path_iff_hprop {A B : hProp}
-: (A -> B) -> (B -> A) -> A = B :> hProp
-  := fun f g => path_iff_hprop_uncurried (f,g).
+  Definition path_iff_hprop {A B : HProp}
+  : (A -> B) -> (B -> A) -> A = B :> HProp
+    := fun f g => path_iff_hprop_uncurried (f,g).
 
-Lemma equiv_path_iff_ishprop {A B : Type} `{IsHProp A, IsHProp B}
-  : (A <-> B) <~> (A = B).
-Proof.
-  exact (Build_Equiv _ _ path_iff_ishprop_uncurried _).
-Defined.
+  Lemma equiv_path_iff_ishprop {A B : Type} `{IsHProp A, IsHProp B}
+    : (A <-> B) <~> (A = B).
+  Proof.
+    exact (Build_Equiv _ _ path_iff_ishprop_uncurried _).
+  Defined.
 
 End TruncType.

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -167,11 +167,11 @@ Local Open Scope trunc_scope.
 
 (** We define [merely A] to be an inhabitant of the universe [hProp] of hprops, rather than a type.  We can always treat it as a type because there is a coercion, but this means that if we need an element of [hProp] then we don't need a separate name for it. *)
 
-Definition merely (A : Type@{i}) : hProp@{i} := BuildhProp (Tr (-1) A).
+Definition merely (A : Type@{i}) : HProp@{i} := Build_HProp (Tr (-1) A).
 
-Definition hexists {X} (P : X -> Type) : hProp := merely (sig P).
+Definition hexists {X} (P : X -> Type) : HProp := merely (sig P).
 
-Definition hor (P Q : Type) : hProp := merely (P + Q).
+Definition hor (P Q : Type) : HProp := merely (P + Q).
 
 Notation "A \/ B" := (hor A B) : type_scope.
 
@@ -304,7 +304,8 @@ Defined.
 Local Instance O_lex_leq_Tr `{Univalence} (n : trunc_index)
   : Tr n <<< Tr n.+1.
 Proof.
-  intros A; unshelve econstructor; intros P' P_inO; pose (P := fun x => BuildTruncType n (P' x)).
+  intros A; unshelve econstructor; intros P' P_inO;
+    pose (P := fun x => Build_TruncType n (P' x)).
   - refine (Trunc_rec P).
   - intros; exact _.
   - intros; cbn. reflexivity.


### PR DESCRIPTION
I have renamed `hProp` and `hSet` to `HProp` and `HSet` to fit with our naming convention.

I have also changed constructors `BuildTruncType` to `Build_TruncType`, `BuildhSet` to `Build_HSet` and `BuildhProp` to `Build_HProp`.
 
I also did some miscellaneous cleanup in `TruncType.v`. This is the only file that needs review really, the rest is renaming.

 