### PR TITLE
Lagrange's theorem

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -395,6 +395,8 @@ theories/Algebra/Groups/FreeProduct.v
 theories/Algebra/Groups/GroupCoeq.v
 theories/Algebra/Groups/Presentation.v
 theories/Algebra/Groups/ShortExactSequence.v
+theories/Algebra/Groups/Lagrange.v
+
 
 theories/Algebra/Groups/FreeGroup.v
 

--- a/theories/Algebra/Groups.v
+++ b/theories/Algebra/Groups.v
@@ -8,6 +8,7 @@ Require Export HoTT.Algebra.Groups.Kernel.
 Require Export HoTT.Algebra.Groups.GrpPullback.
 Require Export HoTT.Algebra.Groups.FreeGroup.
 Require Export HoTT.Algebra.Groups.ShortExactSequence.
+Require Export HoTT.Algebra.Groups.Lagrange.
 
 (** Examples *)
 

--- a/theories/Algebra/Groups/Lagrange.v
+++ b/theories/Algebra/Groups/Lagrange.v
@@ -22,7 +22,7 @@ Proof.
   apply dec_H.
 Defined.
 
-(** Given a finite group G and a finite subgroup H of G, the order of H divides the order G. Note that constructively, a subgroup of a finite group cannot be shown to be finite without exlcluded middle. We therefore have to assume it is. This in turn implies that the subgroup is decidable. *)
+(** Given a finite group G and a finite subgroup H of G, the order of H divides the order of G. Note that constructively, a subgroup of a finite group cannot be shown to be finite without exlcluded middle. We therefore have to assume it is. This in turn implies that the subgroup is decidable. *)
 Theorem lagrange {U : Univalence} (G : Group) (H : Subgroup G)
   (fin_G : Finite G) (fin_H : Finite H)
   : exists d, d * (fcard H) = fcard G.
@@ -44,7 +44,7 @@ Proof.
   exact _.
 Defined.
 
-Corollary lagrange_noraml {U : Univalence} (G : Group) (H : NormalSubgroup G)
+Corollary lagrange_normal {U : Univalence} (G : Group) (H : NormalSubgroup G)
   (fin_G : Finite G) (fin_H : Finite H)
   : fcard (QuotientGroup G H) * fcard H = fcard G.
 Proof.

--- a/theories/Algebra/Groups/Lagrange.v
+++ b/theories/Algebra/Groups/Lagrange.v
@@ -1,0 +1,52 @@
+Require Import Basics Types.
+Require Import Algebra.Groups.Group.
+Require Import Algebra.Groups.Subgroup.
+Require Import Algebra.Groups.QuotientGroup.
+Require Import Spaces.Finite.
+Require Import Spaces.Nat.
+Require Import Colimits.Quotient.
+
+(** ** Lagrange's theorem *)
+
+Local Open Scope nat_scope.
+
+Definition subgroup_index {U : Univalence} (G : Group) (H : Subgroup G)
+  (fin_G : Finite G) (fin_H : Finite H)
+  : nat.
+Proof.
+  refine (fcard (Quotient (in_cosetL H))).
+  nrapply finite_quotient.
+  1-6: exact _.
+  intros x y.
+  pose (dec_H := detachable_finite_subset H).
+  apply dec_H.
+Defined.
+
+(** Given a finite group G and a finite subgroup H of G, the order of H divides the order G. Note that constructively, a subgroup of a finite group cannot be shown to be finite without exlcluded middle. We therefore have to assume it is. This in turn implies that the subgroup is decidable. *)
+Theorem lagrange {U : Univalence} (G : Group) (H : Subgroup G)
+  (fin_G : Finite G) (fin_H : Finite H)
+  : exists d, d * (fcard H) = fcard G.
+Proof.
+  exists (subgroup_index G H _ _).
+  symmetry.
+  refine (fcard_quotient (in_cosetL H) @ _).
+  refine (_ @ finplus_const _ _).
+  apply ap, path_forall.
+  srapply Quotient_ind_hprop.
+  simpl. (** simpl is better than cbn here *)
+  intros x.
+  apply fcard_equiv'.
+  (** Now we must show that cosets are all equivalent as types. *)
+  simpl.
+  snrapply equiv_functor_sigma.
+  2: apply (isequiv_group_left_op (-x)).
+  1: hnf; trivial.
+  exact _.
+Defined.
+
+Corollary lagrange_noraml {U : Univalence} (G : Group) (H : NormalSubgroup G)
+  (fin_G : Finite G) (fin_H : Finite H)
+  : fcard (QuotientGroup G H) * fcard H = fcard G.
+Proof.
+  apply lagrange.
+Defined.

--- a/theories/Algebra/Groups/Lagrange.v
+++ b/theories/Algebra/Groups/Lagrange.v
@@ -16,7 +16,7 @@ Definition subgroup_index {U : Univalence} (G : Group) (H : Subgroup G)
 Proof.
   refine (fcard (Quotient (in_cosetL H))).
   nrapply finite_quotient.
-  1-6: exact _.
+  1-5: exact _.
   intros x y.
   pose (dec_H := detachable_finite_subset H).
   apply dec_H.

--- a/theories/Algebra/Groups/QuotientGroup.v
+++ b/theories/Algebra/Groups/QuotientGroup.v
@@ -1,12 +1,12 @@
 Require Import HoTT.Basics HoTT.Types.
-Require Import HSet.
+Require Import Algebra.Congruence.
 Require Import Algebra.Groups.Group.
 Require Import Algebra.Groups.Subgroup.
-Require Import Algebra.Congruence.
-Require Export Colimits.Quotient.
 Require Export Algebra.Groups.Image.
 Require Export Algebra.Groups.Kernel.
+Require Export Colimits.Quotient.
 Require Import HSet.
+Require Import Spaces.Finite.
 Require Import WildCat.
 
 (** * Quotient groups *)
@@ -16,8 +16,8 @@ Local Open Scope mc_mult_scope.
 Section GroupCongruenceQuotient.
 
   Context {G : Group} {R : Relation G}
-    `{is_mere_relation _ R} `{!IsCongruence R} (* Congruence just means respects op *)
-    `{!Reflexive R} `{!Symmetric R} `{!Transitive R}.
+    `{is_mere_relation _ R, !IsCongruence R,
+      !Reflexive R, !Symmetric R, !Transitive R}.
 
   Definition CongruenceQuotient := G / R.
 
@@ -252,3 +252,16 @@ Section FirstIso.
   Defined.
 
 End FirstIso.
+
+(** Quotient groups are finite. *)
+(** Note that we cannot constructively conclude that the normal subgroup [H] must be finite since [G] is, therefore we keep it as an assumption. *)
+Global Instance finite_quotientgroup {U : Univalence} (G : Group) (H : NormalSubgroup G)
+  (fin_G : Finite G) (fin_H : Finite H)
+  : Finite (QuotientGroup G H).
+Proof.
+  nrapply finite_quotient.
+  1-6: exact _.
+  intros x y.
+  pose (dec_H := detachable_finite_subset H).
+  apply dec_H.
+Defined.

--- a/theories/Algebra/Groups/QuotientGroup.v
+++ b/theories/Algebra/Groups/QuotientGroup.v
@@ -260,7 +260,7 @@ Global Instance finite_quotientgroup {U : Univalence} (G : Group) (H : NormalSub
   : Finite (QuotientGroup G H).
 Proof.
   nrapply finite_quotient.
-  1-6: exact _.
+  1-5: exact _.
   intros x y.
   pose (dec_H := detachable_finite_subset H).
   apply dec_H.


### PR DESCRIPTION
It's a bit annoying that subgroups of finite groups cannot be shown to be finite in general. As I understand, if we could show them to be, then the subgroups would end up being decidable.

Of course, under LEM every subgroup becomes decidable, but I think this is an even more unreasonable assumption to carry around then just asking for a subgroup to be finite.