### PR TITLE
Mark Tr as Opaque

### DIFF
--- a/theories/Spaces/BAut/Rigid.v
+++ b/theories/Spaces/BAut/Rigid.v
@@ -7,6 +7,9 @@ Require Import Spaces.BAut.
 Local Open Scope trunc_scope.
 Local Open Scope path_scope.
 
+(** We mark Tr as transparent here as we need to unfold it. *)
+Transparent Tr.
+
 (** * Rigid types *)
 
 Class IsRigid (A : Type) := 
@@ -27,7 +30,7 @@ Global Instance contr_baut_rigid `{Univalence} {A : Type} `{IsRigid A}
   : Contr (BAut A).
 Proof.
   refine (contr_change_center (point (BAut A))).
-  refine (contr_trunc_conn (Tr 0)).
+  nrefine (contr_trunc_conn (Tr 0)); [|exact _].
   intros Z W; baut_reduce.
   refine (istrunc_equiv_istrunc (n := -1) (A <~> A)
                       (path_baut (point (BAut A)) (point (BAut A)))).

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -63,6 +63,9 @@ Proof.
   - intros; reflexivity.
 Defined.
 
+(** We want to discourage coq from unfolding [Tr] as much as possible. *)
+Global Opaque Tr.
+
 (** We don't usually declare modalities as coercions, but this particular one is convenient so that lemmas about (for instance) connected maps can be applied to truncation modalities without the user/reader needing to be (particularly) aware of the general notion of modality. *)
 Coercion Tr : trunc_index >-> Modality.
 (** However, if the coercion is not printed, then we get things like [Tr (-1) X] being printed as [(-1) X], which is terribly confusing.  So we tell Coq to always print this coercion.  This does mean that although the user can type things like [IsConnected n X], it will always be displayed back as [IsConnected (Tr n) X]. *)


### PR DESCRIPTION
I'm creating this draft so we can see if it fixes some issues highlighted in #1475.

Note that the following now works correctly:
```coq
Require Import HoTT.

Local Open Scope trunc_scope.
Local Open Scope mc_mult_scope.

Definition test (X : pType) `{IsTrunc 1 X}
  : { bloop' : Pi1 X -> loops X &
                   forall x y : Pi1 X, bloop' (x * y) = bloop' x @ bloop' y }.
Proof.
    exists (equiv_tr 0 _)^-1%equiv.
    Time simpl.
```
But I also see that the behaviour of `cbn` is vastly different from `simpl`.


This is currently on top of #1472. 