### PR TITLE
n-fold separation

### DIFF
--- a/theories/Modalities/Lex.v
+++ b/theories/Modalities/Lex.v
@@ -435,5 +435,6 @@ Proof.
     apply mapinO_tr_istruncmap in i.
     apply istruncmap_mapinO_tr, (mapinO_homotopic _ ((equiv_path_O O x y)^-1 o (@ap _ _ (to O A) x y))).
     { intros p; apply moveR_equiv_V; symmetry; apply equiv_path_O_to_O. }
+    pose mapinO_isequiv. (* This speeds up the next line. *)
     rapply mapinO_compose.
 Defined.


### PR DESCRIPTION
For a lex modality O and a type A, the following are equivalent:
- All (n+2)-fold iterated identity types of A are O-modal.
- The O-reflector A -> OA is an n-truncated map.
