### PR TITLE
Update ObjectClassifier.v and classify maps into BAut.

### DIFF
--- a/contrib/HoTTBook.v
+++ b/contrib/HoTTBook.v
@@ -695,12 +695,12 @@ Definition Book_4_8_2 := @HoTT.HFiber.equiv_fibration_replacement.
 (* ================================================== thm:nobject-classifier-appetizer *)
 (** Theorem 4.8.3 *)
 
-Definition Book_4_8_3 := @HoTT.ObjectClassifier.FamequivPow.
+Definition Book_4_8_3 := @HoTT.ObjectClassifier.equiv_sigma_fibration.
 
 (* ================================================== thm:object-classifier *)
 (** Theorem 4.8.4 *)
 
-Definition Book_4_8_4 := @HoTT.ObjectClassifier.objclasspb_is_fibrantreplacement.
+Definition Book_4_8_4 := @HoTT.ObjectClassifier.ispullback_objectclassifier_square.
 
 (* ================================================== weakfunext *)
 (** Definition 4.9.1 *)

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -764,7 +764,7 @@ Class IsPointed (A : Type) := point : A.
 
 Arguments point A {_}.
 
-Record pType :=
+Cumulative Record pType :=
   { pointed_type : Type ;
     ispointed_type : IsPointed pointed_type }.
 

--- a/theories/Homotopy/ExactSequence.v
+++ b/theories/Homotopy/ExactSequence.v
@@ -6,6 +6,7 @@ Require Import Pointed.
 Require Import ReflectiveSubuniverse Modality Modalities.Identity Modalities.Descent.
 Require Import Truncations.
 Require Import HFiber.
+Require Import ObjectClassifier.
 
 Local Open Scope succ_scope.
 Open Scope pointed_scope.
@@ -236,7 +237,7 @@ Global Instance isexact_pfib {X Y} (f : X ->* Y)
 Proof.
   exists (iscomplex_pfib f).
   exact _.
-Defined.    
+Defined.
 
 (** Fiber sequences can alternatively be defined as an equivalence to the fiber of some map. *)
 Definition FiberSeq (F X Y : pType) := { f : X ->* Y & F <~>* pfiber f }.
@@ -445,3 +446,16 @@ Definition Pi_les `{Univalence} {F X Y : pType} (i : F ->* X) (f : X ->* Y)
            `{IsExact purely F X Y i f}
   : LongExactSequence (Tr (-1)) (N3)
   := trunc_les (-1) (loops_les i f).
+
+(** * Classifying fiber sequences *)
+
+(** Fiber sequences correspond to pointed maps into the universe. *)
+Definition classify_fiberseq `{Univalence} {Y F : pType@{u}}
+  : (Y ->* Build_pType Type@{u} F) <~> { X : pType@{u} & FiberSeq F X Y }.
+Proof.
+  refine (_ oE _).
+  (** To apply [equiv_sigma_pfibration] we need to invert the equivalence on the fiber. *)
+  { do 2 (rapply equiv_functor_sigma_id; intro).
+    apply equiv_pequiv_inverse. }
+  exact ((equiv_sigma_assoc _ _)^-1 oE equiv_sigma_pfibration).
+Defined.

--- a/theories/ObjectClassifier.v
+++ b/theories/ObjectClassifier.v
@@ -7,13 +7,12 @@ Local Open Scope pointed_scope.
 
 (** We prove that type families correspond to fibrations [equiv_sigma_fibration] (Theorem 4.8.3) and the projection [pointed_type : pType -> Type] is an object classifier [ispullback_square_objectclassifier] (Theorem 4.8.4). *)
 
-(** We denote the type of all maps into a type [Y] as follows. *)
+(** We denote the type of all maps into a type [Y] as follows, and refer to them "bundles over Y". *)
 Definition Slice (Y : Type@{u}) := { X : Type@{u} & X -> Y }.
 Definition pSlice (Y : pType@{u}) := { X : pType@{u} & X ->* Y }.
 
 Definition sigma_fibration@{u v} {Y : Type@{u}} (P : Y -> Type@{u}) : Slice@{u v} Y
   := (sig@{u u} P; pr1).
-
 
 Definition sigma_fibration_inverse {Y : Type@{u}} (p : Slice Y) : Y -> Type@{u}
   := hfiber p.2.
@@ -61,11 +60,11 @@ Proof.
   - reflexivity.
 Defined.
 
-(** ** Classifying fibrations with specified fiber *)
+(** ** Classifying bundles with specified fiber *)
 
 Local Notation "( X , x )" := (Build_pType X x).
 
-(** Fibrations over [B] with fiber [F] correspond to pointed maps into the universe pointed at [F]. *)
+(** Bundles over [B] with fiber [F] correspond to pointed maps into the universe pointed at [F]. *)
 Proposition equiv_sigma_fibration_p@{u v +} `{Univalence} {Y : pType@{u}} {F : Type@{u}}
   : (Y ->* (Type@{u}, F)) <~> { p : Slice@{u v} Y & hfiber p.2 (point Y) <~> F }.
 Proof.
@@ -104,7 +103,7 @@ Definition equiv_sigma_pfibration@{u v +} `{Univalence} {Y F : pType@{u}}
 
 (** * The classifier for O-local types *)
 
-(** Families of O-local types correspond to fibrations with O-local fibers. *)
+(** Families of O-local types correspond to bundles with O-local fibers. *)
 Theorem equiv_sigma_fibration_O@{u v} `{Univalence} {O : Subuniverse} {Y : Type@{u}}
   : (Y -> Type_@{u v} O) <~> { p : { X : Type@{u} & X -> Y } & MapIn O p.2 }.
 Proof.
@@ -113,11 +112,11 @@ Proof.
   rapply equiv_forall_inO_mapinO_pr1.
 Defined.
 
-(** ** Classifying O-local fibrations with specified fiber *)
+(** ** Classifying O-local bundles with specified fiber *)
 
 (** We consider a pointed base [Y], and the universe of O-local types [Type_ O] pointed at some O-local type [F]. *)
 
-(** Pointed maps into [Type_ O] correspond to O-local fibrations with fiber [F] over the base point of [Y]. *)
+(** Pointed maps into [Type_ O] correspond to O-local bundles with fiber [F] over the base point of [Y]. *)
 Proposition equiv_sigma_fibration_Op@{u v +} `{Univalence} {O : Subuniverse}
             {Y : pType@{u}} {F : Type@{u}} `{inO : In O F}
   : (Y ->* (Type_ O, (F; inO)))
@@ -147,7 +146,7 @@ Proof.
   apply (inO_equiv_inO F e^-1).
 Defined.
 
-(** *** Classifying O-local fibrations with specified pointed fiber *)
+(** *** Classifying O-local bundles with specified pointed fiber *)
 
 (** When the fiber [F] is pointed, the right-hand side can be upgraded to pointed fiber sequences with O-local fibers.  *)
 Proposition equiv_sigma_pfibration_O `{Univalence} (O : Subuniverse)

--- a/theories/ObjectClassifier.v
+++ b/theories/ObjectClassifier.v
@@ -1,118 +1,175 @@
-(** We prove that Fam and Pow are equivalent.
-This equivalence is close to the existence of an object classifier.
-*)
+Require Import HoTT.Basics HoTT.Types HFiber Pullback Pointed Truncations.
+Require Import Modalities.ReflectiveSubuniverse Modalities.Identity.
 
-Require Import HoTT.Basics HoTT.Types.
-Require Import HFiber Pullback.
+Local Open Scope pointed_scope.
 
-Local Open Scope path_scope.
+(** * The object classifier *)
 
-Section AssumeUnivalence.
-Context `{ua:Univalence}.
+(** We prove that type families correspond to fibrations [equiv_sigma_fibration] (Theorem 4.8.3) and the projection [pointed_type : pType -> Type] is an object classifier [ispullback_square_objectclassifier] (Theorem 4.8.4). *)
 
-Section FamPow.
-(** We consider Families and Powers over a fixed type [A] *)
-Variable A : Type.
-Definition Fam A:=sig (fun I:Type  => I->A).
-Definition p2f: (A->Type)-> Fam A:=  fun Q:(A->Type) => ( (sig Q) ; @pr1 _ _).
-Definition f2p: Fam A -> (A->Type):=
- fun F => let (I, f) := F in (fun a => (hfiber f a)).
+(** We denote fibrations over a base [Y] as follows. *)
+Definition Fib (Y : Type@{u}) := { X : Type@{u} & X -> Y }.
+Definition pFib (Y : pType@{u}) := { X : pType@{u} & X ->* Y }.
 
-(* This is generalized in Functorish.v *)
-Theorem transport_exp (U V:Type)(w:U<~>V): forall (f:U->A),
-  (transport (fun I:Type => I->A) (path_universe w) f) = (f o w^-1).
+Definition sigma_fibration@{u v} {Y : Type@{u}} (P : Y -> Type@{u}) : Fib@{u v} Y
+  := (sig@{u u} P; pr1).
+
+
+Definition sigma_fibration_inverse {Y : Type@{u}} (p : Fib Y) : Y -> Type@{u}
+  := hfiber p.2.
+
+Theorem isequiv_sigma_fibration `{Univalence} {Y : Type}
+  : IsEquiv (@sigma_fibration Y).
 Proof.
-  intros f; apply path_arrow; intros y.
-  refine (transport_arrow_toconst _ _ _ @ _).
-  apply ap.
-  by apply transport_path_universe_V.
-Qed.
-
-Theorem FamequivPow : (A->Type)<~>(Fam A).
-Proof.
-apply (equiv_adjointify p2f f2p).
-(* Theorem right (F:Fam A) : F = (p2ff2p F) *)
- +intros [I f]. set (e:=equiv_path_sigma _ (@exist Type (fun I0 : Type => I0 -> A) I f)
-  ({a : A & hfiber f a} ; @pr1 _ _)). simpl in e.
-  enough (X:{p : I = {a : A & @hfiber I A f a} &
-     @transport _ (fun I0 : Type => I0 -> A) _ _ p f = @pr1 _ _}) by apply (e X)^.
-  set (w:=@equiv_fibration_replacement A I f).
-  exists (path_universe w). 
-  transitivity (f o w^-1);[apply transport_exp|apply path_forall;by (intros [a [i p]])].
- (* Theorem left (P:A -> Type) : (f2pp2f P) = P *)
- + intro P. by_extensionality a.
- apply ((path_universe (@hfiber_fibration  _ a P))^).
+  srapply isequiv_adjointify.
+  - exact sigma_fibration_inverse.
+  - intros [X p].
+    srapply path_sigma; cbn.
+    + exact (path_universe (equiv_fibration_replacement _)^-1%equiv).
+    + apply transport_arrow_toconst_path_universe.
+  - intro P.
+    funext y; cbn.
+    exact ((path_universe (@hfiber_fibration  _ y P))^).
 Defined.
 
-(** We construct the universal diagram for the object classifier *)
-Definition topmap {B} (f:B->A) (b:B): pType :=
-  Build_pType (hfiber f (f b)) (b ; idpath (f b)).
+(** Theorem 4.8.3. *)
+Definition equiv_sigma_fibration `{Univalence} {Y : Type@{u}}
+  : (Y -> Type@{u}) <~> { X : Type@{u} & X -> Y }
+  := Build_Equiv _ _ _ isequiv_sigma_fibration.
 
-Local Definition help_objclasspb_is_fibrantreplacement (P:A-> Type): (sig P)->
-  (Pullback P (@pr1 _ (fun u :Type => u))):=
-(fun (X : {a : A & P a}) => (fun (a : A) (q : P a) => (a; ((P a; q); 1))) X.1 X.2).
+(** The universal map is the forgetful map [pointed_type : pType -> Type]. *)
 
-Local Definition help_objclasspb_is_fibrantreplacement2 (P:A-> Type):
- (Pullback P (@pr1 _ (fun u :Type => u))) -> (sig P).
-intros [a [[T t] p]]. exact (a;(transport (fun X => X) (p^) t)).
+(** We construct the universal square for the object classifier. *)
+Local Definition topmap {A : Type} (P : A -> Type) (e : sig P) : pType
+  := Build_pType (P e.1) e.2.
+
+(** The square commutes definitionally. *)
+Definition objectclassifier_square {A : Type} (P : A -> Type)
+  : P o pr1 == pointed_type o (topmap P)
+  := fun e : sig P => idpath (P e.1).
+
+(** Theorem 4.8.4. *)
+Theorem ispullback_objectclassifier_square {A : Type} (P : A -> Type)
+  : IsPullback (objectclassifier_square P).
+Proof.
+  srapply isequiv_adjointify.
+  - intros [a [F p]].
+    exact (a; transport idmap p^ (point F)).
+  - intros [a [[T t] p]]; cbn in p.
+    refine (path_sigma' _ (idpath a) _).
+    by induction p.
+  - reflexivity.
 Defined.
 
-Lemma objclasspb_is_fibrantreplacement (P:A-> Type): (sig P) <~> (Pullback P (@pr1 _ (fun u :Type => u))).
+(** ** Classifying fibrations with specified fiber *)
+
+Local Notation "( X , x )" := (Build_pType X x).
+
+(** Fibrations over [B] with fiber [F] correspond to pointed maps into the universe pointed at [F]. *)
+Proposition equiv_sigma_fibration_p@{u v +} `{Univalence} {Y : pType@{u}} {F : Type@{u}}
+  : (Y ->* (Type@{u}, F)) <~> { p : Fib@{u v} Y & hfiber p.2 (point Y) <~> F }.
 Proof.
-exists (help_objclasspb_is_fibrantreplacement P).
-srapply isequiv_adjointify.
-- exact (help_objclasspb_is_fibrantreplacement2 P).
-- intros [a [[T t] p]].
-  refine (path_sigma' _ (idpath a) _).
-  simpl in p. by path_induction.
-- intros [a p]; apply idpath.
+  refine (_ oE (issig_pmap _ _)^-1).
+  srapply (equiv_functor_sigma' equiv_sigma_fibration); intro P; cbn.
+  refine (_ oE (equiv_path_universe@{u u v} _ _)^-1%equiv).
+  refine (equiv_functor_equiv _ equiv_idmap).
+  apply hfiber_fibration.
 Defined.
 
-End FamPow.
-
-Section Subobjectclassifier.
-(** We prove that hProp is the subobject classifier *)
-(** In fact, the proof works for general mere predicates on [Type], 
-not just [IsHProp], truncations and modalities are important examples.*)
-Variable A : Type.
-Variable isP : Type -> Type.
-Variable ishprop_isP : forall I, IsHProp (isP I).
-Definition IsPfibered {I} (f:I->A):=forall i, isP (hfiber f i).
-Definition PFam := (sig (fun F:Fam A => IsPfibered (pr2 F))).
-(* Bug: abstract should accept more than one tactic.
-https://coq.inria.fr/bugs/show_bug.cgi?id=3609
-Alternatively, we would like to use [Program] here.
-6a99db1c31fe267fdef7be755fa169fb6a87e3cf
-Instead we split the [Definition] and first make a [Local Definition] *)
-Local Definition pow2Pfam_pf (P:forall a:A, {X :Type & isP X}): 
-           IsPfibered (pr2 (p2f A (pr1 o P))). 
+(** If the fiber [F] is pointed we may upgrade the right-hand side to pointed fiber sequences. *)
+Lemma equiv_pfiber_fibration_pfibration@{u v} {Y F : pType@{u}}
+  : { p : Fib@{u v} Y & hfiber p.2 (point Y) <~> F}
+      <~> { p : pFib@{u v} Y & pfiber p.2 <~>* F }.
 Proof.
-intro i. cbn. 
-rewrite <- (path_universe_uncurried (@hfiber_fibration A i (pr1 o P))).
-apply ((P i).2).
-Qed.
-
-Definition pow2Pfam (P:forall a:A, {X :Type & isP X}): PFam:=
-  (p2f A (fun a => (pr1 (P a))); pow2Pfam_pf P).
-
-Local Definition Pfam2pow_pf (F:PFam)(a:A):isP (f2p A F.1 a). 
-unfold f2p. by destruct F as [[I f] p].
-Qed.
-
-Definition Pfam2pow (F:PFam) (a:A): {X :Type & isP X}:=
-   ((f2p A F.1 a); (Pfam2pow_pf F a)).
-
-Theorem PowisoPFam : (forall a:A, {X :Type & isP X})<~>PFam.
-Proof.
-apply (equiv_adjointify pow2Pfam Pfam2pow).
- + intros [[B f] q]. apply path_sigma_hprop. cbn.
-  refine (@eisretr _ _ (FamequivPow A) _ (B;f)).
-+ intro P. apply path_forall. intro a.
- assert (f2p A (p2f A (pr1 o P)) a = (pr1 (P a))).
-- set (p:=@eissect _ _ (FamequivPow A) _).
-  apply (ap10 (p (pr1 o P)) a).
-- by apply path_sigma_hprop.
+  equiv_via
+    (sig@{v u} (fun X : Type@{u} =>
+                  { x : X &
+                        { p : X -> Y &
+                                  { eq : p x = point Y &
+                                         { e : hfiber p (point Y) <~> F
+                                               & e^-1 (point F) = (x; eq) } } } })).
+  - refine (_ oE _).
+    + do 5 (rapply equiv_functor_sigma_id; intro).
+      apply equiv_path_sigma.
+    + make_equiv_contr_basedpaths.
+  - refine (_ oE _).
+    2: { do 5 (rapply equiv_functor_sigma_id; intro).
+         exact (equiv_path_inverse _ _ oE equiv_moveL_equiv_M _ _). }
+    make_equiv.
 Defined.
-End Subobjectclassifier.
 
-End AssumeUnivalence.
+Definition equiv_sigma_pfibration@{u v +} `{Univalence} {Y F : pType@{u}}
+  : (Y ->* (Type@{u}, F)) <~> { p : pFib@{u v} Y & pfiber p.2 <~>* F}
+  := equiv_pfiber_fibration_pfibration oE equiv_sigma_fibration_p.
+
+(** * The classifier for O-local types *)
+
+(** Families of O-local types correspond to fibrations with O-local fibers. *)
+Theorem equiv_sigma_fibration_O@{u v} `{Univalence} {O : Subuniverse} {Y : Type@{u}}
+  : (Y -> Type_@{u v} O) <~> { p : { X : Type@{u} & X -> Y } & MapIn O p.2 }.
+Proof.
+  refine (_ oE (equiv_sig_coind _ _)^-1).
+  apply (equiv_functor_sigma' equiv_sigma_fibration); intro P; cbn.
+  rapply equiv_forall_inO_mapinO_pr1.
+Defined.
+
+(** ** Classifying O-local fibrations with specified fiber *)
+
+(** We consider a pointed base [Y], and the universe of O-local types [Type_ O] pointed at some O-local type [F]. *)
+
+(** Pointed maps into [Type_ O] correspond to O-local fibrations with fiber [F] over the base point of [Y]. *)
+Proposition equiv_sigma_fibration_Op@{u v +} `{Univalence} {O : Subuniverse}
+            {Y : pType@{u}} {F : Type@{u}} `{inO : In O F}
+  : (Y ->* (Type_ O, (F; inO)))
+      <~> { p : { q : Fib@{u v} Y & MapIn O q.2 } & hfiber p.1.2 (point Y) <~> F }.
+Proof.
+  refine (_ oE (issig_pmap _ _)^-1); cbn.
+  srapply (equiv_functor_sigma' equiv_sigma_fibration_O); intro P; cbn.
+  refine (_ oE (equiv_path_sigma_hprop _ _)^-1%equiv); cbn.
+  refine (_ oE (equiv_path_universe _ _)^-1%equiv).
+  refine (equiv_functor_equiv _ equiv_idmap).
+  exact (hfiber_fibration (point Y) _).
+Defined.
+
+(** When the base [Y] is connected, the fibers being O-local follow from the fact that the fiber [F] over the base point is. *)
+Proposition equiv_sigma_fibration_Op_connected@{u v +} `{Univalence} {O : Subuniverse}
+            {Y : pType@{u}} `{IsConnected 0 Y} {F : Type@{u}} `{inO : In O F}
+  : (Y ->* (Type_ O, (F; inO)))
+       <~> { p : Fib@{u v} Y & hfiber p.2 (point Y) <~> F }.
+Proof.
+  refine (_ oE equiv_sigma_fibration_Op).
+  refine (_ oE (equiv_sigma_assoc' _ (fun p _ => hfiber p.2 (point Y) <~> F))^-1%equiv).
+  srapply equiv_functor_sigma_id; intro; cbn.
+  refine (_ oE equiv_sigma_symm0 _ _).
+  apply equiv_sigma_contr; intro e.
+  rapply contr_inhabited_hprop.
+  rapply conn_to_trunc_ind@{u v u u u u u u u}.
+  apply (inO_equiv_inO F e^-1).
+Defined.
+
+(** *** Classifying O-local fibrations with specified pointed fiber *)
+
+(** When the fiber [F] is pointed, the right-hand side can be upgraded to pointed fiber sequences with O-local fibers.  *)
+Proposition equiv_sigma_pfibration_O `{Univalence} (O : Subuniverse)
+            {Y F : pType} `{inO : In O F}
+  : (Y ->* (Type_ O, (pointed_type F; inO)))
+      <~> { p : { q : pFib Y & MapIn O q.2 } & pfiber p.1.2 <~>* F }.
+Proof.
+  refine (_ oE equiv_sigma_fibration_Op).
+  refine (_ oE equiv_sigma_symm' _ (fun q => hfiber q.2 (point Y) <~> F)).
+  refine (equiv_sigma_symm' (fun q => pfiber q.2 <~>* F) _ oE _).
+  by rapply (equiv_functor_sigma' equiv_pfiber_fibration_pfibration).
+Defined.
+
+(** When moreover the base [Y] is connected, the right-hand side is exactly the type of pointed fiber sequences, since the fibers being O-local follow from [F] being O-local and [Y] connected. *)
+Definition equiv_sigma_pfibration_O_connected@{u v +} `{Univalence} (O : Subuniverse)
+          {Y F : pType@{u}} `{IsConnected 0 Y} `{inO : In O F}
+  : (Y ->* (Type_ O, (pointed_type F; inO)))
+      <~> { p : pFib@{u v} Y & pfiber p.2 <~>* F }
+  := equiv_pfiber_fibration_pfibration oE equiv_sigma_fibration_Op_connected.
+
+(** As a corollary, pointed maps into the unverse of O-local types are just pointed maps into the universe, when the base [Y] is connected. *)
+Definition equiv_pmap_typeO_type_connected `{Univalence} {O : Subuniverse}
+      {Y : pType@{u}} `{IsConnected 0 Y} {F : Type@{u}} `{inO : In O F}
+  : (Y ->* (Type_ O, (F; inO))) <~> (Y ->* (Type@{u}, F))
+  := equiv_sigma_fibration_p^-1 oE equiv_sigma_fibration_Op_connected.

--- a/theories/ObjectClassifier.v
+++ b/theories/ObjectClassifier.v
@@ -7,15 +7,15 @@ Local Open Scope pointed_scope.
 
 (** We prove that type families correspond to fibrations [equiv_sigma_fibration] (Theorem 4.8.3) and the projection [pointed_type : pType -> Type] is an object classifier [ispullback_square_objectclassifier] (Theorem 4.8.4). *)
 
-(** We denote fibrations over a base [Y] as follows. *)
-Definition Fib (Y : Type@{u}) := { X : Type@{u} & X -> Y }.
-Definition pFib (Y : pType@{u}) := { X : pType@{u} & X ->* Y }.
+(** We denote the type of all maps into a type [Y] as follows. *)
+Definition Slice (Y : Type@{u}) := { X : Type@{u} & X -> Y }.
+Definition pSlice (Y : pType@{u}) := { X : pType@{u} & X ->* Y }.
 
-Definition sigma_fibration@{u v} {Y : Type@{u}} (P : Y -> Type@{u}) : Fib@{u v} Y
+Definition sigma_fibration@{u v} {Y : Type@{u}} (P : Y -> Type@{u}) : Slice@{u v} Y
   := (sig@{u u} P; pr1).
 
 
-Definition sigma_fibration_inverse {Y : Type@{u}} (p : Fib Y) : Y -> Type@{u}
+Definition sigma_fibration_inverse {Y : Type@{u}} (p : Slice Y) : Y -> Type@{u}
   := hfiber p.2.
 
 Theorem isequiv_sigma_fibration `{Univalence} {Y : Type}
@@ -67,7 +67,7 @@ Local Notation "( X , x )" := (Build_pType X x).
 
 (** Fibrations over [B] with fiber [F] correspond to pointed maps into the universe pointed at [F]. *)
 Proposition equiv_sigma_fibration_p@{u v +} `{Univalence} {Y : pType@{u}} {F : Type@{u}}
-  : (Y ->* (Type@{u}, F)) <~> { p : Fib@{u v} Y & hfiber p.2 (point Y) <~> F }.
+  : (Y ->* (Type@{u}, F)) <~> { p : Slice@{u v} Y & hfiber p.2 (point Y) <~> F }.
 Proof.
   refine (_ oE (issig_pmap _ _)^-1).
   srapply (equiv_functor_sigma' equiv_sigma_fibration); intro P; cbn.
@@ -78,8 +78,8 @@ Defined.
 
 (** If the fiber [F] is pointed we may upgrade the right-hand side to pointed fiber sequences. *)
 Lemma equiv_pfiber_fibration_pfibration@{u v} {Y F : pType@{u}}
-  : { p : Fib@{u v} Y & hfiber p.2 (point Y) <~> F}
-      <~> { p : pFib@{u v} Y & pfiber p.2 <~>* F }.
+  : { p : Slice@{u v} Y & hfiber p.2 (point Y) <~> F}
+      <~> { p : pSlice@{u v} Y & pfiber p.2 <~>* F }.
 Proof.
   equiv_via
     (sig@{v u} (fun X : Type@{u} =>
@@ -99,7 +99,7 @@ Proof.
 Defined.
 
 Definition equiv_sigma_pfibration@{u v +} `{Univalence} {Y F : pType@{u}}
-  : (Y ->* (Type@{u}, F)) <~> { p : pFib@{u v} Y & pfiber p.2 <~>* F}
+  : (Y ->* (Type@{u}, F)) <~> { p : pSlice@{u v} Y & pfiber p.2 <~>* F}
   := equiv_pfiber_fibration_pfibration oE equiv_sigma_fibration_p.
 
 (** * The classifier for O-local types *)
@@ -121,7 +121,7 @@ Defined.
 Proposition equiv_sigma_fibration_Op@{u v +} `{Univalence} {O : Subuniverse}
             {Y : pType@{u}} {F : Type@{u}} `{inO : In O F}
   : (Y ->* (Type_ O, (F; inO)))
-      <~> { p : { q : Fib@{u v} Y & MapIn O q.2 } & hfiber p.1.2 (point Y) <~> F }.
+      <~> { p : { q : Slice@{u v} Y & MapIn O q.2 } & hfiber p.1.2 (point Y) <~> F }.
 Proof.
   refine (_ oE (issig_pmap _ _)^-1); cbn.
   srapply (equiv_functor_sigma' equiv_sigma_fibration_O); intro P; cbn.
@@ -135,7 +135,7 @@ Defined.
 Proposition equiv_sigma_fibration_Op_connected@{u v +} `{Univalence} {O : Subuniverse}
             {Y : pType@{u}} `{IsConnected 0 Y} {F : Type@{u}} `{inO : In O F}
   : (Y ->* (Type_ O, (F; inO)))
-       <~> { p : Fib@{u v} Y & hfiber p.2 (point Y) <~> F }.
+       <~> { p : Slice@{u v} Y & hfiber p.2 (point Y) <~> F }.
 Proof.
   refine (_ oE equiv_sigma_fibration_Op).
   refine (_ oE (equiv_sigma_assoc' _ (fun p _ => hfiber p.2 (point Y) <~> F))^-1%equiv).
@@ -143,7 +143,7 @@ Proof.
   refine (_ oE equiv_sigma_symm0 _ _).
   apply equiv_sigma_contr; intro e.
   rapply contr_inhabited_hprop.
-  rapply conn_to_trunc_ind@{u v u u u u u u u}.
+  rapply conn_point_elim@{u v u u u u u u u}.
   apply (inO_equiv_inO F e^-1).
 Defined.
 
@@ -153,7 +153,7 @@ Defined.
 Proposition equiv_sigma_pfibration_O `{Univalence} (O : Subuniverse)
             {Y F : pType} `{inO : In O F}
   : (Y ->* (Type_ O, (pointed_type F; inO)))
-      <~> { p : { q : pFib Y & MapIn O q.2 } & pfiber p.1.2 <~>* F }.
+      <~> { p : { q : pSlice Y & MapIn O q.2 } & pfiber p.1.2 <~>* F }.
 Proof.
   refine (_ oE equiv_sigma_fibration_Op).
   refine (_ oE equiv_sigma_symm' _ (fun q => hfiber q.2 (point Y) <~> F)).
@@ -165,7 +165,7 @@ Defined.
 Definition equiv_sigma_pfibration_O_connected@{u v +} `{Univalence} (O : Subuniverse)
           {Y F : pType@{u}} `{IsConnected 0 Y} `{inO : In O F}
   : (Y ->* (Type_ O, (pointed_type F; inO)))
-      <~> { p : pFib@{u v} Y & pfiber p.2 <~>* F }
+      <~> { p : pSlice@{u v} Y & pfiber p.2 <~>* F }
   := equiv_pfiber_fibration_pfibration oE equiv_sigma_fibration_Op_connected.
 
 (** As a corollary, pointed maps into the unverse of O-local types are just pointed maps into the universe, when the base [Y] is connected. *)

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -49,7 +49,7 @@ Class IsTrunc_pFam n {A} (X : pFam A)
   := trunc_pfam_is_trunc : forall x, IsTrunc n (X.1 x).
 
 (** Pointed dependent functions *)
-Record pForall (A : pType) (P : pFam A) := {
+Cumulative Record pForall (A : pType) (P : pFam A) := {
   pointed_fun : forall x, P x ;
   dpoint_eq : pointed_fun (point A) = dpoint P ;
 }.

--- a/theories/Pointed/Loops.v
+++ b/theories/Pointed/Loops.v
@@ -370,7 +370,8 @@ Local Notation "( X , x )" := (Build_pType X x).
 
 (* We can convert between families of loops in a type and loops in Type at that type. *)
 Definition loops_type@{i j k} `{Univalence} (A : Type@{i})
-  : pEquiv@{j j k} (loops@{j} (Type@{i}, A)) (A <~> A, equiv_idmap).
+  : pEquiv@{j j k} (loops@{j} (Build_pType@{j} Type@{i} A))
+          (A <~> A, equiv_idmap).
 Proof.
   apply issig_pequiv'.
   exists (equiv_equiv_path A A).

--- a/theories/Pointed/pEquiv.v
+++ b/theories/Pointed/pEquiv.v
@@ -116,3 +116,11 @@ Definition equiv_pequiv_precompose `{Funext} {A B C : pType} (f : A <~>* B)
 Definition equiv_pequiv_postcompose `{Funext} {A B C : pType} (f : B <~>* C)
   : (A ->* B) <~> (A ->* C)
   := equiv_postcompose_cat_equiv f.
+
+Proposition equiv_pequiv_inverse `{Funext} {A B : pType}
+  : (A <~>* B) <~> (B <~>* A).
+Proof.
+  refine (issig_pequiv' _ _ oE _ oE (issig_pequiv' A B)^-1).
+  srapply (equiv_functor_sigma' (equiv_equiv_inverse _ _)); intro e; cbn.
+  exact (equiv_moveR_equiv_V _ _ oE equiv_path_inverse _ _).
+Defined.

--- a/theories/Spaces/BAut.v
+++ b/theories/Spaces/BAut.v
@@ -2,7 +2,9 @@
 Require Import HoTT.Basics HoTT.Types HProp.
 Require Import Constant Factorization.
 Require Import Modalities.Modality HoTT.Truncations.
+Require Import ObjectClassifier Homotopy.ExactSequence Pointed.
 
+Local Open Scope type_scope.
 Local Open Scope path_scope.
 
 (** * BAut(X) *)
@@ -10,13 +12,15 @@ Local Open Scope path_scope.
 (** ** Basics *)
 
 (** [BAut X] is the type of types that are merely equal to [X]. It is connected, by [is0connected_component]. *)
-Definition BAut@{u v} (X : Type@{u}) : Type@{v}
-  := sig@{v v} (fun Z => merely (paths@{v} Z X)).
+Definition BAut (X : Type@{u}) := { Z : Type@{u} & merely (Z = X) }.
+
+Coercion BAut_pr1 X : BAut X -> Type := pr1.
 
 Global Instance ispointed_baut {X : Type} : IsPointed (BAut X) := (X; tr 1).
 
-Definition BAut_pr1 X : BAut X -> Type := pr1.
-Coercion BAut_pr1 : BAut >-> Sortclass.
+(** We also define a pointed version [pBAut X], since the coercion [BAut_pr1] doesn't work if [BAut X] is a [pType]. *)
+Definition pBAut (X : Type) : pType
+  := Build_pType (BAut X) _.
 
 Definition path_baut `{Univalence} {X} (Z Z' : BAut X)
 : (Z <~> Z') <~> (Z = Z' :> BAut X)
@@ -236,3 +240,68 @@ Section Center2BAut.
   Defined.
 
 End Center2BAut.
+
+Section ClassifyingMaps.
+
+  (** ** Maps into [BAut F] classify fibrations with fiber [F] *)
+
+  (** The property of being merely equivalent to a given type [F] defines a subuniverse. *)
+  Definition subuniverse_merely_equiv (F : Type) : Subuniverse.
+  Proof.
+    rapply (Build_Subuniverse (fun E => merely (E <~> F))).
+    intros T U mere_eq f iseq_f.
+    strip_truncations.
+    pose (feq:=Build_Equiv _ _ f iseq_f).
+    exact (tr (mere_eq oE feq^-1)).
+  Defined.
+
+  (** The universe of O-local types for [subuniverse_merely_equiv F] is equivalent to [BAut F]. *)
+  Proposition equiv_baut_typeO `{Univalence} {F : Type}
+    :  BAut F <~> Type_ (subuniverse_merely_equiv F).
+  Proof.
+    srapply equiv_functor_sigma_id; intro X; cbn.
+    rapply Trunc_functor_equiv.
+    exact (equiv_path_universe _ _)^-1%equiv.
+  Defined.
+
+  (** Consequently, maps into [BAut F] correspond to fibrations with fibers merely equivalent to [F]. *)
+  Corollary equiv_map_baut_fibration `{Univalence} {Y : pType} {F : Type}
+    : (Y -> BAut F) <~> { p : Fib Y & forall y:Y, merely (hfiber p.2 y <~> F) }.
+  Proof.
+    refine (_ oE equiv_postcompose' equiv_baut_typeO).
+    refine (_ oE equiv_sigma_fibration_O).
+    snrapply equiv_functor_sigma_id; intro p.
+    rapply equiv_functor_forall_id; intro y.
+    by apply Trunc_functor_equiv.
+  Defined.
+
+  (** The pointed version of [equiv_baut_typeO] above. *)
+  Proposition pequiv_pbaut_typeOp@{u v +} `{Univalence} {F : Type@{u}}
+    : pBAut@{u v} F <~>* Build_pType (Type_ (subuniverse_merely_equiv F)) (F; tr equiv_idmap).
+  Proof.
+    snrapply Build_pEquiv'; cbn.
+    1: exact equiv_baut_typeO.
+    by apply path_sigma_hprop.
+  Defined.
+
+  Definition equiv_pmap_pbaut_pfibration `{Univalence} {Y F : pType@{u}}
+    : (Y ->* pBAut@{u v} F) <~> { p : { q : pFib Y & forall y:Y, merely (hfiber q.2 y <~> F) } &
+                                      pfiber p.1.2 <~>* F }
+    := (equiv_sigma_pfibration_O (subuniverse_merely_equiv F))
+         oE equiv_pequiv_postcompose pequiv_pbaut_typeOp.
+
+  (** When [Y] is connected, pointed maps into [pBAut F] correspond to maps into the universe sending the base point to [F]. *)
+  Proposition equiv_pmap_pbaut_type_p `{Univalence}
+              {Y : pType@{u}} {F : Type@{u}} `{IsConnected 0 Y}
+    : (Y ->* pBAut F) <~> (Y ->* Build_pType Type@{u} F).
+  Proof.
+    refine (_ oE equiv_pequiv_postcompose pequiv_pbaut_typeOp).
+    rapply equiv_pmap_typeO_type_connected.
+  Defined.
+
+  (** When [Y] is connected, [pBAut F] classifies fiber sequences over [Y] with fiber [F]. *)
+  Definition equiv_pmap_pbaut_pfibration_connected `{Univalence} {Y F : pType} `{IsConnected 0 Y}
+    : (Y ->* pBAut F) <~> { X : pType & FiberSeq F X Y }
+    := classify_fiberseq oE equiv_pmap_pbaut_type_p.
+
+End ClassifyingMaps.

--- a/theories/Spaces/BAut.v
+++ b/theories/Spaces/BAut.v
@@ -266,7 +266,7 @@ Section ClassifyingMaps.
 
   (** Consequently, maps into [BAut F] correspond to fibrations with fibers merely equivalent to [F]. *)
   Corollary equiv_map_baut_fibration `{Univalence} {Y : pType} {F : Type}
-    : (Y -> BAut F) <~> { p : Fib Y & forall y:Y, merely (hfiber p.2 y <~> F) }.
+    : (Y -> BAut F) <~> { p : Slice Y & forall y:Y, merely (hfiber p.2 y <~> F) }.
   Proof.
     refine (_ oE equiv_postcompose' equiv_baut_typeO).
     refine (_ oE equiv_sigma_fibration_O).
@@ -285,7 +285,7 @@ Section ClassifyingMaps.
   Defined.
 
   Definition equiv_pmap_pbaut_pfibration `{Univalence} {Y F : pType@{u}}
-    : (Y ->* pBAut@{u v} F) <~> { p : { q : pFib Y & forall y:Y, merely (hfiber q.2 y <~> F) } &
+    : (Y ->* pBAut@{u v} F) <~> { p : { q : pSlice Y & forall y:Y, merely (hfiber q.2 y <~> F) } &
                                       pfiber p.1.2 <~>* F }
     := (equiv_sigma_pfibration_O (subuniverse_merely_equiv F))
          oE equiv_pequiv_postcompose pequiv_pbaut_typeOp.

--- a/theories/Spaces/BAut.v
+++ b/theories/Spaces/BAut.v
@@ -243,7 +243,7 @@ End Center2BAut.
 
 Section ClassifyingMaps.
 
-  (** ** Maps into [BAut F] classify fibrations with fiber [F] *)
+  (** ** Maps into [BAut F] classify bundles with fiber [F] *)
 
   (** The property of being merely equivalent to a given type [F] defines a subuniverse. *)
   Definition subuniverse_merely_equiv (F : Type) : Subuniverse.
@@ -264,7 +264,7 @@ Section ClassifyingMaps.
     exact (equiv_path_universe _ _)^-1%equiv.
   Defined.
 
-  (** Consequently, maps into [BAut F] correspond to fibrations with fibers merely equivalent to [F]. *)
+  (** Consequently, maps into [BAut F] correspond to bundles with fibers merely equivalent to [F]. *)
   Corollary equiv_map_baut_fibration `{Univalence} {Y : pType} {F : Type}
     : (Y -> BAut F) <~> { p : Slice Y & forall y:Y, merely (hfiber p.2 y <~> F) }.
   Proof.

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -55,6 +55,15 @@ Proof.
                        which by induction is m'-truncated. *)
 Defined.
 
+(** ** Connectedness of path spaces *)
+
+Global Instance isconnected_paths `{Univalence} {n A}
+       `{IsConnected n.+1 A} (x y : A)
+: IsConnected n (x = y).
+Proof.
+  refine (contr_equiv' _ (equiv_path_Tr x y)^-1).
+Defined.
+
 (** ** Connectivity of pointed types *)
 
 (** The connectivity of a pointed type and (the inclusion of) its point are intimately connected. *)
@@ -74,6 +83,18 @@ Definition conn_point_incl {n : trunc_index} {A : Type} (a0:A)
 Proof.
   rapply (OO_cancelL_conn_map (Tr n.+1) (Tr n) (unit_name a0) (fun _:A => tt)).
   apply O_lex_leq_Tr.
+Defined.
+
+(** To prove an [n]-truncated predicate on an (n+1)-connected, pointed type, it's enough to prove it for the basepoint. *)
+Definition conn_to_trunc_ind `{Univalence} (n : trunc_index) {A : pType@{u}} `{IsConnected n.+1 A}
+           (P : A -> Type@{u}) `{forall a, IsTrunc n (P a)} (p0 : P (point A))
+  : forall a, P a.
+Proof.
+  intro a.
+  (** Since [A] is [n+1]-connected, [a0 = a] is [n]-connected, which means that [Tr n (a0 = a)] has an element. *)
+  pose proof (p := center _ : Tr n ((point A) = a)).
+  strip_truncations.
+  exact (p # p0).
 Defined.
 
 (** Note that [OO_cancelR_conn_map] and [OO_cancelL_conn_map] (Proposition 2.31 of CORS) generalize the above statements to 2/3 of a 2-out-of-3 property for connected maps, for any reflective subuniverse and its subuniverse of separated types.  If useful, we could specialize that more general form explicitly to truncations. *)
@@ -111,14 +132,6 @@ Proof.
   assumption.
 Defined.
 
-(** ** Connectedness of path spaces *)
-
-Global Instance isconnected_paths `{Univalence} {n A}
-       `{IsConnected n.+1 A} (x y : A)
-: IsConnected n (x = y).
-Proof.
-  refine (contr_equiv' _ (equiv_path_Tr x y)^-1).
-Defined.
 
 (** ** 0-connectedness *)
 

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -86,7 +86,7 @@ Proof.
 Defined.
 
 (** To prove an [n]-truncated predicate on an (n+1)-connected, pointed type, it's enough to prove it for the basepoint. *)
-Definition conn_to_trunc_ind `{Univalence} (n : trunc_index) {A : pType@{u}} `{IsConnected n.+1 A}
+Definition conn_point_elim `{Univalence} (n : trunc_index) {A : pType@{u}} `{IsConnected n.+1 A}
            (P : A -> Type@{u}) `{forall a, IsTrunc n (P a)} (p0 : P (point A))
   : forall a, P a.
 Proof.

--- a/theories/Types/Sigma.v
+++ b/theories/Types/Sigma.v
@@ -524,6 +524,12 @@ Proof.
   make_equiv.
 Defined.
 
+Definition equiv_sigma_symm' {A : Type} `(P : A -> Type) `(Q : A -> Type)
+  : { ap : { a : A & P a } & Q ap.1 } <~> { aq : { a : A & Q a } & P aq.1 }.
+Proof.
+  make_equiv.
+Defined.
+
 Definition equiv_sigma_symm0 (A B : Type)
 : {a : A & B} <~> {b : B & A}.
 Proof.

--- a/theories/Types/Universe.v
+++ b/theories/Types/Universe.v
@@ -269,7 +269,18 @@ Definition transport_path_universe_Vp `{Funext}
   @ transport_path_universe_V f (f z)
   @ eissect f z
   = transport_Vp idmap (path_universe f) z
-:= transport_path_universe_Vp_uncurried (Build_Equiv A B f feq) z.
+  := transport_path_universe_Vp_uncurried (Build_Equiv A B f feq) z.
+
+(** *** Transporting in particular type families *)
+
+Theorem transport_arrow_toconst_path_universe `{Univalence} {A U V : Type} (w : U <~> V)
+  : forall f : U -> A, transport (fun E : Type => E -> A) (path_universe w) f = (f o w^-1).
+Proof.
+  intros f. funext y.
+  refine (transport_arrow_toconst _ _ _ @ _).
+  apply ap.
+  apply transport_path_universe_V.
+Defined.
 
 (** ** 2-paths *)
 


### PR DESCRIPTION
In the 1st commit, we expand `ObjectClassifier.v` to speak about pointed maps into the universe pointed at some type, and into `Type_ O` pointed at some `O`-local type. In particular, the former corresponds to the type of fiber sequences, which we may consider to be pointed (`equiv_sigma_pfibration`) or not (`equiv_sigma_fibration_p`).

In the 2nd commit, we view `X => merely (X <~> F)` as a subuniverse to deduce facts about maps into `BAut F` from the statements about `Type_ O` in `ObjectClassifier.v`. Both `pType` and `pForall` are made cumulative in order for `equiv_pequiv_postcompose` to work at the end of `BAut.v`.

_Question_: in `Truncations/Connectedness.v` we added `conn_to_trunc_ind`, with the naming indicating that this is an induction principle for (n+1)-connected types into n-types. Any suggestions for a better name?

_Comment_: the interest of #1509 is be to make `BAut F` definitionally `Type_ O` for the subuniverse `X => merely (X = F)`, thus letting us simply specialize results in `ObjectClassifier.v` to `BAut F`. An alternative is to redefine `BAut F` to use equivalences, in which case `BAut F` already would be `Type_ O` definitionally for `subuniverse_merely_equiv`. Having these results will help in determining which approach simplifies things.