### PR TITLE
Change Let to Definition in is_adjoint' so that Qed works.

### DIFF
--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -141,7 +141,7 @@ Section Adjointify.
   Let issect' := fun x =>
     ap g (ap f (issect x)^)  @  ap g (isretr (f x))  @  issect x.
 
-  Let is_adjoint' (a : A) : isretr (f a) = ap f (issect' a).
+  Definition is_adjoint' (a : A) : isretr (f a) = ap f (issect' a).
   Proof.
     unfold issect'.
     apply moveR_M1.

--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -141,7 +141,7 @@ Section Adjointify.
   Let issect' := fun x =>
     ap g (ap f (issect x)^)  @  ap g (isretr (f x))  @  issect x.
 
-  Definition is_adjoint' (a : A) : isretr (f a) = ap f (issect' a).
+  Local Definition is_adjoint' (a : A) : isretr (f a) = ap f (issect' a).
   Proof.
     unfold issect'.
     apply moveR_M1.


### PR DESCRIPTION
In #1475, @JasonGross noticed a `Let ... Qed`.  `Qed` leaves things transparent with `Let`, so this changes `Let` to `Definition` so that the `Qed` does what was intended.  The build time of the library is reduced by 3% (and BlakersMassey.v is twice as fast).

```
   After |  Peak Mem | File Name                                                    |   Before |  Peak Mem ||    Change || Change (mem) | % Change | % Change (mem)
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
3m39.85s | 613024 ko | Total Time / Peak Mem                                        | 3m46.88s | 613240 ko || -0m07.02s ||      -216 ko |   -3.09% |         -0.03%
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
0m05.39s | 446632 ko | Cubical/PathCube.vo                                          | 0m06.99s | 444860 ko || -0m01.60s ||      1772 ko |  -22.88% |         +0.39%
0m01.57s | 362828 ko | Homotopy/BlakersMassey.vo                                    | 0m03.17s | 363060 ko || -0m01.59s ||      -232 ko |  -50.47% |         -0.06%
0m00.41s | 343332 ko | Spaces/Finite/Fin.vo                                         | 0m01.16s | 343128 ko || -0m00.75s ||       204 ko |  -64.65% |         +0.05%
0m00.36s | 353380 ko | Truncations/Core.vo                                          | 0m00.94s | 449952 ko || -0m00.57s ||    -96572 ko |  -61.70% |        -21.46%
0m00.11s | 155536 ko | Categories/Grothendieck/ToSet/Univalent.vo                   | 0m00.48s | 280184 ko || -0m00.37s ||   -124648 ko |  -77.08% |        -44.48%
0m00.86s | 385972 ko | Spaces/Universe.vo                                           | 0m01.19s | 385640 ko || -0m00.32s ||       332 ko |  -27.73% |         +0.08%
0m00.25s | 311024 ko | TruncType.vo                                                 | 0m00.51s | 311732 ko || -0m00.26s ||      -708 ko |  -50.98% |         -0.22%
0m01.11s | 325408 ko | PropResizing/Nat.vo                                          | 0m01.37s | 332044 ko || -0m00.26s ||     -6636 ko |  -18.97% |         -1.99%
```