### PR TITLE
standardize naming of istrunc_* lemmas

### DIFF
--- a/contrib/HoTTBook.v
+++ b/contrib/HoTTBook.v
@@ -351,12 +351,12 @@ Definition Book_3_1_4 := @HoTT.Spaces.Nat.hset_nat.
 (* ================================================== thm:isset-prod *)
 (** Example 3.1.5 *)
 
-Definition Book_3_1_5 := @HoTT.Types.Prod.trunc_prod.
+Definition Book_3_1_5 := @HoTT.Types.Prod.istrunc_prod.
 
 (* ================================================== thm:isset-forall *)
 (** Example 3.1.6 *)
 
-Definition Book_3_1_6 := @HoTT.Types.Forall.trunc_forall.
+Definition Book_3_1_6 := @HoTT.Types.Forall.istrunc_forall.
 
 (* ================================================== defn:1type *)
 (** Definition 3.1.7 *)
@@ -366,7 +366,7 @@ Definition Book_3_1_7 := @HoTT.Basics.Overture.IsTrunc 1.
 (* ================================================== thm:isset-is1type *)
 (** Lemma 3.1.8 *)
 
-Definition Book_3_1_8 := @HoTT.Basics.Trunc.trunc_succ 0.
+Definition Book_3_1_8 := @HoTT.Basics.Trunc.istrunc_succ 0.
 
 (* ================================================== thm:type-is-not-a-set *)
 (** Example 3.1.9 *)
@@ -401,7 +401,7 @@ Definition Book_3_3_3 := @HoTT.Basics.Trunc.equiv_iff_hprop.
 (* ================================================== thm:prop-set *)
 (** Lemma 3.3.4 *)
 
-Definition Book_3_3_4 := @HoTT.Basics.Trunc.trunc_succ (-1).
+Definition Book_3_3_4 := @HoTT.Basics.Trunc.istrunc_succ (-1).
 
 (* ================================================== thm:isprop-isset *)
 (** Lemma 3.3.5 *)
@@ -434,7 +434,7 @@ Definition Book_3_5_1 := @HoTT.Types.Sigma.path_sigma_hprop.
 (** Example 3.6.2 *)
 
 Definition Book_3_6_2 `{Funext} (A : Type) (B : A -> Type)
-  := @HoTT.Types.Forall.trunc_forall _ A B (-1).
+  := @HoTT.Types.Forall.istrunc_forall _ A B (-1).
 
 (* ================================================== defn:logical-notation *)
 (** Definition 3.7.1 *)
@@ -484,7 +484,7 @@ Definition Book_3_11_5 := @HoTT.Basics.Contractible.contr_contr.
 (* ================================================== thm:contr-forall *)
 (** Lemma 3.11.6 *)
 
-Definition Book_3_11_6 := @HoTT.Types.Forall.trunc_forall.
+Definition Book_3_11_6 := @HoTT.Types.Forall.istrunc_forall.
 
 (* ================================================== thm:retract-contr *)
 (** Lemma 3.11.7 *)
@@ -991,7 +991,7 @@ Definition Book_6_12_8 := @HoTT.HIT.Flattening.sWtil_rec_beta_ppt.
 (* ================================================== thm:hlevel-prod *)
 (** Theorem 7.1.9 *)
 
-Definition Book_7_1_9 := @HoTT.Types.Forall.trunc_forall.
+Definition Book_7_1_9 := @HoTT.Types.Forall.istrunc_forall.
 
 (* ================================================== thm:isaprop-isofhlevel *)
 (** Theorem 7.1.10 *)
@@ -1486,7 +1486,7 @@ Definition Book_9_1_2 := @HoTT.Categories.Category.Morphisms.Isomorphic.
 (* ================================================== ct:isoprop *)
 (** Lemma 9.1.3 *)
 
-Definition Book_9_1_3 := @HoTT.Categories.Category.Morphisms.trunc_isisomorphism.
+Definition Book_9_1_3 := @HoTT.Categories.Category.Morphisms.istrunc_isisomorphism.
 
 (* ================================================== ct:idtoiso *)
 (** Lemma 9.1.4 *)
@@ -1536,11 +1536,11 @@ Definition Book_9_1_15 A `{H : HoTT.Categories.Category.Univalent.IsCategory A}
 Proof.
   split.
   - intros H' a b.
-    eapply trunc_equiv.
+    eapply istrunc_isequiv_istrunc.
     + refine (H' a b).
     + apply H.
   - intros H' a b.
-    eapply trunc_equiv.
+    eapply istrunc_isequiv_istrunc.
     + apply (H' a b).
     + apply (@isequiv_inverse _ _ _ (H _ _)).
 Defined.

--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -579,7 +579,7 @@ Definition Book_2_13 := @HoTT.Types.Bool.equiv_bool_aut_bool.
 (** Exercise 3.1 *)
 
 Definition Book_3_1_solution_1 {A B} (f : A <~> B) (H : IsHSet A)
-  := @HoTT.Basics.Trunc.trunc_equiv' A B f 0 H.
+  := @HoTT.Basics.Trunc.istrunc_equiv_istrunc A B f 0 H.
 
 (** Alternative solutions: [Book_3_1_solution_2] using UA, and [Book_3_1_solution_3] using two easy lemmas that may be of independent interest *)
 
@@ -626,7 +626,7 @@ Defined.
 (* ================================================== ex:isset-coprod *)
 (** Exercise 3.2 *)
 
-Definition Book_3_2_solution_1 := @HoTT.Types.Sum.hset_sum.
+Definition Book_3_2_solution_1 := @HoTT.Types.Sum.ishset_sum.
 
 (** Alternative solution for replaying *)
 
@@ -646,7 +646,7 @@ Defined.
 (** Exercise 3.3 *)
 
 Definition Book_3_3_solution_1 (A : Type) (B : A -> Type)
-   := @HoTT.Types.Sigma.trunc_sigma A B 0.
+   := @HoTT.Types.Sigma.istrunc_sigma A B 0.
 
 (** This exercise is hard because 2-paths over Sigma types are not treated in the first three chapters of the book. Consult theories/Types/Sigma.v *)
 
@@ -1207,7 +1207,7 @@ Proof.
     refine ((equiv_concat_l (transport_paths_lr q p)^ p)^-1 oE _).
     refine ((equiv_concat_l (concat_p_pp _ _ _) _)^-1 oE _).
     apply equiv_moveR_Vp. }
-  assert (HK := @trunc_equiv _ _ e^-1 (-1)).
+  assert (HK := @istrunc_equiv_istrunc _ _ e^-1 (-1)).
   assert (u : forall (X:Type) (p:X=X), p @ 1 = 1 @ p).
   { intros X p; rewrite concat_p1, concat_1p; reflexivity. }
   pose (alpha := (fun X p => (idpath X ; u X p)) : K).
@@ -1234,7 +1234,7 @@ Defined.
 Definition Book_4_6_iii (qua1 qua2 : QInv_Univalence_type) : Empty.
 Proof.
   apply (Book_4_6_ii qua1 qua2).
-  refine (trunc_succ).
+  refine (istrunc_succ).
   exists (fun A => 1); intros u.
   set (B := {X : Type & X = X}) in *.
   exact (allqinv_coherent qua2 B B (idmap ; (idmap ; (fun A:B => 1 , u)))).
@@ -1527,7 +1527,7 @@ Section Book_6_9.
   Proof. apply path_forall. intro b. pose proof (inverse (negb_ne (f b).2)) as fst.
   unfold centerAllExOthBool.
   apply (@path_sigma _ _ (negb b; not_fixed_negb b) (f b) fst); simpl.
-  apply equiv_hprop_allpath. apply trunc_forall.
+  apply equiv_hprop_allpath. apply istrunc_forall.
   Defined.
 
   Definition contrAllExOthBool `{Funext} : Contr (AllExistsOther Bool) :=

--- a/theories/Algebra/Groups/FreeGroup.v
+++ b/theories/Algebra/Groups/FreeGroup.v
@@ -39,7 +39,7 @@ Global Instance ishprop_isfreegroupon `{Funext} (F : Group) (A : Type) (i : A ->
   : IsHProp (IsFreeGroupOn A F i).
 Proof.
   unfold IsFreeGroupOn.
-  apply trunc_forall.
+  apply istrunc_forall.
 Defined.
 
 (** Both ways of stating the universal property are equivalent. *)

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -129,7 +129,7 @@ Defined.
 Global Instance ishset_grouphomomorphism {F : Funext} {G H : Group}
   : IsHSet (GroupHomomorphism G H).
 Proof.
-  intros f g; apply (trunc_equiv' _ equiv_path_grouphomomorphism).
+  intros f g; apply (istrunc_equiv_istrunc _ equiv_path_grouphomomorphism).
 Defined.
 
 (** * Some basic properties of group homomorphisms *)
@@ -218,7 +218,7 @@ Defined.
 Definition ishset_groupisomorphism `{F : Funext} {G H : Group}
   : IsHSet (GroupIsomorphism G H).
 Proof.
-  intros f g; apply (trunc_equiv' _ (equiv_path_groupisomorphism _ _)).
+  intros f g; apply (istrunc_equiv_istrunc _ (equiv_path_groupisomorphism _ _)).
 Defined.
 
 Definition grp_iso_inverse {G H : Group}

--- a/theories/Algebra/Groups/Subgroup.v
+++ b/theories/Algebra/Groups/Subgroup.v
@@ -48,7 +48,7 @@ Definition issig_issubgroup {G : Group} (H : G -> Type) : _ <~> IsSubgroup H
 Global Instance ishprop_issubgroup `{F : Funext} {G : Group} {H : G -> Type}
   : IsHProp (IsSubgroup H).
 Proof.
-  exact (trunc_equiv' _ (issig_issubgroup H)).
+  exact (istrunc_equiv_istrunc _ (issig_issubgroup H)).
 Defined.
 
 (** The type (set) of subgroups of a group G. *)
@@ -117,7 +117,7 @@ Defined.
 
 Global Instance isembedding_subgroup_incl {G : Group} (H : Subgroup G)
   : IsEmbedding (subgroup_incl H)
-  := fun _ => trunc_equiv' _ (hfiber_fibration _ _).
+  := fun _ => istrunc_equiv_istrunc _ (hfiber_fibration _ _).
 
 Definition issig_subgroup {G : Group} : _ <~> Subgroup G
   := ltac:(issig).
@@ -159,15 +159,15 @@ Defined.
 
 Global Instance ishset_subgroup `{Univalence} {G : Group} : IsHSet (Subgroup G).
 Proof.
-  nrefine (trunc_equiv' _ issig_subgroup).
-  nrefine (trunc_equiv' _ (equiv_functor_sigma_id _)).
+  nrefine (istrunc_equiv_istrunc _ issig_subgroup).
+  nrefine (istrunc_equiv_istrunc _ (equiv_functor_sigma_id _)).
   - intro P; apply issig_issubgroup.
-  - nrefine (trunc_equiv' _ (equiv_sigma_assoc' _ _)^-1%equiv).
-    nrapply trunc_sigma.
-    2: intros []; apply trunc_hprop.
-    nrefine (trunc_equiv'
+  - nrefine (istrunc_equiv_istrunc _ (equiv_sigma_assoc' _ _)^-1%equiv).
+    nrapply istrunc_sigma.
+    2: intros []; apply istrunc_hprop.
+    nrefine (istrunc_equiv_istrunc
                _ (equiv_sig_coind (fun g:G => Type) (fun g x => IsHProp x))^-1%equiv).
-    apply trunc_forall.
+    apply istrunc_forall.
 Defined.
 
 Section Cosets.

--- a/theories/Algebra/Universal/Congruence.v
+++ b/theories/Algebra/Universal/Congruence.v
@@ -48,7 +48,7 @@ Section congruence.
     `{!forall s x y, IsTrunc n (Φ s x y)}
     : IsTrunc n OpsCompatible.
   Proof.
-    apply trunc_forall.
+    apply istrunc_forall.
   Defined.
 
   (** A family of relations [Φ] is a congruence iff it is a family of

--- a/theories/Algebra/Universal/Homomorphism.v
+++ b/theories/Algebra/Universal/Homomorphism.v
@@ -24,7 +24,7 @@ Section is_homomorphism.
     (α : Operation A w) (β : Operation B w)
     : IsHProp (OpPreserving α β).
   Proof.
-    apply trunc_forall.
+    apply istrunc_forall.
   Qed.
 
   Class IsHomomorphism : Type
@@ -33,7 +33,7 @@ Section is_homomorphism.
   Global Instance hprop_is_homomorphism `{Funext}
     : IsHProp IsHomomorphism.
   Proof.
-    apply trunc_forall.
+    apply istrunc_forall.
   Qed.
 End is_homomorphism.
 
@@ -67,7 +67,7 @@ Defined.
 Global Instance hset_homomorphism `{Funext} {σ} (A B : Algebra σ)
   : IsHSet (Homomorphism A B).
 Proof.
-  apply (trunc_equiv _ (issig_homomorphism A B)).
+  apply (istrunc_equiv_istrunc _ (issig_homomorphism A B)).
 Qed.
 
 Lemma path_homomorphism `{Funext} {σ} {A B : Algebra σ}
@@ -97,7 +97,7 @@ Global Instance hprop_is_isomorphism `{Funext} {σ : Signature}
   {A B : Algebra σ} (f : forall s, A s -> B s) `{!IsHomomorphism f}
   : IsHProp (IsIsomorphism f).
 Proof.
-  apply trunc_forall.
+  apply istrunc_forall.
 Qed.
 
 (** The identity homomorphism. *)

--- a/theories/Analysis/Locator.v
+++ b/theories/Analysis/Locator.v
@@ -479,7 +479,7 @@ Section locator.
     Local Definition P_isHProp qeps' : IsHProp (P qeps').
     Proof.
       destruct qeps' as [q eps'].
-      apply trunc_prod.
+      apply istrunc_prod.
     Qed.
 
     Local Definition P_dec qeps' : Decidable (P qeps').

--- a/theories/Basics/Trunc.v
+++ b/theories/Basics/Trunc.v
@@ -259,11 +259,11 @@ Defined.
 (** ** Truncatedness proper. *)
 
 (** A contractible space is (-2)-truncated, by definition. This function is the identity, so there is never any need to actually use it, but it exists to be found in searches. *)
-Definition contr_trunc_minus_two `{H : IsTrunc (-2) A} : Contr A
+Definition contr_istrunc_minus_two `{H : IsTrunc (-2) A} : Contr A
   := H.
 
 (** Truncation levels are cumulative. *)
-Global Instance trunc_succ `{IsTrunc n A}
+Global Instance istrunc_succ `{IsTrunc n A}
   : IsTrunc n.+1 A | 1000.
 Proof.
   generalize dependent A.
@@ -273,7 +273,7 @@ Proof.
 Defined.
 
 (** This could be an [Instance] (with very high priority, so it doesn't get applied trivially).  However, we haven't given typeclass search any hints allowing it to solve goals like [m <= n], so it would only ever be used trivially.  *)
-Definition trunc_leq {m n} (Hmn : m <= n) `{IsTrunc m A}
+Definition istrunc_leq {m n} (Hmn : m <= n) `{IsTrunc m A}
   : IsTrunc n A.
 Proof.
   generalize dependent A; generalize dependent m.
@@ -281,35 +281,31 @@ Proof.
     intros [ | m'] Hmn A ? .
   - (* -2, -2 *) assumption.
   - (* S m', -2 *) destruct Hmn.
-  - (* -2, S n' *) apply @trunc_succ, (IH (-2)); auto.
+  - (* -2, S n' *) apply @istrunc_succ, (IH (-2)); auto.
   - (* S m', S n' *) intros x y; apply (IH m');
                      auto with typeclass_instances.
 Defined.
 
 (** In particular, a contractible type, hprop, or hset is truncated at all higher levels.  We don't allow these to be used as idmaps, since there would be no point to it. *)
 
-Definition trunc_contr {n} {A} `{Contr A} : IsTrunc n.+1 A
-  := (@trunc_leq (-2) n.+1 tt _ _).
+Definition istrunc_contr {n} {A} `{Contr A} : IsTrunc n.+1 A
+  := (@istrunc_leq (-2) n.+1 tt _ _).
 
-Definition trunc_hprop {n} {A} `{IsHProp A} : IsTrunc n.+2 A
-  := (@trunc_leq (-1) n.+2 tt _ _).
+Definition istrunc_hprop {n} {A} `{IsHProp A} : IsTrunc n.+2 A
+  := (@istrunc_leq (-1) n.+2 tt _ _).
 
-Definition trunc_hset {n} {A} `{IsHSet A}
+Definition istrunc_hset {n} {A} `{IsHSet A}
   : IsTrunc n.+3 A
-  := (@trunc_leq 0 n.+3 tt _ _).
+  := (@istrunc_leq 0 n.+3 tt _ _).
 
 (** Consider the preceding definitions as instances for typeclass search, but only if the requisite hypothesis is already a known assumption; otherwise they result in long or interminable searches. *)
-#[export]
-Hint Immediate trunc_contr : typeclass_instances.
-#[export]
-Hint Immediate trunc_hprop : typeclass_instances.
-#[export]
-Hint Immediate trunc_hset : typeclass_instances.
+#[export] Hint Immediate istrunc_contr : typeclass_instances.
+#[export] Hint Immediate istrunc_hprop : typeclass_instances.
+#[export] Hint Immediate istrunc_hset : typeclass_instances.
 
 (** Equivalence preserves truncation (this is, of course, trivial with univalence).
-   This is not an [Instance] because it causes infinite loops.
-   *)
-Definition trunc_equiv A {B} (f : A -> B)
+   This is not an [Instance] because it causes infinite loops. *)
+Definition istrunc_isequiv_istrunc A {B} (f : A -> B)
   `{IsTrunc n A} `{IsEquiv A B f}
   : IsTrunc n B.
 Proof.
@@ -321,9 +317,9 @@ Proof.
       (x = y) ((ap (f^-1))^-1) _).
 Defined.
 
-Definition trunc_equiv' A {B} (f : A <~> B) `{IsTrunc n A}
+Definition istrunc_equiv_istrunc A {B} (f : A <~> B) `{IsTrunc n A}
   : IsTrunc n B
-  := trunc_equiv A f.
+  := istrunc_isequiv_istrunc A f.
 
 (** ** Truncated morphisms *)
 

--- a/theories/Categories/Adjoint/Paths.v
+++ b/theories/Categories/Adjoint/Paths.v
@@ -39,7 +39,7 @@ Section path_adjunction.
   (** ** Adjunctions are an hSet *)
   Global Instance trunc_adjunction : IsHSet (F -| G).
   Proof.
-    eapply trunc_equiv'; [ exact equiv_sig_adjunction | ].
+    eapply istrunc_equiv_istrunc; [ exact equiv_sig_adjunction | ].
     typeclasses eauto.
   Qed.
 

--- a/theories/Categories/Category/Morphisms.v
+++ b/theories/Categories/Category/Morphisms.v
@@ -78,9 +78,9 @@ Section iso_contr.
     Defined.
 
     (** *** Being an isomorphism is a mere proposition *)
-    Global Instance trunc_isisomorphism : IsHProp (IsIsomorphism m).
+    Global Instance istrunc_isisomorphism : IsHProp (IsIsomorphism m).
     Proof.
-      eapply trunc_equiv'; [ exact issig_isisomorphism | ].
+      eapply istrunc_equiv_istrunc; [ exact issig_isisomorphism | ].
       apply hprop_allpath.
       intros [x [? ?]] [y [? ?]].
       let H := fresh in
@@ -118,7 +118,7 @@ Section iso_contr.
   (** *** Isomorphisms form an hSet *)
   Global Instance trunc_Isomorphic : IsHSet (Isomorphic s d).
   Proof.
-    eapply trunc_equiv'; [ exact issig_isomorphic | ].
+    eapply istrunc_equiv_istrunc; [ exact issig_isomorphic | ].
     typeclasses eauto.
   Qed.
 

--- a/theories/Categories/Category/Sigma/Univalent.v
+++ b/theories/Categories/Category/Sigma/Univalent.v
@@ -291,7 +291,7 @@ Section on_both.
   Proof.
     simple refine (path_sigma _ _ _ _ _); cycle 1.
     (* Speed up typeclass search: *)
-    1:pose @trunc_sigma; pose @istrunc_paths;
+    1:pose @istrunc_sigma; pose @istrunc_paths;
       simple refine (path_sigma _ _ _ _ (path_ishprop _ _)).
     all:repeat match goal with
                  | [ |- (transport ?P ?p ?z).1 = _ ] => rewrite (@ap_transport _ P _ _ _ p (fun _ x => x.1))

--- a/theories/Categories/Category/Univalent.v
+++ b/theories/Categories/Category/Univalent.v
@@ -20,7 +20,7 @@ Notation isotoid C s d := (@equiv_inv _ _ (@idtoiso C s d) _).
 Global Instance trunc_category `{IsCategory C} : IsTrunc 1 C | 10000.
 Proof.
   intros ? ?.
-  eapply trunc_equiv';
+  eapply istrunc_equiv_istrunc;
   [ symmetry;
     esplit;
     apply_hyp

--- a/theories/Categories/CategoryOfSections/Core.v
+++ b/theories/Categories/CategoryOfSections/Core.v
@@ -62,6 +62,6 @@ Global Instance isstrict_category_of_sections `{Funext}
       (F : Functor C D)
 : IsStrictCategory (category_of_sections F) | 20.
 Proof.
-  eapply trunc_equiv; [ | apply section_of_functor_sig' ].
+  eapply istrunc_isequiv_istrunc; [ | apply section_of_functor_sig' ].
   typeclasses eauto.
 Qed.

--- a/theories/Categories/ChainCategory.v
+++ b/theories/Categories/ChainCategory.v
@@ -81,7 +81,7 @@ Module Export Univalent.
   Proof.
     intros s d.
     refine (isequiv_iff_hprop _ _).
-    { refine (trunc_equiv' _ (issig_isomorphic _ _ _)); simpl; refine _. }
+    { refine (istrunc_equiv_istrunc _ (issig_isomorphic _ _ _)); simpl; refine _. }
     { intro m; apply leq_antisym; apply m. }
   Defined.
 

--- a/theories/Categories/Comma/Core.v
+++ b/theories/Categories/Comma/Core.v
@@ -81,7 +81,7 @@ Module Import CommaCategory.
            `{forall s d, IsTrunc n (morphism C s d)}
     : IsTrunc n object.
     Proof.
-      eapply trunc_equiv';
+      eapply istrunc_equiv_istrunc;
       [ exact issig_object | ].
       typeclasses eauto.
     Qed.
@@ -182,8 +182,8 @@ Module Import CommaCategory.
     Proof.
       assert (forall m1 m2,
                 IsTrunc n (a'b'f'.(f) o S _1 m1 = T _1 m2 o abf.(f)))
-        by (intros; apply (trunc_equiv _ inverse)).
-      eapply trunc_equiv';
+        by (intros; apply (istrunc_isequiv_istrunc _ inverse)).
+      eapply istrunc_equiv_istrunc;
       [ exact (issig_morphism _ _) | ].
       typeclasses eauto.
     Qed.

--- a/theories/Categories/Functor/Paths.v
+++ b/theories/Categories/Functor/Paths.v
@@ -165,7 +165,7 @@ Section path_functor.
   Global Instance trunc_functor `{IsTrunc n D} `{forall s d, IsTrunc n (morphism D s d)}
   : IsTrunc n (Functor C D).
   Proof.
-    eapply trunc_equiv'; [ exact equiv_sig_functor | ].
+    eapply istrunc_equiv_istrunc; [ exact equiv_sig_functor | ].
     induction n;
     simpl; intros;
     typeclasses eauto.

--- a/theories/Categories/GroupoidCategory/Core.v
+++ b/theories/Categories/GroupoidCategory/Core.v
@@ -18,7 +18,7 @@ Class IsGroupoid (C : PreCategory)
                     IsIsomorphism m.
 
 Global Instance trunc_isgroupoid `{Funext} C : IsHProp (IsGroupoid C)
-  := trunc_forall.
+  := istrunc_forall.
 
 (** We don't want access to all of the internals of a groupoid category at top level. *)
 Module GroupoidCategoryInternals.

--- a/theories/Categories/LaxComma/CoreParts.v
+++ b/theories/Categories/LaxComma/CoreParts.v
@@ -79,7 +79,7 @@ Module Import LaxCommaCategoryParts.
            `{forall s d, IsTrunc n (Functor (S s) (T d))}
     : IsTrunc n object.
     Proof.
-      eapply trunc_equiv';
+      eapply istrunc_equiv_istrunc;
       [ exact issig_object | ].
       typeclasses eauto.
     Qed.
@@ -152,7 +152,7 @@ Module Import LaxCommaCategoryParts.
                             (a'b'f'.(f) o p_morphism_of S m1))}
     : IsTrunc n (morphism abf a'b'f').
     Proof.
-      eapply trunc_equiv';
+      eapply istrunc_equiv_istrunc;
       [ exact (issig_morphism _ _) | ].
       typeclasses eauto.
     Qed.

--- a/theories/Categories/NaturalTransformation/Paths.v
+++ b/theories/Categories/NaturalTransformation/Paths.v
@@ -39,7 +39,7 @@ Section path_natural_transformation.
   Global Instance trunc_natural_transformation
   : IsHSet (NaturalTransformation F G).
   Proof.
-    eapply trunc_equiv'; [ exact equiv_sig_natural_transformation | ].
+    eapply istrunc_equiv_istrunc; [ exact equiv_sig_natural_transformation | ].
     typeclasses eauto.
   Qed.
 

--- a/theories/Categories/Structure/Core.v
+++ b/theories/Categories/Structure/Core.v
@@ -236,7 +236,7 @@ Section precategory.
               _
               _
               _
-              (fun s d => trunc_equiv' _ (issig_morphism P s d)));
+              (fun s d => istrunc_equiv_istrunc _ (issig_morphism P s d)));
     simpl;
     abstract (
         repeat match goal with

--- a/theories/Categories/UniversalProperties.v
+++ b/theories/Categories/UniversalProperties.v
@@ -25,8 +25,8 @@ Section UniversalMorphism.
       following dual (opposite) notions: *)
 
   Local Ltac univ_hprop_t UniversalProperty :=
-    apply @trunc_succ in UniversalProperty;
-    eapply @trunc_sigma;
+    apply @istrunc_succ in UniversalProperty;
+    eapply @istrunc_sigma;
     first [ intro;
             simpl;
             match goal with
@@ -85,7 +85,7 @@ Section UniversalMorphism.
         intro x.
         specialize (UniversalProperty (CommaCategory.b x) (CommaCategory.f x)).
         (** We want to preserve the computation rules for the morphisms, even though they're unique up to unique isomorphism. *)
-        eapply trunc_equiv'.
+        eapply istrunc_equiv_istrunc.
         - apply CommaCategory.issig_morphism.
         - apply contr_inhabited_hprop.
           + abstract univ_hprop_t UniversalProperty.

--- a/theories/Classes/implementations/binary_naturals.v
+++ b/theories/Classes/implementations/binary_naturals.v
@@ -276,7 +276,7 @@ Section semiring_laws.
 
   Global Instance binnat_set : IsHSet binnat.
   Proof.
-    apply (trunc_equiv nat binary).
+    apply (istrunc_isequiv_istrunc nat binary).
   Qed.
 
   Global Instance binnat_semiring : IsSemiRing binnat.

--- a/theories/Classes/implementations/field_of_fractions.v
+++ b/theories/Classes/implementations/field_of_fractions.v
@@ -25,7 +25,7 @@ Lemma Frac_ishset' : IsHSet Frac.
 Proof.
 assert (E : sig (fun n : R => sig (fun d : R => d <> 0 )) <~> Frac).
 - issig.
-- apply (trunc_equiv' _ E).
+- apply (istrunc_equiv_istrunc _ E).
 Qed.
 
 Global Instance Frac_ishset@{} : IsHSet Frac
@@ -266,7 +266,7 @@ Definition F_compute_path P {sP} dclass dequiv q r (E : equiv q r)
 Definition F_ind@{i} (P : F -> Type@{i}) {sP : forall x, IsHProp (P x)}
   (dclass : forall x : Frac R, P (' x)) : forall x, P x.
 Proof.
-apply (@F_rect P (fun _ => trunc_hprop) dclass).
+apply (@F_rect P (fun _ => istrunc_hprop) dclass).
 intros;apply path_ishprop.
 Qed.
 
@@ -274,7 +274,7 @@ Definition F_ind2@{i j} (P : F -> F -> Type@{i}) {sP : forall x y, IsHProp (P x 
   (dclass : forall x y : Frac R, P (' x) (' y)) : forall x y, P x y.
 Proof.
 apply (@F_ind (fun x => forall y, _)).
-- intros;apply Forall.trunc_forall@{UR i j}.
+- intros;apply Forall.istrunc_forall@{UR i j}.
 - intros x.
   apply (F_ind _);intros y.
   apply dclass.
@@ -286,7 +286,7 @@ Definition F_ind3@{i j} (P : F -> F -> F -> Type@{i})
   : forall x y z, P x y z.
 Proof.
 apply (@F_ind (fun x => forall y z, _)).
-- intros;apply Forall.trunc_forall@{UR j j}.
+- intros;apply Forall.istrunc_forall@{UR j j}.
 - intros x.
   apply (F_ind2@{i j} _). auto.
 Qed.

--- a/theories/Classes/implementations/natpair_integers.v
+++ b/theories/Classes/implementations/natpair_integers.v
@@ -44,7 +44,7 @@ Global Instance T_set : IsHSet (T N).
 Proof.
 assert (E : sig (fun _ : N => N) <~> (T N)).
 - issig.
-- apply (trunc_equiv' _ E).
+- apply (istrunc_equiv_istrunc _ E).
 Qed.
 
 Global Instance inject : Cast N (T N) := fun x => C x 0.
@@ -358,8 +358,8 @@ Definition Z_ind3@{i j} (P : Z -> Z -> Z -> Type@{i})
 Proof.
 apply (@Z_ind (fun x => forall y z, _));intros x.
 2:apply (Z_ind2@{i j} _);auto.
-apply (@Forall.trunc_forall@{UN j j} _).
-intros. apply Forall.trunc_forall@{UN i j}.
+apply (@Forall.istrunc_forall@{UN j j} _).
+intros. apply Forall.istrunc_forall@{UN i j}.
 Defined.
 
 Definition Z_rec@{i} {T : Type@{i} } {sT : IsHSet T}
@@ -802,8 +802,8 @@ split;[apply _|split;try apply _|].
     trivial.
 - apply @Z_ind2.
   + intros a b.
-    apply @trunc_prod;[|apply _].
-    apply (@trunc_arrow _).
+    apply @istrunc_prod;[|apply _].
+    apply (@istrunc_arrow _).
     apply ishprop_sum;try apply _.
     intros E1 E2;apply (irreflexivity lt a).
     transitivity b;trivial.

--- a/theories/Classes/interfaces/abstract_algebra.v
+++ b/theories/Classes/interfaces/abstract_algebra.v
@@ -322,9 +322,9 @@ Global Instance ishprop_ismonoidpreserving `{Funext} {A B : Type} `{SgOp A}
   `{SgOp B} `{IsHSet B} `{MonUnit A} `{MonUnit B} (f : A -> B)
   : IsHProp (IsMonoidPreserving f).
 Proof.
-  srapply (trunc_equiv' _ issig_IsMonoidPreserving).
-  srapply (trunc_equiv' _ (equiv_sigma_prod0 _ _)^-1).
-  srapply trunc_prod.
+  srapply (istrunc_equiv_istrunc _ issig_IsMonoidPreserving).
+  srapply (istrunc_equiv_istrunc _ (equiv_sigma_prod0 _ _)^-1).
+  srapply istrunc_prod.
   unfold IsUnitPreserving.
   exact _.
 Defined.
@@ -334,7 +334,7 @@ Global Instance ishprop_issemiringpreserving `{Funext} {A B : Type} `{IsHSet B}
   (f : A -> B)
   : IsHProp (IsSemiRingPreserving f).
 Proof.
-  snrapply (trunc_equiv' _ issig_IsSemiRingPreserving).
+  snrapply (istrunc_equiv_istrunc _ issig_IsSemiRingPreserving).
   exact _.
 Defined.
 
@@ -395,7 +395,7 @@ Proof.
   srapply contr_prod.
   all: srapply contr_paths_contr.
   all: srapply contr_inhabited_hprop.
-  all: srapply trunc_forall.
+  all: srapply istrunc_forall.
 Defined.
 
 Definition issig_isgroup w x y z : _ <~> @IsGroup w x y z := ltac:(issig).
@@ -429,7 +429,7 @@ Proof.
   srapply contr_prod.
   all: srapply contr_paths_contr.
   all: srapply contr_inhabited_hprop.
-  all: srapply trunc_forall.
+  all: srapply istrunc_forall.
 Defined.
 
 End extras.

--- a/theories/Classes/interfaces/canonical_names.v
+++ b/theories/Classes/interfaces/canonical_names.v
@@ -279,9 +279,9 @@ Global Instance trunc_sig_equiv_rel `{Funext} {A : Type}
   (R : Relation A) {n} `{!forall (x y : A), IsTrunc n (R x y)}
   :  IsTrunc n (SigEquivRel R).
 Proof.
-  apply @trunc_sigma.
-  - apply trunc_forall.
-  - intros. apply @trunc_sigma; intros; apply trunc_forall.
+  apply @istrunc_sigma.
+  - apply istrunc_forall.
+  - intros. apply @istrunc_sigma; intros; apply istrunc_forall.
 Defined.
 
 Lemma issig_equiv_rel {A:Type} (R : Relation A)
@@ -290,11 +290,11 @@ Proof.
   issig.
 Defined.
 
-Global Instance trunc_equiv_rel `{Funext} {A : Type}
+Global Instance istrunc_equiv_rel `{Funext} {A : Type}
   (R : Relation A) {n} `{!forall (x y : A), IsTrunc n (R x y)}
   : IsTrunc n (EquivRel R).
 Proof.
-  exact (trunc_equiv (SigEquivRel R) (issig_equiv_rel R)).
+  exact (istrunc_equiv_istrunc (SigEquivRel R) (issig_equiv_rel R)).
 Qed.
 
 Class Conjugate A := conj : A -> A.

--- a/theories/Classes/interfaces/ua_algebra.v
+++ b/theories/Classes/interfaces/ua_algebra.v
@@ -181,7 +181,7 @@ Global Instance hprop_is_trunc_algebra `{Funext} (n : trunc_index)
   {σ : Signature} (A : Algebra σ)
   : IsHProp (IsTruncAlgebra n A).
 Proof.
-  apply trunc_forall.
+  apply istrunc_forall.
 Qed.
 
 Global Instance trunc_algebra_succ {σ : Signature} (A : Algebra σ)

--- a/theories/Classes/interfaces/ua_congruence.v
+++ b/theories/Classes/interfaces/ua_congruence.v
@@ -38,7 +38,7 @@ Section congruence.
     `{!∀ s x y, IsTrunc n (Φ s x y)}
     : IsTrunc n OpsCompatible.
   Proof.
-    apply trunc_forall.
+    apply istrunc_forall.
   Qed.
 
   (** A family of relations [Φ] is a congruence iff it is a family of

--- a/theories/Classes/theory/ua_homomorphism.v
+++ b/theories/Classes/theory/ua_homomorphism.v
@@ -54,7 +54,7 @@ Section is_homomorphism.
     `{!IsTruncAlgebra n.+1 B}
     : IsTrunc n IsHomomorphism.
   Proof.
-    apply trunc_forall.
+    apply istrunc_forall.
   Qed.
 End is_homomorphism.
 
@@ -92,7 +92,7 @@ Global Instance trunc_homomorphism `{Funext} {σ} {A B : Algebra σ}
   {n : trunc_index} `{!IsTruncAlgebra n B}
   : IsTrunc n (Homomorphism A B).
 Proof.
-  apply (trunc_equiv _ (issig_homomorphism A B)).
+  apply (istrunc_equiv_istrunc _ (issig_homomorphism A B)).
 Qed.
 
 (** To find a path between two homomorphisms [f g : Homomorphism A B]
@@ -144,7 +144,7 @@ Global Instance hprop_is_isomorphism `{Funext} {σ : Signature}
   {A B : Algebra σ} (f : ∀ s, A s → B s) `{!IsHomomorphism f}
   : IsHProp (IsIsomorphism f).
 Proof.
-  apply trunc_forall.
+  apply istrunc_forall.
 Qed.
 
 (** Let [f : ∀ s, A s → B s] be a homomorphism. The following

--- a/theories/Classes/theory/ua_subalgebra.v
+++ b/theories/Classes/theory/ua_subalgebra.v
@@ -46,7 +46,7 @@ Section closed_under_op.
     {n} `{∀ s x, IsTrunc n (P s x)}
     : IsTrunc n IsClosedUnderOps.
   Proof.
-    apply trunc_forall.
+    apply istrunc_forall.
   Qed.
 End closed_under_op.
 
@@ -120,7 +120,7 @@ Section subalgebra.
     : IsTruncAlgebra n.+1 Subalgebra.
   Proof.
     pose proof (hprop_subalgebra_predicate A P).
-    intro s. apply @trunc_sigma.
+    intro s. apply @istrunc_sigma.
     - exact _.
     - intro. induction n; exact _.
   Qed.

--- a/theories/Colimits/Quotient.v
+++ b/theories/Colimits/Quotient.v
@@ -190,7 +190,7 @@ Section Equiv.
   Proof.
     apply Quotient_ind with dclass.
     { srapply Quotient_ind.
-      1: intro; apply trunc_succ.
+      1: intro; apply istrunc_succ.
       intros ???; apply path_ishprop. }
     intros; apply path_ishprop.
   Defined.

--- a/theories/Colimits/Sequential.v
+++ b/theories/Colimits/Sequential.v
@@ -566,15 +566,15 @@ Proof.
       * intros A trH a; srapply Colimit_ind.
         { intros m b; revert b; revert a; revert trH; revert A; induction m as [ | m IHm].
           { intros A trH a b.
-            srefine (trunc_equiv' _ (equiv_inverse (equiv_path_colim _ a b))). }
+            srefine (istrunc_equiv_istrunc _ (equiv_inverse (equiv_path_colim _ a b))). }
           { intros A trH a b.
-            srefine (trunc_equiv' _ (equiv_inverse (equiv_concat_l (glue A _ a) _))).
-            srapply (@trunc_equiv' _ _ _ k (IHm (succ_seq A) _ (@arr _ A 0%nat _ 1%path a) b)).
+            srefine (istrunc_equiv_istrunc _ (equiv_inverse (equiv_concat_l (glue A _ a) _))).
+            srapply (@istrunc_equiv_istrunc _ _ _ k (IHm (succ_seq A) _ (@arr _ A 0%nat _ 1%path a) b)).
             srapply (equiv_ap (colim_succ_seq_to_colim_seq A)). }}
         { intros n m p b; snrapply path_ishprop; snrapply ishprop_istrunc; exact _. }
       * intros A trH a; srapply (functor_forall_equiv_pb (colim_succ_seq_to_colim_seq A)).
-        intro x; srapply (@trunc_equiv' _ _ _ k (IHn (succ_seq A) _ a x)); srapply equiv_ap.
-    + intros n m p a; snrapply path_ishprop; snrapply trunc_forall.
+        intro x; srapply (@istrunc_equiv_istrunc _ _ _ k (IHn (succ_seq A) _ a x)); srapply equiv_ap.
+    + intros n m p a; snrapply path_ishprop; snrapply istrunc_forall.
       { exact _. }
       { intro x; srapply ishprop_istrunc. }
 Defined.

--- a/theories/Constant.v
+++ b/theories/Constant.v
@@ -90,7 +90,7 @@ Definition cconst_factors_contr `{Funext}  {X Y : Type} (f : X -> Y)
 Proof.
   assert (merely X -> IsHProp P).
   { apply Trunc_rec.            (** Uses funext *)
-    intros x; pose (Pc x); apply trunc_succ. }
+    intros x; pose (Pc x); apply istrunc_succ. }
   pose (g' := Trunc_ind (fun _ => P) g : merely X -> P).
   exists (h o g'); intros x.
   apply p.

--- a/theories/Cubical/DPath.v
+++ b/theories/Cubical/DPath.v
@@ -35,7 +35,7 @@ Global Instance istrunc_dp {A : Type} {P : A -> Type} {n : trunc_index}
  {a0 a1} {p : a0 = a1} {b0 : P a0} {b1 : P a1} `{IsTrunc n.+1 (P a0)}
   `{IsTrunc n.+1 (P a1)} : IsTrunc n (DPath P p b0 b1).
 Proof.
-  refine (trunc_equiv' _ dp_path_transport).
+  exact (istrunc_equiv_istrunc _ dp_path_transport).
 Defined.
 
 Definition dp_ishprop {A : Type} (P : A -> Type) {a0 a1} {p : a0 = a1}

--- a/theories/Cubical/PathSquare.v
+++ b/theories/Cubical/PathSquare.v
@@ -100,7 +100,7 @@ Global Instance istrunc_sq n
   {p0x : a00 = a01} {p1x : a10 = a11}
   : IsTrunc n (PathSquare px0 px1 p0x p1x).
 Proof.
-  srapply (trunc_equiv _ sq_path).
+  exact (istrunc_equiv_istrunc _ sq_path).
 Defined.
 
 (* We can give degenerate squares *)

--- a/theories/DProp.v
+++ b/theories/DProp.v
@@ -128,7 +128,7 @@ Definition path_dhprop `{Univalence} {P Q : DHProp}
 Global Instance ishset_dprop `{Univalence} : IsHSet DProp.
 Proof.
   intros P Q.
-  refine (trunc_equiv' _ (n := -1) (equiv_path_dprop P Q)).
+  refine (istrunc_equiv_istrunc _ (n := -1) (equiv_path_dprop P Q)).
 Defined.
 
 Global Instance isequiv_dprop_to_bool `{Univalence}

--- a/theories/Extensions.v
+++ b/theories/Extensions.v
@@ -150,7 +150,7 @@ Section Extensions.
          {A B : Type} (C : B -> Type) (f : A -> B)
   : IsHProp (ExtendableAlong n.+2 f C).
   Proof.
-    refine (trunc_equiv' _ (equiv_extendable_pathsplit n.+2 C f)^-1).
+    exact (istrunc_equiv_istrunc _ (equiv_extendable_pathsplit n.+2 C f)^-1).
   Defined.
 
   Definition equiv_extendable_isequiv `{Funext} (n : nat)
@@ -352,7 +352,7 @@ Section Extensions.
          {A B : Type} (C : B -> Type) (f : A -> B)
   : IsHProp (ooExtendableAlong f C).
   Proof.
-    refine (trunc_equiv _ (equiv_ooextendable_pathsplit C f)^-1).
+    refine (istrunc_equiv_istrunc _ (equiv_ooextendable_pathsplit C f)^-1).
   Defined.
 
   Definition equiv_ooextendable_isequiv `{Funext}

--- a/theories/Factorization.v
+++ b/theories/Factorization.v
@@ -78,7 +78,7 @@ Section Factorization.
     refine (contr_equiv' {ff' : f2 o f1 == f & ff == ff'} _).
     symmetry; srefine (equiv_functor_sigma' (equiv_sigma_contr _) _).
     { intros h; cbn.
-      srefine (@trunc_sigma _ _ _ _ _); [ | intros a];
+      srefine (@istrunc_sigma _ _ _ _ _); [ | intros a];
         apply contr_inhabited_hprop; try exact _; assumption. }
     intros [ff' [oc1' oc2']]; cbn.
     refine (equiv_functor_forall' (equiv_idmap _) _); intros a.

--- a/theories/HFiber.v
+++ b/theories/HFiber.v
@@ -201,7 +201,7 @@ Section UnstableOctahedral.
     : IsTruncMap n (g o f).
   Proof.
     intros c.
-    exact (trunc_equiv _ (hfiber_compose c)^-1).
+    exact (istrunc_isequiv_istrunc _ (hfiber_compose c)^-1).
   Defined.
 
 End UnstableOctahedral.
@@ -220,14 +220,14 @@ Global Instance istruncmap_const n {A B} `{!IsTrunc n A}
 Global Instance istruncmap_ap {A B} n (f:A -> B) `{!IsTruncMap n.+1 f}
   : forall x y, IsTruncMap n (@ap _ _ f x y)
   := fun x x' y =>
-       trunc_equiv' _ (hfiber_ap y)^-1.
+       istrunc_equiv_istrunc _ (hfiber_ap y)^-1.
 
 Definition istruncmap_from_ap {A B} n (f:A -> B) `{!forall x y, IsTruncMap n (@ap _ _ f x y)}
   : IsTruncMap n.+1 f.
 Proof.
   intros y [a p] [b q];
     destruct q;
-    exact (trunc_equiv' _ (hfiber_ap p)).
+    exact (istrunc_equiv_istrunc _ (hfiber_ap p)).
 Defined.
 
 Definition equiv_istruncmap_ap `{Funext} {A B} n (f:A -> B)
@@ -255,3 +255,5 @@ Definition equiv_isequiv_ap_isembedding `{Funext} {A B} (f : A -> B)
 Proof.
   exact (equiv_iff_hprop (@isequiv_ap_isembedding _ _ f) (@isembedding_isequiv_ap _ _ f)).
 Defined.
+
+

--- a/theories/HIT/FreeIntQuotient.v
+++ b/theories/HIT/FreeIntQuotient.v
@@ -26,7 +26,7 @@ Section FreeIntAction.
   (** Together, [R] and [f] define a fibration over [Circle].  By the flattening lemma, its total space is equivalent to the quotient. *)
   Global Instance isset_RmodZ : IsHSet RmodZ.
   Proof.
-    refine (trunc_equiv'
+    refine (istrunc_equiv_istrunc
               { z : Circle & Circle_rec Type R (path_universe f) z}
               (_ oE (@equiv_flattening _ Unit Unit idmap idmap
                                   (fun _ => R) (fun _ => f))^-1
@@ -74,7 +74,7 @@ Section FreeIntAction.
       unfold loop.
       exact (Coeq_rec_beta_cglue _ _ _ _).
     - intros xu yv.
-      refine (trunc_equiv' (n := -1) _ (equiv_path_sigma _ xu yv)).
+      refine (istrunc_equiv_istrunc (n := -1) _ (equiv_path_sigma _ xu yv)).
       destruct xu as [x u], yv as [y v]; cbn.
       apply hprop_allpath.
       intros [p r] [q s].

--- a/theories/HIT/V.v
+++ b/theories/HIT/V.v
@@ -26,8 +26,8 @@ Axiom setext : forall {A B : Type} (R : A -> B -> HProp)
   (bitot_R : bitotal R) (h : SPushout R -> V),
 set (h o (spushl R)) = set (h o (spushr R)).
 
-Axiom is0trunc_V : IsTrunc 0 V.
-Existing Instance is0trunc_V.
+Axiom ishset_V : IsHSet V.
+Existing Instance ishset_V.
 
 Fixpoint V_ind (P : V -> Type)
   (H_0trunc : forall v : V, IsTrunc 0 (P v))

--- a/theories/HProp.v
+++ b/theories/HProp.v
@@ -84,7 +84,7 @@ Proof.
   assert (f : Contr A -> A * IsHProp A).
   - intro P. split.
     + exact (@center _ P).
-    + apply @trunc_succ. exact P.
+    + apply @istrunc_succ. exact P.
   - assert (g : A * IsHProp A -> Contr A).
     + intros [a P]. apply (@contr_inhabited_hprop _ P a).
     + refine (@equiv_iff_hprop _ _ _ _ f g).

--- a/theories/HSet.v
+++ b/theories/HSet.v
@@ -40,7 +40,7 @@ Defined.
 
 Global Instance axiomK_isprop A : IsHProp (axiomK A) | 0.
 Proof.
-  apply (trunc_equiv _ equiv_hset_axiomK).
+  apply (istrunc_equiv_istrunc _ equiv_hset_axiomK).
 Defined.
 
 Theorem hset_path2 {A} `{IsHSet A} {x y : A} (p q : x = y):
@@ -59,7 +59,7 @@ Defined.
 Lemma axiomK_idpath {A} (x : A) (K : axiomK A) :
   K x (idpath x) = idpath (idpath x).
 Proof.
-  pose (T1A := @trunc_succ _ A (@hset_axiomK A K)).
+  pose (T1A := @istrunc_succ _ A (@hset_axiomK A K)).
   exact (@hset_path2 (x=x) (T1A x x) _ _ _ _).
 Defined.
 

--- a/theories/Homotopy/ClassifyingSpace.v
+++ b/theories/Homotopy/ClassifyingSpace.v
@@ -566,9 +566,9 @@ Proof.
     snrapply isequiv_contr_contr.
     { nrapply contr_equiv'.
       { apply equiv_tr.
-        nrapply trunc_contr.
+        nrapply istrunc_contr.
         apply equiv_istrunc_contr_iterated_loops.
-        snrapply trunc_leq.
+        snrapply istrunc_leq.
         1: exact 1.
         { induction n.
           1: exact tt.
@@ -578,9 +578,9 @@ Proof.
       induction n; exact _. }
     { nrapply contr_equiv'.
       { apply equiv_tr.
-        nrapply trunc_contr.
+        nrapply istrunc_contr.
         apply equiv_istrunc_contr_iterated_loops.
-        snrapply trunc_leq.
+        snrapply istrunc_leq.
         1: exact 1.
         { induction n.
           1: exact tt.

--- a/theories/Homotopy/Join.v
+++ b/theories/Homotopy/Join.v
@@ -168,7 +168,7 @@ Section Join.
     refine (Pushout_rec _ _ _ (fun _ => path_ishprop _ _)).
     - intros a; apply contr_join.  
       exact (contr_inhabited_hprop A a).
-    - intros b; refine (trunc_equiv (Join B A) (join_sym B A)).
+    - intros b; refine (istrunc_equiv_istrunc (Join B A) (join_sym B A)).
       apply contr_join.
       exact (contr_inhabited_hprop B b).
   Defined.

--- a/theories/Modalities/Lex.v
+++ b/theories/Modalities/Lex.v
@@ -172,7 +172,7 @@ Section LexModality.
     - exact _.               (** Already proven for all modalities. *)
     - refine (O_ind (fun x => forall y, IsTrunc n (x = y)) _); intros x.
       refine (O_ind (fun y => IsTrunc n (to O A x = y)) _); intros y.
-      refine (trunc_equiv _ (equiv_path_O x y)).
+      refine (istrunc_equiv_istrunc _ (equiv_path_O x y)).
   Defined.
 
 End LexModality.

--- a/theories/Modalities/Localization.v
+++ b/theories/Modalities/Localization.v
@@ -352,7 +352,7 @@ Proof.
                                  (fun A => Build_Reflects _ _ _ _)).
   - (** Typeclass inference can find this, but we give it explicitly to prevent extra universes from cropping up. *)
     intros ? T; unfold IsLocal.
-    nrefine (trunc_forall@{a i i}); try assumption.
+    nrefine (istrunc_forall@{a i i}); try assumption.
     intros i.
     apply ishprop_ooextendable@{a a i i i i i i i i i i i}.
   - apply islocal_equiv_islocal.

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -85,7 +85,7 @@ Section Subuniverse.
   Global Instance ishprop_mapinO `{Funext} {A B : Type} (f : A -> B)
   : IsHProp (MapIn O f).
   Proof.
-    apply trunc_forall.
+    apply istrunc_forall.
   Defined.
 
   (** Anything homotopic to a local map is local. *)
@@ -1529,7 +1529,7 @@ Section ConnectedMaps.
   Global Instance ishprop_isconnmap `{Funext} {A B : Type} (f : A -> B)
   : IsHProp (IsConnMap O f).
   Proof.
-    apply trunc_forall.
+    apply istrunc_forall.
   Defined.
 
   (** Connected maps are orthogonal to modal maps (i.e. familes of modal types). *)
@@ -1615,7 +1615,7 @@ Section ConnectedMaps.
   Proof.
     apply isequiv_contr_map; intros d.
     apply contr_inhabited_hprop.
-    - nrefine (@trunc_equiv' {g : forall b, P b & g oD f == d} _ _ _ _).
+    - nrefine (@istrunc_equiv_istrunc {g : forall b, P b & g oD f == d} _ _ _ _).
       { refine (equiv_functor_sigma_id _); intros g.
         apply equiv_path_forall. }
       apply hprop_allpath. intros g h.
@@ -1945,7 +1945,7 @@ Proof.
   destruct O1 as [O1 [O1h ?]]; destruct O2 as [O2 [O2h ?]]; cbn.
   refine (equiv_path_arrow _ _ oE _).
   srapply (equiv_iff_hprop).
-  - srapply trunc_sigma; unfold O_leq; exact _.
+  - srapply istrunc_sigma; unfold O_leq; exact _.
   - intros [h k] A; specialize (h A); specialize (k A); cbn in *.
     apply path_universe_uncurried, equiv_iff_hprop; assumption.
   - intros h; split; intros A e; specialize (h A); cbn in *.

--- a/theories/NullHomotopy.v
+++ b/theories/NullHomotopy.v
@@ -6,20 +6,20 @@ Local Open Scope path_scope.
 
 (** * Null homotopies of maps *)
 Section NullHomotopy.
-Context `{Funext}.
+  Context `{Funext}.
 
-(** Geometrically, a nullhomotopy of a map [f : X -> Y] is an extension of [f] to a map [Cone X -> Y].  One might more simply call it e.g. [Constant f], but that is a little ambiguous: it could also reasonably mean e.g. a factorisation of [f] through [ Trunc -1 X ].  (Should the unique map [0 -> Y] be constant in one way, or in [Y]-many ways?) *)
+  (** Geometrically, a nullhomotopy of a map [f : X -> Y] is an extension of [f] to a map [Cone X -> Y].  One might more simply call it e.g. [Constant f], but that is a little ambiguous: it could also reasonably mean e.g. a factorisation of [f] through [ Trunc -1 X ].  (Should the unique map [0 -> Y] be constant in one way, or in [Y]-many ways?) *)
 
-Definition NullHomotopy {X Y : Type} (f : X -> Y)
-  := {y : Y & forall x:X, f x = y}.
+  Definition NullHomotopy {X Y : Type} (f : X -> Y)
+    := {y : Y & forall x:X, f x = y}.
 
-Lemma istrunc_nullhomotopy {n : trunc_index}
-  {X Y : Type} (f : X -> Y) `{IsTrunc n Y}
-  : IsTrunc n (NullHomotopy f).
-Proof.
-  apply @trunc_sigma; auto.
-  intros y. apply (@trunc_forall _).
-  intros x. apply trunc_succ.
-Defined.
+  Lemma istrunc_nullhomotopy {n : trunc_index}
+    {X Y : Type} (f : X -> Y) `{IsTrunc n Y}
+    : IsTrunc n (NullHomotopy f).
+  Proof.
+    apply @istrunc_sigma; auto.
+    intros y. apply (@istrunc_forall _).
+    intros x. apply istrunc_succ.
+  Defined.
 
 End NullHomotopy.

--- a/theories/Pointed/Loops.v
+++ b/theories/Pointed/Loops.v
@@ -169,7 +169,7 @@ Defined.
 Global Instance istrunc_loops_functor {n} (A B : pType) (f : A ->* B)
   `{IsTruncMap n.+1 _ _ f} : IsTruncMap n (loops_functor f).
 Proof.
-  intro p. apply (trunc_equiv' _ (hfiber_loops_functor f p)).
+  intro p. apply (istrunc_equiv_istrunc _ (hfiber_loops_functor f p)).
 Defined.
 
 (** And likewise the connectedness.  *)

--- a/theories/PropResizing/Nat.v
+++ b/theories/PropResizing/Nat.v
@@ -212,7 +212,7 @@ Section AssumeStuff.
 
   Lemma ishprop_in_N0 (n : Graph) : IsHProp (in_N@{p} n).
   Proof.
-    apply trunc_forall.
+    apply istrunc_forall.
   Qed.
 
   Instance ishprop_in_N@{p sp} : forall n, IsHProp (in_N n)
@@ -276,7 +276,7 @@ Section AssumeStuff.
   Proof.
     intros n m.
     change (IsHProp (n = m)).
-    refine (trunc_equiv (n.1 = m.1) (equiv_path_sigma_hprop n m)).
+    refine (istrunc_equiv_istrunc (n.1 = m.1) (equiv_path_sigma_hprop n m)).
   Qed.
 
   Definition graph_zero_neq_succ@{} {A : Graph}
@@ -312,10 +312,10 @@ Section AssumeStuff.
       IsHProp ((n = graph_zero) + { m : N & n = graph_succ m.1 }).
   Proof.
     intros n. apply ishprop_sum@{p u p}.
-    - apply (@trunc_equiv' _ _ (equiv_path_inverse _ _)),ishprop_path_graph_in_N.
+    - apply (@istrunc_equiv_istrunc _ _ (equiv_path_inverse _ _)),ishprop_path_graph_in_N.
       exact zero.2.
     - apply @ishprop_sigma_disjoint.
-      + intros m;apply (@trunc_equiv' _ _ (equiv_path_inverse _ _)).
+      + intros m;apply (@istrunc_equiv_istrunc _ _ (equiv_path_inverse _ _)).
         apply ishprop_path_graph_in_N. exact ((succ m).2).
       + intros x y ex ey.
         apply succ_inj, path_N. path_via n.
@@ -399,7 +399,7 @@ Section AssumeStuff.
   Definition N_neq_succ@{} (n : N) : n <> succ n.
   Proof.
     revert n; apply N_propind@{p}.
-    - intros n;exact trunc_arrow@{p p p}.
+    - intros n;exact istrunc_arrow@{p p p}.
     - apply zero_neq_succ.
     - intros n H e.
       apply H.
@@ -640,7 +640,7 @@ Section AssumeStuff.
   Definition N_lt_irref@{} (n : N) : ~(n < n).
   Proof.
     revert n; apply N_propind@{p}.
-    - intros n;exact trunc_arrow@{p p p}.
+    - intros n;exact istrunc_arrow@{p p p}.
     - apply N_lt_zero.
     - intros n H [k K].
       apply H; exists k.
@@ -668,7 +668,7 @@ Section AssumeStuff.
   Definition N_succ_nlt@{} (n : N) : ~(succ n < n).
   Proof.
     revert n; apply N_propind@{p}.
-    - intros n;exact trunc_arrow@{p p p}.
+    - intros n;exact istrunc_arrow@{p p p}.
     - apply N_lt_zero.
     - intros n H L.
       apply H; clear H.
@@ -808,7 +808,7 @@ Section AssumeStuff.
     Lemma contr_partial_Nrec_zero0 : Contr (partial_Nrec zero).
     Proof.
       unfold partial_Nrec.
-      srefine (trunc_equiv' {f0 : {f : {m : N & m <= zero} -> X &
+      srefine (istrunc_equiv_istrunc {f0 : {f : {m : N & m <= zero} -> X &
     (f (zero_seg zero) = x0)} &
     (forall mh : {m : N & m < zero},
      f0.1 (succ_seg zero mh) =
@@ -817,7 +817,7 @@ Section AssumeStuff.
       - refine (_ oE equiv_inverse (equiv_sigma_assoc _ _)).
         apply equiv_functor_sigma_id; intros f.
         cbn; apply equiv_sigma_prod0.
-      - refine (@trunc_sigma@{nr nr large nr} _ _ _ _ _).
+      - refine (@istrunc_sigma@{nr nr large nr} _ _ _ _ _).
         + srefine (Build_Contr _ _ _).
           * exists (fun _ => x0); reflexivity.
           * intros [g H].
@@ -946,7 +946,7 @@ Section AssumeStuff.
     Proof.
       revert n; apply N_propind; try exact _.
       intros n H.
-      refine (trunc_equiv' _ (partial_Nrec_succ n)).
+      refine (istrunc_equiv_istrunc _ (partial_Nrec_succ n)).
     Qed.
 
     (** This will be useful later. *)
@@ -976,7 +976,7 @@ Section AssumeStuff.
     the types of partial attempts, which is contractible since each of
     them is.  *)
     Local Definition partials@{} := forall n, partial_Nrec n.
-    Local Instance contr_partials@{} : Contr partials := trunc_forall@{p nr nr}.
+    Local Instance contr_partials@{} : Contr partials := istrunc_forall@{p nr nr}.
 
     (** From a family of partial attempts, we get a totally defined
     recursive function. *)
@@ -1107,7 +1107,7 @@ Section AssumeStuff.
     (** And we're done! *)
     Global Instance contr_NRec@{} : Contr NRec.
     Proof.
-      refine (trunc_equiv partials partials_nrec).
+      refine (istrunc_isequiv_istrunc partials partials_nrec).
       refine (isequiv_adjointify _ nrec_partials nrec_partials_sect _).
       intros x; apply path_contr.
     Defined.

--- a/theories/PropResizing/PropResizing.v
+++ b/theories/PropResizing/PropResizing.v
@@ -14,4 +14,4 @@ Axiom equiv_resize_hprop : forall `{PropResizing} (A : Type@{i}) `{IsHProp A},
 Global Instance ishprop_resize_hprop
        `{PropResizing} (A : Type) `{IsHProp A}
   : IsHProp (resize_hprop A)
-  := trunc_equiv A (equiv_resize_hprop A).
+  := istrunc_equiv_istrunc A (equiv_resize_hprop A).

--- a/theories/Spaces/BAut.v
+++ b/theories/Spaces/BAut.v
@@ -44,7 +44,7 @@ Global Instance trunc_baut `{Univalence} {n X} `{IsTrunc n.+1 X}
 Proof.
   intros [Z p] [W q].
   strip_truncations.
-  refine (@trunc_equiv' _ _ (path_baut _ _) n.+1 _); simpl.
+  refine (@istrunc_equiv_istrunc _ _ (path_baut _ _) n.+1 _); simpl.
   symmetry in q; destruct q.
   symmetry in p; destruct p.
   exact _.

--- a/theories/Spaces/BAut/Rigid.v
+++ b/theories/Spaces/BAut/Rigid.v
@@ -29,7 +29,7 @@ Proof.
   refine (contr_change_center (point (BAut A))).
   refine (contr_trunc_conn (Tr 0)).
   intros Z W; baut_reduce.
-  refine (trunc_equiv (n := -1) (A <~> A)
+  refine (istrunc_equiv_istrunc (n := -1) (A <~> A)
                       (path_baut (point (BAut A)) (point (BAut A)))).
 Defined.
 

--- a/theories/Spaces/Card.v
+++ b/theories/Spaces/Card.v
@@ -5,7 +5,7 @@ Require Import HoTT.Classes.interfaces.abstract_algebra.
 Require Import HoTT.Truncations.
 
 (** This speeds things up considerably *)
-Local Opaque equiv_isequiv trunc_equiv.
+Local Opaque equiv_isequiv istrunc_isequiv_istrunc.
 
 (** ** Definitions and operations *)
 

--- a/theories/Spaces/Circle.v
+++ b/theories/Spaces/Circle.v
@@ -209,7 +209,7 @@ Proof.
   assert (q := merely_path_is0connected Circle base y).
   strip_truncations.
   destruct p, q.
-  refine (trunc_equiv' (n := 0) Int equiv_loopCircle_int^-1).
+  refine (istrunc_equiv_istrunc (n := 0) Int equiv_loopCircle_int^-1).
 Defined.
 
 (** ** Iteration of equivalences *)

--- a/theories/Spaces/Finite/Finite.v
+++ b/theories/Spaces/Finite/Finite.v
@@ -35,7 +35,7 @@ Defined.
 Global Instance ishprop_finite X
 : IsHProp (Finite X).
 Proof.
-  refine (trunc_equiv' _ (issig_finite X)).
+  refine (istrunc_equiv_istrunc _ (issig_finite X)).
   apply ishprop_sigma_disjoint; intros n m Hn Hm.
   strip_truncations.
   refine (nat_eq_fin_equiv n m (Hm oE Hn^-1)).

--- a/theories/Spaces/No/Core.v
+++ b/theories/Spaces/No/Core.v
@@ -903,9 +903,7 @@ Section NoCodes.
   Proof.
     revert x y.
     refine (No_ind_hprop _ _); intros L R ? xL xR xcut xHL xHR.
-    (** TODO: Why can't Coq find [trunc_arrow] here? *)
-    refine (@No_ind_hprop _ _
-              (fun y => @trunc_prod _ _ trunc_arrow _ trunc_arrow) _).
+    refine (@No_ind_hprop _ _ _ _).
     intros L' R' ? yL yR ycut yHL yHR. split.
     - intros x_le_y.
       rewrite le'_cut in x_le_y.

--- a/theories/Spaces/Spheres.v
+++ b/theories/Spaces/Spheres.v
@@ -245,13 +245,13 @@ Definition equiv_S2_TwoSphere : Sphere 2 <~> TwoSphere
 (** S0 is 0-truncated. *)
 Global Instance istrunc_s0 : IsHSet (Sphere 0).
 Proof.
-  srapply (trunc_equiv _ S0_to_Bool^-1).
+  srapply (istrunc_isequiv_istrunc _ S0_to_Bool^-1).
 Defined.
 
 (** S1 is 1-truncated. *)
 Global Instance istrunc_s1 `{Univalence} : IsTrunc 1 (Sphere 1).
 Proof.
-  srapply (trunc_equiv _ S1_to_Circle^-1).
+  srapply (istrunc_isequiv_istrunc _ S1_to_Circle^-1).
 Defined.
 
 Global Instance isconnected_sn n : IsConnected n.+1 (Sphere n.+2).
@@ -278,7 +278,7 @@ Proof.
     apply allnullhomot_trunc; auto with typeclass_instances.
 Defined.
 
-Fixpoint trunc_allnullhomot {n : trunc_index} {X : Type}
+Fixpoint istrunc_allnullhomot {n : trunc_index} {X : Type}
   (HX : forall (f : Sphere n.+2 -> X), NullHomotopy f) {struct n}
 : IsTrunc n.+1 X.
 Proof.
@@ -287,6 +287,6 @@ Proof.
     intros x0 x1. set (f := (fun b => if (S0_to_Bool b) then x0 else x1)).
     set (n := HX f). exact (n.2 North @ (n.2 South)^).
   - (* n ≥ -1 *) intros x0 x1.
-    apply (trunc_allnullhomot n').
+    apply (istrunc_allnullhomot n').
     intro f. apply nullhomot_paths_from_susp, HX.
 Defined.

--- a/theories/Spaces/Torus/TorusHomotopy.v
+++ b/theories/Spaces/Torus/TorusHomotopy.v
@@ -17,7 +17,7 @@ Local Open Scope pointed_scope.
 
 Global Instance is1type_Torus `{Univalence} : IsTrunc 1 Torus.
 Proof.
-  refine (trunc_equiv _ equiv_torus_prod_Circle^-1).
+  refine (istrunc_equiv_istrunc _ equiv_torus_prod_Circle^-1).
 Qed.
 
 (** The torus is 0-connected *)

--- a/theories/TruncType.v
+++ b/theories/TruncType.v
@@ -98,7 +98,7 @@ Section TruncType.
     : IsTrunc n.+1 (TruncType n) | 0.
   Proof.
     intros A B.
-    refine (trunc_equiv _ (equiv_path_trunctype@{i j} A B)).
+    refine (istrunc_equiv_istrunc _ (equiv_path_trunctype@{i j} A B)).
     case n as [ | n'].
     - apply contr_equiv_contr_contr. (* The reason is different in this case. *)
     - apply istrunc_equiv.
@@ -109,7 +109,7 @@ Section TruncType.
   Global Instance istrunc_sig_istrunc : forall n, IsTrunc n.+1 (sig (IsTrunc n)) | 0.
   Proof.
     intro n.
-    apply (trunc_equiv' _ issig_trunctype^-1).
+    apply (istrunc_equiv_istrunc _ issig_trunctype^-1).
   Defined.
 
   (** ** Some standard inhabitants *)

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -50,7 +50,7 @@ Proof.
   - exists (extension_conn_map_elim n f P d).
     intros y. apply (allpath_extension_conn_map n); assumption.
     (* m = S m' *)
-  - intros e e'. refine (trunc_equiv _ (path_extension e e')).
+  - intros e e'. refine (istrunc_isequiv_istrunc _ (path_extension e e')).
 (* magically infers: paths in extensions = extensions into paths,
                        which by induction is m'-truncated. *)
 Defined.

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -54,7 +54,7 @@ Definition Trunc_rec {n A X} `{IsTrunc n X}
 Definition Tr (n : trunc_index) : Modality.
 Proof.
   srapply (Build_Modality (IsTrunc n)).
-  - intros A B ? f ?; apply (trunc_equiv A f).
+  - intros A B ? f ?; apply (istrunc_isequiv_istrunc A f).
   - exact (Trunc n).
   - intros; apply istrunc_truncation.
   - intros A; apply tr.
@@ -240,7 +240,7 @@ Proof.
       exact (fun x => tr (tr x)). }
     { srapply Trunc_rec.
       srapply Trunc_rec.
-      1: srapply trunc_leq.
+      1: srapply istrunc_leq.
       exact tr. }
     { srapply Trunc_ind.
       simpl.
@@ -248,7 +248,7 @@ Proof.
       2: reflexivity.
       intro.
       apply istrunc_paths.
-      srapply (trunc_leq (m:=n)).
+      srapply (istrunc_leq (m:=n)).
       by apply trunc_index_leq_succ'. }
     srapply Trunc_ind; reflexivity.
   + set (min := trunc_index_min n m).
@@ -257,7 +257,7 @@ Proof.
     unfold min; clear min.
     symmetry.
     srapply equiv_tr.
-    srapply trunc_leq.
+    srapply istrunc_leq.
     3:{ (** Strangely, if [istrunc_inO_tr] were a [Hint Immediate], rather than our [Hint Extern], then typeclass inference would be able to find this all on its own, although the documentation for [Hint Immediate] suggests that it shouldn't because the following tactic doesn't solve it completely. *)
         simple apply istrunc_inO_tr; trivial.
         exact _. }

--- a/theories/Types/Arrow.v
+++ b/theories/Types/Arrow.v
@@ -176,11 +176,11 @@ Definition ap_functor_arrow `(f : B -> A) `(g : C -> D)
 
 Global Instance contr_arrow {A B : Type} `{Contr B}
   : Contr (A -> B) | 100
-:= contr_forall.
+  := contr_forall.
 
-Global Instance trunc_arrow {A B : Type} `{IsTrunc n B}
+Global Instance istrunc_arrow {A B : Type} `{IsTrunc n B}
   : IsTrunc n (A -> B) | 100
-:= trunc_forall.
+  := istrunc_forall.
 
 (** ** Equivalences *)
 

--- a/theories/Types/Equiv.v
+++ b/theories/Types/Equiv.v
@@ -114,7 +114,7 @@ Section AssumeFunext.
   : IsTrunc n.+1 (A <~> B).
   Proof.
     simpl. intros e1 e2.
-    apply (trunc_equiv _ (equiv_path_equiv e1 e2)).
+    apply (istrunc_equiv_istrunc _ (equiv_path_equiv e1 e2)).
   Defined.
 
   (** In the contractible case, we have to assume that *both* types are contractible to get a contractible type of equivalences. *)
@@ -189,5 +189,4 @@ Section AssumeFunext.
 End AssumeFunext.
 
 (** We make this a global hint outside of the section. *)
-#[export]
-Hint Immediate isequiv_contr_map : typeclass_instances.
+#[export] Hint Immediate isequiv_contr_map : typeclass_instances.

--- a/theories/Types/Forall.v
+++ b/theories/Types/Forall.v
@@ -346,7 +346,7 @@ Proof.
   intro f.  apply path_forall.  intro a.  apply contr.
 Defined.
 
-Global Instance trunc_forall `{P : A -> Type} `{forall a, IsTrunc n (P a)}
+Global Instance istrunc_forall `{P : A -> Type} `{forall a, IsTrunc n (P a)}
   : IsTrunc n (forall a, P a) | 100.
 Proof.
   generalize dependent P.
@@ -354,7 +354,7 @@ Proof.
   (* case [n = -2], i.e. contractibility *)
   - exact _.
   (* case n = n'.+1 *)
-  - intros f g; apply (trunc_equiv _ (apD10 ^-1)).
+  - intros f g; apply (istrunc_isequiv_istrunc _ (apD10 ^-1)).
 Defined.
 
 (** ** Contractibility: A product over a contractible type is equivalent to the fiber over the center. *)

--- a/theories/Types/Prod.v
+++ b/theories/Types/Prod.v
@@ -358,18 +358,18 @@ Definition equiv_prod_coind `(A : X -> Type) (B : X -> Type)
 
 (** ** Products preserve truncation *)
 
-Global Instance trunc_prod `{IsTrunc n A} `{IsTrunc n B} : IsTrunc n (A * B) | 100.
+Global Instance istrunc_prod `{IsTrunc n A} `{IsTrunc n B} : IsTrunc n (A * B) | 100.
 Proof.
   generalize dependent B; generalize dependent A.
   simple_induction n n IH; simpl; (intros A ? B ?).
   { exists (center A, center B).
     intros z; apply path_prod; apply contr. }
-  { intros x y.
-    exact (trunc_equiv _ (equiv_path_prod x y)). }
+  intros x y.
+  exact (istrunc_equiv_istrunc _ (equiv_path_prod x y)).
 Defined.
 
 Global Instance contr_prod `{CA : Contr A} `{CB : Contr B} : Contr (A * B) | 100
-  := @trunc_prod (-2) A CA B CB.
+  := @istrunc_prod (-2) A CA B CB.
 
 (** ** Decidability *)
 
@@ -415,4 +415,4 @@ Defined.
 Global Instance istruncmap_functor_prod (n : trunc_index) {A B C D : Type}
   (f : A -> B) (g : C -> D) `{!IsTruncMap n f} `{!IsTruncMap n g}
   : IsTruncMap n (Prod.functor_prod f g)
-  := fun y =>  trunc_equiv _ (hfiber_functor_prod _ _ _)^-1.
+  := fun y => istrunc_equiv_istrunc _ (hfiber_functor_prod _ _ _)^-1.

--- a/theories/Types/Sigma.v
+++ b/theories/Types/Sigma.v
@@ -590,7 +590,7 @@ Definition equiv_sig_coind
 
 (** ** Sigmas preserve truncation *)
 
-Global Instance trunc_sigma `{P : A -> Type}
+Global Instance istrunc_sigma `{P : A -> Type}
          `{IsTrunc n A} `{forall a, IsTrunc n (P a)}
 : IsTrunc n (sig P) | 100.
 Proof.
@@ -599,8 +599,8 @@ Proof.
   { exists (center A; center (P (center A))).
     intros [a ?].
     refine (path_sigma' P (contr a) (path_contr _ _)). }
-  { intros u v.
-    refine (trunc_equiv _ (path_sigma_uncurried P u v)). }
+  intros u v.
+  refine (istrunc_isequiv_istrunc _ (path_sigma_uncurried P u v)).
 Defined.
 
 (** The sigma of an arbitrary family of *disjoint* hprops is an hprop. *)
@@ -732,7 +732,7 @@ Global Instance istruncmap_functor_sigma n {A B P Q}
   : IsTruncMap n (functor_sigma f g).
 Proof.
   intros [a b].
-  exact (trunc_equiv _ (hfiber_functor_sigma _ _ _ _ _ _)^-1).
+  exact (istrunc_equiv_istrunc _ (hfiber_functor_sigma _ _ _ _ _ _)^-1).
 Defined.
 
 (** Theorem 4.7.6 *)
@@ -754,5 +754,5 @@ Definition istruncmap_from_functor_sigma n {A P Q}
   : forall a, IsTruncMap n (g a).
 Proof.
   intros a v.
-  exact (trunc_equiv' _ (hfiber_functor_sigma_idmap _ _ _ _ _)).
+  exact (istrunc_equiv_istrunc _ (hfiber_functor_sigma_idmap _ _ _ _ _)).
 Defined.

--- a/theories/Types/Sum.v
+++ b/theories/Types/Sum.v
@@ -118,10 +118,10 @@ Global Instance ishprop_hfiber_inl {A B : Type} (z : A + B)
 : IsHProp (hfiber inl z).
 Proof.
   destruct z as [a|b]; unfold hfiber.
-  - refine (trunc_equiv' _
+  - refine (istrunc_equiv_istrunc _
               (equiv_functor_sigma_id
                  (fun x => equiv_path_sum (inl x) (inl a)))).
-  - refine (trunc_equiv _
+  - refine (istrunc_isequiv_istrunc _
               (fun xp => inl_ne_inr (xp.1) b xp.2)^-1).
 Defined.
 
@@ -140,9 +140,9 @@ Global Instance ishprop_hfiber_inr {A B : Type} (z : A + B)
 : IsHProp (hfiber inr z).
 Proof.
   destruct z as [a|b]; unfold hfiber.
-  - refine (trunc_equiv _
+  - refine (istrunc_isequiv_istrunc _
               (fun xp => inr_ne_inl (xp.1) a xp.2)^-1).
-  - refine (trunc_equiv' _
+  - refine (istrunc_equiv_istrunc _
               (equiv_functor_sigma_id
                  (fun x => equiv_path_sum (inr x) (inr b)))).
 Defined.
@@ -904,20 +904,20 @@ Definition equiv_sum_distributive `{Funext} (A B C : Type)
 
 (** ** Sums preserve most truncation *)
 
-Global Instance trunc_sum n' (n := n'.+2)
+Global Instance istrunc_sum n' (n := n'.+2)
          `{IsTrunc n A, IsTrunc n B}
 : IsTrunc n (A + B) | 100.
 Proof.
   intros a b.
-  eapply trunc_equiv';
+  eapply istrunc_equiv_istrunc;
     [ exact (equiv_path_sum _ _) | ].
   destruct a, b; simpl in *;
   try typeclasses eauto;
   intros [].
 Defined.
 
-Global Instance hset_sum `{HA : IsHSet A, HB : IsHSet B} : IsHSet (A + B) | 100
-  := @trunc_sum (-2) A HA B HB.
+Global Instance ishset_sum `{HA : IsHSet A, HB : IsHSet B} : IsHSet (A + B) | 100
+  := @istrunc_sum (-2) A HA B HB.
 
 (** Sums don't preserve hprops in general, but they do for disjoint sums. *)
 
@@ -1014,7 +1014,7 @@ Global Instance isequiv_sum_of_sig A B : IsEquiv (sum_of_sig A B)
 Definition trunc_sum' n A B `{IsTrunc n Bool, IsTrunc n A, IsTrunc n B}
 : (IsTrunc n (A + B)).
 Proof.
-  eapply trunc_equiv'; [ esplit;
+  eapply istrunc_equiv_istrunc; [ esplit;
                          exact (@isequiv_sum_of_sig _ _)
                        | ].
   typeclasses eauto.

--- a/theories/Types/Universe.v
+++ b/theories/Types/Universe.v
@@ -520,7 +520,7 @@ Global Instance istrunc_paths_Type `{Funext}
        {n : trunc_index} {A B : Type} `{IsTrunc n.+1 B}
 : IsTrunc n.+1 (A = B).
 Proof.
-  refine (trunc_equiv _ path_universe_uncurried).
+  refine (istrunc_isequiv_istrunc _ path_universe_uncurried).
 Defined.
 
 (** We can also say easily that the universe is not a set. *)

--- a/theories/Types/Wtype.v
+++ b/theories/Types/Wtype.v
@@ -77,11 +77,12 @@ Global Instance trunc_wtype `{Funext} `{B : A -> Type}
 : IsTrunc n.+1 (W A B) | 100.
 Proof.
   generalize dependent A; intros A B ac; intros z; induction z as [a w].
-  intro y; destruct y as [a0 w0]; refine (trunc_equiv _ (equiv_path_wtype _ _)).
-  apply (trunc_equiv' {p : a = a0 & forall b, w b = w0 (p # b)}).
+  intro y; destruct y as [a0 w0];
+    refine (istrunc_equiv_istrunc _ (equiv_path_wtype _ _)).
+  apply (istrunc_equiv_istrunc {p : a = a0 & forall b, w b = w0 (p # b)}).
   { transitivity {p : a = a0 & transport (fun a => B a -> W A B) p w = w0}.
     { apply equiv_functor_sigma_id; intro p; induction p.
       by apply equiv_path_forall. }
     by rapply (equiv_path_sigma _ (a;w) (a0;w0)). }
-  apply (@trunc_sigma _ _ _ (ac a a0)); intro p; rapply @trunc_forall.
+  apply (@istrunc_sigma _ _ _ (ac a a0)); intro p; rapply @istrunc_forall.
 Defined.


### PR DESCRIPTION
I've tried my best to standardise the `trunc_*` lemmas. I may have missed a few, but I guess we can change them when we come across them. They should now be `istrunc_*`.

 * In `Types/` you will find the obvious changes like `trunc_forall` to `istrunc_forall` for each type.
 * We change `trunc_equiv` to `istrunc_isequiv_istrunc` and `trunc_equiv'` to `istrunc_equiv_istrunc`. This is how the corresponding modality lemma is named, as mentioned in #1226.
 * In renaming `trunc_equiv` I have occasionally swapped which lemma is being used, this ought to save some typeclass search.

closes #1226