### PR TITLE
Make x and y implicit args in (is)equiv_transport

### DIFF
--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -475,7 +475,7 @@ Lemma equiv_grp_hfiber {A B : Group} (f : GroupHomomorphism A B) (b : B)
   : forall (a0 : hfiber f b), hfiber f b <~> hfiber f mon_unit.
 Proof.
   intros [a0 p].
-  refine (equiv_transport (hfiber f) _ _ (right_inverse b) oE _).
+  refine (equiv_transport (hfiber f) (right_inverse b) oE _).
   rapply (equiv_functor_hfiber (h:=right_mult_equiv (-a0)) (k:=right_mult_equiv (- b))).
   intro a; cbn; symmetry.
   refine (_ @ ap (fun x => f a * (- x)) p).

--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -115,7 +115,7 @@ Definition isequiv_homotopic' {A B : Type} (f : A <~> B) {g : A -> B} (h : f == 
 (** Transporting is an equivalence. *)
 Section EquivTransport.
 
-  Context {A : Type} (P : A -> Type) (x y : A) (p : x = y).
+  Context {A : Type} (P : A -> Type) {x y : A} (p : x = y).
 
   Global Instance isequiv_transport : IsEquiv (transport P p) | 0
     := Build_IsEquiv (P x) (P y) (transport P p) (transport P p^)

--- a/theories/Homotopy/BlakersMassey.v
+++ b/theories/Homotopy/BlakersMassey.v
@@ -19,9 +19,11 @@ Definition transport_singleton `{Univalence}
            (ev : ap10 (apD B p) p =
    transport_arrow_toconst p (B x) p @
    path_universe_uncurried
-     (equiv_transport (B y) (concat_pV_p p p)
+     (@equiv_transport _ (B y) ((p @ p^) @ p) p (concat_pV_p p p)
       oE (f (p @ p^))
-      oE equiv_transport (B x) (transport_paths_r p^ p)))
+      oE @equiv_transport _ (B x)
+           (transport (fun y => x = y) p^ p)
+           (p @ p^) (transport_paths_r p^ p)))
   : transport (fun yp:{y:A & x=y} => B yp.1 yp.2)
               (path_contr (A := {y:A & x=y}) (x;idpath) (y;p)) u
     = transport (B y) (concat_1p _) (f idpath u).
@@ -429,9 +431,12 @@ Now we claim that the left-hand map of this span is also an equivalence.  Rather
       : ap10 (apD code (glue q11)) r
         = transport_arrow_toconst (glue q11) codeleft r
         @ path_universe_uncurried
-           (equiv_transport coderight (concat_pV_p r (glue q11))
+           (@equiv_transport _ coderight ((r @ (glue q11)^) @ glue q11) r
+                            (concat_pV_p r (glue q11))
             oE (codeglue (r @ (glue q11)^) q11)
-            oE equiv_transport codeleft (transport_paths_r (glue q11)^ r)).
+            oE @equiv_transport _ codeleft
+                 (transport (fun y : SPushout Q => left x0 = y) (glue q11)^ r)
+                 (r @ (glue q11)^) (transport_paths_r (glue q11)^ r)).
     Proof.
       refine (ap (fun h => ap10 h r)
              (spushout_ind_beta_sglue Q (fun p => left x0 = p -> Type)

--- a/theories/Homotopy/BlakersMassey.v
+++ b/theories/Homotopy/BlakersMassey.v
@@ -19,11 +19,9 @@ Definition transport_singleton `{Univalence}
            (ev : ap10 (apD B p) p =
    transport_arrow_toconst p (B x) p @
    path_universe_uncurried
-     (equiv_transport (B y) ((p @ p^) @ p) p (concat_pV_p p p)
+     (equiv_transport (B y) (concat_pV_p p p)
       oE (f (p @ p^))
-      oE equiv_transport (B x)
-           (transport (fun y => x = y) p^ p)
-           (p @ p^) (transport_paths_r p^ p)))
+      oE equiv_transport (B x) (transport_paths_r p^ p)))
   : transport (fun yp:{y:A & x=y} => B yp.1 yp.2)
               (path_contr (A := {y:A & x=y}) (x;idpath) (y;p)) u
     = transport (B y) (concat_1p _) (f idpath u).
@@ -412,9 +410,9 @@ Now we claim that the left-hand map of this span is also an equivalence.  Rather
       apply path_arrow; intros z.
       refine ((transport_arrow_toconst _ _ _) @ _).
       apply path_universe_uncurried.
-      refine (_ oE equiv_transport codeleft _ _ (transport_paths_r _ _)).
+      refine (_ oE equiv_transport codeleft (transport_paths_r _ _)).
       refine (_ oE codeglue _ q11).
-      refine (equiv_transport coderight _ _ _).
+      refine (equiv_transport coderight _).
       refine (concat_pV_p z (glue q11)).
     Defined.
 
@@ -431,12 +429,9 @@ Now we claim that the left-hand map of this span is also an equivalence.  Rather
       : ap10 (apD code (glue q11)) r
         = transport_arrow_toconst (glue q11) codeleft r
         @ path_universe_uncurried
-           (equiv_transport coderight ((r @ (glue q11)^) @ glue q11) r
-                            (concat_pV_p r (glue q11))
+           (equiv_transport coderight (concat_pV_p r (glue q11))
             oE (codeglue (r @ (glue q11)^) q11)
-            oE equiv_transport codeleft
-                 (transport (fun y : SPushout Q => left x0 = y) (glue q11)^ r)
-                 (r @ (glue q11)^) (transport_paths_r (glue q11)^ r)).
+            oE equiv_transport codeleft (transport_paths_r (glue q11)^ r)).
     Proof.
       refine (ap (fun h => ap10 h r)
              (spushout_ind_beta_sglue Q (fun p => left x0 = p -> Type)

--- a/theories/Homotopy/Suspension.v
+++ b/theories/Homotopy/Suspension.v
@@ -313,7 +313,7 @@ Section UnivPropNat.
       <~> DPath (P o functor_susp f) (merid x) (fst NS) (snd NS).
   Proof.
     etransitivity.
-    - apply (equiv_transport (fun p => DPath P p (fst NS) (snd NS))).
+    - nrapply (equiv_transport (fun p => DPath P p (fst NS) (snd NS))).
       symmetry; apply ap_functor_susp_merid.
     - symmetry. 
       apply (dp_compose (functor_susp f) P (merid x)).

--- a/theories/Limits/Pullback.v
+++ b/theories/Limits/Pullback.v
@@ -204,13 +204,13 @@ Section Functor_Pullback.
     refine (_ oE hfiber_functor_sigma _ _ _ _ _ _).
     apply equiv_functor_sigma_id.
     intros [b1 e1]; simpl.
-    refine (_ oE (equiv_transport _ _ _ (transport_sigma' e1^ (c2; e2)))).
+    refine (_ oE (equiv_transport _ (transport_sigma' e1^ (c2; e2)))).
     refine (_ oE hfiber_functor_sigma _ _ _ _ _ _); simpl.
     apply equiv_functor_sigma_id.
     intros [c1 e3]; simpl.
-    refine (_ oE (equiv_transport _ _ _
+    refine (_ oE (equiv_transport _
                    (ap (fun e => e3^ # e) (transport_paths_Fl e1^ e2)))).
-    refine (_ oE (equiv_transport _ _ _ (transport_paths_Fr e3^ _))).
+    refine (_ oE (equiv_transport _ (transport_paths_Fr e3^ _))).
     unfold functor_hfiber; simpl.
     refine (equiv_concat_l (transport_sigma' e2 _) _ oE _); simpl.
     refine (equiv_path_sigma _ _ _ oE _); simpl.

--- a/theories/Modalities/Descent.v
+++ b/theories/Modalities/Descent.v
@@ -125,7 +125,7 @@ Proof.
   refine (OO_descend_beta O' O P a oE _).
   assert (p := (to_O_natural O' f a)^).
   apply moveR_equiv_V in p.
-  exact (equiv_transport _ _ _ p).
+  exact (equiv_transport _ p).
 Defined.
 
 (** Morally, an equivalent way of saying [O <<< O'] is that the universe of [O]-modal types is [O']-modal.  We can't say this directly since this type lives in a higher universe, but here is a rephrasing of it. *)

--- a/theories/Modalities/Lex.v
+++ b/theories/Modalities/Lex.v
@@ -379,7 +379,7 @@ Proof.
   assert (wc : forall y z, P y <~> P z).
   { intros y z.
     (** Here we use the hypothesis [lexgen] (typeclass inference finds it automatically). *)
-    refine (pr1 (isconnected_elim O _ (equiv_transport P y z))). }
+    refine (pr1 (isconnected_elim O _ (@equiv_transport _ P y z))). }
   intros x; apply path_TypeO, path_universe_uncurried.
   refine (equiv_adjointify (fun f => f x) (fun u y => wc x y ((wc x x)^-1 u)) _ _).
   - intros u; apply eisretr.

--- a/theories/Spaces/Finite/Finite.v
+++ b/theories/Spaces/Finite/Finite.v
@@ -321,7 +321,7 @@ Proof.
   strip_truncations.
   simple refine (finite_equiv' _
             (equiv_functor_forall' (P := fun x => Y (e^-1 x)) e _) _); try exact _.
-  { intros x; refine (equiv_transport _ _ _ (eissect e x)). }
+  { intros x; refine (equiv_transport _ (eissect e x)). }
   set (Y' := Y o e^-1); change (Finite (forall x, Y' x)).
   assert (forall x, Finite (Y' x)) by exact _; clearbody Y'; clear e.
   generalize dependent (fcard X); intros n Y' ?.

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -127,11 +127,7 @@ Definition merely_path_is0connected `{Univalence}
            (A : Type) `{IsConnected 0 A} (x y : A)
 : merely (x = y).
 Proof.
-  (** This follows immediately from the previous result. *)
-  rapply center.
-(* Old proof:
   refine ((equiv_path_Tr x y)^-1 (path_contr (tr x) (tr y))).
-*)
 Defined.
 
 Definition is0connected_merely_allpath `{Univalence}

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -127,7 +127,11 @@ Definition merely_path_is0connected `{Univalence}
            (A : Type) `{IsConnected 0 A} (x y : A)
 : merely (x = y).
 Proof.
+  (** This follows immediately from the previous result. *)
+  rapply center.
+(* Old proof:
   refine ((equiv_path_Tr x y)^-1 (path_contr (tr x) (tr y))).
+*)
 Defined.
 
 Definition is0connected_merely_allpath `{Univalence}

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -266,7 +266,7 @@ Defined.
 
 Definition Trunc_swap n m X : Tr n (Tr m X) <~> Tr m (Tr n X).
 Proof.
-  refine (_ oE equiv_transport (fun x => Tr x _) _ _ _ oE Trunc_min n m _).
+  refine (_ oE equiv_transport (fun x => Tr x _) _ oE Trunc_min n m _).
   2: apply trunc_index_min_swap.
   symmetry.
   apply Trunc_min.

--- a/theories/Types/Universe.v
+++ b/theories/Types/Universe.v
@@ -86,7 +86,7 @@ Definition path_universe_transport_idmap {A B : Type} (p : A = B)
   : path_universe (transport idmap p) = p
   := eissect (equiv_path A B) p.
 Definition path_universe_uncurried_transport_idmap {A B : Type} (p : A = B)
-  : path_universe_uncurried (equiv_transport idmap A B p) = p
+  : path_universe_uncurried (equiv_transport idmap p) = p
   := eissect (equiv_path A B) p.
 Definition equiv_path_path_universe {A B : Type} (f : A <~> B)
   : equiv_path A B (path_universe f) = f


### PR DESCRIPTION
This makes them match `transport`.  Those args were only needed in one spot in the library, so I had to use the `@` notation there.  But many other places are simpler now.