### PR TITLE
Parametrise IsProjective and IsQuotientChoosable

### DIFF
--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -1645,7 +1645,7 @@ End Book_7_1.
 (** Exercise 7.9 *)
 
 (** Solution for the case (oo,-1). *)
-Definition Book_7_9_oo_neg1 `{Univalence} (AC_oo_neg1 : forall X : HSet, IsProjective' X) (A : Type)
+Definition Book_7_9_oo_neg1 `{Univalence} (AC_oo_neg1 : forall X : HSet, IsPureChoosable X) (A : Type)
   : merely (exists X : HSet, exists p : X -> A, IsSurjection p)
   := @HoTT.Projective.projective_cover_AC AC_oo_neg1 _ A.
 

--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -1645,7 +1645,7 @@ End Book_7_1.
 (** Exercise 7.9 *)
 
 (** Solution for the case (oo,-1). *)
-Definition Book_7_9_oo_neg1 `{Univalence} (AC_oo_neg1 : forall X : HSet, IsPureChoosable X) (A : Type)
+Definition Book_7_9_oo_neg1 `{Univalence} (AC_oo_neg1 : forall X : HSet, HasChoice X) (A : Type)
   : merely (exists X : HSet, exists p : X -> A, IsSurjection p)
   := @HoTT.Projective.projective_cover_AC AC_oo_neg1 _ A.
 

--- a/theories/Algebra/Universal/Congruence.v
+++ b/theories/Algebra/Universal/Congruence.v
@@ -2,7 +2,7 @@
     universal algebra generalization of normal subgroup, ring ideal, etc.
 
     Congruence is used to construct quotients, in similarity with how
-    normal subgroup and ring ideal is used to construct quotients. *)
+    normal subgroup and ring ideal are used to construct quotients. *)
 
 Require Export HoTT.Algebra.Universal.Algebra.
 

--- a/theories/Algebra/Universal/TermAlgebra.v
+++ b/theories/Algebra/Universal/TermAlgebra.v
@@ -412,3 +412,4 @@ Section ump_term_algebra.
   Defined.
 
 End ump_term_algebra.
+

--- a/theories/HIT/quotient/choice.v
+++ b/theories/HIT/quotient/choice.v
@@ -1,0 +1,336 @@
+Require Import
+  HoTT.Basics
+  HoTT.Types
+  HoTT.HSet
+  HoTT.Truncations
+  HoTT.TruncType
+  HoTT.HIT.quotient
+  HoTT.Projective.
+
+(** The following is an alternative (0,-1)-projective predicate.
+    Given a family of quotient sets [forall x : A, quotient (R x)],
+    for [R : forall x : A, Relation (B x)], we merely have a choice
+    function [g : forall x, B x], such that [class_of (g x) = f x]. *)
+
+Definition IsQuotientChoosable (A : Type) :=
+  forall (B : A -> Type), (forall x, IsHSet (B x)) ->
+  forall (R : forall x, Relation (B x))
+         (pR : forall x, is_mere_relation (B x) (R x)),
+         (forall x, Reflexive (R x)) ->
+         (forall x, Symmetric (R x)) ->
+         (forall x, Transitive (R x)) ->
+  forall (f : forall x : A, quotient (R x)),
+  hexists (fun g : (forall x : A, B x) =>
+                   forall x, class_of (R x) (g x) = f x).
+
+Section choose_isquotientchoosable.
+  Context `{Univalence}
+    {A : Type} {B : A -> Type} `{!forall x, IsHSet (B x)}
+    (P : forall x, B x -> Type) `{!forall x (a : B x), IsHProp (P x a)}.
+
+  Local Definition RelClassEquiv (x : A) (a : B x) (b : B x) : Type
+    := P x a <~> P x b.
+
+  Local Instance reflexive_relclass
+    : forall x, Reflexive (RelClassEquiv x).
+  Proof.
+    intros a b. apply equiv_idmap.
+  Qed.
+
+  Local Instance symmetric_relclass
+    : forall x, Symmetric (RelClassEquiv x).
+  Proof.
+    intros a b1 b2 p. apply (equiv_inverse p).
+  Qed.
+
+  Local Instance transitive_relclass
+    : forall x, Transitive (RelClassEquiv x).
+  Proof.
+    intros a b1 b2 b3 p q. apply (equiv_compose q p).
+  Qed.
+
+  Local Instance hprop_choose_cod (a : A)
+    : IsHProp {c : quotient (RelClassEquiv a)
+                 | forall b, in_class (RelClassEquiv a) c b <~> P a b}.
+  Proof.
+    apply ishprop_sigma_disjoint.
+    refine (quotient_ind_prop _ _ _).
+    intro b1.
+    refine (quotient_ind_prop _ _ _).
+    intros b2 f g.
+    apply related_classes_eq.
+    apply (f b2)^-1.
+    apply g.
+    apply reflexive_relclass.
+  Qed.
+
+  Local Definition prechoose (i : forall x, hexists (P x)) (a : A)
+    : {c : quotient (RelClassEquiv a)
+         | forall b : B a, in_class (RelClassEquiv a) c b <~> P a b}.
+  Proof.
+    specialize (i a).
+    strip_truncations.
+    destruct i as [b1 h].
+    exists (class_of _ b1).
+    intro b2.
+    apply equiv_iff_hprop.
+    - intro f. exact (f h).
+    - intro p. by apply equiv_iff_hprop.
+  Defined.
+
+  Local Definition choose (i : forall x, hexists (P x)) (a : A)
+    : quotient (RelClassEquiv a)
+    := (prechoose i a).1.
+
+End choose_isquotientchoosable.
+
+(** The following section derives [IsTrChoosable 0 A]
+    from [IsQuotientChoosable A]. *)
+
+Section isquotientchoosable_to_istr0choosable.
+  Context `{Univalence} (A : Type) (qch : IsQuotientChoosable A).
+
+  Local Definition RelUnit (B : A -> Type) (a : A) (b1 b2 : B a) : HProp
+    := Build_HProp Unit.
+
+  Local Instance reflexive_relunit (B : A -> Type) (a : A)
+    : Reflexive (RelUnit B a).
+  Proof.
+    done.
+  Qed.
+
+  Local Instance symmetric_relunit (B : A -> Type) (a : A)
+    : Symmetric (RelUnit B a).
+  Proof.
+    done.
+  Qed.
+
+  Local Instance transitive_relunit (B : A -> Type) (a : A)
+    : Transitive (RelUnit B a).
+  Proof.
+    done.
+  Qed.
+
+  Local Instance ishprop_quotient_relunit (B : A -> Type) (a : A)
+    : IsHProp (quotient (RelUnit B a)).
+  Proof.
+    apply hprop_allpath.
+    refine (quotient_ind_prop _ _ _).
+    intro r.
+    refine (quotient_ind_prop _ _ _).
+    intro s.
+    by apply related_classes_eq.
+  Qed.
+
+  Lemma isquotientchoosable_to_istr0choosable : IsTrChoosable 0 A.
+  Proof.
+    intros B sB f.
+    transparent assert (g : (forall a, quotient (RelUnit B a))).
+    - intro a.
+      specialize (f a).
+      strip_truncations.
+      exact (class_of _ f).
+    - specialize (qch B _ (RelUnit B) _ _ _ _ g).
+      strip_truncations.
+      apply tr.
+      apply qch.
+  Qed.
+
+End isquotientchoosable_to_istr0choosable.
+
+Lemma istr0choosable_to_isquotientchoosable (A : Type)
+  : IsTrChoosable 0 A -> IsQuotientChoosable A.
+Proof.
+  intros ch B sB R pR rR sR tR f.
+  set (P := fun a b => class_of (R a) b = f a).
+  assert (forall a, merely ((fun x => {b | P x b}) a)) as g.
+  - intro a.
+    refine (quotient_ind_prop _
+              (fun c => merely {b | class_of (R a) b = c}) _ (f a)).
+    intro b.
+    apply tr.
+    by exists b.
+  - pose proof (ch (fun a => {b | P a b}) _ g) as h.
+    strip_truncations.
+    apply tr.
+    exists (fun x => (h x).1).
+    intro a.
+    apply h.
+Qed.
+
+Global Instance isequiv_istr0choosable_to_isquotientchoosable
+  `{Univalence} (A : Type)
+  : IsEquiv (istr0choosable_to_isquotientchoosable A).
+Proof.
+  srapply isequiv_iff_hprop.
+  - apply istrunc_forall.
+  - apply isquotientchoosable_to_istr0choosable.
+Qed.
+
+Definition equiv_istr0choosable_isquotientchoosable `{Univalence} (A : Type)
+  : IsTrChoosable 0 A <~> IsQuotientChoosable A
+  := Build_Equiv _ _ (istr0choosable_to_isquotientchoosable A) _.
+
+(** The next section uses [istr0choosable_to_isquotientchoosable] to
+    generalize [quotient_rec2], see [choose_quotient_ind] below. *)
+
+Section choose_quotient_ind.
+  Context `{Univalence}
+    {I : Type} `{!IsTrChoosable 0 I}
+    {A : I -> Type} `{!forall i, IsHSet (A i)}
+    (R : forall i, Relation (A i))
+    `{!forall i, is_mere_relation (A i) (R i)}
+    {rR : forall i, Reflexive (R i)}
+    {sR : forall i, Symmetric (R i)}
+    {tR : forall i, Transitive (R i)}.
+
+(** First generalize the [related_classes_eq] constructor. *)
+
+  Lemma pointwise_related_classes_eq
+    (f g : forall i, A i) (r : forall i, R i (f i) (g i))
+    : (fun i => class_of (R i) (f i)) = (fun i => class_of (R i) (g i)).
+  Proof.
+    funext s.
+    by apply related_classes_eq.
+  Defined.
+
+(** Given suitable preconditions, we will show that [ChooseProp P a g]
+    is inhabited, rather than directly showing [P q]. This turns
+    out to be beneficial because [ChooseProp P a g] is a proposition. *)
+
+  Local Definition ChooseProp
+    (P : (forall i, quotient (R i)) -> Type) `{!forall g, IsHSet (P g)}
+    (a : forall (f : forall i, A i), P (fun i => class_of (R i) (f i)))
+    (g : forall i, quotient (R i))
+    : Type
+    := {b : P g
+       | merely (exists (f : forall i, A i)
+                        (q : g = fun i => class_of (R i) (f i)),
+                 forall (f' : forall i, A i)
+                        (r : forall i, R i (f i) (f' i)),
+                 pointwise_related_classes_eq f f' r # q # b = a f')}.
+
+  Local Instance ishprop_choose_quotient_ind_chooseprop
+    (P : (forall i, quotient (R i)) -> Type) `{!forall g, IsHSet (P g)}
+    (a : forall (f : forall i, A i), P (fun i => class_of (R i) (f i)))
+    (g : forall i, quotient (R i))
+    : IsHProp (ChooseProp P a g).
+  Proof.
+    apply ishprop_sigma_disjoint.
+    intros x y h1 h2.
+    strip_truncations.
+    destruct h1 as [f1 [q1 p1]].
+    destruct h2 as [f2 [q2 p2]].
+    specialize (p1 f1 (fun i => rR i (f1 i))).
+    set (pR := fun i => classes_eq_related (R i) _ _ (ap (fun h => h i) q2^
+                        @ ap (fun h => h i) q1)).
+    specialize (p2 f1 pR).
+    do 2 apply moveL_transport_V in p1.
+    do 2 apply moveL_transport_V in p2.
+    refine (p1 @ _ @ p2^).
+    apply moveR_transport_p.
+    rewrite inv_V.
+    rewrite <- transport_pp.
+    apply moveR_transport_p.
+    rewrite inv_V.
+    do 2 rewrite <- transport_pp.
+    set (pa := (pointwise_related_classes_eq f2 f1 pR)^
+               @ (q2^ @ q1
+               @ pointwise_related_classes_eq f1 f1 _)).
+    by induction (hset_path2 idpath pa).
+  Qed.
+
+(* Since [ChooseProp P a g] is a proposition, we can apply
+   [istr0choosable_to_isquotientchoosable] and strip its truncation
+   in order to derive [ChooseProp P a g]. *)
+
+  Lemma chooseprop_quotient_ind
+    (P : (forall i, quotient (R i)) -> Type) `{!forall g, IsHSet (P g)}
+    (a : forall (f : forall i, A i), P (fun i => class_of (R i) (f i)))
+    (E : forall (f f' : forall i, A i) (r : forall i, R i (f i) (f' i)),
+         pointwise_related_classes_eq f f' r # a f = a f')
+    (g : forall i, quotient (R i))
+    : ChooseProp P a g.
+  Proof.
+    pose proof
+      (istr0choosable_to_isquotientchoosable I _ A _ R _ _ _ _ g) as h.
+    strip_truncations.
+    destruct h as [h p].
+    apply path_forall in p.
+    refine (transport _ p _).
+    exists (a h).
+    apply tr.
+    exists h.
+    exists 1.
+    apply E.
+  Defined.
+
+(** By projecting out of [chooseprop_quotient_ind] we obtain a
+    generalization of [quotient_rec2]. *)
+
+  Lemma choose_quotient_ind
+    (P : (forall i, quotient (R i)) -> Type) `{!forall g, IsHSet (P g)}
+    (a : forall (f : forall i, A i), P (fun i => class_of (R i) (f i)))
+    (E : forall (f f' : forall i, A i) (r : forall i, R i (f i) (f' i)),
+         pointwise_related_classes_eq f f' r # a f = a f')
+    (g : forall i, quotient (R i))
+    : P g.
+  Proof.
+    exact (chooseprop_quotient_ind P a E g).1.
+  Defined.
+
+(** A specialization of [choose_quotient_ind] to the case where
+    [P g] is a proposition. *)
+
+  Lemma choose_quotient_ind_prop
+    (P : (forall i, quotient (R i)) -> Type) `{!forall g, IsHProp (P g)}
+    (a : forall (f : forall i, A i), P (fun i => class_of (R i) (f i)))
+    (g : forall i, quotient (R i))
+    : P g.
+  Proof.
+    refine (choose_quotient_ind P a _ g). intros. apply path_ishprop.
+  Defined.
+
+(** The recursion principle derived from [choose_quotient_ind]. *)
+
+  Definition choose_quotient_rec
+    {B : Type} `{!IsHSet B} (a : (forall i, A i) -> B)
+    (E : forall (f f' : forall i, A i),
+         (forall i, R i (f i) (f' i)) -> a f = a f')
+    (g : forall i, quotient (R i))
+    : B
+    := choose_quotient_ind (fun _ => B) a
+        (fun f f' r => transport_const _ _ @ E f f' r) g.
+
+(** The "beta-rule" of [choose_quotient_ind]. *)
+
+  Lemma choose_quotient_ind_compute
+    (P : (forall i, quotient (R i)) -> Type) `{!forall g, IsHSet (P g)}
+    (a : forall (f : forall i, A i), P (fun i => class_of (R i) (f i)))
+    (E : forall (f f' : forall i, A i) (r : forall i, R i (f i) (f' i)),
+         pointwise_related_classes_eq f f' r # a f = a f')
+    (f : forall i, A i)
+    : choose_quotient_ind P a E (fun i => class_of (R i) (f i)) = a f.
+  Proof.
+    refine (Trunc_ind (fun a => (_ a).1 = _) _ _). cbn.
+    intros [f' p].
+    rewrite transport_sigma.
+    set (p' := fun x => classes_eq_related (R x) _ _ (p x)).
+    assert (p = (fun i => related_classes_eq (R i) (p' i))) as pE.
+    - funext x. apply hset_path2.
+    - rewrite pE. apply E.
+  Qed.
+
+(** The "beta-rule" of [choose_quotient_rec]. *)
+
+  Lemma choose_quotient_rec_compute
+    {B : Type} `{!IsHSet B} (a : (forall i, A i) -> B)
+    (E : forall (f f' : forall i, A i),
+         (forall i, R i (f i) (f' i)) -> a f = a f')
+    (f : forall i, A i)
+    : choose_quotient_rec a E (fun i => class_of (R i) (f i)) = a f.
+  Proof.
+    apply (choose_quotient_ind_compute (fun _ => B)).
+  Qed.
+End choose_quotient_ind.
+

--- a/theories/Projective.v
+++ b/theories/Projective.v
@@ -1,27 +1,41 @@
 Require Import Basics Types HProp HFiber HSet.
 Require Import Truncations.
-Require Import Modalities.Descent Modalities.Separated.
+Require Import Modalities.Descent.
+Require Import Modalities.Separated.
+Require Import Modalities.Identity.
 Require Import Limits.Pullback.
 
 
 (** * Projective types *)
 
-Definition IsProjective (X : Type) : Type
-  := forall A B : Type, forall f : X -> B, forall p : A -> B,
-        IsSurjection p -> merely (exists s : X -> A, p o s == f).
+(** To quantify over all truncation levels including infinity, we parametrize [IsProjective] by a [Modality]. When specializing to [IsProjective purely] we get an (oo,-1)-projective predicate. When specializing to [IsProjective (Tr n)] we get an (n,-1)-projective predicate. *)
+
+Definition IsProjective (O : Modality) (X : Type) : Type
+  := forall A, In O A -> forall B, In O B ->
+     forall f : X -> B, forall p : A -> B,
+     IsSurjection p -> merely (exists s : X -> A, p o s == f).
+
+(** An (oo,-1)-projective predicate [IsPureProjective]. *)
+
+Notation IsPureProjective := (IsProjective purely).
+
+(** An (n,-1)-projective predicate [IsTrProjective]. *)
+
+Notation IsTrProjective n := (IsProjective (Tr n)).
 
 (** A type X is projective if and only if surjections into X merely split. *)
-Proposition iff_isprojective_surjections_split (X : Type)
-  : IsProjective X <->
-    (forall (Y : Type), forall (p : Y -> X),
+Proposition iff_isprojective_surjections_split
+  (O : Modality) (X : Type) `{In O X}
+  : IsProjective O X <->
+    (forall (Y : Type), In O Y -> forall (p : Y -> X),
           IsSurjection p -> merely (exists s : X -> Y, p o s == idmap)).
 Proof.
   split.
-  - intros isprojX Y p S; unfold IsProjective in isprojX.
-    exact (isprojX Y X idmap p S).
+  - intros isprojX Y oY p S; unfold IsProjective in isprojX.
+    exact (isprojX Y _ X _ idmap p S).
   - intro splits. unfold IsProjective.
-    intros A B f p S.
-    pose proof (splits (Pullback p f) pullback_pr2 _) as s'.
+    intros A oA B oB f p S.
+    pose proof (splits (Pullback p f) _ pullback_pr2 _) as s'.
     strip_truncations.
     destruct s' as [s E].
     refine (tr (pullback_pr1 o s; _)).
@@ -31,53 +45,84 @@ Proof.
     apply E.
 Defined.
 
-Corollary equiv_isprojective_surjections_split `{Funext} (X : Type)
-  : IsProjective X <~>
-    (forall (Y : Type), forall (p : Y -> X),
+Corollary equiv_isprojective_surjections_split
+  `{Funext} (O : Modality) (X : Type) `{In O X}
+  : IsProjective O X <~>
+    (forall (Y : Type), In O Y -> forall (p : Y -> X),
           IsSurjection p -> merely (exists s : X -> Y, p o s == idmap)).
 Proof.
-  exact (equiv_iff_hprop_uncurried (iff_isprojective_surjections_split X)).
+  exact (equiv_iff_hprop_uncurried (iff_isprojective_surjections_split O X)).
 Defined.
 
 
 (** ** Projectivity and the axiom of choice *)
 
-(** In topos theory, an object X is said to be projective if the axiom of choice holds when making choices indexed by X. *)
-Definition IsProjective' (X : Type) : Type := forall P : X -> Type,
-    (forall x, merely (P x)) -> merely (forall x, P x).
+(** In topos theory, an object X is said to be projective if the axiom of choice holds when making choices indexed by X. We will refer to this as [IsChoosable], to avoid confusion with [IsProjective] above. In similarity with [IsProjective], we parametrize it by a [Modality]. *)
 
-Proposition iff_isprojective_choice (X : Type)
-  : IsProjective X <-> IsProjective' X.
+Class IsChoosable (O : Modality) (A : Type) :=
+  ischoosable :
+    forall (B : A -> Type), (forall x, In O (B x)) ->
+    (forall x, merely (B x)) -> merely (forall x, B x).
+
+(** An (oo,-1)-choice predicate [IsPureChoosable]. *)
+
+Notation IsPureChoosable := (IsChoosable purely).
+
+(** An (n,-1)-choice predicate [IsTrChoosable]. *)
+
+Notation IsTrChoosable n := (IsChoosable (Tr n)).
+
+Global Instance ischoosable_sigma
+  `{Funext} {A : Type} {B : A -> Type} (O : Modality)
+  (chA : IsChoosable O A)
+  (chB : forall a : A, IsChoosable O (B a))
+  : IsChoosable O {a : A | B a}.
 Proof.
-  refine (iff_compose (iff_isprojective_surjections_split X) _).
+  intros C sC f.
+  set (f' := fun a => chB a (fun b => C (a; b)) _ (fun b => f (a; b))).
+  specialize (chA (fun a => forall b, C (a; b)) _ f').
+  strip_truncations.
+  apply tr.
+  intro.
+  apply chA.
+Qed.
+
+Proposition iff_isprojective_ischoosable
+  (O : Modality) (X : Type) `{In O X}
+  : IsProjective O X <-> IsChoosable O X.
+Proof.
+  refine (iff_compose (iff_isprojective_surjections_split O X) _).
   split.
-  - intros splits P S.
+  - intros splits P oP S.
     specialize splits with {x : X & P x} pr1.
-    pose proof (splits (fst (iff_merely_issurjection P) S)) as M.
+    pose proof (splits _ (fst (iff_merely_issurjection P) S)) as M.
     clear S splits.
     strip_truncations; apply tr.
     destruct M as [s p].
     intro x.
     exact (transport _ (p x) (s x).2).
-  - intros choiceX Y p S.
+  - intros choiceX Y oY p S.
     unfold IsConnMap, IsConnected in S.
     pose proof (fun b => (@center _ (S b))) as S'; clear S.
-    pose proof (choiceX (hfiber p) S') as M; clear S'.
+    pose proof (choiceX (hfiber p) _ S') as M; clear S'.
     strip_truncations; apply tr.
     exists (fun x => (M x).1).
     exact (fun x => (M x).2).
 Defined.
 
-Proposition equiv_isprojective_choice `{Funext} (X : Type)
-  : IsProjective X <~> IsProjective' X.
+Proposition equiv_isprojective_ischoosable
+  `{Funext} (O : Modality) (X : Type) `{In O X}
+  : IsProjective O X <~> IsChoosable O X.
 Proof.
-  exact (equiv_iff_hprop_uncurried (iff_isprojective_choice X)).
+  nrapply (equiv_iff_hprop_uncurried
+            (iff_isprojective_ischoosable O X)); try exact _.
+  apply istrunc_forall.
 Defined.
 
-Proposition isprojective_unit : IsProjective Unit.
+Proposition ispureprojective_unit : IsPureProjective Unit.
 Proof.
-  apply (iff_isprojective_choice Unit).
-  intros P S.
+  apply (iff_isprojective_ischoosable purely Unit).
+  intros P trP S.
   specialize S with tt.
   strip_truncations; apply tr.
   apply Unit_ind.
@@ -88,15 +133,15 @@ Section AC_oo_neg1.
   (** ** Projectivity and AC_(oo,-1) (defined in HoTT book, Exercise 7.8) *)
   (* TODO: Generalize to n, m. *)
 
-  Context {AC : forall X : HSet, IsProjective' X}.
+  Context {AC : forall X : HSet, IsPureChoosable X}.
 
   (** (Exercise 7.9) Assuming AC_(oo,-1) every type merely has a projective cover. *)
   Proposition projective_cover_AC `{Univalence} (A : Type)
     : merely (exists X:HSet, exists p : X -> A, IsSurjection p).
   Proof.
     pose (X := Build_HSet (Tr 0 A)).
-    pose proof ((equiv_isprojective_choice X)^-1 (AC X)) as P.
-    pose proof (P A X idmap tr _) as F; clear P.
+    pose proof ((equiv_isprojective_ischoosable _ X)^-1 (AC X)) as P.
+    pose proof (P A _ X _ idmap tr _) as F; clear P.
     strip_truncations.
     destruct F as [f p].
     refine (tr (X; (f; BuildIsSurjection f _))).
@@ -109,19 +154,19 @@ Section AC_oo_neg1.
 
   (** Assuming AC_(oo,-1), projective types are exactly sets. *)
   Theorem equiv_isprojective_ishset_AC `{Univalence} (X : Type)
-    : IsProjective X <~> IsHSet X.
+    : IsPureProjective X <~> IsHSet X.
   Proof.
     apply equiv_iff_hprop.
     - intro isprojX. unfold IsProjective in isprojX.
       pose proof (projective_cover_AC X) as P; strip_truncations.
       destruct P as [P [p issurj_p]].
-      pose proof (isprojX P X idmap p issurj_p) as S; strip_truncations.
+      pose proof (isprojX P _ X _ idmap p issurj_p) as S; strip_truncations.
       destruct S as [s h].
       rapply (istrunc_embedding_trunc s).
       apply isembedding_isinj_hset.
       exact (isinj_section h).
     - intro ishsetX.
-      apply (equiv_isprojective_choice X)^-1.
+      apply (equiv_isprojective_ischoosable purely X)^-1.
       rapply AC.
   Defined.
 

--- a/theories/Spaces/Finite/Finite.v
+++ b/theories/Spaces/Finite/Finite.v
@@ -211,7 +211,7 @@ Defined.
 
 (** ** The finite axiom of choice, and projectivity *)
 
-Definition finite_choice {X} `{Finite X} : IsPureChoosable X.
+Definition finite_choice {X} `{Finite X} : HasChoice X.
 Proof.
   intros P oP f; clear oP.
   assert (e := merely_equiv_fin X).
@@ -230,9 +230,9 @@ Proof.
       exact (tr (sum_ind P IH (Unit_ind e))).
 Defined.
 
-Corollary isprojective_fin_n (n : nat) : IsPureProjective (Fin n).
+Corollary isprojective_fin_n (n : nat) : IsProjective (Fin n).
 Proof.
-  apply (iff_isprojective_ischoosable _ (Fin n)).
+  apply (iff_isoprojective_hasochoice _ (Fin n)).
   rapply finite_choice.
 Defined.
 

--- a/theories/Spaces/Finite/Finite.v
+++ b/theories/Spaces/Finite/Finite.v
@@ -211,10 +211,9 @@ Defined.
 
 (** ** The finite axiom of choice, and projectivity *)
 
-Definition finite_choice {X} `{Finite X} (P : X -> Type)
-  : (forall x, merely (P x)) -> merely (forall x, P x).
+Definition finite_choice {X} `{Finite X} : IsPureChoosable X.
 Proof.
-  intros f.
+  intros P oP f; clear oP.
   assert (e := merely_equiv_fin X).
   strip_truncations.
   set (P' := P o e^-1).
@@ -231,9 +230,9 @@ Proof.
       exact (tr (sum_ind P IH (Unit_ind e))).
 Defined.
 
-Corollary isprojective_fin_n (n : nat) : IsProjective (Fin n).
+Corollary isprojective_fin_n (n : nat) : IsPureProjective (Fin n).
 Proof.
-  apply (iff_isprojective_choice (Fin n)).
+  apply (iff_isprojective_ischoosable _ (Fin n)).
   rapply finite_choice.
 Defined.
 
@@ -429,7 +428,7 @@ Definition fcard_sigma {X} (Y : X -> Type)
 Proof.
   set (f := fun x => fcard (Y x)).
   set (g := fun x => merely_equiv_fin (Y x) : merely (Y x <~> Fin (f x))).
-  apply finite_choice in g.
+  apply finite_choice in g; [| exact _].
   strip_truncations.
   unfold finadd.
   refine (fcard_equiv' (equiv_functor_sigma_id g)).
@@ -481,7 +480,7 @@ Definition fcard_forall `{Funext} {X} (Y : X -> Type)
 Proof.
   set (f := fun x => fcard (Y x)).
   set (g := fun x => merely_equiv_fin (Y x) : merely (Y x <~> Fin (f x))).
-  apply finite_choice in g.
+  apply finite_choice in g; [| exact _].
   strip_truncations.
   unfold finmult.
   refine (fcard_equiv' (equiv_functor_forall' (equiv_idmap X) g)).


### PR DESCRIPTION
I have parametrised `IsProjective` by a modality, which was suggested by @Alizter as a way to generalise over all truncation levels including infinity.

I have changed name of `IsProjective'` to `IsChoosable`, to avoid confusion with `IsProjective`.

I have moreover defined `IsQuotientChoosable`, equivalent to `(0,-1)-projective`, which I will need later on. Although I do not use it, I have included `choose_quotient_ind`, which generalises `quotient_rec2`. I think it is a nice recursion principle for `quotient`.