### PR TITLE
Cleanups to Factorization.v

### DIFF
--- a/theories/Factorization.v
+++ b/theories/Factorization.v
@@ -122,6 +122,19 @@ Record FactorizationSystem@{i j k} :=
 
 Global Existing Instances ishprop_class1 ishprop_class2.
 
+(** The type of factorizations is, as promised, contractible. *)
+Theorem contr_factor `{Univalence} (factsys : FactorizationSystem)
+        {X Y : Type} (f : X -> Y)
+  : Contr (Factorization (@class1 factsys) (@class2 factsys) f).
+Proof.
+  apply contr_inhabited_hprop.
+  - apply hprop_allpath.
+    intros fact fact'.
+    apply path_factorization; try exact _.
+    apply path_factor.
+  - apply factor.
+Defined.
+
 Section FactSys.
 
   Context (factsys : FactorizationSystem).
@@ -131,18 +144,6 @@ Section FactSys.
 
   Definition Build_PathFactorization' {X Y}
     := @Build_PathFactorization (@class1 factsys) (@class2 factsys) X Y.
-
-  (** The type of factorizations is, as promised, contractible. *)
-  Theorem contr_factor `{Univalence} {X Y} (f : X -> Y)
-  : Contr (Factorization (@class1 factsys) (@class2 factsys) f).
-  Proof.
-    apply contr_inhabited_hprop.
-    - apply hprop_allpath.
-      intros fact fact'.
-      apply path_factorization; try exact _.
-      apply path_factor.
-    - apply factor.
-  Defined.
 
   (** The left class is right-cancellable and the right class is left-cancellable. *)
   Definition cancelR_class1 `{Funext} {X Y Z} (f : X -> Y) (g : Y -> Z)


### PR DESCRIPTION
Broken into two commits, as the second one moves code.  So it's best to view the two commits separately.

The first commit reduces the number of universes for Factorization and PathFactorization, reduces the use of Univalence, and simplifies the proofs of `cancelR_class1` and `cancelL_class2`.  It also makes the proofs of those dual to each other.

The second commit moves `contr_factor` outside of the Section, mainly so that the Univalence hypothesis comes first, but also because it doesn't benefit much from being in the Section.