### PR TITLE
Fix generation of library dep graphs

### DIFF
--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -135,11 +135,11 @@ strict: strict-test strict-no-axiom hottlib hott-core hott-categories contrib
 # The deps file, for graphs
 HoTT.deps: $(ALL_VFILES)
 	$(SHOW)'COQDEP > $@'
-	$(HIDE)$(COQDEP) $(CMDLINE_COQLIBS) $(ALL_VFILES) | sed s'#\\#/#g' >$@
+	$(HIDE)$(COQDEP) $(COQLIBS) $(ALL_VFILES) | sed s'#\\#/#g' >$@
 
 HoTTCore.deps: $(CORE_VFILES)
 	$(SHOW)'COQDEP > $@'
-	$(HIDE)$(COQDEP) $(CMDLINE_COQLIBS) $(CORE_VFILES) | sed s'#\\#/#g' >$@
+	$(HIDE)$(COQDEP) $(COQLIBS) $(CORE_VFILES) | sed s'#\\#/#g' >$@
 
 # The HTML files
 # We have a dummy file, to allow us to depend on the html files


### PR DESCRIPTION
Since we are not passing all .v files, we cannot use `-f _CoqProject` to
invoke coqdep.  Since we are not using `-f _CoqProject`, we must pass
all of the `COQLIBS` arguments, not just the ones that got passed on the
command line.