### PR TITLE
Added .opam file to library

### DIFF
--- a/hott.opam
+++ b/hott.opam
@@ -8,7 +8,7 @@ build: [
 ]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.13.2"}
+  "coq" {>= "8.13~"}
 ]
 authors: ["The HoTT Library Development Team"]
 dev-repo: "git+https://github.com/HoTT/HoTT.git"

--- a/hott.opam
+++ b/hott.opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: [ "Jason Gross <jgross@mit.edu>" "Ali Caglayan <alizter@gmail.com>" ]
+homepage: "http://homotopytypetheory.org/"
+bug-reports: "https://github.com/HoTT/HoTT/issues"
+license: "BSD-2-Clause"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+depends: [
+  "coq" {>= "8.13.2"}
+]
+authors: ["The HoTT Library Development Team"]
+dev-repo: "git+https://github.com/HoTT/HoTT.git"
+synopsis: "The Homotopy Type Theory library"
+description: """
+To use the HoTT library, the following flags must be passed to coqc:
+  -noinit -indices-matter
+To use the HoTT library in a project, add the following to _CoqProject:
+  -arg -noinit
+  -arg -indices-matter
+"""
+tags: [ "logpath:HoTT" ]
+url {
+  src: "git+https://github.com/HoTT/HoTT.git#master"
+}


### PR DESCRIPTION
This lets us use `opam` to build and install the library from the source directory. This will be useful for the CI.