### PR TITLE
Ideal arithmetic and Chinese remainder theorem

### DIFF
--- a/theories/Algebra/Groups/QuotientGroup.v
+++ b/theories/Algebra/Groups/QuotientGroup.v
@@ -210,7 +210,7 @@ Proof.
     apply ap.
     apply qglue; cbn.
     rewrite right_identity;
-      by apply issubgroup_inverse.
+      by apply issubgroup_in_inv.
   - intros f.
     rapply equiv_path_grouphomomorphism.
       by srapply Quotient_ind_hprop.

--- a/theories/Algebra/Rings.v
+++ b/theories/Algebra/Rings.v
@@ -3,6 +3,7 @@
 Require Export HoTT.Algebra.Rings.CRing.
 Require Export HoTT.Algebra.Rings.Ideal.
 Require Export HoTT.Algebra.Rings.QuotientRing.
+Require Export HoTT.Algebra.Rings.ChineseRemainder.
 
 (** Examples *)
 

--- a/theories/Algebra/Rings/ChineseRemainder.v
+++ b/theories/Algebra/Rings/ChineseRemainder.v
@@ -1,0 +1,149 @@
+Require Import Basics Types WildCat.
+Require Import Algebra.Congruence.
+Require Import Algebra.AbGroups.
+Require Import Algebra.Rings.CRing.
+Require Import Algebra.Rings.Ideal.
+Require Import Algebra.Rings.QuotientRing.
+
+(** * Chinese remainder theorem *)
+
+Import Ideal.Notation.
+Local Open Scope ring_scope.
+
+Section ChineseRemainderTheorem.
+
+  (** We assume [Univalence] in order to work with quotients. We also need it for [Funext] in a few places.*)
+  Context `{Univalence}
+    (** We need two coprime ideals [I] and [J] to state the theorem. We don't introduce the coprimeness assumption as of yet in order to show something slightly stronger. *)
+    {R : CRing} (I J : Ideal R).
+
+  (** We begin with the homomorphism which will show to be a surjection. Using the first isomorphism theorem for rings we can improve this to be the isomorphism we want. *)
+  (** TODO: rename *)
+  (** This is the corecursion of the two quotient maps *)
+  Definition rng_homo_crt : R $-> (R / I) × (R / J).
+  Proof.
+    apply cring_product_corec.
+    1,2: apply rng_quotient_map.
+  Defined.
+
+  (** Since we are working with quotients, we make the following notation to make working with the proof somewhat easier. *)
+  Notation "[ x ]" := (rng_quotient_map _ x).
+
+  (** We then need to prove the following lemma. The hypotheses here can be derived by coprimality of [I] and [J]. But we don't need that here. *)
+  Lemma issurjection_rng_homo_crt' (x y : R)
+    (q1 : rng_homo_crt x = (0, 1)) (q2 : rng_homo_crt y = (1, 0))
+    : IsSurjection rng_homo_crt.
+  Proof.
+    (** In order to show that [rng_homo_crt] is a surjection, we need to show that its propositional truncation of the fiber at any point is contractible. *)
+    intros [a b].
+    revert a; srapply QuotientRing_ind_hprop; intro a.
+    revert b; srapply QuotientRing_ind_hprop; intro b.
+    (** We can think of [a] and [b] as the pair [(a mod I, b mod J)]. We need to show that there merely exists some element in [R] that gets mapped by  [rng_homo_crt] to the pair. *)
+    snrapply Build_Contr; [|intros z; strip_truncations; apply path_ishprop].
+    (** We make this choice and show it maps as desired. *)
+    apply tr; exists (b * x + a * y).
+    (** Finally using some simple ring laws we can show it maps to our pair. *)
+    rewrite rng_homo_plus.
+    rewrite 2 rng_homo_mult.
+    rewrite q1, q2.
+    apply path_prod.
+    + change ([b] * 0 + [a] * 1 = [a] :> R / I).
+      by rewrite rng_mult_one_r, rng_mult_zero_r, rng_plus_zero_l.
+    + change ([b] * 1 + [a] * 0 = [b] :> R / J).
+      by rewrite rng_mult_one_r, rng_mult_zero_r, rng_plus_zero_r.
+  Defined.
+
+  (** Now we show that if [x + y = 1] for [I x] and [J y] then we can satisfy the hypotheses of the previous lemma. *)
+  Section rng_homo_crt_beta.
+
+    Context (x y : R) (ix : I x) (iy : J y) (p : x + y = 1).
+
+    Lemma rng_homo_crt_beta_left : rng_homo_crt x = (0, 1).
+    Proof.
+      apply rng_moveR_Mr in p.
+      rewrite rng_plus_comm in p.
+      apply path_prod; apply qglue.
+      - change (I (-x + 0)).
+        apply ideal_in_negate_plus.
+        1: assumption.
+        apply ideal_in_zero.
+      - change (J (-x + 1)).
+        rewrite rng_plus_comm.
+        by rewrite <- p.
+    Defined.
+
+    Lemma rng_homo_crt_beta_right : rng_homo_crt y = (1, 0).
+    Proof.
+      apply rng_moveR_rM in p.
+      rewrite rng_plus_comm in p.
+      apply path_prod; apply qglue.
+      - change (I (-y + 1)).
+        by rewrite <- p.
+      - change (J (-y + 0)).
+        apply ideal_in_negate_plus.
+        1: assumption.
+        apply ideal_in_zero.
+    Defined.
+
+  End rng_homo_crt_beta.
+
+  (** We can now show the map is surjective from coprimality of [I] and [J]. *)
+  Global Instance issurjection_rng_homo_crt
+    : Coprime I J -> IsSurjection rng_homo_crt.
+  Proof.
+    intros c.
+    (** First we turn the coprimality assumption into an equivalent assumption about the mere existence of two elements of each ideal which sum to one. *)
+    apply equiv_coprime_sum in c.
+    (** Since the goal is a hprop we may strip the truncations. *)
+    strip_truncations.
+    (** Now we can break apart the data of this witness. *)
+    destruct c as [[[x ix] [y jy]] p];
+    change (x + y = 1) in p.
+    (** Now we apply all our previous lemmas *)
+    apply (issurjection_rng_homo_crt' x y).
+    1: exact (rng_homo_crt_beta_left x y ix jy p).
+    exact (rng_homo_crt_beta_right x y ix jy p).
+  Defined.
+
+  (** Now suppose [I] and [J] are coprime. *)
+  Context (c : Coprime I J).
+
+  (** The Chinese Remainder Theorem *)
+  Theorem chinese_remainder : R / (I ∩ J)%ideal ≅ (R / I) × (R / J).
+  Proof.
+    (** We use the first isomorphism theorem. Coq can already infer which map we wish to use, so for clarity we tell it not to do so. *)
+    snrapply rng_first_iso'.
+    1: rapply rng_homo_crt.
+    1: exact _.
+    (** Finally we must show the ideal of this map is the intersection. *)
+    apply ideal_subset_antisymm.
+    - intros r [i j].
+      apply path_prod; apply qglue.
+      1: change (I (- r + 0)).
+      2: change (J (- r + 0)).
+      1,2: rewrite rng_plus_comm.
+      1,2: apply ideal_in_plus_negate.
+      1,3: apply ideal_in_zero.
+      1,2: assumption.
+    - intros i p.
+      apply equiv_path_prod in p.
+      destruct p as [p q].
+      apply ideal_in_negate'.
+      rewrite <- rng_plus_zero_r.
+      (** Here we need to derive the relation from paths in the quotient. This is what requires univalence. *)
+      split.
+      1: exact (related_quotient_paths _ _ _ p).
+      1: exact (related_quotient_paths _ _ _ q).
+  Defined.
+
+  (** We also have the same for products of ideals. *)
+  Theorem chinese_remainder_prod : R / (I ⋅ J)%ideal ≅ (R / I) × (R / J).
+  Proof.
+    etransitivity.
+    { rapply rng_quotient_invar.
+      symmetry.
+      rapply ideal_intersection_is_product. }
+    rapply chinese_remainder.
+  Defined.
+
+End ChineseRemainderTheorem.

--- a/theories/Algebra/Rings/ChineseRemainder.v
+++ b/theories/Algebra/Rings/ChineseRemainder.v
@@ -19,7 +19,6 @@ Section ChineseRemainderTheorem.
     {R : CRing} (I J : Ideal R).
 
   (** We begin with the homomorphism which will show to be a surjection. Using the first isomorphism theorem for rings we can improve this to be the isomorphism we want. *)
-  (** TODO: rename *)
   (** This is the corecursion of the two quotient maps *)
   Definition rng_homo_crt : R $-> (R / I) × (R / J).
   Proof.

--- a/theories/Algebra/Rings/ChineseRemainder.v
+++ b/theories/Algebra/Rings/ChineseRemainder.v
@@ -9,6 +9,7 @@ Require Import Algebra.Rings.QuotientRing.
 
 Import Ideal.Notation.
 Local Open Scope ring_scope.
+Local Open Scope wc_iso_scope.
 
 Section ChineseRemainderTheorem.
 

--- a/theories/Algebra/Rings/Ideal.v
+++ b/theories/Algebra/Rings/Ideal.v
@@ -1,17 +1,23 @@
 Require Import Basics Types.
+Require Import Spaces.Nat Spaces.Finite.
 Require Import Algebra.Rings.CRing.
 Require Import Algebra.AbGroups.
 
 Local Open Scope mc_scope.
 
-(** In this file we define Ideals *)
+Declare Scope ideal_scope.
+Delimit Scope ideal_scope with ideal.
 
-(** TODO: In the future it might be useful to define ideals as submodules when we go about defining R-modules. *)
+(** In this file we define Ideals *)
 
 (** An additive subgroup I of a ring R is an ideal when: *)
 Class IsIdeal {R : CRing} (I : Subgroup R) :=
   isideal (r x : R) : I x -> I (r * x).
 
+Global Instance ishprop_isideal `{Funext} {R : CRing} (I : Subgroup R)
+  : IsHProp (IsIdeal I) := ltac:(unfold IsIdeal; exact _).
+
+(** An ideal of a ring [R] is a subgroup of R which is closed under left multiplication. *)
 Record Ideal (R : CRing) := {
   ideal_subgroup : Subgroup R;
   ideal_isideal : IsIdeal ideal_subgroup;
@@ -20,40 +26,146 @@ Record Ideal (R : CRing) := {
 Coercion ideal_subgroup : Ideal >-> Subgroup.
 Global Existing Instances ideal_isideal.
 
-Section Examples.
+Definition issig_Ideal (R : CRing) : _ <~> Ideal R := ltac:(issig).
 
-  Context (R : CRing).
+Global Instance ishset_ideal `{Univalence} {R : CRing} : IsHSet (Ideal R).
+Proof.
+  nrapply istrunc_equiv_istrunc.
+  1: apply issig_Ideal.
+  rapply istrunc_sigma.
+Defined.
 
-  (** The zero ideal is an ideal *)
-  Global Instance isideal_trivial_subgroup
-    : IsIdeal (R:=R) trivial_subgroup.
+(** Here are some lemmas for proving certain elements are in an ideal. *)
+Section IdealElements.
+
+  Context {R : CRing} (I : Ideal R).
+
+  Definition ideal_in_zero : I cring_zero := subgroup_unit I.
+  Definition ideal_in_plus a b : I a -> I b -> I (a + b) := subgroup_op I a b.
+  Definition ideal_in_negate a : I a -> I (- a) := subgroup_inverse I a.
+  Definition ideal_in_plus_negate a b : I a -> I b -> I (a - b)
+    := subgroup_op_inverse I a b.
+
+  Lemma ideal_in_negate' a : I (- a) -> I a.
   Proof.
-    hnf; cbn. intros r x p.
-    refine (_ @ rng_mult_zero_r r).
-    f_ap.
+    intros p; rewrite <- (negate_involutive a); revert p.
+    apply ideal_in_negate.
   Defined.
 
-  (** Zero ideal *)
-  Definition ideal_zero : Ideal R
-    := Build_Ideal R _ isideal_trivial_subgroup.
-
-  (** The unit ideal is an ideal *)
-  Global Instance isideal_maximal_subgroup
-    : IsIdeal (R:=R) maximal_subgroup.
+  Lemma ideal_in_plus_l a b : I (a + b) -> I b -> I a.
   Proof.
-    split.
+    intros p q; rewrite <- (rng_plus_zero_r a); revert p q.
+    rewrite <- (rng_plus_negate_r b).
+    rewrite rng_plus_assoc.
+    apply ideal_in_plus_negate.
   Defined.
 
-  (** Unit ideal *)
-  Definition ideal_unit : Ideal R
-    := Build_Ideal R _ isideal_maximal_subgroup.
+End IdealElements.
 
-(** TODO: Intersection of ideals *)
-(** TODO: Sum of ideals *)
-(** TODO: Product of ideals *)
+(** The zero ideal is an ideal *)
+Global Instance isideal_trivial_subgroup (R : CRing)
+  : IsIdeal (R:=R) trivial_subgroup.
+Proof.
+  hnf; cbn. intros r x p.
+  refine (_ @ rng_mult_zero_r r).
+  f_ap.
+Defined.
 
-End Examples.
+(** Zero ideal *)
+Definition ideal_zero (R : CRing) : Ideal R
+  := Build_Ideal R _ (isideal_trivial_subgroup R).
 
+(** The unit ideal is an ideal *)
+Global Instance isideal_maximal_subgroup (R : CRing)
+  : IsIdeal (R:=R) maximal_subgroup.
+Proof.
+  split.
+Defined.
+
+(** Unit ideal *)
+Definition ideal_unit (R : CRing) : Ideal R
+  := Build_Ideal R _ (isideal_maximal_subgroup R).
+
+(** Intersections of underlying subgroups of ideals are again ideals *)
+Global Instance isideal_subgroup_intersection (R : CRing) (I J : Ideal R)
+  : IsIdeal (subgroup_intersection I J).
+Proof.
+  intros r x [a b]; split; by apply isideal.
+Defined.
+
+(** Intersection of ideals *)
+Definition ideal_intersection {R : CRing} : Ideal R -> Ideal R -> Ideal R
+  := fun I J => Build_Ideal R _ (isideal_subgroup_intersection R I J).
+
+(** The subgroup product of ideals is again an ideal. *)
+Global Instance isideal_subgroup_product (R : CRing) (I J : Ideal R)
+  : IsIdeal (subgroup_product I J).
+Proof.
+  intros r.
+  refine (subgroup_product_ind I J _  _ _ _ _).
+  + intros x p.
+    apply tr, sgt_in.
+    left; by apply isideal.
+  + intros x p.
+    apply tr, sgt_in.
+    right; by apply isideal.
+  + apply tr, sgt_in.
+    left; apply isideal.
+    apply subgroup_unit.
+  + intros x y p q IHp IHq.
+    rewrite rng_dist_l.
+    rewrite rng_mult_negate_r.
+    by rapply subgroup_op_inverse.
+Defined.
+
+(** Sum of ideals *)
+Definition ideal_sum {R : CRing} : Ideal R -> Ideal R -> Ideal R
+  := fun I J => Build_Ideal R _ (isideal_subgroup_product R I J).
+
+Definition ideal_sum_ind {R : CRing} (I J : Ideal R)
+  (P : forall x, ideal_sum I J x -> Type)
+  (P_I_in : forall x y, P x (tr (sgt_in (inl y))))
+  (P_J_in : forall x y, P x (tr (sgt_in (inr y))))
+  (P_unit : P mon_unit (tr sgt_unit))
+  (P_op : forall x y h k, P x (tr h) -> P y (tr k) -> P (x - y) (tr (sgt_op h k)))
+  `{forall x y, IsHProp (P x y)}
+  : forall x (p : ideal_sum I J x), P x p
+  := subgroup_product_ind I J P P_I_in P_J_in P_unit P_op.
+
+(** *** Product of ideals *)
+
+(** First we form the "naive" product of ideals { a * b | a ∈ I /\ b ∈ J } *)
+(** Note that this is not an ideal, but we can fix this later. *)
+Inductive ideal_product_naive_type {R : CRing} (I J : Ideal R) : R -> Type :=
+| ipn_in : forall x y, I x -> J y -> ideal_product_naive_type I J (x * y)
+.
+
+(** Now we can close this under addition to get the product ideal. *)
+
+(** Product of ideals *)
+Definition ideal_product {R : CRing} : Ideal R -> Ideal R -> Ideal R.
+Proof.
+  intros I J.
+  snrapply Build_Ideal.
+  1: exact (subgroup_generated (G := R) (ideal_product_naive_type I J)).
+  intros r s.
+  apply Trunc_functor.
+  intros p.
+  induction p as [s i | | g h p1 IHp1 p2 IHp2].
+  + destruct i.
+    apply sgt_in.
+    rewrite simple_associativity.
+    apply ipn_in.
+    1: apply isideal.
+    1,2: assumption.
+  + rewrite rng_mult_zero_r.
+    rapply sgt_unit.
+  + rewrite rng_dist_l.
+    rewrite rng_mult_negate_r.
+    by rapply sgt_op.
+Defined.
+
+(** The kernel of a ring homomorphism is an ideal. *)
 Definition ideal_kernel {R S : CRing} (f : CRingHomomorphism R S) : Ideal R.
 Proof.
   snrapply Build_Ideal.
@@ -65,7 +177,719 @@ Proof.
   f_ap.
 Defined.
 
-(** Properties of ideals *)
+(** *** Ideal generated by a subset *)
+
+(** It seems tempting to define ideals generated by a subset in terms of subgroups generated by a subset but this does not work. Ideals also have to be closed under left multiplciation by ring elements so they end up having more elements than the subgroup that gets generated. *)
+
+(** Therefore we will do an analagous construction to the one done in Subgroup.v *)
+
+(** Underlying type family of an ideal generated by subset *)
+Inductive ideal_generated_type (R : CRing) (X : R -> Type) : R -> Type :=
+(** The iddeal should contain all elements of the original family. *)
+| igt_in (r : R) : X r -> ideal_generated_type R X r
+(** It should contain zero. *)
+| igt_zero : ideal_generated_type R X cring_zero
+(** It should be closed under negation and addition. *)
+| igt_add_neg (r s : R)
+  : ideal_generated_type R X r
+  -> ideal_generated_type R X s
+  -> ideal_generated_type R X (r - s)
+(** And finally, it should be closed under left multiplication. *)
+| igt_mul (r s : R)
+  : ideal_generated_type R X s
+  -> ideal_generated_type R X (r * s)
+.
+
+Arguments ideal_generated_type {R} X r.
+Arguments igt_in {R X r}.
+Arguments igt_zero {R X}.
+Arguments igt_add_neg {R X r s}.
+Arguments igt_mul {R X r s}.
+
+(** Again, as with subgroups we need to truncate this to make it a predicate. *)
+
+(** Ideal generated by a subset *)
+Definition ideal_generated {R : CRing} (X : R -> Type) : Ideal R.
+Proof.
+  snrapply Build_Ideal.
+  { snrapply Build_Subgroup'.
+    1: exact (fun x => merely (ideal_generated_type X x)).
+    1: exact _.
+    1: apply tr, igt_zero.
+    intros x y p q; strip_truncations.
+    by apply tr, igt_add_neg. }
+  intros r x; apply Trunc_functor.
+  apply igt_mul.
+Defined.
+
+(** Finitely generated ideal *)
+Definition ideal_generated_finite {R : CRing} {n : nat} (X : Fin n -> R) : Ideal R.
+Proof.
+  apply ideal_generated.
+  intros r.
+  exact {x : Fin n & X x = r}.
+Defined.
+
+(** Principal ideal *)
+Definition ideal_principal {R : CRing} (x : R) : Ideal R
+  := ideal_generated (fun r => x = r).
+
+(** *** Ideal equality *)
+
+(** Classically, set based equality suffices for ideals. Since we are talking about predicates, we use pointwise iffs. This can of course be shown to be equivalent to the identity type. *)
+Definition ideal_eq {R : CRing} (I J : Ideal R) := forall x, I x <-> J x.
+
+(** With univalence we can characterize paths of ideals *)
+Lemma equiv_path_ideal `{Univalence} {R : CRing} {I J : Ideal R} : ideal_eq I J <~> I = J.
+Proof.
+  refine ((equiv_ap' (issig_Ideal R)^-1 _ _)^-1 oE _).
+  refine (equiv_path_sigma_hprop _ _ oE _).
+  rapply equiv_path_subgroup'.
+Defined.
+
+Global Instance reflexive_ideal_eq {R : CRing} : Reflexive (@ideal_eq R).
+Proof.
+  intros I x; by split.
+Defined.
+
+Global Instance symmetric_ideal_eq {R : CRing} : Symmetric (@ideal_eq R).
+Proof.
+  intros I J p x; specialize (p x); by symmetry.
+Defined.
+
+Global Instance transitive_ideal_eq {R : CRing} : Transitive (@ideal_eq R).
+Proof.
+  intros I J K p q x; specialize (p x); specialize (q x); by transitivity (J x).
+Defined.
+
+(** We define the subset relation on ideals in the usual way: *)
+Definition ideal_subset {R : CRing} (I J : Ideal R) := (forall x, I x -> J x).
+
+Global Instance reflexive_ideal_subset {R : CRing} : Reflexive (@ideal_subset R)
+  := fun _ _ => idmap.
+
+Global Instance transitive_ideal_subset {R : CRing} : Transitive (@ideal_subset R).
+Proof.
+  intros x y z p q a.
+  specialize (p a); specialize (q a).
+  exact (q o p).
+Defined.
+
+Coercion ideal_eq_subset {R : CRing} {I J : Ideal R} : ideal_eq I J -> ideal_subset I J.
+Proof.
+  intros f x; apply f.
+Defined.
+
+(** Quotient (a.k.a colon) ideal *)
+(** Unfortunately, due to truncatedness constraints, we need to assume funext. *)
+Definition ideal_quotient `{Funext} {R : CRing} (I J : Ideal R) : Ideal R.
+Proof.
+  snrapply Build_Ideal.
+  { snrapply Build_Subgroup'.
+    1: exact (fun r => forall x, J x -> I (r * x)).
+    1: exact _.
+    { intros r p.
+      rewrite rng_mult_zero_l.
+      apply ideal_in_zero. }
+    hnf; intros x y p q r s.
+    rewrite rng_dist_r.
+    rewrite rng_mult_negate_l.
+    apply ideal_in_plus_negate.
+    1: by apply p.
+    by apply q. }
+  hnf; cbn.
+  intros r x p q s.
+  rewrite <- rng_mult_assoc.
+  by apply isideal, p.
+Defined.
+
+(** The annihilator of an ideal. *)
+Definition ideal_annihilator `{Funext} {R : CRing} (I : Ideal R) : Ideal R
+  := ideal_quotient (ideal_zero R) I.
+
+(** *** Ideal notations *)
+
+(** We declare a module for various (unicode) ideal notations. These exist in their own special case, and can be imported and used when needing to reason about ideals. *)
+
+(** TODO: reserve these properly *)
+Module Notation.
+  Infix "⊆" := ideal_subset : ideal_scope.
+  Infix "↔" := ideal_eq : ideal_scope.
+  Infix "+" := ideal_sum : ideal_scope.
+  Infix "⋅" := ideal_product (at level 20) : ideal_scope.
+  Infix "∩" := ideal_intersection (at level 20)  : ideal_scope.
+  Infix "::" := ideal_quotient : ideal_scope.
+  Notation "〈 X 〉" := (ideal_generated X)  : ideal_scope.
+  Notation Ann := ideal_annihilator.
+End Notation.
+
+(** ** Properties of ideals *)
+
+(** *** Coprime ideals *)
+
+(** Two ideals are coprime if their sum is the unit ideal. *)
+Definition Coprime {R : CRing} (I J : Ideal R) : Type
+  := ideal_eq (ideal_sum I J) (ideal_unit R).
+Existing Class Coprime.
+
+(* Lemma coprime_property {R : CRing} {I J : Ideal R} (p : Coprime I J)
+  : merely {x : R & I x /\ {y : R & J y /\ x + y = 1}}.
+Proof.
+  pose (q := p); clearbody q.
+  specialize (p cring_one).
+  destruct p as [_ p].
+  specialize (p tt).
+  revert p; apply Trunc_functor; intros p.
+  destruct p as [x [s | t] | | ].
+  - 
+  
+  
+  
+  rapply (subgroup_generated_type_rec _ _ (fun _ _ => _) _ _ _ _ p).
+  { intros x t.
+    destruct t as [s | t].
+    + apply tr.
+      exists x.
+      exists (1 - x).
+      rewrite rng_plus_comm, <- rng_plus_assoc, rng_plus_negate_l.
+      apply rng_plus_zero_r.
+    + apply tr.
+      exists x.
+      exists (1 - x).
+      rewrite rng_plus_comm, <- rng_plus_assoc, rng_plus_negate_l.
+      apply rng_plus_zero_r. }
+  { apply tr.
+      
+      reflexivity.
+      rewrite 
+      rewrite (rng_plus_assoc x (-x) 1). *)
+
+(** *** Ideal lemmas *)
+
+(** We use these notations in the rest of this file *)
+Import Notation.
+Local Open Scope ideal_scope.
+
+Section IdealLemmas.
+
+  Context {R : CRing}.
+
+  (** Subset relation is antisymmetric *)
+  Lemma ideal_subset_antisymm (I J : Ideal R) : I ⊆ J -> J ⊆ I -> I ↔ J.
+  Proof.
+    intros p q x; split; by revert x.
+  Defined.
+
+  (** The zero ideal is contained by all ideals *)
+  Lemma ideal_zero_subset I : ideal_zero R ⊆ I.
+  Proof.
+    intros x p; rewrite p; apply ideal_in_zero.
+  Defined.
+
+  (** The unit ideal contains all ideals *)
+  Lemma ideal_unit_subset I : I ⊆ ideal_unit R.
+  Proof.
+    hnf; cbn; trivial.
+  Defined.
+
+  (** Intersection includes into the left *)
+  Lemma ideal_intersection_subset_l (I J : Ideal R) : I ∩ J ⊆ I.
+  Proof.
+    intro; exact fst.
+  Defined.
+
+  (** Intersection includes into the right *)
+  Lemma ideal_intersection_subset_r (I J : Ideal R) : I ∩ J ⊆ J.
+  Proof.
+    intro; exact snd.
+  Defined.
+
+  (** Subsets of intersections *)
+  Lemma ideal_intersection_subset (I J K : Ideal R)
+    : K ⊆ I -> K ⊆ J -> K ⊆ I ∩ J.
+  Proof.
+    intros p q x r; specialize (p x r); specialize (q x r); by split.
+  Defined.
+
+  (** Ideals include into their sum on the left *)
+  Lemma ideal_sum_subset_l (I J : Ideal R) : I ⊆ (I + J).
+  Proof.
+    intros x p.
+    apply tr, sgt_in.
+    left; exact p.
+  Defined.
+
+  (** Ideals include into their sum on the right *)
+  Lemma ideal_sum_subset_r (I J : Ideal R) : J ⊆ (I + J).
+  Proof.
+    intros x p.
+    apply tr, sgt_in.
+    right; exact p.
+  Defined.
+
+  (** Products of ideals are included in their left factor *)
+  Lemma ideal_product_subset_l (I J : Ideal R) : I ⋅ J ⊆ I.
+  Proof.
+    intros r p.
+    strip_truncations.
+    induction p as [r i | | r s p1 IHp1 p2 IHp2 ].
+    + destruct i as [s t].
+      rewrite commutativity.
+      by apply isideal.
+    + rapply ideal_in_zero.
+    + by rapply ideal_in_plus_negate.
+  Defined.
+
+  (** Products of ideals are included in their right factor. *)
+  Lemma ideal_product_subset_r (I J : Ideal R) : I ⋅ J ⊆ J.
+  Proof.
+    intros r p.
+    strip_truncations.
+    induction p as [r i | | r s p1 IHp1 p2 IHp2 ].
+    + destruct i as [s t].
+      by apply isideal.
+    + rapply ideal_in_zero.
+    + by rapply ideal_in_plus_negate.
+  Defined.
+
+  (** Products of ideals preserve subsets on the left *)
+  Lemma ideal_product_subset_pres_l (I J K : Ideal R) : I ⊆ J -> I ⋅ K ⊆ J ⋅ K.
+  Proof.
+    intros p r q.
+    strip_truncations.
+    induction q as [r i | | r s ].
+    + destruct i.
+      apply tr, sgt_in, ipn_in.
+      1: apply p.
+      1,2: assumption.
+    + apply ideal_in_zero.
+    + by apply ideal_in_plus_negate.
+  Defined.
+
+  (** Products of ideals preserve subsets on the right *)
+  Lemma ideal_product_subset_pres_r (I J K : Ideal R) : I ⊆ J -> K ⋅ I ⊆ K ⋅ J.
+  Proof.
+    intros p r q.
+    strip_truncations.
+    induction q as [r i | | r s ].
+    + destruct i.
+      apply tr, sgt_in, ipn_in.
+      2: apply p.
+      1,2: assumption.
+    + apply ideal_in_zero.
+    + by apply ideal_in_plus_negate.
+  Defined.
+
+  (** Products of ideals are subsets of their intersection. *)
+  Lemma ideal_product_subset_intersection (I J : Ideal R) : I ⋅ J ⊆ I ∩ J.
+  Proof.
+    apply ideal_intersection_subset.
+    + apply ideal_product_subset_l.
+    + apply ideal_product_subset_r.
+  Defined.
+
+  (** Sums of ideals are the smallest ideal containing the summand. *)
+  Lemma ideal_sum_smallest (I J K : Ideal R) : I ⊆ K -> J ⊆ K -> (I + J) ⊆ K.
+  Proof.
+    intros p q.
+    refine (ideal_sum_ind I J (fun x _ => K x) p q _ _).
+    1: apply subgroup_unit.
+    intros y z s t.
+    rapply subgroup_op_inverse.
+  Defined.
+
+  (** Ideals absorb themselves under sum. *)
+  Lemma ideal_sum_self (I : Ideal R) : I + I ↔ I.
+  Proof.
+    apply ideal_subset_antisymm.
+    1: by rapply ideal_sum_smallest.
+    rapply ideal_sum_subset_l.
+  Defined.
+
+  (** Sums preserve inclusions in left summand. *)
+  Lemma ideal_sum_subset_pres_l (I J K : Ideal R) : I ⊆ J -> (I + K) ⊆ (J + K).
+  Proof.
+    intros p.
+    apply ideal_sum_smallest.
+    { transitivity J.
+      1: exact p.
+      apply ideal_sum_subset_l. }
+    apply ideal_sum_subset_r.
+  Defined.
+
+  (** Sums preserve inclusions in right summand. *)
+  Lemma ideal_sum_subset_pres_r (I J K : Ideal R) : I ⊆ J -> (K + I) ⊆ (K + J).
+  Proof.
+    intros p.
+    apply ideal_sum_smallest.
+    1: apply ideal_sum_subset_l.
+    transitivity J.
+    1: exact p.
+    apply ideal_sum_subset_r.
+  Defined.
+
+  (** Products left distribute over sums *)
+  Lemma ideal_dist_l (I J K : Ideal R) : I ⋅ (J + K) ↔ I ⋅ J + I ⋅ K.
+  Proof.
+    (** We split into two directions. *)
+    apply ideal_subset_antisymm.
+    (** We deal with the difficult inclusion first. The proof comes down to breaking down the definition and reassembling into the right. *)
+    { intros r p.
+      strip_truncations.
+      induction p as [ r i | | r s p1 IHp1 p2 IHp2].
+      - destruct i as [r s p q].
+        strip_truncations.
+        induction q as [ t k | | t k p1 IHp1 p2 IHp2 ].
+        + apply tr, sgt_in.
+          destruct k as [j | k].
+          * left; by apply tr, sgt_in, ipn_in.
+          * right; by apply tr, sgt_in, ipn_in.
+        + apply tr, sgt_in; left.
+          rewrite rng_mult_zero_r.
+          apply ideal_in_zero.
+        + rewrite rng_dist_l.
+          rewrite rng_mult_negate_r.
+          by apply ideal_in_plus_negate.
+      - apply ideal_in_zero.
+      - by apply ideal_in_plus_negate. }
+    (** This is the easy direction which can use previous lemmas. *)
+    apply ideal_sum_smallest.
+    1,2: apply ideal_product_subset_pres_r.
+    1: apply ideal_sum_subset_l.
+    apply ideal_sum_subset_r.
+  Defined.
+
+  (** Products distribute over sums on the right. *)
+  (** The proof is very similar to the left version *)
+  Lemma ideal_dist_r (I J K : Ideal R) : (I + J) ⋅ K ↔ I ⋅ K + J ⋅ K.
+  Proof.
+    apply ideal_subset_antisymm.
+    { intros r p.
+      strip_truncations.
+      induction p as [ r i | | r s p1 IHp1 p2 IHp2].
+      - destruct i as [r s p q].
+        strip_truncations.
+        induction p as [ t k | | t k p1 IHp1 p2 IHp2 ].
+        + apply tr, sgt_in.
+          destruct k as [j | k].
+          * left; by apply tr, sgt_in, ipn_in.
+          * right; by apply tr, sgt_in, ipn_in.
+        + apply tr, sgt_in; left.
+          rewrite rng_mult_zero_l.
+          apply ideal_in_zero.
+        + rewrite rng_dist_r.
+          rewrite rng_mult_negate_l.
+          by apply ideal_in_plus_negate.
+      - apply ideal_in_zero.
+      - by apply ideal_in_plus_negate. }
+    apply ideal_sum_smallest.
+    1,2: apply ideal_product_subset_pres_l.
+    1: apply ideal_sum_subset_l.
+    apply ideal_sum_subset_r.
+  Defined.
+
+(*   Lemma ideal_dist_inter (I J K : Ideal R) : J ⊆ I -> I ∩ (J + K) ↔ J + (I ∩ K).
+  Proof. 
+    intros ji.
+    apply ideal_subset_antisymm.
+    { intros x [i jk].
+      strip_truncations.
+      apply tr, sgt_in.
+      induction jk as [r [] | | k].
+      1: by left.
+      1: right; by split.
+      1: left; apply ideal_in_zero.
+      admit. }
+    apply ideal_sum_smallest.
+    - apply ideal_intersection_subset.
+      1: exact p.
+      apply ideal_sum_subset_l.
+    - apply ideal_intersection_subset.
+      1: apply ideal_intersection_subset_l.
+      etransitivity.
+      2: apply ideal_sum_subset_r.
+      apply ideal_intersection_subset_r.
+  Admitted. *)
+  
+  (** Ideal sums are commutative *)
+  Lemma ideal_sum_comm (I J : Ideal R) : I + J ↔ J + I.
+  Proof.
+    apply ideal_subset_antisymm; apply ideal_sum_smallest.
+    1,3: apply ideal_sum_subset_r.
+    1,2: apply ideal_sum_subset_l.
+  Defined.
+
+  (** Zero ideal is left additive identity. *) 
+  Lemma ideal_sum_zero_l I : ideal_zero R + I ↔ I.
+  Proof.
+    apply ideal_subset_antisymm.
+    1: apply ideal_sum_smallest.
+    1: apply ideal_zero_subset.
+    1: reflexivity.
+    apply ideal_sum_subset_r.
+  Defined.
+
+  (** Zero ideal is right additive identity. *)
+  Lemma ideal_sum_zero_r I : I + ideal_zero R ↔ I.
+  Proof.
+    apply ideal_subset_antisymm.
+    1: apply ideal_sum_smallest.
+    1: reflexivity.
+    1: apply ideal_zero_subset.
+    apply ideal_sum_subset_l.
+  Defined.
+
+  (** Ideal products are commutative. *)
+  (** This only holds because we are in a commutative ring. *)
+  Lemma ideal_product_comm (I J : Ideal R) : I ⋅ J ↔ J ⋅ I.
+  Proof.
+    (** WLOG we show one direction *)
+    assert (p : forall K L : Ideal R, K ⋅ L ⊆ L ⋅ K).
+    { clear I J; intros I J.
+      intros r p.
+      strip_truncations.
+      induction p as [r p | |].
+      2: apply ideal_in_zero.
+      2: by apply ideal_in_plus_negate.
+      destruct p as [s t p q].
+      rewrite rng_mult_comm.
+      by apply tr, sgt_in, ipn_in. }
+    apply ideal_subset_antisymm; apply p.
+  Defined.
+
+  (** Unit ideal is left multiplicative identity *)
+  Lemma ideal_product_unit_l I : ideal_unit R ⋅ I ↔ I.
+  Proof.
+    apply ideal_subset_antisymm.
+    1: apply ideal_product_subset_r.
+    intros r p.
+    rewrite <- rng_mult_one_l.
+    by apply tr, sgt_in, ipn_in.
+  Defined.
+
+  (** Unit ideal is right multiplicative ideal. *)
+  Lemma ideal_product_unit_r I : I ⋅ ideal_unit R ↔ I.
+  Proof.
+    apply ideal_subset_antisymm.
+    1: apply ideal_product_subset_l.
+    intros r p.
+    rewrite <- rng_mult_one_r.
+    by apply tr, sgt_in, ipn_in.
+  Defined.
+
+  (** Intersecting with unit ideal on the left does nothing. *)
+  Lemma ideal_intresection_unit_l I : ideal_unit R ∩ I ↔ I.
+  Proof.
+    apply ideal_subset_antisymm.
+    1: apply ideal_intersection_subset_r.
+    apply ideal_intersection_subset.
+    1: apply ideal_unit_subset.
+    reflexivity.
+  Defined.
+
+  (** Intersecting with unit ideal on right does nothing. *)
+  Lemma ideal_intersection_unit_r I : I ∩ ideal_unit R ↔ I.
+  Proof.
+    apply ideal_subset_antisymm.
+    1: apply ideal_intersection_subset_l.
+    apply ideal_intersection_subset.
+    1: reflexivity.
+    apply ideal_unit_subset.
+  Defined.
+
+  (** Product of intersection and sum is subset of sum of products *)
+  (** This is stated a bit more generally, like we would for a general ring .*)
+  Lemma ideal_product_intersection_sum_subset (I J : Ideal R)
+    : (I ∩ J) ⋅ (I + J) ⊆ (I ⋅ J + J ⋅ I).
+  Proof.
+    etransitivity.
+    1: rapply ideal_dist_l.
+    etransitivity.
+    1: rapply ideal_sum_subset_pres_r.
+    1: rapply ideal_product_subset_pres_l.
+    1: apply ideal_intersection_subset_l.
+    etransitivity.
+    1: rapply ideal_sum_subset_pres_l.
+    1: rapply ideal_product_subset_pres_l.
+    1: apply ideal_intersection_subset_r.
+    rapply ideal_sum_comm.
+  Defined.
+
+  (** Product of intersection and sum is a subset of product *)
+  (** Note that this is a generalization of lcm * gcd = product *)
+  (** In a commutative ring we can simplify the right hand side of the previous lemma. *)
+  Lemma ideal_product_intersection_sum_subset' (I J : Ideal R)
+    : (I ∩ J) ⋅ (I + J) ⊆ I ⋅ J.
+  Proof.
+    etransitivity.
+    2: rapply ideal_sum_self.
+    etransitivity.
+    2: rapply ideal_sum_subset_pres_r.
+    2: rapply ideal_product_comm.
+    apply ideal_product_intersection_sum_subset.
+  Defined.
+
+  (** If the sum of ideals is the whole ring then their product is a subset of their intersection. *)
+  Lemma ideal_intersection_subset_product (I J : Ideal R)
+    : ideal_unit R ⊆ (I + J) -> I ∩ J ⊆ I ⋅ J.
+  Proof.
+    intros p.
+    etransitivity.
+    { apply ideal_eq_subset.
+      symmetry.
+      apply ideal_product_unit_r. }
+    etransitivity.
+    { rapply ideal_product_subset_pres_r.
+      exact p. }
+    rapply ideal_product_intersection_sum_subset'.
+  Defined.
+
+  (** This can be combined into a sufficient (but not necessery) condition for equality of intersections and products. *)
+  Lemma ideal_intersection_is_product (I J : Ideal R)
+    : Coprime I J -> I ∩ J ↔ I ⋅ J.
+  Proof.
+    intros p.
+    apply ideal_subset_antisymm.
+    - apply ideal_intersection_subset_product.
+      unfold Coprime in p.
+      apply symmetry in p.
+      rapply p.
+    - apply ideal_product_subset_intersection.
+  Defined.
+
+  Section AssumeFunext.
+    Context `{Funext}.
+
+    (** Ideals are subsets of their ideal quotients *)
+    Lemma ideal_quotient_subset (I J : Ideal R) : I ⊆ (I :: J).
+    Proof.
+      intros x i r j.
+      rewrite rng_mult_comm.
+      by apply isideal.
+    Defined.
+
+    (** Products are subsets iff the first factor is a subset of the ideal quotient *)
+    Lemma ideal_quotient_subset_prod (I J K : Ideal R)
+      : I ⋅ J ⊆ K <-> I ⊆ (K :: J).
+    Proof.
+      split.
+      { intros p r i s j.
+        by apply p, tr, sgt_in, ipn_in. }
+      intros p x q.
+      strip_truncations.
+      induction q as [r x | | ].
+      { destruct x.
+        cbv in p.
+        by apply p. }
+      1: apply ideal_in_zero.
+      by apply ideal_in_plus_negate.
+    Defined.
+
+    (** Ideal quotients partially cancel *)
+    Lemma ideal_quotient_susbset_left_inverse (I J : Ideal R)
+      : (I :: J) ⋅ J ⊆ I.
+    Proof.
+      by apply ideal_quotient_subset_prod.
+    Defined.
+
+    (** If J divides I then the ideal quotient of J by I is trivial. *)
+    Lemma ideal_quotient_trivial (I J : Ideal R)
+      : I ⊆ J -> J :: I ↔ ideal_unit R.
+    Proof.
+      intros p.
+      apply ideal_subset_antisymm.
+      1: cbv; trivial.
+      intros r _ x q.
+      by apply isideal, p.
+    Defined.
+
+    (** The ideal quotient of I by unit is I *)
+    Lemma ideal_quotient_unit_bottom (I : Ideal R)
+      : (I :: ideal_unit R) ↔ I.
+    Proof.
+      apply ideal_subset_antisymm.
+      { intros r p.
+        rewrite <- rng_mult_one_r.
+        exact (p cring_one tt). }
+      apply ideal_quotient_subset.
+    Defined.
+
+    (** The ideal quotient of unit by I is unit *)
+    Lemma ideal_quotient_unit_top (I : Ideal R)
+      : (ideal_unit R :: I) ↔ ideal_unit R.
+    Proof.
+      cbv; split; trivial.
+    Defined.
+
+    (** The ideal quotient by a sum is an intersecton of ideal quotients *)
+    Lemma ideal_quotient_sum (I J K : Ideal R)
+      : (I :: (J + K)) ↔ (I :: J) ∩ (I :: K).
+    Proof.
+      apply ideal_subset_antisymm.
+      { intros r p; split.
+        + intros x j.
+          hnf in p; apply p.
+          by apply ideal_sum_subset_l.
+        + intros x k.
+          hnf in p; apply p.
+          by apply ideal_sum_subset_r. }
+      intros r [p q] x jk.
+      hnf in p, q.
+      strip_truncations.
+      induction jk as [s x | | ].
+      - destruct x.
+        1: by apply p.
+        by apply q.
+      - rewrite rng_mult_zero_r.
+        apply ideal_in_zero.
+      - rewrite rng_dist_l.
+        rewrite rng_mult_negate_r.
+        by apply ideal_in_plus_negate.
+    Defined.
+
+    Lemma ideal_quotient_product (I J K : Ideal R)
+      : (I :: J) :: K ↔ (I :: (J ⋅ K)).
+    Proof.
+      apply ideal_subset_antisymm.
+      { hnf. intros x p y q. cbv in p.
+        strip_truncations.
+        induction q as [y i | | ].
+        - destruct i as [ y z s t ].
+          rewrite (rng_mult_comm y).
+          rewrite rng_mult_assoc.
+          by apply p.
+        - rewrite rng_mult_zero_r.
+          apply ideal_in_zero.
+        - rewrite rng_dist_l.
+          rewrite rng_mult_negate_r.
+          by apply ideal_in_plus_negate. }
+      intros x p y k z j; hnf in p.
+      rewrite <- rng_mult_assoc.
+      rewrite (rng_mult_comm y).
+      by apply p, tr, sgt_in, ipn_in.
+    Defined.
+
+    (** Ideal quotients distribute over intersections *)
+    Lemma ideal_quotient_intersection (I J K : Ideal R)
+      : (I ∩ J :: K) ↔ (I :: K) ∩ (J :: K).
+    Proof.
+      apply ideal_subset_antisymm.
+      1: intros r p; hnf in p; split; hnf; intros; by apply p.
+      intros r [p q]; hnf in p, q; intros x k; by split; [apply p | apply q].
+    Defined.
+
+    (** Annihilators reverse the order of inclusion. *)
+    Lemma ideal_annihilator_subset (I J : Ideal R) : I ⊆ J -> Ann J ⊆ Ann I.
+    Proof.
+      intros p x q y i.
+      hnf in q.
+      by apply q, p.
+    Defined.
+
+  End AssumeFunext.
+
+End IdealLemmas.
+
 
 (** TODO: Maximal ideals *)
 (** TODO: Principal ideal *)

--- a/theories/Algebra/Rings/Ideal.v
+++ b/theories/Algebra/Rings/Ideal.v
@@ -627,29 +627,6 @@ Section IdealLemmas.
     apply ideal_sum_subset_r.
   Defined.
 
-(*   Lemma ideal_dist_inter (I J K : Ideal R) : J ⊆ I -> I ∩ (J + K) ↔ J + (I ∩ K).
-  Proof. 
-    intros ji.
-    apply ideal_subset_antisymm.
-    { intros x [i jk].
-      strip_truncations.
-      apply tr, sgt_in.
-      induction jk as [r [] | | k].
-      1: by left.
-      1: right; by split.
-      1: left; apply ideal_in_zero.
-      admit. }
-    apply ideal_sum_smallest.
-    - apply ideal_intersection_subset.
-      1: exact p.
-      apply ideal_sum_subset_l.
-    - apply ideal_intersection_subset.
-      1: apply ideal_intersection_subset_l.
-      etransitivity.
-      2: apply ideal_sum_subset_r.
-      apply ideal_intersection_subset_r.
-  Admitted. *)
-  
   (** Ideal sums are commutative *)
   Lemma ideal_sum_comm (I J : Ideal R) : I + J ↔ J + I.
   Proof.

--- a/theories/Algebra/Rings/Ideal.v
+++ b/theories/Algebra/Rings/Ideal.v
@@ -60,6 +60,13 @@ Section IdealElements.
     apply ideal_in_plus_negate.
   Defined.
 
+  Lemma ideal_in_negate_plus a b : I a -> I b -> I (-a + b).
+  Proof.
+    intros p q.
+    rewrite rng_plus_comm.
+    by apply ideal_in_plus_negate.
+  Defined.
+
 End IdealElements.
 
 (** The zero ideal is an ideal *)
@@ -247,6 +254,9 @@ Proof.
   rapply equiv_path_subgroup'.
 Defined.
 
+Global Instance ishprop_ideal_eq `{Funext} {R : CRing} (I J : Ideal R)
+  : IsHProp (ideal_eq I J) := _.
+
 Global Instance reflexive_ideal_eq {R : CRing} : Reflexive (@ideal_eq R).
 Proof.
   intros I x; by split.
@@ -332,37 +342,66 @@ Definition Coprime {R : CRing} (I J : Ideal R) : Type
   := ideal_eq (ideal_sum I J) (ideal_unit R).
 Existing Class Coprime.
 
-(* Lemma coprime_property {R : CRing} {I J : Ideal R} (p : Coprime I J)
-  : merely {x : R & I x /\ {y : R & J y /\ x + y = 1}}.
+Global Instance ishprop_coprime `{Funext} {R : CRing}
+  (I J : Ideal R) : IsHProp (Coprime I J).
 Proof.
-  pose (q := p); clearbody q.
-  specialize (p cring_one).
-  destruct p as [_ p].
-  specialize (p tt).
-  revert p; apply Trunc_functor; intros p.
-  destruct p as [x [s | t] | | ].
-  - 
-  
-  
-  
-  rapply (subgroup_generated_type_rec _ _ (fun _ _ => _) _ _ _ _ p).
-  { intros x t.
-    destruct t as [s | t].
-    + apply tr.
-      exists x.
-      exists (1 - x).
-      rewrite rng_plus_comm, <- rng_plus_assoc, rng_plus_negate_l.
-      apply rng_plus_zero_r.
-    + apply tr.
-      exists x.
-      exists (1 - x).
-      rewrite rng_plus_comm, <- rng_plus_assoc, rng_plus_negate_l.
-      apply rng_plus_zero_r. }
-  { apply tr.
-      
-      reflexivity.
-      rewrite 
-      rewrite (rng_plus_assoc x (-x) 1). *)
+    unfold Coprime.
+    exact _.
+Defined.
+
+Lemma equiv_coprime_sum `{Funext} {R : CRing} (I J : Ideal R)
+  : Coprime I J
+  <~> hexists (fun '(((i ; p) , (j ; q)) : sig I * sig J)
+      => i + j = cring_one).
+Proof.
+  simpl.
+  srapply equiv_iff_hprop.
+  { intros c.
+    pose (snd (c cring_one) tt) as d; clearbody d; clear c.
+    strip_truncations.
+    apply tr.
+    induction d.
+    - destruct x.
+      + exists ((g ; s), (cring_zero; ideal_in_zero _)).
+        apply rng_plus_zero_r.
+      + exists ((cring_zero; ideal_in_zero _), (g ; s)).
+        apply rng_plus_zero_l.
+    - exists ((cring_zero; ideal_in_zero _), (cring_zero; ideal_in_zero _)).
+      apply rng_plus_zero_l.
+    - destruct IHd1 as [[[x xi] [y yj]] p].
+      destruct IHd2 as [[[w wi] [z zj]] q].
+      srefine (((_;_),(_;_));_).
+      + exact (x - w).
+      + by apply ideal_in_plus_negate.
+      + exact (y - z).
+      + by apply ideal_in_plus_negate.
+      + cbn.
+        refine (_ @ ap011 (fun x y => x - y) p q).
+        rewrite <- 2 rng_plus_assoc.
+        f_ap.
+        rewrite negate_sg_op.
+        rewrite rng_plus_comm.
+        rewrite rng_plus_assoc.
+        reflexivity. }
+  intro x.
+  strip_truncations.
+  intros r.
+  split;[intro; exact tt|].
+  intros _.
+  destruct x as [[[x xi] [y yj]] p].
+  rewrite <- rng_mult_one_r.
+  change (x + y = 1) in p.
+  rewrite <- p.
+  rewrite rng_dist_l.
+  apply tr.
+  rapply sgt_op'.
+  - apply sgt_in.
+    left.
+    by apply isideal.
+  - apply sgt_in.
+    right.
+    by apply isideal.
+Defined.
 
 (** *** Ideal lemmas *)
 

--- a/theories/Algebra/Rings/Ideal.v
+++ b/theories/Algebra/Rings/Ideal.v
@@ -7,6 +7,7 @@ Local Open Scope mc_scope.
 
 Declare Scope ideal_scope.
 Delimit Scope ideal_scope with ideal.
+Local Open Scope ideal_scope.
 
 (** In this file we define Ideals *)
 
@@ -296,22 +297,6 @@ Defined.
 Definition ideal_annihilator `{Funext} {R : CRing} (I : Ideal R) : Ideal R
   := ideal_quotient (ideal_zero R) I.
 
-(** *** Ideal notations *)
-
-(** We declare a module for various (unicode) ideal notations. These exist in their own special case, and can be imported and used when needing to reason about ideals. *)
-
-(** TODO: reserve these properly *)
-Module Notation.
-  Infix "⊆" := ideal_subset       : ideal_scope.
-  Infix "↔" := ideal_eq           : ideal_scope.
-  Infix "+" := ideal_sum          : ideal_scope.
-  Infix "⋅" := ideal_product      : ideal_scope.
-  Infix "∩" := ideal_intersection : ideal_scope.
-  Infix "::" := ideal_quotient    : ideal_scope.
-  Notation "〈 X 〉" := (ideal_generated X)  : ideal_scope.
-  Notation Ann := ideal_annihilator.
-End Notation.
-
 (** ** Properties of ideals *)
 
 (** *** Coprime ideals *)
@@ -382,11 +367,22 @@ Proof.
     by apply isideal.
 Defined.
 
-(** *** Ideal lemmas *)
+(** *** Ideal notations *)
 
-(** We use the Ideal.Notation notations in the rest of this file *)
-Import Ideal.Notation.
-Local Open Scope ideal_scope.
+(** We declare and import a module for various (unicode) ideal notations. These exist in their own special case, and can be imported and used in other files when needing to reason about ideals. *)
+
+Module Import Notation.
+  Infix "⊆" := ideal_subset       : ideal_scope.
+  Infix "↔" := ideal_eq           : ideal_scope.
+  Infix "+" := ideal_sum          : ideal_scope.
+  Infix "⋅" := ideal_product      : ideal_scope.
+  Infix "∩" := ideal_intersection : ideal_scope.
+  Infix "::" := ideal_quotient    : ideal_scope.
+  Notation "〈 X 〉" := (ideal_generated X)  : ideal_scope.
+  Notation Ann := ideal_annihilator.
+End Notation.
+
+(** *** Ideal lemmas *)
 
 Section IdealLemmas.
 

--- a/theories/Algebra/Rings/Ideal.v
+++ b/theories/Algebra/Rings/Ideal.v
@@ -494,6 +494,10 @@ Section IdealLemmas.
     + by apply ideal_in_plus_negate.
   Defined.
 
+  (** TODO: *)
+  (** The product of ideals is an associative operation. *)
+  (* Lemma ideal_product_assoc (I J K : Ideal R) : I ⋅ (J ⋅ K) ↔ (I ⋅ J) ⋅ K. *)
+
   (** Products of ideals are subsets of their intersection. *)
   Lemma ideal_product_subset_intersection (I J : Ideal R) : I ⋅ J ⊆ I ∩ J.
   Proof.

--- a/theories/Algebra/Rings/Ideal.v
+++ b/theories/Algebra/Rings/Ideal.v
@@ -302,12 +302,12 @@ Definition ideal_annihilator `{Funext} {R : CRing} (I : Ideal R) : Ideal R
 
 (** TODO: reserve these properly *)
 Module Notation.
-  Infix "⊆" := ideal_subset : ideal_scope.
-  Infix "↔" := ideal_eq : ideal_scope.
-  Infix "+" := ideal_sum : ideal_scope.
-  Infix "⋅" := ideal_product (at level 20) : ideal_scope.
-  Infix "∩" := ideal_intersection (at level 20)  : ideal_scope.
-  Infix "::" := ideal_quotient : ideal_scope.
+  Infix "⊆" := ideal_subset       : ideal_scope.
+  Infix "↔" := ideal_eq           : ideal_scope.
+  Infix "+" := ideal_sum          : ideal_scope.
+  Infix "⋅" := ideal_product      : ideal_scope.
+  Infix "∩" := ideal_intersection : ideal_scope.
+  Infix "::" := ideal_quotient    : ideal_scope.
   Notation "〈 X 〉" := (ideal_generated X)  : ideal_scope.
   Notation Ann := ideal_annihilator.
 End Notation.
@@ -384,8 +384,8 @@ Defined.
 
 (** *** Ideal lemmas *)
 
-(** We use these notations in the rest of this file *)
-Import Notation.
+(** We use the Ideal.Notation notations in the rest of this file *)
+Import Ideal.Notation.
 Local Open Scope ideal_scope.
 
 Section IdealLemmas.
@@ -398,7 +398,7 @@ Section IdealLemmas.
     intros p q x; split; by revert x.
   Defined.
 
-  (** The zero ideal is contained by all ideals *)
+  (** The zero ideal is contained in all ideals *)
   Lemma ideal_zero_subset I : ideal_zero R ⊆ I.
   Proof.
     intros x p; rewrite p; apply ideal_in_zero.
@@ -547,6 +547,7 @@ Section IdealLemmas.
   Defined.
 
   (** Products left distribute over sums *)
+  (** Note that this follows from left adjoints preserving colimits. The product of ideals is a functor whose right adjoint is the quotient ideal. *)
   Lemma ideal_dist_l (I J K : Ideal R) : I ⋅ (J + K) ↔ I ⋅ J + I ⋅ K.
   Proof.
     (** We split into two directions. *)
@@ -724,7 +725,7 @@ Section IdealLemmas.
     apply ideal_product_intersection_sum_subset.
   Defined.
 
-  (** If the sum of ideals is the whole ring then their product is a subset of their intersection. *)
+  (** If the sum of ideals is the whole ring then their intersection is a subset of their product. *)
   Lemma ideal_intersection_subset_product (I J : Ideal R)
     : ideal_unit R ⊆ (I + J) -> I ∩ J ⊆ I ⋅ J.
   Proof.
@@ -763,7 +764,7 @@ Section IdealLemmas.
       by apply isideal.
     Defined.
 
-    (** Products are subsets iff the first factor is a subset of the ideal quotient *)
+    (** The ideal quotient is a right adjoint to the product in the monoidal lattice of ideals. *)
     Lemma ideal_quotient_subset_prod (I J K : Ideal R)
       : I ⋅ J ⊆ K <-> I ⊆ (K :: J).
     Proof.
@@ -781,7 +782,7 @@ Section IdealLemmas.
     Defined.
 
     (** Ideal quotients partially cancel *)
-    Lemma ideal_quotient_susbset_left_inverse (I J : Ideal R)
+    Lemma ideal_quotient_product_left (I J : Ideal R)
       : (I :: J) ⋅ J ⊆ I.
     Proof.
       by apply ideal_quotient_subset_prod.
@@ -816,7 +817,7 @@ Section IdealLemmas.
       cbv; split; trivial.
     Defined.
 
-    (** The ideal quotient by a sum is an intersecton of ideal quotients *)
+    (** The ideal quotient by a sum is an intersection of ideal quotients *)
     Lemma ideal_quotient_sum (I J K : Ideal R)
       : (I :: (J + K)) ↔ (I :: J) ∩ (I :: K).
     Proof.

--- a/theories/Algebra/Rings/Ideal.v
+++ b/theories/Algebra/Rings/Ideal.v
@@ -271,6 +271,7 @@ Proof.
 Defined.
 
 (** Quotient (a.k.a colon) ideal *)
+(** Note that this is quotient as in division rather than a colimit. In fact, the quotient ideal is more like an internal hom as we will see later. *)
 (** Unfortunately, due to truncatedness constraints, we need to assume funext. *)
 Definition ideal_quotient `{Funext} {R : CRing} (I J : Ideal R) : Ideal R.
 Proof.
@@ -893,4 +894,3 @@ End IdealLemmas.
 (** TODO: Radical ideals *)
 (** TODO: Minimal ideals *)
 (** TODO: Primary ideals *)
-

--- a/theories/Algebra/Rings/Ideal.v
+++ b/theories/Algebra/Rings/Ideal.v
@@ -35,38 +35,17 @@ Proof.
   rapply istrunc_sigma.
 Defined.
 
-(** Here are some lemmas for proving certain elements are in an ideal. *)
+(** Here are some lemmas for proving certain elements are in an ideal. They are just special cases of the underlying subgroup lemmas. We write them out for clarity. *)
 Section IdealElements.
-
-  Context {R : CRing} (I : Ideal R).
-
-  Definition ideal_in_zero : I cring_zero := subgroup_unit I.
-  Definition ideal_in_plus a b : I a -> I b -> I (a + b) := subgroup_op I a b.
-  Definition ideal_in_negate a : I a -> I (- a) := subgroup_inverse I a.
-  Definition ideal_in_plus_negate a b : I a -> I b -> I (a - b)
-    := subgroup_op_inverse I a b.
-
-  Lemma ideal_in_negate' a : I (- a) -> I a.
-  Proof.
-    intros p; rewrite <- (negate_involutive a); revert p.
-    apply ideal_in_negate.
-  Defined.
-
-  Lemma ideal_in_plus_l a b : I (a + b) -> I b -> I a.
-  Proof.
-    intros p q; rewrite <- (rng_plus_zero_r a); revert p q.
-    rewrite <- (rng_plus_negate_r b).
-    rewrite rng_plus_assoc.
-    apply ideal_in_plus_negate.
-  Defined.
-
-  Lemma ideal_in_negate_plus a b : I a -> I b -> I (-a + b).
-  Proof.
-    intros p q.
-    rewrite rng_plus_comm.
-    by apply ideal_in_plus_negate.
-  Defined.
-
+  Context {R : CRing} (I : Ideal R) (a b : R).
+  Definition ideal_in_zero : I cring_zero := subgroup_in_unit I.
+  Definition ideal_in_plus : I a -> I b -> I (a + b) := subgroup_in_op I a b.
+  Definition ideal_in_negate  : I a -> I (- a) := subgroup_in_inv  I a.
+  Definition ideal_in_negate' : I (- a) -> I a := subgroup_in_inv' I a.
+  Definition ideal_in_plus_negate : I a -> I b -> I (a - b) := subgroup_in_op_inv I a b.
+  Definition ideal_in_negate_plus : I a -> I b -> I (-a + b) := subgroup_in_inv_op I a b.
+  Definition ideal_in_plus_l : I (a + b) -> I b -> I a := subgroup_in_op_l I a b.
+  Definition ideal_in_plus_r : I (a + b) -> I a -> I b := subgroup_in_op_r I a b.
 End IdealElements.
 
 (** The zero ideal is an ideal *)
@@ -118,11 +97,11 @@ Proof.
     right; by apply isideal.
   + apply tr, sgt_in.
     left; apply isideal.
-    apply subgroup_unit.
+    apply ideal_in_zero.
   + intros x y p q IHp IHq.
     rewrite rng_dist_l.
     rewrite rng_mult_negate_r.
-    by rapply subgroup_op_inverse.
+    by rapply subgroup_in_op_inv.
 Defined.
 
 (** Sum of ideals *)
@@ -532,9 +511,9 @@ Section IdealLemmas.
   Proof.
     intros p q.
     refine (ideal_sum_ind I J (fun x _ => K x) p q _ _).
-    1: apply subgroup_unit.
+    1: apply ideal_in_zero.
     intros y z s t.
-    rapply subgroup_op_inverse.
+    rapply ideal_in_plus_negate.
   Defined.
 
   (** Ideals absorb themselves under sum. *)

--- a/theories/Algebra/Rings/QuotientRing.v
+++ b/theories/Algebra/Rings/QuotientRing.v
@@ -4,9 +4,13 @@ Require Import Algebra.AbGroups.
 Require Import Algebra.Rings.CRing.
 Require Import Algebra.Rings.Ideal.
 
+(** In this file we define the quotient of a commutative ring by an ideal *)
+
+Import Ideal.Notation.
+Local Open Scope ring_scope.
 Local Open Scope wc_iso_scope.
 
-(** In this file we define the quotient of a commutative ring by an ideal *)
+(** In this file we define the quotient of a commutative ring by an ideal and prove some basic facts. *)
 
 Section QuotientRing.
 
@@ -102,58 +106,88 @@ Section QuotientRing.
 
 End QuotientRing.
 
-(** Here is an alternative way to build a commutative ring using the underlying abelian group. *)
-Definition Build_CRing' (R : AbGroup)
-  `(Mult R, One R, LeftDistribute R mult (@group_sgop R))
-  (iscomm : @IsCommutativeMonoid R mult one)
-  : CRing
-  := Build_CRing R (@group_sgop R) _ (@group_unit R) _
-       (@group_inverse R) (Build_IsRing _ _ _ _).
+Infix "/" := QuotientRing : ring_scope.
 
-(** The image of a ring homomorphism *)
-Definition rng_image {R S : CRing} (f : R $-> S) : CRing.
+(** Quotient map *)
+Definition rng_quotient_map {R : CRing} (I : Ideal R)
+  : CRingHomomorphism R (R / I).
 Proof.
-  snrapply (Build_CRing' (abgroup_image f)).
-  { simpl.
-    intros [x p] [y q].
-    exists (x * y).
-    strip_truncations; apply tr.
-    destruct p as [p p'], q as [q q'].
-    exists (p * q).
-    refine (rng_homo_mult _ _ _ @ _).
-    f_ap. }
-  { exists 1.
-    apply tr.
-    exists 1.
-    exact (rng_homo_one f). }
-  (** Much of this proof is doing the same thing over, so we use some compact tactics. *)
-  2: repeat split.
-  2: exact _.
-  all: intros [].
-  1,2,5: intros [].
-  1,2: intros [].
-  all: apply path_sigma_hprop; cbn.
-  1: apply distribute_l.
-  1: apply associativity.
-  1: apply commutativity.
-  1: apply left_identity.
-  apply right_identity.
+  snrapply Build_CRingHomomorphism'.
+  1: rapply grp_quotient_map.
+  repeat split.
 Defined.
 
+Global Instance issurj_rng_quotient_map {R : CRing} (I : Ideal R)
+  : IsSurjection (rng_quotient_map I).
+Proof.
+  exact _.
+Defined.
+
+(** *** Specialized induction principles *)
+
+(** We provide some specialized induction principes for [QuotientRing] that require cleaner hypotheses than the ones given by [Quotient_ind]. *)
+Definition QuotientRing_ind {R : CRing} {I : Ideal R} (P : R / I -> Type)
+  `{forall x, IsHSet (P x)}
+  (c : forall (x : R), P (rng_quotient_map I x))
+  (g : forall (x y : R) (h : I (- x + y)), qglue h # c x = c y)
+  : forall (r : R / I), P r
+  := Quotient_ind _ P c g.
+
+(** And a version eliminating into hprops. This one is especially useful. *)
+Definition QuotientRing_ind_hprop {R : CRing} {I : Ideal R} (P : R / I -> Type)
+  `{forall x, IsHProp (P x)} (c : forall (x : R), P (rng_quotient_map I x))
+  : forall (r : R / I), P r
+  := Quotient_ind_hprop _ P c.
+
+(** ** Quotient thoery *)
+
 (** First isomorphism theorem for commutative rings *)
-Definition rng_first_iso `{Funext} {A B : CRing} (phi : A $-> B)
-  : QuotientRing A (ideal_kernel phi) ≅ rng_image phi.
+Definition rng_first_iso `{Funext} {A B : CRing} (f : A $-> B)
+  : A / ideal_kernel f ≅ rng_image f.
 Proof.
   snrapply Build_CRingIsomorphism''.
-  { etransitivity.
-    2: exact (grp_first_iso phi).
-    apply grp_iso_quotient_normal. }
+  1: rapply abgroup_first_iso.
   split.
-  { intros x.
-    srapply Quotient_ind_hprop; intro y; revert x.
-    srapply Quotient_ind_hprop; intro x.
+  { intros x y.
+    revert y; srapply QuotientRing_ind_hprop; intros y.
+    revert x; srapply QuotientRing_ind_hprop; intros x.
     srapply path_sigma_hprop.
     exact (rng_homo_mult _ _ _). }
   srapply path_sigma_hprop.
   exact (rng_homo_one _).
 Defined.
+
+(** Invariance of equal ideals *)
+Lemma rng_quotient_invar {R : CRing} {I J : Ideal R} (p : (I ↔ J)%ideal)
+  : R / I ≅ R / J.
+Proof.
+  snrapply Build_CRingIsomorphism'.
+  { srapply equiv_quotient_functor'.
+    1: exact equiv_idmap.
+    intros x y; cbn.
+    apply p. }
+  repeat split.
+  1,2: intros x; simpl.
+  1,2: srapply QuotientRing_ind_hprop.
+  1,2: intros y; revert x.
+  1,2: srapply QuotientRing_ind_hprop.
+  1,2: intros x; rapply qglue.
+  1: change (J ( - (x + y) + (x + y))).
+  2: change (J (- ( x * y) + (x * y))).
+  1,2: rewrite rng_plus_negate_l.
+  1,2: apply ideal_in_zero.
+Defined.
+
+(** We phrase the first ring isomorphism theroem in a slightly differnt way so that it is easier to use. This form specifically asks for a surjective map *)
+Definition rng_first_iso' `{Funext} {A B : CRing} (f : A $-> B)
+  (issurj_f : IsSurjection f)
+  (I : Ideal A) (p : (I ↔ ideal_kernel f)%ideal)
+  : A / I ≅ B.
+Proof.
+  etransitivity.
+  1: apply (rng_quotient_invar p).
+  etransitivity.
+  2: rapply (rng_image_issurj f).
+  apply rng_first_iso.
+Defined.
+

--- a/theories/Algebra/Rings/QuotientRing.v
+++ b/theories/Algebra/Rings/QuotientRing.v
@@ -34,7 +34,7 @@ Section QuotientRing.
     rewrite <- simple_associativity.
     rewrite negate_mult_distr_r.
     rewrite <- simple_distribute_l.
-    rapply subgroup_op.
+    rapply subgroup_in_op.
     1: rewrite (commutativity _ y).
     all: by rapply isideal.
   Defined.

--- a/theories/Basics/Utf8.v
+++ b/theories/Basics/Utf8.v
@@ -13,6 +13,8 @@ Reserved Notation "x ↔ y" (at level 95, no associativity).
 (*Notation "¬ x" (at level 75, right associativity).*)
 (*Notation "x ≠ y" (at level 70).*)
 
+Reserved Infix "∩" (at level 20).
+Reserved Infix "⋅" (at level 20).
 Reserved Infix "∙" (at level 20).
 Reserved Infix "∘" (at level 40, left associativity).
 Reserved Infix "∘ˡ" (at level 40, left associativity).


### PR DESCRIPTION
This PR builds on top of #1496 and #1495.

Here is a summary of the PR:

The biggest changes are in Ideal.v which looks like it has been written from scratch:

 * We begin with various lemmas about ring elements being in an ideal
 * We define intersection ideals, sums of ideals, products of ideals
 * We define the ideal generated by a family on a ring (different but analagous to the subgroup generated in #1495)
 * We can define principal ideals (but not what it means to be principal yet)
 * We define equality of ideals, which is just a family of "if and only if"'s
 * We define subsets of ideals, i.e. a family of implications (this is our notion of "divded by" for ideals)
 * Define the colon ideal
 * Define the annihilator of an ideal
 * We define some ideal (unicode) notations. These are convenient to use and we are running out of ascii.
 * Define coprime (comaximal) ideals and properties (e.g. existence of x and y such that x + y = 1).
 * We state and prove every lemmas about ideal arithmetic I could think of / find. There are a lot!
 
Next we do some improvements and cleanup in QuotientRing.v:
 * We add a quotient notation and use previous ring notations to make statements more concise
 * We add convenient induction principles for ring quotients whose hypothesis talk about ring elements.
 * We add a quality-of-life improvement to the first isomorphism theorem 

Finally we have a new file called Algebra/Rings/ChineseRemainder.v in which we prove the chinese remainder theorem. I've spent some time documenting the proof so it is easy to read. Interestingly it uses univalence since we need to reason about equalities in the quotient ring. Since our rings are commutative, we also state and prove the version that uses products of ideals instead of intersections.

