### PR TITLE
More ring theory, movement lemmas and cleanup

### DIFF
--- a/theories/Algebra/AbGroups/Abelianization.v
+++ b/theories/Algebra/AbGroups/Abelianization.v
@@ -7,6 +7,7 @@ Require Import Algebra.AbGroups.AbelianGroup.
 (** In this file we define what it means for a group homomorphism G -> H into an abelian group H to be an abelianization. We then construct an example of an abelianization. *)
 
 Local Open Scope mc_mult_scope.
+Local Open Scope wc_iso_scope.
 
 (** Definition of Abelianization.
 
@@ -317,7 +318,7 @@ Theorem groupiso_isabelianization {G : Group}
   (eta2 : GroupHomomorphism G B)
   {isab1 : IsAbelianization A eta1}
   {isab2 : IsAbelianization B eta2}
-  : GroupIsomorphism A B.
+  : A ≅ B.
 Proof.
   destruct (esssurj (group_precomp B eta1) eta2) as [a ac].
   destruct (esssurj (group_precomp A eta2) eta1) as [b bc].

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -15,6 +15,7 @@ Declare Scope group_scope.
 
 Local Open Scope pointed_scope.
 Local Open Scope mc_mult_scope.
+Local Open Scope wc_iso_scope.
 
 (** * Definition of Group *)
 
@@ -449,6 +450,75 @@ Section GroupMovement.
 
 End GroupMovement.
 
+(** The wild cat of Groups *)
+Global Instance isgraph_group : IsGraph Group
+  := Build_IsGraph Group GroupHomomorphism.
+
+Global Instance is01cat_group : Is01Cat Group :=
+  (Build_Is01Cat Group _ (@grp_homo_id) (@grp_homo_compose)).
+
+Global Instance isgraph_grouphomomorphism {A B : Group} : IsGraph (A $-> B)
+  := induced_graph (@grp_homo_map A B).
+
+Global Instance is01cat_grouphomomorphism {A B : Group} : Is01Cat (A $-> B)
+  := induced_01cat (@grp_homo_map A B).
+
+Global Instance is0gpd_grouphomomorphism {A B : Group}: Is0Gpd (A $-> B)
+  := induced_0gpd (@grp_homo_map A B).
+
+Global Instance is0functor_postcomp_grouphomomorphism {A B C : Group} (h : B $-> C)
+  : Is0Functor (@cat_postcomp Group _ _ A B C h).
+Proof.
+  apply Build_Is0Functor.
+  intros [f ?] [g ?] p a ; exact (ap h (p a)).
+Defined.
+
+Global Instance is0functor_precomp_grouphomomorphism
+       {A B C : Group} (h : A $-> B)
+  : Is0Functor (@cat_precomp Group _ _ A B C h).
+Proof.
+  apply Build_Is0Functor.
+  intros [f ?] [g ?] p a ; exact (p (h a)).
+Defined.
+
+(** Group forms a 1Cat *)
+Global Instance is1cat_group : Is1Cat Group.
+Proof.
+  by rapply Build_Is1Cat.
+Defined.
+
+Instance hasmorext_group `{Funext} : HasMorExt Group.
+Proof.
+  srapply Build_HasMorExt.
+  intros A B f g; cbn in *.
+  snrapply @isequiv_homotopic.
+  1: exact (equiv_path_grouphomomorphism^-1%equiv).
+  1: exact _.
+  intros []; reflexivity. 
+Defined.
+
+Global Instance hasequivs_group : HasEquivs Group.
+Proof.
+  unshelve econstructor.
+  + exact GroupIsomorphism.
+  + exact (fun G H f => IsEquiv f).
+  + intros G H f; exact f.
+  + exact Build_GroupIsomorphism.
+  + intros G H; exact grp_iso_inverse.
+  + cbn; exact _.
+  + reflexivity.
+  + intros ????; apply eissect.
+  + intros ????; apply eisretr.
+  + intros G H f g p q.
+    exact (isequiv_adjointify f g p q).
+Defined.
+
+Global Instance is1cat_strong `{Funext} : Is1Cat_Strong Group.
+Proof.
+  rapply Build_Is1Cat_Strong.
+  all: intros; apply equiv_path_grouphomomorphism; intro; reflexivity.
+Defined.
+
 (** Given a group element [a0 : A] over [b : B], multiplication by [a] establishes an equivalence between the kernel and the fiber over [b]. *)
 Lemma equiv_grp_hfiber {A B : Group} (f : GroupHomomorphism A B) (b : B)
   : forall (a0 : hfiber f b), hfiber f b <~> hfiber f mon_unit.
@@ -526,8 +596,7 @@ Definition grp_prod_inr {H K : Group}
   := grp_prod_corec grp_homo_const grp_homo_id.
 
 Definition grp_iso_prod {A B C D : Group}
-  : GroupIsomorphism A B -> GroupIsomorphism C D
-    -> GroupIsomorphism (grp_prod A C) (grp_prod B D).
+  : A ≅ B -> C ≅ D -> (grp_prod A C) ≅ (grp_prod B D).
 Proof.
   intros f g.
   srapply Build_GroupIsomorphism'.
@@ -537,75 +606,6 @@ Proof.
   intros x y.
   apply path_prod.
   1,2: apply grp_homo_op.
-Defined.
-
-(** The wild cat of Groups *)
-Global Instance isgraph_group : IsGraph Group
-  := Build_IsGraph Group GroupHomomorphism.
-
-Global Instance is01cat_group : Is01Cat Group :=
-  (Build_Is01Cat Group _ (@grp_homo_id) (@grp_homo_compose)).
-
-Global Instance isgraph_grouphomomorphism {A B : Group} : IsGraph (A $-> B)
-  := induced_graph (@grp_homo_map A B).
-
-Global Instance is01cat_grouphomomorphism {A B : Group} : Is01Cat (A $-> B)
-  := induced_01cat (@grp_homo_map A B).
-
-Global Instance is0gpd_grouphomomorphism {A B : Group}: Is0Gpd (A $-> B)
-  := induced_0gpd (@grp_homo_map A B).
-
-Global Instance is0functor_postcomp_grouphomomorphism {A B C : Group} (h : B $-> C)
-  : Is0Functor (@cat_postcomp Group _ _ A B C h).
-Proof.
-  apply Build_Is0Functor.
-  intros [f ?] [g ?] p a ; exact (ap h (p a)).
-Defined.
-
-Global Instance is0functor_precomp_grouphomomorphism
-       {A B C : Group} (h : A $-> B)
-  : Is0Functor (@cat_precomp Group _ _ A B C h).
-Proof.
-  apply Build_Is0Functor.
-  intros [f ?] [g ?] p a ; exact (p (h a)).
-Defined.
-
-(** Group forms a 1Cat *)
-Global Instance is1cat_group : Is1Cat Group.
-Proof.
-  by rapply Build_Is1Cat.
-Defined.
-
-Instance hasmorext_group `{Funext} : HasMorExt Group.
-Proof.
-  srapply Build_HasMorExt.
-  intros A B f g; cbn in *.
-  snrapply @isequiv_homotopic.
-  1: exact (equiv_path_grouphomomorphism^-1%equiv).
-  1: exact _.
-  intros []; reflexivity. 
-Defined.
-
-Global Instance hasequivs_group : HasEquivs Group.
-Proof.
-  unshelve econstructor.
-  + exact GroupIsomorphism.
-  + exact (fun G H f => IsEquiv f).
-  + intros G H f; exact f.
-  + exact Build_GroupIsomorphism.
-  + intros G H; exact grp_iso_inverse.
-  + cbn; exact _.
-  + reflexivity.
-  + intros ????; apply eissect.
-  + intros ????; apply eisretr.
-  + intros G H f g p q.
-    exact (isequiv_adjointify f g p q).
-Defined.
-
-Global Instance is1cat_strong `{Funext} : Is1Cat_Strong Group.
-Proof.
-  rapply Build_Is1Cat_Strong.
-  all: intros; apply equiv_path_grouphomomorphism; intro; reflexivity.
 Defined.
 
 (** *** Properties of maps to and from the trivial group *)
@@ -650,7 +650,7 @@ Proof.
 Defined.
 
 Global Instance ishprop_grp_iso_trivial `{Univalence} (G : Group)
-  : IsHProp (GroupIsomorphism G grp_trivial).
+  : IsHProp (G ≅ grp_trivial).
 Proof.
   apply equiv_hprop_allpath.
   intros f g.

--- a/theories/Algebra/Groups/GroupCoeq.v
+++ b/theories/Algebra/Groups/GroupCoeq.v
@@ -1,4 +1,4 @@
-Require Import Basics Types.
+Require Import Basics Types WildCat.
 Require Import Algebra.Groups.Group.
 Require Import HIT.Coeq.
 Require Import Algebra.Groups.FreeProduct.
@@ -8,7 +8,7 @@ Local Open Scope mc_mult_scope.
 
 (** Coequalizers of group homomorphisms *)
 
-Definition GroupCoeq {A B : Group} (f g : GroupHomomorphism A B) : Group.
+Definition GroupCoeq {A B : Group} (f g : A $-> B) : Group.
 Proof.
   rapply (AmalgamatedFreeProduct (FreeProduct A A) A B).
   1,2: apply FreeProduct_rec.
@@ -19,7 +19,7 @@ Proof.
 Defined.
 
 Definition equiv_groupcoeq_rec `{Funext} {A B C : Group} (f g : GroupHomomorphism A B)
-  : {h : GroupHomomorphism B C & h o f == h o g} <~> GroupHomomorphism (GroupCoeq f g) C.
+  : {h : B $-> C & h o f == h o g} <~> (GroupCoeq f g $-> C).
 Proof.
   refine (equiv_amalgamatedfreeproduct_rec _ _ _ _ _ _ oE _).
   refine (equiv_sigma_symm _ oE _).

--- a/theories/Algebra/Groups/QuotientGroup.v
+++ b/theories/Algebra/Groups/QuotientGroup.v
@@ -12,6 +12,7 @@ Require Import WildCat.
 (** * Quotient groups *)
 
 Local Open Scope mc_mult_scope.
+Local Open Scope wc_iso_scope.
 
 Section GroupCongruenceQuotient.
 
@@ -184,7 +185,7 @@ Defined.
 (** The proof of normality is irrelevent up to equivalence. This is unfortunate that it doesn't hold definitionally. *)
 Definition grp_iso_quotient_normal (G : Group) (H : Subgroup G)
   {k k' : IsNormalSubgroup H}
-  : GroupIsomorphism (QuotientGroup' G H k) (QuotientGroup' G H k').
+  : QuotientGroup' G H k ≅ QuotientGroup' G H k'.
 Proof.
   snrapply Build_GroupIsomorphism'.
   1: reflexivity.
@@ -196,7 +197,8 @@ Defined.
 
 (** The universal mapping property for groups *)
 Theorem equiv_grp_quotient_ump {F : Funext} {G : Group} (N : NormalSubgroup G) (H : Group)
-  : {f : G $-> H & forall (n : G), N n -> f n = mon_unit} <~> (G / N $-> H).
+  : {f : G $-> H & forall (n : G), N n -> f n = mon_unit}
+    <~> (G / N $-> H).
 Proof.
   srapply equiv_adjointify.
   - intros [f p].
@@ -222,7 +224,8 @@ Section FirstIso.
   Context `{Funext} {A B : Group} (phi : A $-> B).
 
   (** First we define a map from the quotient by the kernel of phi into the image of phi *)
-  Definition grp_image_quotient : GroupHomomorphism (A / grp_kernel phi) (grp_image phi).
+  Definition grp_image_quotient
+    : A / grp_kernel phi $-> grp_image phi.
   Proof.
     srapply grp_quotient_rec.
     + srapply grp_image_in.
@@ -231,7 +234,8 @@ Section FirstIso.
   Defined.
 
   (** The underlying map of this homomorphism is an equivalence *)
-  Global Instance isequiv_grp_image_quotient : IsEquiv grp_image_quotient.
+  Global Instance isequiv_grp_image_quotient
+    : IsEquiv grp_image_quotient.
   Proof.
     snrapply isequiv_surj_emb.
     1: srapply cancelR_conn_map.
@@ -246,7 +250,7 @@ Section FirstIso.
   Defined.
 
   (** First isomorphism theorem for groups *)
-  Theorem grp_first_iso : GroupIsomorphism (A / grp_kernel phi) (grp_image phi) .
+  Theorem grp_first_iso : A / grp_kernel phi ≅ grp_image phi.
   Proof.
     exact (Build_GroupIsomorphism _ _ grp_image_quotient _).
   Defined.

--- a/theories/Algebra/Groups/Subgroup.v
+++ b/theories/Algebra/Groups/Subgroup.v
@@ -121,7 +121,7 @@ Defined.
 Coercion subgroup_group : Subgroup >-> Group.
 
 Definition subgroup_incl {G : Group} (H : Subgroup G)
-  : GroupHomomorphism (subgroup_group G H) G.
+  : subgroup_group G H $-> G.
 Proof.
   snrapply Build_GroupHomomorphism'.
   1: exact pr1.

--- a/theories/Algebra/Rings/CRing.v
+++ b/theories/Algebra/Rings/CRing.v
@@ -306,8 +306,51 @@ Proof.
   intros [r1 s1] [r2 s2]; apply path_prod; cbn; apply rng_mult_comm.
 Defined.
 
+Infix "×" := cring_product : ring_scope.
+
+Definition cring_product_fst {R S : CRing} : R × S $-> R.
+Proof.
+  snrapply Build_CRingHomomorphism.
+  1: exact fst.
+  repeat split.
+Defined.
+
+Definition cring_product_snd {R S : CRing} : R × S $-> S.
+Proof.
+  snrapply Build_CRingHomomorphism.
+  1: exact snd.
+  repeat split.
+Defined.
+
+Definition cring_product_corec (R S T : CRing)
+  : (R $-> S) -> (R $-> T) -> (R $-> S × T).
+Proof.
+  intros f g.
+  srapply Build_CRingHomomorphism'.
+  1: apply (ab_biprod_corec f g).
+  repeat split.
+  1: cbn; intros x y; apply path_prod; apply rng_homo_mult.
+  cbn; apply path_prod; apply rng_homo_one.
+Defined.
+
+Definition equiv_cring_product_corec `{Funext} (R S T : CRing)
+  : (R $-> S) * (R $-> T) <~> (R $-> S × T).
+Proof.
+  snrapply equiv_adjointify.
+  1: exact (uncurry (cring_product_corec _ _ _)).
+  { intros f.
+    exact (cring_product_fst $o f , cring_product_snd $o f). }
+  { hnf; intros f.
+    by apply path_hom. }
+  intros [f g].
+  apply path_prod.
+  1,2: by apply path_hom.
+Defined.
+
+(** ** Image ring *)
+
 (** The image of a ring homomorphism *)
-Definition rng_image {R S : CRing} (f : CRingHomomorphism R S) : CRing.
+Definition rng_image {R S : CRing} (f : R $-> S) : CRing.
 Proof.
   snrapply (Build_CRing' (abgroup_image f)).
   { simpl.
@@ -337,7 +380,7 @@ Proof.
 Defined.
 
 Lemma rng_homo_image_incl {R S} (f : CRingHomomorphism R S)
-  : CRingHomomorphism (rng_image f) S.
+  : rng_image f $-> S.
 Proof.
   snrapply Build_CRingHomomorphism.
   1: exact pr1.
@@ -352,20 +395,6 @@ Proof.
   1: exact (rng_homo_image_incl f).
   exact _.
 Defined. 
-
-Infix "×" := cring_product : ring_scope.
-
-Definition cring_product_corec (R S T : CRing)
-  : CRingHomomorphism R S -> CRingHomomorphism R T
-  -> CRingHomomorphism R (S × T).
-Proof.
-  intros f g.
-  srapply Build_CRingHomomorphism'.
-  1: apply (ab_biprod_corec f g).
-  repeat split.
-  1: cbn; intros x y; apply path_prod; apply rng_homo_mult.
-  cbn; apply path_prod; apply rng_homo_one.
-Defined.
 
 (** *** More Ring laws *)
 
@@ -403,5 +432,3 @@ Proof.
   rewrite <- (rng_mult_assoc _ (rng_power x n)).
   f_ap.
 Defined.
-
-

--- a/theories/Algebra/Rings/CRing.v
+++ b/theories/Algebra/Rings/CRing.v
@@ -73,7 +73,7 @@ Proof.
   rapply compose_sr_morphism.
 Defined.
 
-(** Ring laws *)
+(** ** Ring laws *)
 
 Section RingLaws.
 
@@ -242,7 +242,34 @@ Proof.
   exact _.
 Defined. 
 
-(** Wild category of commutative rings *)
+(** ** Ring movement lemmas *)
+
+Section RingMovement.
+
+  (** We adopt a similar naming convention to the [moveR_equiv] style lemmas that can be found in Types.Paths. *)
+
+  Context {R : CRing} {x y z : R}.
+
+  Definition rng_moveL_Mr : - y + x = z <~> x = y + z := @grp_moveL_Mg R x y z.
+  Definition rng_moveL_rM : x + - z = y <~> x = y + z := @grp_moveL_gM R x y z.
+  Definition rng_moveR_Mr : y = - x + z <~> x + y = z := @grp_moveR_Mg R x y z.
+  Definition rng_moveR_rM : x = z + - y <~> x + y = z := @grp_moveR_gM R x y z.
+
+  Definition rng_moveL_Vr : x + y = z <~> y = - x + z := @grp_moveL_Vg R x y z.
+  Definition rng_moveL_rV : x + y = z <~> x = z + - y := @grp_moveL_gV R x y z.
+  Definition rng_moveR_Vr : x = y + z <~> - y + x = z := @grp_moveR_Vg R x y z.
+  Definition rng_moveR_rV : x = y + z <~> x + - z = y := @grp_moveR_gV R x y z.
+
+  Definition rng_moveL_M0 : - y + x = 0 <~> x = y := @grp_moveL_M1 R x y.
+  Definition rng_moveL_0M :	x + - y = 0 <~> x = y := @grp_moveL_1M R x y.
+  Definition rng_moveR_M0 : 0 = - x + y <~> x = y := @grp_moveR_M1 R x y.
+  Definition rng_moveR_0M : 0 = y + - x <~> x = y := @grp_moveR_1M R x y.
+
+  (** TODO: Movement laws about mult *)
+
+End RingMovement.
+
+(** ** Wild category of commutative rings *)
 
 Global Instance isgraph_cring : IsGraph CRing
   := Build_IsGraph _ CRingHomomorphism.

--- a/theories/Algebra/Rings/CRing.v
+++ b/theories/Algebra/Rings/CRing.v
@@ -11,6 +11,8 @@ Require Export Classes.theory.rings.
 Declare Scope ring_scope.
 
 Local Open Scope ring_scope.
+(** We want to print equivalences as [≅]. *)
+Local Open Scope wc_iso_scope.
 
 (** A commutative ring consists of the following data *)
 Record CRing := {
@@ -125,8 +127,6 @@ Arguments rng_iso_homo {_ _ }.
 Coercion rng_iso_homo : CRingIsomorphism >-> CRingHomomorphism.
 Global Existing Instance isequiv_rng_iso_homo.
 
-Infix "≅" := CRingIsomorphism : ring_scope.
-
 Definition issig_CRingIsomorphism {A B : CRing}
   : _ <~> CRingIsomorphism A B := ltac:(issig).
 
@@ -194,53 +194,6 @@ Definition Build_CRing' (R : AbGroup)
   : CRing
   := Build_CRing R (abgroup_sgop R) _ (abgroup_unit R) _
        (abgroup_inverse R) (Build_IsRing _ _ _ _).
-
-(** The image of a ring homomorphism *)
-Definition rng_image {R S : CRing} (f : CRingHomomorphism R S) : CRing.
-Proof.
-  snrapply (Build_CRing' (abgroup_image f)).
-  { simpl.
-    intros [x p] [y q].
-    exists (x * y).
-    strip_truncations; apply tr.
-    destruct p as [p p'], q as [q q'].
-    exists (p * q).
-    refine (rng_homo_mult _ _ _ @ _).
-    f_ap. }
-  { exists 1.
-    apply tr.
-    exists 1.
-    exact (rng_homo_one f). }
-  (** Much of this proof is doing the same thing over, so we use some compact tactics. *)
-  2: repeat split.
-  2: exact _.
-  all: intros [].
-  1,2,5: intros [].
-  1,2: intros [].
-  all: apply path_sigma_hprop; cbn.
-  1: apply distribute_l.
-  1: apply associativity.
-  1: apply commutativity.
-  1: apply left_identity.
-  apply right_identity.
-Defined.
-
-Lemma rng_homo_image_incl {R S} (f : CRingHomomorphism R S)
-  : CRingHomomorphism (rng_image f) S.
-Proof.
-  snrapply Build_CRingHomomorphism.
-  1: exact pr1.
-  repeat split.
-Defined.
-
-(** Image of a surjective ring homomorphism *)
-Lemma rng_image_issurj {R S} (f : CRingHomomorphism R S) {issurj : IsSurjection f}
-  : rng_image f ≅ S.
-Proof.
-  snrapply Build_CRingIsomorphism.
-  1: exact (rng_homo_image_incl f).
-  exact _.
-Defined. 
 
 (** ** Ring movement lemmas *)
 
@@ -352,6 +305,53 @@ Proof.
   1: intros [r1 s1]; apply path_prod; cbn; apply rng_mult_one_r.
   intros [r1 s1] [r2 s2]; apply path_prod; cbn; apply rng_mult_comm.
 Defined.
+
+(** The image of a ring homomorphism *)
+Definition rng_image {R S : CRing} (f : CRingHomomorphism R S) : CRing.
+Proof.
+  snrapply (Build_CRing' (abgroup_image f)).
+  { simpl.
+    intros [x p] [y q].
+    exists (x * y).
+    strip_truncations; apply tr.
+    destruct p as [p p'], q as [q q'].
+    exists (p * q).
+    refine (rng_homo_mult _ _ _ @ _).
+    f_ap. }
+  { exists 1.
+    apply tr.
+    exists 1.
+    exact (rng_homo_one f). }
+  (** Much of this proof is doing the same thing over, so we use some compact tactics. *)
+  2: repeat split.
+  2: exact _.
+  all: intros [].
+  1,2,5: intros [].
+  1,2: intros [].
+  all: apply path_sigma_hprop; cbn.
+  1: apply distribute_l.
+  1: apply associativity.
+  1: apply commutativity.
+  1: apply left_identity.
+  apply right_identity.
+Defined.
+
+Lemma rng_homo_image_incl {R S} (f : CRingHomomorphism R S)
+  : CRingHomomorphism (rng_image f) S.
+Proof.
+  snrapply Build_CRingHomomorphism.
+  1: exact pr1.
+  repeat split.
+Defined.
+
+(** Image of a surjective ring homomorphism *)
+Lemma rng_image_issurj {R S} (f : CRingHomomorphism R S) {issurj : IsSurjection f}
+  : rng_image f ≅ S.
+Proof.
+  snrapply Build_CRingIsomorphism.
+  1: exact (rng_homo_image_incl f).
+  exact _.
+Defined. 
 
 Infix "×" := cring_product : ring_scope.
 

--- a/theories/Algebra/Rings/QuotientRing.v
+++ b/theories/Algebra/Rings/QuotientRing.v
@@ -4,6 +4,8 @@ Require Import Algebra.AbGroups.
 Require Import Algebra.Rings.CRing.
 Require Import Algebra.Rings.Ideal.
 
+Local Open Scope wc_iso_scope.
+
 (** In this file we define the quotient of a commutative ring by an ideal *)
 
 Section QuotientRing.
@@ -109,7 +111,7 @@ Definition Build_CRing' (R : AbGroup)
        (abgroup_inverse R) (Build_IsRing _ _ _ _).
 
 (** The image of a ring homomorphism *)
-Definition rng_image {R S : CRing} (f : CRingHomomorphism R S) : CRing.
+Definition rng_image {R S : CRing} (f : R $-> S) : CRing.
 Proof.
   snrapply (Build_CRing' (abgroup_image f)).
   { simpl.
@@ -140,7 +142,7 @@ Defined.
 
 (** First isomorphism theorem for commutative rings *)
 Definition rng_first_iso `{Funext} {A B : CRing} (phi : A $-> B)
-  : CRingIsomorphism (QuotientRing A (ideal_kernel phi)) (rng_image phi).
+  : QuotientRing A (ideal_kernel phi) ≅ rng_image phi.
 Proof.
   snrapply Build_CRingIsomorphism''.
   { etransitivity.

--- a/theories/Algebra/Rings/Z.v
+++ b/theories/Algebra/Rings/Z.v
@@ -106,14 +106,12 @@ Proof.
       rewrite pos_peano_rec_beta_pos_succ.
       rewrite int_pos_sub_succ_r.
       cbn; rewrite <- simple_associativity.
-      srapply moveL_equiv_M.
-      1: apply isequiv_group_left_op.
+      apply rng_moveL_Mr.
       cbn; rewrite involutive.
       apply commutativity. }
     induction x as [|x IHx] using pos_peano_ind.
     { rewrite int_pos_sub_succ_l.
-      cbn; srapply moveL_equiv_M.
-      1: apply isequiv_group_left_op.
+      cbn; apply rng_moveL_Mr.
       cbn; rewrite involutive.
       by rewrite pos_peano_rec_beta_pos_succ. }
     rewrite int_pos_sub_succ_succ.

--- a/theories/Homotopy/Pi1S1.v
+++ b/theories/Homotopy/Pi1S1.v
@@ -1,4 +1,4 @@
-Require Import Basics Types.
+Require Import Basics Types WildCat.
 Require Import Pointed.
 Require Import Spaces.Int Spaces.Circle Spaces.Spheres.
 Require Import Algebra.AbGroups.
@@ -6,6 +6,8 @@ Require Import Homotopy.HomotopyGroup.
 Require Import Truncations.
 
 (** The fundamental group of the 1-sphere *)
+
+Local Open Scope wc_iso_scope.
 
 Section Pi1S1.
   Context `{Univalence}.
@@ -15,7 +17,7 @@ Section Pi1S1.
   Local Open Scope int_scope.
   Local Open Scope pointed_scope.
 
-  Theorem Pi1Circle : GroupIsomorphism (Pi 1 (Circle, base)) abgroup_Z.
+  Theorem Pi1Circle : Pi 1 (Circle, base) ≅ abgroup_Z.
   Proof.
     (** We give the isomorphism backwards, so we check the operation is preserved coming from the integer side. *)
     symmetry.
@@ -29,7 +31,7 @@ Section Pi1S1.
     apply loopexp_add.
   Defined.
 
-  Theorem Pi1S1 : GroupIsomorphism (Pi 1 (psphere 1)) abgroup_Z.
+  Theorem Pi1S1 : Pi 1 (psphere 1) ≅ abgroup_Z.
   Proof.
     etransitivity.
     2: apply Pi1Circle.

--- a/theories/WildCat/Equiv.v
+++ b/theories/WildCat/Equiv.v
@@ -3,6 +3,9 @@
 Require Import Basics.
 Require Import WildCat.Core.
 
+(** We declare a scope for printing [CatEquiv] as [≅] *)
+Declare Scope wc_iso_scope.
+
 (** * Equivalences in wild categories *)
 
 (** We could define equivalences in any wild 2-category as bi-invertible maps, or in a wild 3-category as half-adjoint equivalences.  However, in concrete cases there is often an equivalent definition of equivalences that we want to use instead, and the important property we need is that it's logically equivalent to (quasi-)isomorphism. *)
@@ -31,6 +34,7 @@ Definition CatEquiv {A} `{HasEquivs A} (a b : A)
   := @CatEquiv' A _ _ _ _ a b.
 
 Notation "a $<~> b" := (CatEquiv a b).
+Infix "≅" := CatEquiv : wc_iso_scope.
 Arguments CatEquiv : simpl never.
 
 Definition cate_fun {A} `{HasEquivs A} {a b : A} (f : a $<~> b)


### PR DESCRIPTION
This builds on top of #1495 so for the time being, I've marked it as draft.

Here is a summary of the changes:
 * Add more ring laws
 * Add `≅` notation for `CRingIsomorphism` as that was quickly getting tiresome to write. This notation lives in `ring_scope`. 
 * Add another constructor for Rings that takes in the underlying abelian group.
 * Image of a ring homomorphism as a ring together with inclusion maps
 * Product ring
 * Define powers of ring elements together with some basic laws
 * Add in ring movement lemmas (for now only for addition) e.g. `rng_moveR_Mr : y = - x + z <~> x + y = z `
 