### PR TITLE
Clean up natural number library

### DIFF
--- a/theories/Algebra/Universal/Operation.v
+++ b/theories/Algebra/Universal/Operation.v
@@ -15,6 +15,8 @@ Require Import
 
 Import notations_algebra.
 
+Local Open Scope nat_scope.
+
 (** Functions [head_dom'] and [head_dom] are used to get the first
     element of a nonempty operation domain [a : forall i, A (ss i)]. *)
 
@@ -22,14 +24,14 @@ Monomorphic Definition head_dom' {σ} (A : Carriers σ) (n : nat)
   : forall (N : n > 0) (ss : FinSeq n (Sort σ)) (a : forall i, A (ss i)),
     A (fshead' n N ss)
   := match n with
-     | 0 => fun N ss _ => Empty_rec N
+     | 0 => fun N ss _ => Empty_rec (not_lt_n_n _ N)
      | n'.+1 => fun N ss a => a fin_zero
      end.
 
 Monomorphic Definition head_dom {σ} (A : Carriers σ) {n : nat}
   (ss : FinSeq n.+1 (Sort σ)) (a : forall i, A (ss i))
   : A (fshead ss)
-  := head_dom' A n.+1 tt ss a.
+  := head_dom' A n.+1 _ ss a.
 
 (** Functions [tail_dom'] and [tail_dom] are used to obtain the tail
     of an operation domain [a : forall i, A (ss i)]. *)
@@ -57,14 +59,14 @@ Monomorphic Definition cons_dom' {σ} (A : Carriers σ) {n : nat}
       (fun n i =>
         forall (ss : Fin n -> Sort σ) (N : n > 0),
         A (fshead' n N ss) -> (forall i, A (fstail' n ss i)) -> A (ss i))
-      (fun n' => fun _ z => match z with tt => fun x _ => x end)
+      (fun n' _ z x _ => x)
       (fun n' i' _ => fun _ _ _ xs => xs i').
 
 Definition cons_dom {σ} (A : Carriers σ)
   {n : nat} (ss : FinSeq n.+1 (Sort σ))
   (x : A (fshead ss)) (xs : forall i, A (fstail ss i))
   : forall i : Fin n.+1, A (ss i)
-  := fun i => cons_dom' A i ss tt x xs.
+  := fun i => cons_dom' A i ss _ x xs.
 
 (** The empty domain: *)
 
@@ -159,7 +161,7 @@ Proof.
   induction i using fin_ind; intros ss N a.
   - unfold cons_dom'.
     rewrite compute_fin_ind_fin_zero.
-    by destruct N.
+    reflexivity.
   - unfold cons_dom'.
     by rewrite compute_fin_ind_fsucc.
 Qed.

--- a/theories/Basics/Datatypes.v
+++ b/theories/Basics/Datatypes.v
@@ -79,22 +79,6 @@ Definition iff (A B : Type) := prod (A -> B) (B -> A).
 
 Notation "A <-> B" := (iff A B) : type_scope.
 
-(* Natural numbers. *)
-
-Inductive nat : Type :=
-  | O : nat
-  | S : nat -> nat.
-
-Scheme nat_rect := Induction for nat Sort Type.
-
-(* It would be nice not to need this, but the tactic [induction] requires it when the target is in [Set], and the above definition of [nat] puts it in [Set]. *)
-Scheme nat_rec := Induction for nat Sort Set.
-
-Declare Scope nat_scope.
-Delimit Scope nat_scope with nat.
-Bind Scope nat_scope with nat.
-Arguments S _%nat.
-
 (** Another way of interpreting booleans as propositions *)
 
 (* Definition is_true b := b = true. *)

--- a/theories/Basics/Nat.v
+++ b/theories/Basics/Nat.v
@@ -1,5 +1,12 @@
 Require Import Basics.Overture Basics.Decimal Basics.Hexadecimal Basics.Numeral.
 
+Notation "n .+1" := (S n) : nat_scope.
+Notation "n .+2" := (n.+1.+1)%nat   : nat_scope.
+Notation "n .+3" := (n.+1.+2)%nat   : nat_scope.
+Notation "n .+4" := (n.+1.+3)%nat   : nat_scope.
+Notation "n .+5" := (n.+1.+4)%nat   : nat_scope.
+
+
 (** ** Tail-recursive versions of [add] and [mul] *)
 
 Fixpoint tail_add n m :=

--- a/theories/Basics/Tactics.v
+++ b/theories/Basics/Tactics.v
@@ -1,4 +1,5 @@
-Require Import Basics.Overture.
+Require Import Basics.Overture Basics.Nat.
+
 
 (** TODO: Clean up *)
 (** This module implements various tactics used to simplify the goals produced by Program,

--- a/theories/BoundedSearch.v
+++ b/theories/BoundedSearch.v
@@ -10,13 +10,11 @@ Section bounded_search.
           {P_hprop : forall n, IsHProp (P n)}
           (P_dec : forall n, Decidable (P n))
           (P_inhab : hexists (fun n => P n)).
-  (** We reopen these scopes so they take precedence over nat_scope; otherwise, now that we have [Coq.Init.Peano], we'd get [* : nat -> nat -> nat] rather than [* : Type -> Type -> Type]. *)
-  Global Open Scope type_scope.
-  Global Open Scope core_scope.
-
-  (** But in this file, we want to be able to use the usual symbols for natural number arithmetic. *)
+  
+  (** We open type_scope again after nat_scope in order to use the product type notation. *)
   Local Open Scope nat_scope.
-
+  Local Open Scope type_scope.
+  
   Local Definition minimal (n : nat) : Type := forall m : nat, P m -> n <= m.
   Local Definition ishprop_minimal (n : nat) : IsHProp (minimal n).
   Proof.
@@ -42,9 +40,7 @@ Section bounded_search.
     induction k as [l [[p m] z]].
     exists l.
     repeat split; try assumption.
-    refine (leq_trans _ _ _ _ _).
-    - exact z.
-    - apply leqnSn.
+    exact _.
   Qed.
 
   Local Definition bounded_search (n : nat) : smaller n + forall l : nat, (l <= n) -> not (P l).
@@ -54,15 +50,10 @@ Section bounded_search.
       induction X as [h|].
       + left.
         refine (0;(h,_,_)).
-        * intros ? ?. apply leq0n.
-        * reflexivity.
+        * intros ? ?. exact _.
       + right.
         intros l lleq0.
-        assert (l0 : l = 0).
-        {
-          apply leq_antisym; try assumption.
-          apply leq0n.
-        }
+        assert (l0 : l = 0) by rapply leq_antisym.
         rewrite l0; assumption.
     - induction IHn as [|n0].
       + left. apply smaller_S. assumption.
@@ -71,22 +62,18 @@ Section bounded_search.
         * left.
           refine (n.+1;(h,_,_)).
           -- intros m pm.
-             assert ((n.+1 <= m)+(n.+1>m))%type as X by apply leqdichot.
+             assert ((n.+1 <= m)+(n.+1>m))%type as X by apply leq_dichot.
              destruct X as [leqSnm|ltmSn].
              ++ assumption.
-             ++ unfold lt in ltmSn.
-                assert (m <= n) as X by assumption.
+             ++ unfold gt, lt in ltmSn.
+                assert (m <= n) as X by rapply leq_S_n.
                 destruct (n0 m X pm).
-          -- apply leq_refl.
         * right. intros l q.
-          assert ((l <= n) + (l > n)) as X by apply leqdichot.
+          assert ((l <= n) + (l > n)) as X by apply leq_dichot.
           induction X as [h|h].
           -- exact (n0 l h).
           -- unfold lt in h.
-             assert (eqlSn : l = n.+1).
-             {
-               apply leq_antisym; assumption.
-             }
+             assert (eqlSn : l = n.+1) by (apply leq_antisym; assumption).
              rewrite eqlSn; assumption.
   Qed.
 

--- a/theories/Categories/ChainCategory.v
+++ b/theories/Categories/ChainCategory.v
@@ -9,6 +9,8 @@ Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
 
+Local Open Scope nat_scope.
+
 (** ** Definitions *)
 (** Quoting Wikipedia (http://en.wikipedia.org/wiki/Total_order##Chains):
 
@@ -31,7 +33,7 @@ Module Export Core.
          nat
          leq
          leq_refl
-         (fun x y z p q => leq_trans _ _ _ q p)
+         (fun x y z p q => leq_trans q p)
          (fun _ _ _ _ _ _ _ => path_ishprop _ _)
          (fun _ _ _ => path_ishprop _ _)
          (fun _ _ _ => path_ishprop _ _)

--- a/theories/Classes/implementations/ne_list.v
+++ b/theories/Classes/implementations/ne_list.v
@@ -4,6 +4,9 @@ Require Import
   HoTT.Basics.Overture
   HoTT.Spaces.Nat.
 
+Local Open Scope nat_scope.
+Local Open Scope type_scope.
+
 Declare Scope ne_list_scope.
 
 Delimit Scope ne_list_scope with ne_list.
@@ -119,7 +122,7 @@ Fixpoint tails {T} (l: ne_list T): ne_list (ne_list T) :=
 
 Lemma tails_are_shorter {T} (y x: ne_list T):
   InList x (to_list (tails y)) →
-  le' (length (to_list x)) (length (to_list y)).
+  leq (length (to_list x)) (length (to_list y)).
 Proof with auto.
  induction y; cbn.
  - intros [[] | C].

--- a/theories/Classes/implementations/peano_naturals.v
+++ b/theories/Classes/implementations/peano_naturals.v
@@ -8,6 +8,9 @@ Require Import
   HoTT.Classes.orders.semirings
   HoTT.Classes.theory.apartness.
 
+Local Open Scope nat_scope.
+Local Open Scope mc_scope.
+
 Local Set Universe Minimization ToSet.
 
 (* This should go away one Coq has universe cumulativity through inductives. *)
@@ -23,20 +26,18 @@ Proof. unfold natpaths;apply _. Qed.
 Global Instance nat_0: Zero@{N} nat := 0%nat.
 Global Instance nat_1: One@{N} nat := 1%nat.
 
-Global Instance nat_plus: Plus@{N} nat := Nat.plus.
+Global Instance nat_plus: Plus@{N} nat := Nat.add.
 
-Notation mul := Nat.mult.
+Notation mul := Nat.mul.
 
-Global Instance nat_mult: Mult@{N} nat := Nat.mult.
+Global Instance nat_mult: Mult@{N} nat := Nat.mul.
 
 Ltac simpl_nat :=
-  change (@plus nat _) with Nat.plus;
-  change (@mult nat _) with Nat.mult;
+  change (@plus nat _) with Nat.add;
+  change (@mult nat _) with Nat.mul;
   simpl;
-  change nat_plus with (@plus nat nat_plus);
-  change Nat.plus with (@plus nat nat_plus);
-  change nat_mult with (@mult nat nat_mult);
-  change Nat.mult with (@mult nat nat_mult).
+  change Nat.add with (@plus nat Nat.add);
+  change Nat.mul with (@mult nat Nat.mul).
 
 Local Instance add_assoc : Associative@{N} (plus : Plus nat).
 Proof.
@@ -237,13 +238,13 @@ induction b as [|b IHb];intros [|c];simpl_nat;intros a Ea E.
 Qed.
 
 (* Order *)
-Global Instance nat_le: Le@{N N} nat := Nat.le'.
-Global Instance nat_lt: Lt@{N N} nat := Nat.lt'.
+Global Instance nat_le: Le@{N N} nat := Nat.leq.
+Global Instance nat_lt: Lt@{N N} nat := Nat.lt.
 
 Lemma le_plus : forall n k, n <= k + n.
 Proof.
 induction k.
-- apply Nat.le_n.
+- apply Nat.leq_n.
 - simpl_nat. constructor. assumption.
 Qed.
 
@@ -392,7 +393,7 @@ Qed.
 Local Instance nat_strict : StrictOrder (_:Lt nat).
 Proof.
 split.
-- apply _.
+- cbv; exact _.
 - apply _.
 - hnf. intros a b c E1 E2.
   apply le_exists;apply le_exists in E1;apply le_exists in E2.
@@ -420,6 +421,11 @@ intros;apply ishprop_sum;try apply _.
 intros E1 E2. apply (irreflexivity nat_lt x).
 transitivity y;trivial.
 Qed.
+
+Instance decidable_nat_apart x y : Decidable (nat_apart x y).
+Proof.
+  rapply decidable_sum; apply Nat.decidable_lt.
+Defined.
 
 Global Instance nat_trivial_apart : TrivialApart nat.
 Proof.
@@ -631,14 +637,14 @@ Section for_another_semiring.
   Qed.
 End for_another_semiring.
 
-Lemma nat_naturals@{i} : Naturals@{N N N N N N N i} nat.
+Lemma nat_naturals : Naturals@{N N N N N N N i} nat.
 Proof.
 split;try apply _.
 intros;apply toR_unique, _.
 Qed.
 Global Existing Instance nat_naturals.
 
-Global Instance nat_cut_minus: CutMinus@{N} nat := Nat.minus.
+Global Instance nat_cut_minus: CutMinus@{N} nat := Nat.sub.
 
 Lemma plus_minus : forall a b, cut_minus (a + b) b =N= a.
 Proof.

--- a/theories/Classes/interfaces/cauchy.v
+++ b/theories/Classes/interfaces/cauchy.v
@@ -61,7 +61,7 @@ Section cauchy.
       assert (isclose := isclose' n leNn).
       clear isclose'.
       assert (leMn := le_nat_max_l (M (epsilon / 2)) N : M (epsilon / 2) ≤ n).
-      assert (leMM : M (epsilon / 2) ≤ M (epsilon / 2) ) by apply (Nat.le_n).
+      assert (leMM : M (epsilon / 2) ≤ M (epsilon / 2) ) by apply (Nat.leq_n).
       assert (x_close := cauchy_convergence x (epsilon/2) n (M (epsilon / 2)) leMn leMM).
       cbn in isclose, x_close.
       rewrite (@preserves_mult Q F _ _ _ _ _ _ _ _ _ _ _ _) in isclose, x_close.

--- a/theories/Colimits/Sequential.v
+++ b/theories/Colimits/Sequential.v
@@ -10,6 +10,7 @@ Require Import Spaces.Nat.
 Require Import HProp.
 Require Import PathAny.
 
+Local Open Scope nat_scope.
 Local Open Scope path_scope.
 
 Notation coe := (transport idmap).
@@ -164,23 +165,23 @@ Proof.
   induction n as [ | n e]; srapply isequiv_homotopic'.
   - srapply equiv_functor_colimit; srapply Build_diagram_equiv.
     + srapply Build_DiagramMap.
-      * exact (fun k => coe (ap A (nat_plus_n_O k)^)).
-      * intros k l p a; destruct p; srapply (K S (fun n a => a^+) (nat_plus_n_O k)^ @ _).
+      * exact (fun k => coe (ap A (nat_add_n_O k)^)).
+      * intros k l p a; destruct p; srapply (K S (fun n a => a^+) (nat_add_n_O k)^ @ _).
         srapply (ap10 (ap coe (ap (ap _) (ap_V _ _)))).
     + intro k; srapply isequiv_path.
   - symmetry; srapply seq_colimit_uniq.
-    + intros k a; exact (J (nat_plus_n_O k)).
+    + intros k a; exact (J (nat_add_n_O k)).
     + intros k a; rewrite !Colimit_rec_beta_colimp; srapply (L (glue A)).
   - transitivity (Colimit (succ_seq (shift_seq A n))).
     + srapply equiv_functor_colimit; srapply Build_diagram_equiv.
       * srapply Build_DiagramMap.
-        { exact (fun k => coe (ap A (nat_plus_n_Sm k n)^)). }
-        { intros k l p a; destruct p; rapply (K S (fun n a => a^+) (nat_plus_n_Sm k n)^ @ _).
+        { exact (fun k => coe (ap A (nat_add_n_Sm k n)^)). }
+        { intros k l p a; destruct p; rapply (K S (fun n a => a^+) (nat_add_n_Sm k n)^ @ _).
           srapply (ap10 (ap coe (ap (ap _) (ap_V _ _)))). }
       * intro k; srapply isequiv_path.
     + srefine (transitivity (equiv_colim_succ_seq_to_colim_seq _) (Build_Equiv _ _ _ e)).
   - symmetry; srapply seq_colimit_uniq.
-    + intros k a; exact (J (nat_plus_n_Sm k n)).
+    + intros k a; exact (J (nat_add_n_Sm k n)).
     + intros k a; rewrite Colimit_rec_beta_colimp; simpl.
       rewrite 2(ap_compose' _ _ (glue _ k a)), Colimit_rec_beta_colimp, 2ap_pp.
       rewrite colim_succ_seq_to_colim_seq_ap_inj, colim_shift_seq_to_colim_seq_ap_inj.

--- a/theories/Spaces/Finite/Fin.v
+++ b/theories/Spaces/Finite/Fin.v
@@ -399,11 +399,11 @@ Proof.
   induction n as [|n IH].
   - contradiction.
   - destruct k as [k|?]; simpl.
-    + rewrite nat_plus_comm.
+    + rewrite nat_add_comm.
       specialize (IH k).
-      rewrite nat_plus_comm in IH.
+      rewrite nat_add_comm in IH.
       exact (ap S IH).
-    + rewrite nat_plus_comm; reflexivity.
+    + rewrite nat_add_comm; reflexivity.
 Qed.
 
 (** [fsucc_mod] is the successor function mod n *)

--- a/theories/Spaces/Finite/FinInduction.v
+++ b/theories/Spaces/Finite/FinInduction.v
@@ -33,9 +33,7 @@ Proof.
   intro p.
   destruct (hset_path2 1 p).
   cbn.
-  set (q := path_zero_finnat n leq_1_Sn).
-  change (path_zero_finnat n leq_1_Sn) with q.
-  by destruct (hset_path2 1 q).
+  by destruct (hset_path2 1 (path_zero_finnat n leq_1_Sn)).
 Defined.
 
 Lemma compute_fin_ind_fsucc (P : forall n : nat, Fin n -> Type)
@@ -78,3 +76,4 @@ Lemma compute_fin_rec_fsucc (B : nat -> Type)
 Proof.
   apply (compute_fin_ind_fsucc (fun n _ => B n)).
 Defined.
+

--- a/theories/Spaces/Finite/FinInduction.v
+++ b/theories/Spaces/Finite/FinInduction.v
@@ -1,9 +1,12 @@
 Require Import
   HoTT.Basics
+  HoTT.Types
   HoTT.HSet
   HoTT.Spaces.Nat
   HoTT.Spaces.Finite.FinNat
   HoTT.Spaces.Finite.Fin.
+
+Local Open Scope nat_scope.
 
 Definition fin_ind (P : forall n : nat, Fin n -> Type)
   (z : forall n : nat, P n.+1 fin_zero)
@@ -14,7 +17,9 @@ Proof.
   refine (transport (P n) (path_fin_to_finnat_to_fin k) _).
   refine (finnat_ind (fun n u => P n (finnat_to_fin u)) _ _ _).
   - intro. apply z.
-  - intros n' u c. apply s. exact c.
+  - intros n' u c.
+    refine ((path_finnat_to_fin_succ _)^ # _).
+    by apply s.
 Defined.
 
 Lemma compute_fin_ind_fin_zero (P : forall n : nat, Fin n -> Type)
@@ -26,7 +31,11 @@ Proof.
   generalize (path_fin_to_finnat_to_fin (@fin_zero n)).
   induction (path_fin_to_finnat_fin_zero n)^.
   intro p.
-  by induction (hset_path2 1 p).
+  destruct (hset_path2 1 p).
+  cbn.
+  set (q := path_zero_finnat n leq_1_Sn).
+  change (path_zero_finnat n leq_1_Sn) with q.
+  by destruct (hset_path2 1 q).
 Defined.
 
 Lemma compute_fin_ind_fsucc (P : forall n : nat, Fin n -> Type)
@@ -44,7 +53,8 @@ Proof.
   induction (path_fin_to_finnat_to_fin k).
   induction (path_fin_to_finnat_to_fin k)^.
   intro p.
-  now induction (hset_path2 1 p).
+  induction (hset_path2 p (path_finnat_to_fin_succ (fin_to_finnat k))).
+  apply transport_pV.
 Defined.
 
 Definition fin_rec (B : nat -> Type)

--- a/theories/Spaces/Finite/FinNat.v
+++ b/theories/Spaces/Finite/FinNat.v
@@ -76,17 +76,14 @@ Lemma compute_finnat_ind_succ (P : forall n : nat, FinNat n -> Type)
   {n : nat} (u : FinNat n)
   : finnat_ind P z s (succ_finnat u) = s n u (finnat_ind P z s u).
 Proof.
-  refine (_ @ transport (fun p => transport _ p (s n u _)
-                             = s n u (finnat_ind P z s u))
-                   (hset_path2 1
-                    (@path_succ_finnat n u (leq_S_n' _ _ u.2))) idpath).
-  simpl.
+  refine
+    (_ @ transport
+          (fun p => transport _ p (s n u _) = s n u (finnat_ind P z s u))
+          (hset_path2 1 (path_succ_finnat u (leq_S_n' _ _ u.2))) 1).
   destruct u as [u1 u2].
-  assert (u2 = leq_S_n u1.+1 n (leq_S_n' u1.+1 n u2)).
+  assert (u2 = leq_S_n u1.+1 n (leq_S_n' u1.+1 n u2)) as p.
   - apply path_ishprop.
-  - simpl.
-    rewrite <- X.
-    reflexivity.
+  - simpl. by induction p.
 Defined.
 
 Monomorphic Definition is_bounded_fin_to_nat {n} (k : Fin n)
@@ -97,7 +94,7 @@ Proof.
   - destruct k as [k | []].
     + apply (@leq_trans _ n _).
       * apply IHn.
-      * apply leq_S. reflexivity.
+      * by apply leq_S.
     + apply leq_refl.
 Defined.
 
@@ -161,8 +158,7 @@ Proof.
     destruct x as [| x]; [reflexivity|].
     refine ((ap _ (ap _ (path_succ_finnat (x; leq_S_n _ _ h) h)))^ @ _).
     refine (_ @ ap fsucc (IHn (x; leq_S_n _ _ h))).
-    rewrite <- path_finnat_to_fin_succ.
-    reflexivity.
+    by induction (path_finnat_to_fin_succ (incl_finnat (x; leq_S_n _ _ h))).
 Defined.
 
 Lemma path_finnat_to_fin_last (n : nat)
@@ -179,10 +175,10 @@ Proof.
   induction n as [| n IHn].
   - elim (not_lt_n_0 _ u.2).
   - destruct u as [x h].
+    apply path_sigma_hprop.
     destruct x as [| x].
-    + rewrite path_fin_to_finnat_fin_zero. by apply path_sigma_hprop.
-    + apply path_sigma_hprop.
-      refine ((path_fin_to_finnat_fsucc _)..1 @ _).
+    + exact (ap pr1 (path_fin_to_finnat_fin_zero n)).
+    + refine ((path_fin_to_finnat_fsucc _)..1 @ _).
       exact (ap S (IHn (x; leq_S_n _ _ h))..1).
 Defined.
 
@@ -202,3 +198,4 @@ Definition equiv_fin_finnat (n : nat) : Fin n <~> FinNat n
   := equiv_adjointify fin_to_finnat finnat_to_fin
       path_finnat_to_fin_to_finnat
       path_fin_to_finnat_to_fin.
+

--- a/theories/Spaces/Finite/FinSeq.v
+++ b/theories/Spaces/Finite/FinSeq.v
@@ -7,6 +7,8 @@ Require Import
   HoTT.Spaces.Finite.FinInduction
   HoTT.Spaces.Nat.
 
+Local Open Scope nat_scope.
+
 (** Finite-dimensional sequence. It is often referred to as vector,
     but we call it finite sequence [FinSeq] to avoid confusion with
     vector from linear algebra.
@@ -37,18 +39,18 @@ Definition fscons {A : Type} {n : nat} : A -> FinSeq n A -> FinSeq n.+1 A
 (** Take the first element of a non-empty finite sequence,
     [fshead'] and [fshead]. *)
 
-Definition fshead' {A} (n : nat) : n > 0 -> FinSeq n A -> A
+Definition fshead' {A} (n : nat) : 0 < n -> FinSeq n A -> A
   := match n with
-     | 0 => fun N _ => Empty_rec N
+     | 0 => fun N _ => Empty_rec (not_lt_n_0 _ N)
      | n'.+1 => fun _ v => v fin_zero
      end.
 
-Definition fshead {A} {n : nat} : FinSeq n.+1 A -> A := fshead' n.+1 tt.
+Definition fshead {A} {n : nat} : FinSeq n.+1 A -> A := fshead' n.+1 _.
 
 Definition compute_fshead' {A} n (N : n > 0) (a : A) (v : FinSeq (pred n) A)
   : fshead' n N (fscons' n a v) = a.
 Proof.
-  destruct n; [elim N|].
+  destruct n; [elim (not_lt_n_n _ N)|].
   exact (apD10 (compute_fin_rec_fin_zero _ _ _ _) v).
 Defined.
 
@@ -176,7 +178,7 @@ Proof.
   funext i.
   pose (p := eisretr apD10 (compute_fstail' n.+1 a v)).
   refine (_ @ (ap (fun f => _ f i) p)^).
-  exact (path_expand_fscons_fscons' n.+1 tt a v i).
+  exact (path_expand_fscons_fscons' n.+1 _ a v i).
 Defined.
 
 (** The induction principle for finite sequence, [finseq_ind].

--- a/theories/Spaces/Finite/Finite.v
+++ b/theories/Spaces/Finite/Finite.v
@@ -263,7 +263,7 @@ Abort.
 Definition fcard_sum X Y `{Finite X} `{Finite Y}
 : fcard (X + Y) = (fcard X + fcard Y).
 Proof.
-  refine (_ @ nat_plus_comm _ _).
+  refine (_ @ nat_add_comm _ _).
   assert (e := merely_equiv_fin Y).
   strip_truncations.
   refine (fcard_equiv' (1 +E e) @ _).
@@ -303,8 +303,8 @@ Proof.
   - refine (fcard_equiv (sum_distrib_r Y (Fin n) Unit) @ _).
     refine (fcard_sum _ _ @ _).
     simpl.
-    refine (_ @ nat_plus_comm _ _).
-    refine (ap011 plus _ _).
+    refine (_ @ nat_add_comm _ _).
+    refine (ap011 add _ _).
     + apply IH.
     + apply fcard_equiv', prod_unit_l.
   Defined.
@@ -346,7 +346,7 @@ Proof.
   - reflexivity.
   - refine (fcard_equiv (equiv_sum_ind (fun (_:Fin n.+1) => Y))^-1 @ _).
     refine (fcard_prod _ _ @ _).
-    apply (ap011 mult).
+    apply (ap011 mul).
     + assumption.
     + refine (fcard_equiv (@Unit_ind (fun (_:Unit) => Y))^-1).
 Defined.
@@ -420,24 +420,24 @@ Defined.
 
 (** Amusingly, this automatically gives us a way to add up a family of natural numbers indexed by any finite set.  (We could of course also define such an operation directly, probably using [merely_ind_hset].) *)
 
-Definition finplus {X} `{Finite X} (f : X -> nat) : nat
+Definition finadd {X} `{Finite X} (f : X -> nat) : nat
   := fcard { x:X & Fin (f x) }.
 
 Definition fcard_sigma {X} (Y : X -> Type)
        `{Finite X} `{forall x, Finite (Y x)}
-: fcard { x:X & Y x } = finplus (fun x => fcard (Y x)).
+: fcard { x:X & Y x } = finadd (fun x => fcard (Y x)).
 Proof.
   set (f := fun x => fcard (Y x)).
   set (g := fun x => merely_equiv_fin (Y x) : merely (Y x <~> Fin (f x))).
   apply finite_choice in g.
   strip_truncations.
-  unfold finplus.
+  unfold finadd.
   refine (fcard_equiv' (equiv_functor_sigma_id g)).
 Defined.
 
 (** The sum of a finite constant family is the product by its cardinality. *)
-Definition finplus_const X `{Finite X} n
-: finplus (fun x:X => n) = fcard X * n.
+Definition finadd_const X `{Finite X} n
+: finadd (fun x:X => n) = fcard X * n.
 Proof.
   transitivity (fcard (X * Fin n)).
   - exact (fcard_equiv' (equiv_sigma_prod0 X (Fin n))).
@@ -454,7 +454,7 @@ Defined.
 
 (** Therefore, the cardinality of the domain of a map between finite sets is the sum of the cardinalities of its hfibers. *)
 Definition fcard_domain {X Y} (f : X -> Y) `{Finite X} `{Finite Y}
-: fcard X = finplus (fun y => fcard (hfiber f y)).
+: fcard X = finadd (fun y => fcard (hfiber f y)).
 Proof.
   refine (_ @ fcard_sigma (hfiber f)).
   refine (fcard_equiv' (equiv_fibration_replacement f)).
@@ -617,7 +617,7 @@ Section DecidableQuotients.
 
   (** Therefore, the cardinality of [X] is the sum of the cardinalities of its equivalence classes. *)
   Definition fcard_quotient
-  : fcard X = finplus (fun z:Quotient R => fcard {x:X & in_class R z x}).
+  : fcard X = finadd (fun z:Quotient R => fcard {x:X & in_class R z x}).
   Proof.
     refine (fcard_domain (class_of R) @ _).
     apply ap, path_arrow; intros z; revert z.
@@ -646,7 +646,7 @@ Proof.
   assert (MapIn (Tr (-1)) g) by (unfold g; exact _).
   clearbody g. clear e e'. generalize dependent m.
   induction n as [|n IHn].
-  { intros; exact tt. }
+  1: exact _.
   intros m g ?.
   assert (i : isinj g) by (apply isinj_embedding; exact _).
   destruct m as [|m].
@@ -678,6 +678,7 @@ Proof.
     { unfold h; apply moveR_equiv_V; symmetry.
       apply fin_transpose_last_with_last. }
     rewrite q; exact tt. }
+  apply leq_S_n'.
   exact (IHn m (unfunctor_sum_l h Ha)
              (mapinO_unfunctor_sum_l (Tr (-1)) h Ha Hb)).
 Qed.
@@ -730,7 +731,7 @@ Section Enumeration.
   Proof.
     destruct (finite_enumeration_stage (fcard X).+1) as [p|?].
     - assert (q := leq_inj_finite (er (fcard X).+1) p); simpl in q.
-      elim (not_nltn _ q).
+      elim (not_lt_n_n _ q).
     - assumption.
   Defined.
 

--- a/theories/Spaces/Nat.v
+++ b/theories/Spaces/Nat.v
@@ -1,79 +1,77 @@
 (* -*- mode: coq; mode: visual-line -*- *)
-(** * Theorems about the natural numbers *)
-
-Require Import HoTT.Basics.
-Require Import HoTT.Types.Bool.
+Require Import Basics Types.
+Require Export Basics.Nat.
 Require Import HoTT.TruncType.
 Require Export HoTT.DProp.
-Require Export HoTT.Basics.Nat.
 
-Close Scope trunc_scope.
-Open Scope nat_scope.
-Local Notation "0" := O.
+Local Unset Elimination Schemes.
 
+Scheme nat_ind := Induction for nat Sort Type.
+Scheme nat_rect := Induction for nat Sort Type.
+Scheme nat_rec := Minimality for nat Sort Type.
 
-(** ** Constants *)
+(** * Theorems about the natural numbers *)
 
-Local Notation "0" := O.
-Local Notation "1" := (S O).
-Local Notation "2" := (S (S O)).
+(** Many of these definitions and proofs have been ported from the coq stdlib. *)
 
-Definition zero := 0.
-Definition one := 1.
-Definition two := 2.
+(** We want to close the trunc_scope so that notations from there don't conflict here. *)
+Local Close Scope trunc_scope.
+Local Open Scope nat_scope.
 
-(** ** Basic operations *)
+(** ** Basic operations on naturals *)
 
-Definition succ := S.
+(** It is common to call [S] [succ] so we add it as a parsing only notation. *)
+Notation succ := S (only parsing).
 
-Definition pred n :=
+(** The predecessor of a natural number. *)
+Definition pred n : nat :=
   match n with
-    | 0 => n
-    | S u => u
+  | 0 => n
+  | S n' => n'
   end.
 
-Fixpoint add n m :=
+(** Addition of natural numbers *)
+Fixpoint add n m : nat :=
   match n with
   | 0 => m
-  | S p => S (p + m)
-  end
+  | S n' => S (add n' m)
+  end.
 
-where "n + m" := (add n m) : nat_scope.
+Notation "n + m" := (add n m) : nat_scope.
 
-Definition double n := n + n.
+Definition double n : nat := n + n.
 
-Fixpoint mul n m :=
+Fixpoint mul n m : nat :=
   match n with
   | 0 => 0
-  | S p => m + p * m
-  end
+  | S n' => m + (mul n' m)
+  end.
 
-where "n * m" := (mul n m) : nat_scope.
+Notation "n * m" := (mul n m) : nat_scope.
 
-(** Truncated subtraction: [n-m] is [0] if [n<=m] *)
-
-Fixpoint sub n m :=
+(** Truncated subtraction: [n - m] is [0] if [n <= m] *)
+Fixpoint sub n m : nat :=
   match n, m with
-  | S k, S l => k - l
-  | _, _ => n
-  end
+  | S n' , S m' => sub n' m'
+  | _ , _ => n
+  end.
 
-where "n - m" := (sub n m) : nat_scope.
+Notation "n - m" := (sub n m) : nat_scope.
 
 (** ** Minimum, maximum *)
 
 Fixpoint max n m :=
   match n, m with
-    | 0, _ => m
-    | S n', 0 => n
-    | S n', S m' => S (max n' m')
+  | 0 , _ => m
+  | S n' , 0 => n'.+1
+  | S n' , S m' => (max n' m').+1
   end.
 
 Fixpoint min n m :=
   match n, m with
-    | 0, _ => 0
-    | S n', 0 => 0
-    | S n', S m' => S (min n' m')
+  | 0 , _ => 0
+  | S n' , 0 => 0
+  | S n' , S m' => S (min n' m')
   end.
 
 (** ** Power *)
@@ -81,33 +79,30 @@ Fixpoint min n m :=
 Fixpoint pow n m :=
   match m with
   | 0 => 1
-  | S m => n * (pow n m)
+  | S m' => n * (pow n m')
   end.
-
 
 (** ** Euclidean division *)
 
-(** This division is linear and tail-recursive.
-    In [divmod], [y] is the predecessor of the actual divisor,
-    and [u] is [y] minus the real remainder
-*)
+(** This division is linear and tail-recursive. In [divmod], [y] is the predecessor of the actual divisor, and [u] is [y] sub the real remainder. *)
 
-Fixpoint divmod x y q u :=
+Fixpoint divmod x y q u : nat * nat :=
   match x with
-    | 0 => (q,u)
-    | S x' => match u with
-                | 0 => divmod x' y (S q) y
-                | S u' => divmod x' y q u'
-              end
+  | 0 => (q , u)
+  | S x' =>
+    match u with
+    | 0 => divmod x' y (S q) y
+    | S u' => divmod x' y q u'
+    end
   end.
 
-Definition div x y :=
+Definition div x y : nat :=
   match y with
     | 0 => y
     | S y' => fst (divmod x y' 0 y')
   end.
 
-Definition modulo x y :=
+Definition modulo x y : nat :=
   match y with
     | 0 => y
     | S y' => y' - snd (divmod x y' 0 y')
@@ -116,23 +111,19 @@ Definition modulo x y :=
 Infix "/" := div : nat_scope.
 Infix "mod" := modulo : nat_scope.
 
-
 (** ** Greatest common divisor *)
 
-(** We use Euclid algorithm, which is normally not structural,
-    but Coq is now clever enough to accept this (behind modulo
-    there is a subtraction, which now preserves being a subterm)
-*)
+(** We use Euclid algorithm, which is normally not structural, but Coq is now clever enough to accept this (behind modulo there is a subtraction, which now preserves being a subterm) *)
 
 Fixpoint gcd a b :=
   match a with
-   | O => b
-   | S a' => gcd (b mod (S a')) (S a')
+  | O => b
+  | S a' => gcd (b mod a'.+1) a'.+1
   end.
 
 (** ** Square *)
 
-Definition square n := n * n.
+Definition square n : nat := n * n.
 
 (** ** Square root *)
 
@@ -149,16 +140,17 @@ Definition square n := n * n.
   in n, hence the square root of n is p.
 *)
 
-Fixpoint sqrt_iter k p q r :=
+Fixpoint sqrt_iter k p q r : nat :=
   match k with
-    | O => p
-    | S k' => match r with
-                | O => sqrt_iter k' (S p) (S (S q)) (S (S q))
-                | S r' => sqrt_iter k' p q r'
-              end
+  | O => p
+  | S k' =>
+    match r with
+    | O => sqrt_iter k' p.+1 q.+2 q.+2
+    | S r' => sqrt_iter k' p q r'
+    end
   end.
 
-Definition sqrt n := sqrt_iter n 0 0 0.
+Definition sqrt n : nat := sqrt_iter n 0 0 0.
 
 (** ** Log2 *)
 
@@ -193,47 +185,46 @@ Definition sqrt n := sqrt_iter n 0 0 0.
   [k+q] is invariant), and [p] its logarithm.
 *)
 
-Fixpoint log2_iter k p q r :=
+Fixpoint log2_iter k p q r : nat :=
   match k with
-    | O => p
-    | S k' => match r with
-                | O => log2_iter k' (S p) (S q) q
-                | S r' => log2_iter k' p (S q) r'
-              end
+  | O    => p
+  | S k' =>
+    match r with
+    | O => log2_iter k' (S p) (S q) q
+    | S r' => log2_iter k' p (S q) r'
+    end
   end.
 
-Definition log2 n := log2_iter (pred n) 0 1 0.
+Definition log2 n : nat := log2_iter (pred n) 0 1 0.
 
-(** Iterator on natural numbers *)
+(** ** Iterator on natural numbers *)
 
-Definition iter (n:nat) {A} (f:A->A) (x:A) : A :=
- nat_rect (fun _ => A) x (fun _ => f) n.
-
-
-Definition eq_S := @ap _ _ S.
+Definition iter (n : nat) {A} (f : A -> A) (x : A) : A :=
+  nat_rec A x (fun _ => f) n.
 
 Local Definition ap_S := @ap _ _ S.
 Local Definition ap_nat := @ap nat.
-#[export] Hint Resolve ap_S : v62.
+#[export] Hint Resolve ap_S : core.
 #[export] Hint Resolve ap_nat : core.
 
 Theorem pred_Sn : forall n:nat, n = pred (S n).
 Proof.
-  simpl; reflexivity.
-Qed.
+  auto.
+Defined.
 
 (** Injectivity of successor *)
 
-Definition eq_add_S n m (H: S n = S m): n = m := ap pred H.
-#[export] Hint Immediate eq_add_S: core.
+Definition path_nat_S n m (H : S n = S m) : n = m := ap pred H.
+#[export] Hint Immediate path_nat_S : core.
 
 Theorem not_eq_S : forall n m:nat, n <> m -> S n <> S m.
 Proof.
-  red; auto.
-Qed.
-#[export] Hint Resolve not_eq_S: core.
+  auto.
+Defined.
+#[export] Hint Resolve not_eq_S : core.
 
-Definition IsSucc (n:nat) : Type :=
+(** TODO: keep or remove? *)
+Definition IsSucc (n: nat) : Type :=
   match n with
   | O => False
   | S p => True
@@ -241,283 +232,93 @@ Definition IsSucc (n:nat) : Type :=
 
 (** Zero is not the successor of a number *)
 
-Theorem O_S : forall n:nat, 0 <> S n.
+Theorem not_eq_O_S : forall n:nat, 0 <> S n.
 Proof.
   discriminate.
-Qed.
-#[export] Hint Resolve O_S : core.
+Defined.
+#[export] Hint Resolve not_eq_O_S : core.
 
-Theorem n_Sn : forall n:nat, n <> S n.
+Theorem not_eq_n_Sn : forall n:nat, n <> S n.
 Proof.
   induction n; auto.
-Qed.
-#[export] Hint Resolve n_Sn : core.
+Defined.
+#[export] Hint Resolve not_eq_n_Sn : core.
 
-(** addition *)
-(* TODO: remove and use one def *)
-Definition plus (n m:nat) : nat := add n m.
-
-Local Definition ap011_plus := @ap011 _ _ _ plus.
+Local Definition ap011_add := @ap011 _ _ _ add.
 Local Definition ap011_nat := @ap011 nat nat.
-#[export] Hint Resolve ap011_plus : v62.
+#[export] Hint Resolve ap011_add : core.
 #[export] Hint Resolve ap011_nat : core.
 
-Lemma plus_n_O : forall n:nat, n = n + 0.
+Lemma add_n_O : forall (n : nat), n = n + 0.
 Proof.
   induction n; simpl; auto.
-Qed.
-#[export] Hint Resolve plus_n_O: core.
+Defined.
+#[export] Hint Resolve add_n_O : core.
 
-Lemma plus_O_n : forall n:nat, 0 + n = n.
+Lemma add_O_n : forall (n : nat), 0 + n = n.
 Proof.
   auto.
-Qed.
+Defined.
 
-Lemma plus_n_Sm : forall n m:nat, S (n + m) = n + S m.
+Lemma add_n_Sm : forall n m:nat, S (n + m) = n + S m.
 Proof.
   intros n m; induction n; simpl; auto.
-Qed.
-#[export] Hint Resolve plus_n_Sm: core.
+Defined.
+#[export] Hint Resolve add_n_Sm: core.
 
-Lemma plus_Sn_m : forall n m:nat, S n + m = S (n + m).
+Lemma add_Sn_m : forall n m:nat, S n + m = S (n + m).
 Proof.
   auto.
-Qed.
-
-(** Standard associated names *)
-
-Notation plus_0_r_reverse := plus_n_O (only parsing).
-Notation plus_succ_r_reverse := plus_n_Sm (only parsing).
+Defined.
 
 (** Multiplication *)
 
-(** TODO: remove and use one def *)
-Definition mult (n m:nat) : nat := mul n m.
+Local Definition ap011_mul := @ap011 _ _ _  mul.
+#[export] Hint Resolve ap011_mul : core.
 
-Local Definition ap011_mult := @ap011 _ _ _  mult.
-#[export] Hint Resolve ap011_mult : core.
-
-Lemma mult_n_O : forall n:nat, 0 = n * 0.
+Lemma mul_n_O : forall n:nat, 0 = n * 0.
 Proof.
   induction n; simpl; auto.
-Qed.
-#[export] Hint Resolve mult_n_O : core.
+Defined.
+#[export] Hint Resolve mul_n_O : core.
 
-Lemma mult_n_Sm : forall n m:nat, n * m + n = n * S m.
+Lemma mul_n_Sm : forall n m:nat, n * m + n = n * S m.
 Proof.
   intros; induction n as [| p H]; simpl; auto.
-  destruct H; rewrite <- plus_n_Sm; apply eq_S.
+  destruct H; rewrite <- add_n_Sm; apply ap.
   pattern m at 1 3; elim m; simpl; auto.
-Qed.
-#[export] Hint Resolve mult_n_Sm: core.
+Defined.
+#[export] Hint Resolve mul_n_Sm: core.
 
 (** Standard associated names *)
 
-Notation mult_0_r_reverse := mult_n_O (only parsing).
-Notation mult_succ_r_reverse := mult_n_Sm (only parsing).
+Notation mul_0_r_reverse := mul_n_O (only parsing).
+Notation mul_succ_r_reverse := mul_n_Sm (only parsing).
 
-(** Truncated subtraction: [m-n] is [0] if [n>=m] *)
+(** ** Equality of natural numbers *)
 
-Definition minus (n m:nat) : nat := sub n m.
-
-(** Definition of the usual orders, the basic properties of [le] and [lt]
-    can be found in files Le and Lt *)
-
-Inductive le' (n:nat) : nat -> Type :=
-  | le_n : le' n n
-  | le_S : forall m:nat, le' n m -> le' n (S m).
-(* Local Notation "n <= m" := (le' n m) : nat_scope. *)
-
-#[export] Hint Constructors le' : core.
-(*i equivalent to : "Hints Resolve le_n le_S : core." i*)
-
-Definition lt' (n m:nat) := le' (S n) m.
-#[export] Hint Unfold lt' : core.
-
-(* Local Infix "<" := lt' : nat_scope. *)
-
-Definition ge (n m:nat) := le' m n.
-#[export] Hint Unfold ge: core.
-
-(* Local Infix ">=" := ge : nat_scope. *)
-
-Definition gt (n m:nat) := lt' m n.
-#[export] Hint Unfold gt: core.
-
-(* Local Infix ">" := gt : nat_scope. *)
-
-(* Local Notation "x <= y <= z" := (x <= y /\ y <= z) : nat_scope. *)
-(* (* Local Notation "x <= y < z" := (x <= y /\ y < z) : nat_scope. *) *)
-(* Local Notation "x < y < z" := (x < y /\ y < z) : nat_scope. *)
-(* Local Notation "x < y <= z" := (x < y /\ y <= z) : nat_scope. *)
-
-Theorem le_pred : forall n m, le' n m -> le' (pred n) (pred m).
-Proof.
-induction 1; auto. destruct m; simpl; auto.
-Qed.
-
-Theorem le_S_n : forall n m, le' (S n) (S m) -> le' n m.
-Proof.
-intros n m. exact (le_pred (S n) (S m)).
-Qed.
-
-(** Case analysis *)
-
-Theorem nat_case :
- forall (n:nat) (P:nat -> Type), P 0 -> (forall m:nat, P (S m)) -> P n.
-Proof.
-  induction n; auto.
-Qed.
-
-(** Principle of double induction *)
-
-Theorem nat_double_ind :
- forall R:nat -> nat -> Type,
-   (forall n:nat, R 0 n) ->
-   (forall n:nat, R (S n) 0) ->
-   (forall n m:nat, R n m -> R (S n) (S m)) -> forall n m:nat, R n m.
-Proof.
-  induction n; auto.
-  destruct m; auto.
-Qed.
-
-(** Maximum and minimum : definitions and specifications *)
-
-(* Theorem max_l : forall n m : nat, m <= n -> max n m = n. *)
-(* Proof. *)
-(* induction n; destruct m; simpl; auto. inversion 1. *)
-(* intros. apply f_equal. apply IHn. apply le_S_n. trivial. *)
-(* Qed. *)
-
-(* Theorem max_r : forall n m : nat, n <= m -> max n m = m. *)
-(* Proof. *)
-(* induction n; destruct m; simpl; auto. inversion 1. *)
-(* intros. apply f_equal. apply IHn. apply le_S_n. trivial. *)
-(* Qed. *)
-
-(* Theorem min_l : forall n m : nat, n <= m -> min n m = n. *)
-(* Proof. *)
-(* induction n; destruct m; simpl; auto. inversion 1. *)
-(* intros. apply f_equal. apply IHn. apply le_S_n. trivial. *)
-(* Qed. *)
-
-(* Theorem min_r : forall n m : nat, m <= n -> min n m = m. *)
-(* Proof. *)
-(* induction n; destruct m; simpl; auto. inversion 1. *)
-(* intros. apply f_equal. apply IHn. apply le_S_n. trivial. *)
-(* Qed. *)
-
-(** [n]th iteration of the function [f] *)
-
-Fixpoint nat_iter (n:nat) {A} (f:A->A) (x:A) : A :=
-  match n with
-    | O => x
-    | S n' => f (nat_iter n' f x)
-  end.
-
-Lemma nat_iter_succ_r n {A} (f:A->A) (x:A) :
-  nat_iter (S n) f x = nat_iter n f (f x).
-Proof.
-  induction n; intros; simpl; rewrite <- ?IHn; trivial.
-Qed.
-
-Theorem nat_iter_plus :
-  forall (n m:nat) {A} (f:A -> A) (x:A),
-    nat_iter (n + m) f x = nat_iter n f (nat_iter m f x).
-Proof.
-  induction n; intros; simpl; rewrite ?IHn; trivial.
-Qed.
-
-(** Preservation of invariants : if [f : A->A] preserves the invariant [Inv],
-    then the iterates of [f] also preserve it. *)
-
-Theorem nat_iter_invariant :
-  forall (n:nat) {A} (f:A -> A) (P : A -> Type),
-    (forall x, P x -> P (f x)) ->
-    forall x, P x -> P (nat_iter n f x).
-Proof.
-  induction n; simpl; trivial.
-  intros A f P Hf x Hx. apply Hf, IHn; trivial.
-Qed.
-
-(** We reopen these scopes so they take precedence over nat_scope; otherwise, now that we have [Coq.Init.Peano], we'd get [* : nat -> nat -> nat] rather than [* : Type -> Type -> Type]. *)
-Global Open Scope type_scope.
-Global Open Scope core_scope.
-
-(** But in this file, we want to be able to use the usual symbols for natural number arithmetic. *)
-Local Open Scope nat_scope.
-
-Scheme nat_ind := Induction for nat Sort Type.
-Scheme nat_rec := Minimality for nat Sort Type.
-
-(** ** Arithmetic *)
-
-Lemma nat_plus_n_O : forall n:nat, n = n + 0.
-Proof.
-  induction n.
-  - reflexivity.
-  - simpl; apply ap; assumption.
-Defined.
-
-Lemma nat_plus_n_Sm : forall n m:nat, (n + m).+1 = n + m.+1.
-Proof.
-  intros n m; induction n; simpl.
-  - reflexivity.
-  - apply ap; assumption.
-Defined.
-
-Definition nat_plus_comm (n m : nat) : n + m = m + n.
-Proof.
-  revert m; induction n as [|n IH]; intros m; simpl.
-  - refine (nat_plus_n_O m).
-  - transitivity (m + n).+1.
-    + apply ap, IH.
-    + apply nat_plus_n_Sm.
-Qed.
-
-(** ** Exponentiation *)
-
-Fixpoint nat_exp (n m : nat) : nat
-  := match m with
-       | 0 => 1
-       | S m => nat_exp n m * n
-     end.
-
-(** ** Factorials *)
-
-Fixpoint factorial (n : nat) : nat
-  := match n with
-       | 0 => 1
-       | S n => S n * factorial n
-     end.
-
-(* here ends the old Types/Nat.v and starts Spaces.v *)
-
-(** Much of the layout of this file is adapted from ssreflect *)
-
-(** ** Equality *)
 (** *** Boolean equality and its properties *)
 
 Fixpoint code_nat (m n : nat) {struct m} : DHProp :=
   match m, n with
-    | 0, 0 => True
-    | m'.+1, n'.+1 => code_nat m' n'
-    | _, _ => False
+  | 0, 0 => True
+  | m'.+1, n'.+1 => code_nat m' n'
+  | _, _ => False
   end.
 
 Infix "=n" := code_nat : nat_scope.
 
 Fixpoint idcode_nat {n} : (n =n n) :=
   match n as n return (n =n n) with
-    | 0 => tt
-    | S n' => @idcode_nat n'
+  | 0 => tt
+  | S n' => @idcode_nat n'
   end.
 
 Fixpoint path_nat {n m} : (n =n m) -> (n = m) :=
   match m as m, n as n return (n =n m) -> (n = m) with
-    | 0, 0 => fun _ => idpath
-    | m'.+1, n'.+1 => fun H : (n' =n m') => ap S (path_nat H)
-    | _, _ => fun H => match H with end
+  | 0, 0 => fun _ => idpath
+  | m'.+1, n'.+1 => fun H : (n' =n m') => ap S (path_nat H)
+  | _, _ => fun H => match H with end
   end.
 
 Global Instance isequiv_path_nat {n m} : IsEquiv (@path_nat n m).
@@ -535,90 +336,407 @@ Defined.
 Definition equiv_path_nat {n m} : (n =n m) <~> (n = m)
   := Build_Equiv _ _ (@path_nat n m) _.
 
+(** Thus [nat] has decidable paths *)
 Global Instance decidable_paths_nat : DecidablePaths nat
   := fun n m => decidable_equiv _ (@path_nat n m) _.
 
+(** And is therefore a HSet *)
 Global Instance hset_nat : IsHSet nat := _.
+
+(** ** Inequality of natural numbers *)
+
+Inductive leq (n : nat) : nat -> Type :=
+| leq_n : leq n n
+| leq_S : forall m, leq n m -> leq n (S m).
+
+Scheme leq_ind := Induction for leq Sort Type.
+Scheme leq_rect := Induction for leq Sort Type.
+Scheme leq_rec := Minimality for leq Sort Type.
+
+Notation "n <= m" := (leq n m) : nat_scope.
+#[export] Hint Constructors leq : core.
+
+Existing Class leq.
+Global Existing Instances leq_n leq_S.
+
+Notation leq_refl := leq_n (only parsing).
+Global Instance reflexive_leq : Reflexive leq := leq_n.
+
+Lemma leq_trans {x y z} : x <= y -> y <= z -> x <= z.
+Proof.
+  induction 2; auto.
+Defined.
+
+Global Instance transitive_leq : Transitive leq := @leq_trans.
+
+Lemma leq_n_pred n m : leq n m -> leq (pred n) (pred m).
+Proof.
+  induction 1; auto.
+  destruct m; simpl; auto.
+Defined.
+
+Lemma leq_S_n : forall n m, n.+1 <= m.+1 -> n <= m.
+Proof.
+  intros n m.
+  apply leq_n_pred.
+Defined.
+
+Lemma leq_S_n' n m : n <= m -> n.+1 <= m.+1.
+Proof.
+  induction 1; auto.
+Defined.
+Global Existing Instance leq_S_n' | 100.
+
+Lemma not_leq_Sn_n n : ~ (n.+1 <= n).
+Proof.
+  induction n.
+  { intro p.
+    inversion p. }
+  intros p.
+  by apply IHn, leq_S_n.
+Defined.
+
+(** A general form for injectivity of this constructor *)
+Definition leq_n_inj_gen n k (p : n <= k) (r : n = k) : p = r # leq_n n.
+Proof.
+  induction p.
+  + assert (c : idpath = r) by apply path_ishprop.
+    destruct c.
+    reflexivity.
+  + destruct r^.
+    contradiction (not_leq_Sn_n _ p).
+Defined.
+
+(** Which we specialise to this lemma *)
+Definition leq_n_inj n (p : n <= n) : p = leq_n n
+  := leq_n_inj_gen n n p idpath.
+
+Fixpoint leq_S_inj_gen n m k (p : n <= k) (q : n <= m) (r : m.+1 = k)
+  : p = r # leq_S n m q.
+Proof.
+  revert m q r.
+  induction p.
+  + intros k p r.
+    destruct r.
+    contradiction (not_leq_Sn_n _ p).
+  + intros m' q r.
+    pose (r' := path_nat_S _ _ r).
+    destruct r'.
+    assert (t : idpath = r) by apply path_ishprop.
+    destruct t.
+    cbn. apply ap.
+    destruct q.
+    1:  apply leq_n_inj.
+    apply (leq_S_inj_gen n m _ p q idpath).
+Defined.
+
+Definition leq_S_inj n m (p : n <= m.+1) (q : n <= m) : p = leq_S n m q
+  := leq_S_inj_gen n m m.+1 p q idpath.
+
+Global Instance ishprop_leq n m : IsHProp (n <= m).
+Proof.
+  apply hprop_allpath.
+  intros p q; revert p.
+  induction q.
+  + intros y.
+    rapply leq_n_inj.
+  + intros y.
+    rapply leq_S_inj.
+Defined.
+
+Global Instance leq_0_n n : 0 <= n | 10.
+Proof.
+  induction n; auto.
+Defined.
+
+Lemma not_leq_Sn_0 n : ~ (n.+1 <= 0).
+Proof.
+  intros p.
+  apply (fun x => leq_trans x (leq_0_n n)) in p.
+  contradiction (not_leq_Sn_n _ p).
+Defined.
+
+Definition equiv_leq_S_n n m : n.+1 <= m.+1 <~> n <= m.
+Proof.
+  srapply equiv_iff_hprop.
+  apply leq_S_n.
+Defined.
+
+Global Instance decidable_leq n m : Decidable (n <= m).
+Proof.
+  revert n.
+  induction m; intros n.
+  - destruct n.
+    + left; exact _.
+    + right; apply not_leq_Sn_0.
+  - destruct n.
+    + left; exact _.
+    + rapply decidable_equiv'.
+      symmetry.
+      apply equiv_leq_S_n.
+Defined.
+
+Fixpoint leq_add n m : n <= (m + n).
+Proof.
+  destruct m.
+  1: apply leq_n.
+  apply leq_S, leq_add.
+Defined.
+
+Lemma equiv_leq_add n m
+  : leq n m <~> exists k, k + n = m.
+Proof.
+  srapply equiv_iff_hprop.
+  { apply hprop_allpath.
+    intros [x p] [y q].
+    apply path_sigma_hprop.
+    simpl.
+    revert m p q.
+    induction n.
+    { intros m p q.
+      rewrite <- add_n_O in p,q.
+      exact (p @ q^). }
+    intros m p q.
+    rewrite <- add_n_Sm in p,q.
+    destruct m.
+    { inversion p. }
+    apply path_nat_S in p, q.
+    by apply (IHn m). }
+  { intros p.
+    induction p.
+    + exists 0.
+      reflexivity.
+    + exists IHp.1.+1.
+      apply ap_S, IHp.2. }
+  intros [k p].
+  destruct p.
+  apply leq_add.
+Defined.
+
+(** We define the less-than relation [lt] in terms of [leq] *)
+Definition lt n m : Type := leq (S n) m.
+(** We declare it as an existing class so typeclass search is performed on its goals. *)
+Existing Class lt.
+#[export] Hint Unfold lt : core typeclass_instances.
+Infix "<" := lt : nat_scope.
+(** We add a typeclass instance for unfolding the definition so lemmas about [leq] can be used. *)
+Global Instance lt_is_leq n m : leq n.+1 m -> lt n m | 100 := idmap.
+
+(** We should also give them their various typeclass instances *)
+Global Instance transitive_lt : Transitive lt.
+Proof.
+  hnf; unfold lt in *.
+  intros x y z p q.
+  rapply leq_trans.
+Defined.
+
+Global Instance decidable_lt n m : Decidable (lt n m) := _.
+
+Definition ge n m := leq m n.
+Existing Class ge.
+#[export] Hint Unfold ge : core typeclass_instances.
+Infix ">=" := ge : nat_scope.
+Global Instance ge_is_leq n m : leq m n -> ge n m | 100 := idmap.
+
+Global Instance reflexive_ge : Reflexive ge := leq_n.
+Global Instance transitive_ge : Transitive ge := fun x y z p q => leq_trans q p.
+Global Instance decidable_ge n m : Decidable (ge n m) := _.
+
+Definition gt n m := lt m n.
+Existing Class gt.
+#[export] Hint Unfold gt : core typeclass_instances.
+Infix ">" := gt : nat_scope.
+Global Instance gt_is_leq n m : leq m.+1 n -> gt n m | 100 := idmap.
+
+Global Instance transitive_gt : Transitive gt
+  := fun x y z p q => transitive_lt _ _ _ q p.
+Global Instance decidable_gt n m : Decidable (gt n m) := _.
+
+Notation "x <= y <= z" := (x <= y /\ y <= z) : nat_scope.
+Notation "x <= y < z"  := (x <= y /\  y < z) : nat_scope.
+Notation "x < y < z"   := (x < y  /\  y < z) : nat_scope.
+Notation "x < y <= z"  := (x < y  /\ y <= z) : nat_scope.
+
+(** Principle of double induction *)
+
+Theorem nat_double_ind (R : nat -> nat -> Type)
+  (H1 : forall n, R 0 n) (H2 : forall n, R (S n) 0)
+  (H3 : forall n m, R n m -> R (S n) (S m))
+  : forall n m:nat, R n m.
+Proof.
+  induction n; auto.
+  destruct m; auto.
+Defined.
+
+(** Maximum and minimum : definitions and specifications *)
+
+Lemma max_n_n n : max n n = n.
+Proof.
+  induction n; cbn; auto.
+Defined.
+#[export] Hint Resolve max_n_n : core.
+
+Lemma max_Sn_n n : max (S n) n = S n.
+Proof.
+  induction n; cbn; auto.
+Defined.
+#[export] Hint Resolve max_Sn_n : core.
+
+Lemma max_comm n m : max n m = max m n.
+Proof.
+  revert m; induction n; destruct m; cbn; auto.
+Defined.
+
+Lemma max_0_n n : max 0 n = n.
+Proof.
+  auto.
+Defined.
+#[export] Hint Resolve max_0_n : core.
+
+Lemma max_n_0 n : max n 0 = n.
+Proof.
+  by rewrite max_comm.
+Defined.
+#[export] Hint Resolve max_n_0 : core.
+
+Theorem max_l : forall n m, m <= n -> max n m = n.
+Proof.
+  intros n m; revert n; induction m; auto.
+  intros [] p.
+  1: inversion p.
+  cbn; by apply ap_S, IHm, leq_S_n.
+Defined.
+
+Theorem max_r : forall n m : nat, n <= m -> max n m = m.
+Proof.
+  intros; rewrite max_comm; by apply max_l.
+Defined.
+
+Lemma min_comm : forall n m, min n m = min m n.
+Proof.
+  induction n; destruct m; cbn; auto.
+Defined. 
+
+Theorem min_l : forall n m : nat, n <= m -> min n m = n.
+Proof.
+  intros n m; revert m; induction n; auto.
+  intros [] p.
+  1: inversion p.
+  cbn; by apply ap_S, IHn, leq_S_n.
+Defined.
+
+Theorem min_r : forall n m : nat, m <= n -> min n m = m.
+Proof.
+  intros; rewrite min_comm; by apply min_l.
+Defined.
+
+(** [n]th iteration of the function [f] *)
+
+Fixpoint nat_iter (n:nat) {A} (f:A->A) (x:A) : A :=
+  match n with
+    | O => x
+    | S n' => f (nat_iter n' f x)
+  end.
+
+Lemma nat_iter_succ_r n {A} (f:A->A) (x:A) :
+  nat_iter (S n) f x = nat_iter n f (f x).
+Proof.
+  induction n; intros; simpl; rewrite <- ?IHn; trivial.
+Defined.
+
+Theorem nat_iter_add :
+  forall (n m:nat) {A} (f:A -> A) (x:A),
+    nat_iter (n + m) f x = nat_iter n f (nat_iter m f x).
+Proof.
+  induction n; intros; simpl; rewrite ?IHn; trivial.
+Defined.
+
+(** Preservation of invariants : if [f : A -> A] preserves the invariant [Inv], then the iterates of [f] also preserve it. *)
+
+Theorem nat_iter_invariant (n : nat) {A} (f : A -> A) (P : A -> Type)
+  : (forall x, P x -> P (f x)) -> forall x, P x -> P (nat_iter n f x).
+Proof.
+  revert n A f P.
+  induction n; simpl; trivial.
+  intros A f P Hf x Hx.
+  apply Hf, IHn; trivial.
+Defined.
+
+(** ** Arithmetic *)
+
+Lemma nat_add_n_O : forall n:nat, n = n + 0.
+Proof.
+  induction n.
+  - reflexivity.
+  - simpl; apply ap; assumption.
+Defined.
+
+Lemma nat_add_n_Sm : forall n m:nat, (n + m).+1 = n + m.+1.
+Proof.
+  intros n m; induction n; simpl.
+  - reflexivity.
+  - apply ap; assumption.
+Defined.
+
+Definition nat_add_comm (n m : nat) : n + m = m + n.
+Proof.
+  revert m; induction n as [|n IH]; intros m; simpl.
+  - refine (nat_add_n_O m).
+  - transitivity (m + n).+1.
+    + apply ap, IH.
+    + apply nat_add_n_Sm.
+Defined.
+
+(** ** Exponentiation *)
+
+Fixpoint nat_exp (n m : nat) : nat
+  := match m with
+       | 0 => 1
+       | S m => nat_exp n m * n
+     end.
+
+(** ** Factorials *)
+
+Fixpoint factorial (n : nat) : nat
+  := match n with
+       | 0 => 1
+       | S n => S n * factorial n
+     end.
 
 (** ** Natural number ordering *)
 
-Definition leq m n := ((m - n) =n 0).
-Definition lt m n := leq (m.+1) n.
-
-Notation "m <= n" := (leq m n) : nat_scope.
-Notation "m < n" := (lt m n) : nat_scope.
-Notation "m >= n" := (n <= m) (only parsing) : nat_scope.
-Notation "m > n" := (n < m) (only parsing) : nat_scope.
-
 (** ** Theorems about natural number ordering *)
 
-Fixpoint leq0n {n} : 0 <= n :=
-  match n as n return 0 <= n with
-    | 0 => tt
-    | n'.+1 => @leq0n n'
-  end.
-
-Fixpoint subnn {n} : n - n =n 0 :=
-  match n as n return n - n =n 0 with
-    | 0 => tt
-    | n'.+1 => @subnn n'
-  end.
-
-Global Instance leq_refl : Reflexive leq
-  := @subnn.
-
-Fixpoint leqnSn {n} : n <= S n :=
-  match n as n return n <= S n with
-  | 0 => tt
-  | n'.+1 => @leqnSn n'
-  end.
-
-Fixpoint leq_transd {x y z} : (x <= y -> y <= z -> x <= z)%dprop :=
-  match x as x, y as y, z as z return (x <= y -> y <= z -> x <= z)%dprop with
-    | 0, 0, 0 => dprop_istrue
-    | x'.+1, 0, 0 => dprop_istrue
-    | 0, y'.+1, 0 => dprop_istrue
-    | 0, 0, z'.+1 => dprop_istrue
-    | x'.+1, y'.+1, 0 => dprop_istrue
-    | x'.+1, 0, z'.+1 => dprop_istrue
-    | 0, y'.+1, z'.+1 => @leq_transd 0 y' z'
-    | x'.+1, y'.+1, z'.+1 => @leq_transd x' y' z'
-  end.
-
-Global Instance leq_trans : Transitive (fun n m => leq n m)
-  := @leq_transd.
-
-Fixpoint leq_antisymd {x y} : (x <= y -> y <= x -> x =n y)%dprop :=
-  match x as x, y as y return (x <= y -> y <= x -> x =n y)%dprop with
-    | 0, 0 => dprop_istrue
-    | x'.+1, y'.+1 => @leq_antisymd x' y'
-    | _, _ => dprop_istrue
-  end.
-
-Lemma leq_antisym : forall {x y}, x <= y -> y <= x -> x = y.
+Lemma leq_antisym {x y} : x <= y -> y <= x -> x = y.
 Proof.
-  intros x y p q.
-  apply path_nat.
-  apply leq_antisymd; assumption.
+  intros p q.
+  destruct p.
+  1: reflexivity.
+  destruct x; [inversion q|].
+  apply leq_S_n in q.
+  pose (r := leq_trans p q).
+  by apply not_leq_Sn_n in r.
 Defined.
 
-Definition not_nltn n : ~ (n < n).
-Proof.
-  induction n as [|n IH]; simpl.
-  - auto.
-  - apply IH.
-Defined.
+Definition not_lt_n_n n : ~ (n < n) := not_leq_Sn_n n.
 
-Definition leq1Sn {n} : 1 <= n.+1 := tt.
 
-Fixpoint leqdichot {m} {n} : ((m <= n) + (m > n))%type.
+Definition leq_1_Sn {n} : 1 <= n.+1 := leq_S_n' 0 n (leq_0_n _).
+
+Fixpoint leq_dichot {m} {n} : (m <= n) + (m > n).
 Proof.
   induction m, n.
   - left; reflexivity.
-  - left; apply leq0n.
-  - right; unfold lt; apply leq1Sn.
-  - assert ((m <= n) + (n < m)) as X by apply leqdichot.
+  - left; apply leq_0_n.
+  - right; unfold lt; apply leq_1_Sn.
+  - assert ((m <= n) + (n < m)) as X by apply leq_dichot.
     induction X as [leqmn|ltnm].
-    + left; assumption.
-    + right; assumption.
+    + left; apply leq_S_n'; assumption.
+    + right; apply leq_S_n'; assumption.
 Defined.
+
+Lemma not_lt_n_0 n : ~ (n < 0).
+Proof.
+  apply not_leq_Sn_0.
+Defined.
+


### PR DESCRIPTION
<s>This PR is a WIP attempt at cleaning up the natural numbers library.

This PR isn't currently ready for review but was opened so I can get some help.

@andreaslyn a lot of my changes are breaking the FinNat and FinInduction library. Could you take a look? The last commit should contain the changes I tried, but I am unable to get some of the proofs to go through. Especially in FinInduction.v

When I finish this PR I will force push better commits then currently exist.</s>

---

OK, this is ready for review. Here is what has been done.

The organization has changed a bit:
 * `nat` is now defined in `Overture.v`.
 * There is a file `Basics/Nat.v` that contains very basic functions about `nat`. These are necessery to have since numeral notations (conversion between decimal, hexadecimal, TruncIndex etc.) use them.
 * Definitions of basic arithmetic, orders and lemmas about `nat` can be found in `Spaces.Nat` as expected.

Importantly, we no longer have the arbitrary organization of Coq.Peano / Spaces.nat.

Notably, we define `leq` as an inductive type, no longer as a DProp. There is still some discussion going on in #1468 about it, but at least we have something to experiment with.

The other changes are compatibility changes. Thanks to @andreaslyn for helping with the `Finite` library.

There are still some more things we can do:
 * Rename `nat` to `Nat`. #1470 I feel it will be too noisy to do here
 * Split up Spaces.Nat into smaller files (separating the theory about `leq` for example). Similar to the organization in `Pos` and `Int`.
 * Reorganise some theory about `nat` found in the hottclasse library. I didn't do this yet since it seemed like a rabbit hole, and it isn't used in many places.

closes #1367 