### PR TITLE
Reduce universes in BAut from 19 to 3.

### DIFF
--- a/theories/Algebra/Aut.v
+++ b/theories/Algebra/Aut.v
@@ -3,21 +3,10 @@ Require Import Basics.
 Require Import Types.
 Require Import Truncations.
 Require Import Algebra.ooGroup.
-
-Local Open Scope path_scope.
+Require Import Spaces.BAut.
 
 (** * Automorphism oo-Groups *)
 
-(** To define the automorphism oo-group [Aut X], we have to construct its classifying space [BAut X]. *)
-
-(** [BAut X] is the type of types that are merely equal to [X]. *)
-Definition BAut@{u v} (X : Type@{u}) : Type@{v}
-  := sig@{v v} (fun Z => merely (paths@{v} Z X)).
-
-Global Instance ispointed_baut {X : Type} : IsPointed (BAut X) := (X; tr 1).
-
-(** Now we can define [Aut X], since [BAut X] is connected by [is0connected_component]. *)
+(** We define [Aut X] using the pointed, connected type [BAut X]. *)
 Definition Aut (X : Type) : ooGroup
   := Build_ooGroup (Build_pType (BAut X) _) _.
-
-(** The type [BAut X] is studied further in [Spaces.BAut] and its subdirectories. *)

--- a/theories/Algebra/Aut.v
+++ b/theories/Algebra/Aut.v
@@ -2,7 +2,6 @@
 Require Import Basics.
 Require Import Types.
 Require Import Truncations.
-Require Import Factorization.
 Require Import Algebra.ooGroup.
 
 Local Open Scope path_scope.
@@ -11,35 +10,13 @@ Local Open Scope path_scope.
 
 (** To define the automorphism oo-group [Aut X], we have to construct its classifying space [BAut X]. *)
 
-(** [BAut X] is the type of types that are merely equivalent to [X]. *)
+(** [BAut X] is the type of types that are merely equal to [X]. *)
 Definition BAut@{u v} (X : Type@{u}) : Type@{v}
   := sig@{v v} (fun Z => merely (paths@{v} Z X)).
 
 Global Instance ispointed_baut {X : Type} : IsPointed (BAut X) := (X; tr 1).
 
-(** Equivalently, [BAut X] is the (-1)-image of the classifying map [1 -> Type] of [X]. *)
-Definition equiv_baut_image_unit X
-: BAut X <~> image (Tr (-1)) (unit_name X).
-Proof.
-  unfold BAut, image; simpl.
-  apply equiv_functor_sigma_id; intros Z; simpl.
-  apply Trunc_functor_equiv; unfold hfiber.
-  refine ((equiv_contr_sigma _)^-1 oE _).
-  apply equiv_path_inverse.
-Defined.
-
-Global Instance isconnected_baut {X : Type}
-  : IsConnected 0 (BAut X).
-Proof.
-  exists (tr (X; tr 1)).
-  rapply Trunc_ind; intros [Z p].
-  strip_truncations.
-  apply (ap tr).
-  rapply path_sigma_hprop.
-  exact p^.
-Defined.
-
-(** Now we can define [Aut X], since [BAut X] is connected. *)
+(** Now we can define [Aut X], since [BAut X] is connected by [is0connected_component]. *)
 Definition Aut (X : Type) : ooGroup
   := Build_ooGroup (Build_pType (BAut X) _) _.
 

--- a/theories/Algebra/Aut.v
+++ b/theories/Algebra/Aut.v
@@ -27,17 +27,20 @@ Proof.
   apply equiv_path_inverse.
 Defined.
 
-(** Now we can define [Aut X], by proving that [BAut X] is connected. *)
-Definition Aut (X : Type) : ooGroup.
+Definition isconnected_baut {X : Type}
+  : IsConnected 0 (BAut X).
 Proof.
-  refine (Build_ooGroup
-            (Build_pType { Z : Type & merely (Z = X) } (X ; tr 1)) _).
-  refine (conn_pointed_type (point _)); try exact _.
-  pose (c := conn_map_compose (Tr (-1))
-                              (factor1 (image (Tr (-1)) (unit_name X)))
-                              (equiv_baut_image_unit X)^-1).
-  refine (conn_map_homotopic _ _ _ _ c); intros []; reflexivity.
+  exists (tr (X; tr 1)).
+  rapply Trunc_ind; intros [Z p].
+  strip_truncations.
+  rapply path_Tr; apply tr.
+  apply (path_sigma' _ p^).
+  apply path_ishprop.
 Defined.
+
+(** Now we can define [Aut X], since [BAut X] is connected. *)
+Definition Aut (X : Type) : ooGroup
+  := Build_ooGroup (Build_pType (BAut X) (X; tr 1)) isconnected_baut.
 
 Definition BAut X : Type := classifying_space (Aut X).
 

--- a/theories/Algebra/Aut.v
+++ b/theories/Algebra/Aut.v
@@ -11,10 +11,11 @@ Local Open Scope path_scope.
 
 (** To define the automorphism oo-group [Aut X], we have to construct its classifying space [BAut X]. *)
 
-(** [BAut X] is the type of types that are merely equivalent to [X].  We put this in a module to make it local to this file; at the end of the file we'll redefine [BAut X] for export to be the classifying space of [Aut X] (which will be judgmentally, but not syntactically, equal to this definition.) *)
-Module Import BAut.
-  Definition BAut (X : Type) := { Z : Type & merely (Z = X) }.
-End BAut.
+(** [BAut X] is the type of types that are merely equivalent to [X]. *)
+Definition BAut@{u v} (X : Type@{u}) : Type@{v}
+  := sig@{v v} (fun Z => merely (paths@{v} Z X)).
+
+Global Instance ispointed_baut {X : Type} : IsPointed (BAut X) := (X; tr 1).
 
 (** Equivalently, [BAut X] is the (-1)-image of the classifying map [1 -> Type] of [X]. *)
 Definition equiv_baut_image_unit X
@@ -27,21 +28,19 @@ Proof.
   apply equiv_path_inverse.
 Defined.
 
-Definition isconnected_baut {X : Type}
+Global Instance isconnected_baut {X : Type}
   : IsConnected 0 (BAut X).
 Proof.
   exists (tr (X; tr 1)).
   rapply Trunc_ind; intros [Z p].
   strip_truncations.
-  rapply path_Tr; apply tr.
-  apply (path_sigma' _ p^).
-  apply path_ishprop.
+  apply (ap tr).
+  rapply path_sigma_hprop.
+  exact p^.
 Defined.
 
 (** Now we can define [Aut X], since [BAut X] is connected. *)
 Definition Aut (X : Type) : ooGroup
-  := Build_ooGroup (Build_pType (BAut X) (X; tr 1)) isconnected_baut.
-
-Definition BAut X : Type := classifying_space (Aut X).
+  := Build_ooGroup (Build_pType (BAut X) _) _.
 
 (** The type [BAut X] is studied further in [Spaces.BAut] and its subdirectories. *)

--- a/theories/Spaces/BAut.v
+++ b/theories/Spaces/BAut.v
@@ -36,6 +36,17 @@ Proof.
   apply ap10, ap, ap_pr1_path_baut.
 Defined.
 
+(** [BAut X] is the (-1)-image of the classifying map [1 -> Type] of [X]. *)
+Definition equiv_baut_image_unit X
+: BAut X <~> image (Tr (-1)) (unit_name X).
+Proof.
+  unfold BAut, image; simpl.
+  apply equiv_functor_sigma_id; intros Z; simpl.
+  apply Trunc_functor_equiv; unfold hfiber.
+  refine ((equiv_contr_sigma _)^-1 oE _).
+  apply equiv_path_inverse.
+Defined.
+
 (** ** Truncation *)
 
 (** If [X] is an [n.+1]-type, then [BAut X] is an [n.+2]-type. *)

--- a/theories/Spaces/BAut.v
+++ b/theories/Spaces/BAut.v
@@ -2,7 +2,6 @@
 Require Import HoTT.Basics HoTT.Types HProp.
 Require Import Constant Factorization.
 Require Import Modalities.Modality HoTT.Truncations.
-Require Export Algebra.ooGroup Algebra.Aut.
 
 Local Open Scope path_scope.
 
@@ -10,7 +9,11 @@ Local Open Scope path_scope.
 
 (** ** Basics *)
 
-(** The type [BAut X] is defined in [Algebra.Aut]. *)
+(** [BAut X] is the type of types that are merely equal to [X]. It is connected, by [is0connected_component]. *)
+Definition BAut@{u v} (X : Type@{u}) : Type@{v}
+  := sig@{v v} (fun Z => merely (paths@{v} Z X)).
+
+Global Instance ispointed_baut {X : Type} : IsPointed (BAut X) := (X; tr 1).
 
 Definition BAut_pr1 X : BAut X -> Type := pr1.
 Coercion BAut_pr1 : BAut >-> Sortclass.
@@ -34,17 +37,6 @@ Proof.
   refine (transport_compose idmap (BAut_pr1 X) _ _ @ _).
   refine (_ @ transport_path_universe f z).
   apply ap10, ap, ap_pr1_path_baut.
-Defined.
-
-(** [BAut X] is the (-1)-image of the classifying map [1 -> Type] of [X]. *)
-Definition equiv_baut_image_unit X
-: BAut X <~> image (Tr (-1)) (unit_name X).
-Proof.
-  unfold BAut, image; simpl.
-  apply equiv_functor_sigma_id; intros Z; simpl.
-  apply Trunc_functor_equiv; unfold hfiber.
-  refine ((equiv_contr_sigma _)^-1 oE _).
-  apply equiv_path_inverse.
 Defined.
 
 (** ** Truncation *)

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -144,7 +144,7 @@ Proof.
   - apply tr; assumption.
 Defined.
 
-(** The path component of an point [x : X] is connected. *)
+(** The path component of a point [x : X] is connected. *)
 Global Instance is0connected_component {X : Type} (x : X)
   : IsConnected 0 { z : X & merely (z = x) }.
 Proof.

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -156,6 +156,17 @@ Proof.
   exact p^.
 Defined.
 
+(** The path component of a point [x : X] is equivalent to the image of the constant map [Unit -> X] at [x]. *)
+Definition equiv_component_image_unit {X : Type} (x : X)
+: { z : X & merely (z = x) } <~> image (Tr (-1)) (unit_name x).
+Proof.
+  unfold image; simpl.
+  apply equiv_functor_sigma_id; intros z; simpl.
+  apply Trunc_functor_equiv; unfold hfiber.
+  refine ((equiv_contr_sigma _)^-1 oE _).
+  apply equiv_path_inverse.
+Defined.
+
 (** 0-connected types are indecomposable *)
 Global Instance indecomposable_0connected `{Univalence}
        (X : Type) `{IsConnected 0 X}

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -144,6 +144,18 @@ Proof.
   - apply tr; assumption.
 Defined.
 
+(** The path component of an point [x : X] is connected. *)
+Global Instance is0connected_component {X : Type} (x : X)
+  : IsConnected 0 { z : X & merely (z = x) }.
+Proof.
+  exists (tr (x; tr idpath)).
+  rapply Trunc_ind; intros [Z p].
+  strip_truncations.
+  apply (ap tr).
+  rapply path_sigma_hprop.
+  exact p^.
+Defined.
+
 (** 0-connected types are indecomposable *)
 Global Instance indecomposable_0connected `{Univalence}
        (X : Type) `{IsConnected 0 X}


### PR DESCRIPTION
As noted by @Alizter [here](https://github.com/HoTT/HoTT/issues/1452#issuecomment-820810626), `BAut` has 19 universe variables. By proving connectedness more directly it is reduced to 3. This makes reasoning about the universe level of `BAut` easier, and resolved some unification errors I ran into when experimenting.