### PR TITLE
Reduce universe levels in equiv_induction_inv and dependencies.

### DIFF
--- a/theories/Types/Universe.v
+++ b/theories/Types/Universe.v
@@ -489,7 +489,8 @@ Theorem equiv_induction_inv {U : Type} (P : forall V, V <~> U -> Type) :
 Proof.
   intros H0 V.
   apply (equiv_ind (equiv_path V U)).
-  intro p; induction p; apply H0.
+  (* We manually apply [paths_ind_r] to reduce universe levels. *)
+  revert V; rapply paths_ind_r; apply H0.
 Defined.
 
 Definition equiv_induction_inv_comp {U : Type} (P : forall V, V <~> U -> Type)
@@ -499,16 +500,16 @@ Definition equiv_induction_inv_comp {U : Type} (P : forall V, V <~> U -> Type)
 
 (** ** Based equivalence types *)
 
-Global Instance contr_basedequiv {X : Type}
-: Contr {Y : Type & X <~> Y}.
+Global Instance contr_basedequiv@{u +} {X : Type@{u}}
+: Contr {Y : Type@{u} & X <~> Y}.
 Proof.
   exists (X; equiv_idmap).
   intros [Y f]; revert Y f.
   exact (equiv_induction _ idpath).
 Defined.
 
-Global Instance contr_basedequiv' {X : Type}
-: Contr {Y : Type & Y <~> X}.
+Global Instance contr_basedequiv'@{u +} {X : Type@{u}}
+: Contr {Y : Type@{u} & Y <~> X}.
 Proof.
   (* The next line is used so that Coq can figure out the type of (X; equiv_idmap). *)
   srapply Build_Contr.


### PR DESCRIPTION
This slight tweak to the proof reduces the number of universe levels required, for some reason.  In a downstream application, the old proof forced another universe strictly larger than the others.

The changes to `contr_basedequiv` and `contr_basedequiv'` are just "documentation" to the reader, since nothing in the statement forces those universes to be equal.  It only happens in the proof, implicitly.