### PR TITLE
Update CI to use docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,8 @@ jobs:
           env: { UPDATE_QUICK_DOC: "yes" }
         - label: update html
           env: { UPDATE_HTML: "yes", UPDATE_QUICK_DOC: "" }
-        
+        - label: validate
+          env: { VALIDATE: "yes"   , UPDATE_QUICK_DOC: "" }
     env: ${{ matrix.env }}
 
     # The operating system

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,8 @@ jobs:
           startGroup "Workaround permission issue" # https://github.com/coq-community/docker-coq-action#permissions
           sudo chown -R coq:coq .
           endGroup
-          etc/coq-scripts/github/reportify-coq.sh --errors make TIMED=1 -j2     --output-sync GH_REPORT_ERRORS=1
+          etc/coq-scripts/github/reportify-coq.sh --stdout --errors ${{ matrix.extra_gh_reportify }} etc/coq-scripts/timing/make-pretty-timed.sh -j2 TIMING=1
+          make
     - name: Revert permissions
       # to avoid a warning at cleanup time - https://github.com/coq-community/docker-coq-action#permissions
       if: ${{ always() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         # We build on our supported version of coq and the master version
-        coq_version: [ '8.13' , 'latest' ]
+        coq_version: [ '8.13' , 'latest' , 'dev' ]
         ocaml_version: [ '4.11-flambda' ]
         
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 ## This is the name of the CI
 name: CI
 
-## These are the tiggers for the CI to run
+## These are the triggers for the CI to run
 on: [ push , pull_request ]
 
 jobs:
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # We build on our supported version of coq and master
+        # We build on our supported version of coq and the master version
         coq_version: [ '8.13' , 'latest' ]
         ocaml_version: [ '4.11-flambda' ]
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
         # We build on our supported version of coq and the master version
         coq_version: [ '8.13' , 'latest' , 'dev' ]
         ocaml_version: [ '4.11-flambda' ]
+        include:
+        - coq_version: 'dev'
+          extra_gh_reportify: '--warnings'
         
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,10 @@ jobs:
         ocaml_version: ${{ matrix.ocaml_version }}
         custom_script: |
           startGroup "Workaround permission issue" # https://github.com/coq-community/docker-coq-action#permissions
-          sudo chown -R coq:coq .
+            sudo chown -R coq:coq .
           endGroup
+          sudo apt-get -o Acquire::Retries=30 update -q
+          sudo apt-get -o Acquire::Retries=30 install python -y --allow-unauthenticated
           etc/coq-scripts/github/reportify-coq.sh --stdout --errors ${{ matrix.extra_gh_reportify }} etc/coq-scripts/timing/make-pretty-timed.sh -j2 TIMING=1
           make
     - name: Revert permissions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
           env: { UPDATE_HTML: "yes", UPDATE_QUICK_DOC: "" }
         - label: validate
           env: { VALIDATE: "yes"   , UPDATE_QUICK_DOC: "" }
-        - label: with submodule coq
-          env: { FORCE_COQ_VERSION: ""      , BUILD_COQ: "yes", UPDATE_QUICK_DOC: "" }
         - label: building coq master
           env: { FORCE_COQ_VERSION: "master", BUILD_COQ: "yes", UPDATE_QUICK_DOC: "", EXTRA_GH_REPORTIFY: "--warnings" }
           display-warnings: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,30 +1,53 @@
 ## This is the name of the CI
 name: CI
 
-## These are the actions that trigger the CI to run
-on: [push, pull_request]
+## These are the tiggers for the CI to run
+on: [ push , pull_request ]
 
 jobs:
-  build:
-    # TODO: Eventually include different OS's in the matrix
 
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        # We build on our supported version of coq and master
+        coq_version: [ '8.13' , 'latest' ]
+        ocaml_version: [ '4.11-flambda' ]
+        
+    runs-on: ubuntu-latest
+    steps:
+    # Checkout branch
+    - uses: actions/checkout@v2
+    # Checkout submodules
+    - uses: snickerbockers/submodules-init@v4
+    # We use the coq docker so we don't have to build coq
+    - uses: coq-community/docker-coq-action@v1
+      with:
+        coq_version: ${{ matrix.coq_version }}
+        ocaml_version: ${{ matrix.ocaml_version }}
+        custom_script: |
+          startGroup "Workaround permission issue" # https://github.com/coq-community/docker-coq-action#permissions
+          sudo chown -R coq:coq .
+          endGroup
+          etc/coq-scripts/github/reportify-coq.sh --errors make TIMED=1 -j2     --output-sync GH_REPORT_ERRORS=1
+    - name: Revert permissions
+      # to avoid a warning at cleanup time - https://github.com/coq-community/docker-coq-action#permissions
+      if: ${{ always() }}
+      run: sudo chown -R 1001:116 .
+
+
+  doc:
     strategy:
       fail-fast: false
       matrix:
         include:
-        - env: { UPDATE_HTML: "", UPDATE_QUICK_DOC: "", UPDATE_DEP_GRAPHS: "", BUILD_COQ: "", FORCE_COQ_VERSION: "", VALIDATE: "" }
         - label: update dep graphs
           env: { UPDATE_DEP_GRAPHS: "yes", BUILD_COQ: "yes", UPDATE_QUICK_DOC: "" }
         - label: update quick doc
           env: { UPDATE_QUICK_DOC: "yes" }
         - label: update html
           env: { UPDATE_HTML: "yes", UPDATE_QUICK_DOC: "" }
-        - label: validate
-          env: { VALIDATE: "yes"   , UPDATE_QUICK_DOC: "" }
-        - label: building coq master
-          env: { FORCE_COQ_VERSION: "master", BUILD_COQ: "yes", UPDATE_QUICK_DOC: "", EXTRA_GH_REPORTIFY: "--warnings" }
-          display-warnings: true
-
+        
     env: ${{ matrix.env }}
 
     # The operating system
@@ -111,7 +134,7 @@ jobs:
       run: etc/ci/after_success.sh
       env:
         ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-
+  
   alectryon:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
I've updated the CI to use docker images (basically precompiled versions of coq). I've gotten rid of the old build jobs that use the submodule. We only leave the quickdoc, html, dpdgraph and validate together with alyectron.

Note that we are building the library on the following versions:
 * Our current supported version 8.13
 * The latest stable version of coq
 * The dev version of coq

<s> I don't think it makes sense to try the dev version as that can be unstable.</s>

The advantage of doing things like this is that we can build the library in around 4min!

In the future, we want the build jobs to upload their image as an artifact so that the documentation jobs can work directly with that. Something similar was suggested by Jason in https://github.com/HoTT/HoTT/issues/1388#issuecomment-826792147.

closes #1494