### PR TITLE
Define hExt and characterise trivial extensions

### DIFF
--- a/theories/Algebra/AbGroups/AbExt.v
+++ b/theories/Algebra/AbGroups/AbExt.v
@@ -1,0 +1,225 @@
+Require Import HoTT.Basics HoTT.Types HSet.
+Require Import Groups AbGroups.AbelianGroup WildCat.
+Require Import Homotopy.ExactSequence Pointed.
+
+Local Open Scope pointed_scope.
+Local Open Scope type_scope.
+Local Open Scope mc_add_scope.
+
+(** * Extensions of abelian groups *)
+
+(** The type of abelian group extensions [A -> E -> B]. *)
+Record hExt (B A : AbGroup) : Type := {
+  hext_E : AbGroup;
+  hext_i : A $-> hext_E;
+  hext_p : hext_E $-> B;
+  hext_isembedding_i : IsEmbedding hext_i;
+  hext_issurjection_p : IsSurjection hext_p;
+  hext_isexact : IsExact (Tr (-1)) hext_i hext_p;
+}.
+
+(** Given an extension [A -> E -> B : hExt B A], we coerce it to [E]. *)
+Coercion hext_E : hExt >-> AbGroup.
+
+Global Existing Instances hext_isembedding_i hext_issurjection_p hext_isexact.
+
+Arguments hext_E {B A E} : rename.
+Arguments hext_i {B A E} : rename.
+Arguments hext_p {B A E} : rename.
+
+Arguments Build_hExt {B A} _ _ _ _ _ _.
+  
+Definition issig_hext {B A : AbGroup} : _ <~> hExt B A := ltac:(issig).
+
+(** A more useful organization of [hExt] as a sigma-type. *)
+Definition issig_hext' {B A : AbGroup}
+  : {X : {E : AbGroup & (A $-> E) * (E $-> B)} &
+          (IsEmbedding (fst X.2)
+           * IsSurjection (snd X.2)
+           * IsExact (Tr (-1)) (fst X.2) (snd X.2))}
+      <~> hExt B A.
+Proof. (** [make_equiv] is slow to solve this, so we prove it by hand. *)
+  refine (issig_hext oE _).
+  equiv_via {X : {E : AbGroup & (A $-> E) * (E $-> B)} &
+                  {_ : IsEmbedding (fst X.2) &
+                       {_ : IsConnMap (Tr (-1)) (snd X.2) & IsExact (Tr (-1)) (fst X.2) (snd X.2)}}}.
+  - apply equiv_functor_sigma_id; intro X.
+    exact (equiv_sigma_prod1 _ _ _)^-1%equiv.
+  - refine (_ oE (equiv_sigma_assoc _ _)^-1%equiv).
+    apply equiv_functor_sigma_id; intro E.
+    exact (equiv_sigma_prod _)^-1%equiv.
+Defined.
+
+(** [hExt B A] is pointed by the split sequence [A -> A+B -> B]. *)
+Global Instance ispointed_hext {B A : AbGroup} : IsPointed (hExt B A).
+Proof.
+  rapply (Build_hExt (ab_biprod A B) ab_biprod_inl ab_biprod_pr2).
+  snrapply Build_IsExact.
+  - srapply Build_pHomotopy.
+    + intro x; cbn.
+      apply ab_unit_l.
+    + apply path_ishprop.
+  - intros [[a b] p]; cbn; cbn in p.
+    rapply contr_inhabited_hprop.
+    apply tr.
+    exists a.
+    srapply path_sigma_hprop; cbn.
+    apply (path_prod' idpath).
+    exact (p^ @ left_identity _).
+Defined.
+
+(** Paths in [hExt] corespond to isomorphisms between the [hext_E]s respecting [hext_i] and [hext_i]. *)
+Proposition equiv_path_hext `{Univalence} {B A : AbGroup} (E F : hExt B A)
+  : (E = F :> hExt B A)
+      <~> {phi : GroupIsomorphism E F &
+                 (phi $o hext_i = hext_i)
+                 * (hext_p $o grp_iso_inverse phi = hext_p)}.
+Proof.
+  refine (_ oE equiv_ap issig_hext'^-1 _ _).
+  refine (_ oE (equiv_path_sigma_hprop _ _)^-1).
+  refine (_ oE (equiv_path_sigma _ _ _)^-1).
+  srapply equiv_functor_sigma'.
+  1: exact equiv_path_abgroup^-1%equiv.
+  intro q; lazy beta.
+  snrefine (_ oE equiv_concat_l _ _); only 3: symmetry.
+  2: exact (grp_homo_compose (equiv_path_abgroup^-1 q) hext_i,
+            (grp_homo_compose hext_p (grp_iso_inverse (equiv_path_abgroup^-1 q)))).
+  1: exact (equiv_path_prod _ _)^-1%equiv.
+  refine (transport_prod _ _ @ _).
+  apply path_prod'.
+  - apply transport_abgrouphomomorphism_from_const.
+  - apply transport_abgrouphomomorphism_to_const.
+Defined.
+
+
+(** * Characterization of trivial extensions
+
+    We characterize trivial extensions in [hExt] as those for which [hext_p] splits. *)
+
+(** If [hext_p : E -> B] splits, we get an induced map [fun e => e - s(hext_p s)] from [E] to [ab_kernel hext_p]. *)
+Definition hext_p_split_to_kernel {B A : AbGroup} (E : hExt B A)
+      {s : GroupHomomorphism B E} (h : hext_p $o s == idmap)
+  : GroupHomomorphism E (@ab_kernel E B hext_p).
+Proof.
+  snrapply (grp_kernel_corec (G:=E) (A:=E)).
+  - (** We construct the map [fun e => e - s(hext_p e)] by going via [E + E]. *)
+    rapply grp_homo_compose.
+    (** [fun e => (e,-e)] *)
+    1: exact (ab_biprod_rec grp_homo_id ab_homo_negation).
+    (** [fun (e,f) => e + s(hext_p s)] **)
+    refine (ab_biprod_corec grp_homo_id (s $o hext_p)).
+  - intro x; simpl.
+    refine (grp_homo_op hext_p x _ @ _).
+    refine (ap (fun y => hext_p x + y) _ @ right_inverse (hext_p x)).
+    refine (grp_homo_inv _ _ @ ap (-) _ ).
+    apply h.
+Defined.
+
+(** The composite [A -> E -> (ab_kernel hext_p) + B] is [grp_cxfib]. *)
+Lemma hext_p_split_to_kernel_beta {B A : AbGroup} (E : hExt B A)
+      {s : GroupHomomorphism B E} (h : hext_p $o s == idmap)
+  : hext_p_split_to_kernel E h $o hext_i == grp_cxfib cx_isexact.
+Proof.
+  intro a.
+  apply path_sigma_hprop; cbn.
+  refine (ap _ _ @ right_identity (hext_i a)).
+  refine (ap (fun x => - s x) _ @ _).
+  1: rapply cx_isexact.
+  exact (ap _ (grp_homo_unit _) @ negate_mon_unit).
+Defined.
+
+(** The induced map [E -> ab_kernel hext_p + B] is an isomorphism. We suffix it with 1 since it is the first composite in the desired isomorphism [E -> A + B]. *)
+Definition hext_p_split_iso1 {B A : AbGroup} (E : hExt B A)
+      {s : GroupHomomorphism B E} (h : hext_p $o s == idmap)
+  : GroupIsomorphism E (ab_biprod (@ab_kernel E B hext_p) B).
+Proof.
+  srapply Build_GroupIsomorphism.
+  - refine (ab_biprod_corec _ hext_p).
+    exact (hext_p_split_to_kernel E h).
+  - srapply isequiv_adjointify.
+    + refine (ab_biprod_rec _ s).
+      rapply subgroup_incl.
+    + intros [a b]; simpl.
+      apply path_prod'.
+      * srapply path_sigma_hprop; cbn.
+        refine ((ab_assoc _ _ _)^ @ _).
+        apply ab_cancelL1.
+        refine (ap _ _ @ ab_inv_r _).
+        apply (ap (-)).
+        refine (grp_homo_op (s $o hext_p) _ _ @ _).
+        refine (ap (fun x => x + _) (ap s a.2 @ grp_homo_unit s) @ _).
+        exact (ab_unit_l _ @ ap s (h b)).
+      * refine (grp_homo_op hext_p a.1 (s b) @ _).
+        exact (ap (fun y => y + _) a.2 @ left_identity _ @ h b).
+    + intro e; simpl.
+      by apply ab_moveR_gM.
+Defined.
+
+(** The full isomorphism [E -> A + B]. *)
+Definition hext_p_split_iso {B A : AbGroup} (E : hExt B A)
+      {s : GroupHomomorphism B E} (h : hext_p $o s == idmap)
+  : GroupIsomorphism E (ab_biprod A B).
+Proof.
+  etransitivity (ab_biprod (ab_kernel _) B).
+  - exact (hext_p_split_iso1 E h).
+  - srapply (equiv_functor_ab_biprod (grp_iso_inverse _) grp_iso_id).
+    rapply grp_iso_cxfib.
+Defined.
+
+Proposition hext_p_split_beta `{Funext} {B A : AbGroup} (E : hExt B A)
+      {s : GroupHomomorphism B E} (h : hext_p $o s == idmap)
+  : hext_p_split_iso E h $o hext_i == ab_biprod_inl.
+Proof.
+  intro a.
+  refine (ap _ (ab_corec_beta _ _ _ _) @ _).
+  refine (ab_biprod_functor_beta _ _ _ _ _ @ _).
+  srefine (ap (fun p => ab_biprod_corec p _ a) _ @ _).
+  1: exact grp_homo_id.
+  - refine (ap (fun g => _ $o g) _ @ _);
+      apply equiv_path_grouphomomorphism; intro.
+    1: apply hext_p_split_to_kernel_beta.
+    apply eissect.
+  - refine (path_prod' idpath _); cbn.
+    rapply cx_isexact.
+Defined.
+
+(** An extension [E] in [hExt B A] is trivial if and only if it splits. *)
+Proposition iff_hext_trivial_split `{Univalence} {B A : AbGroup} (E : hExt B A)
+  : (E = point _ :> hExt B A)
+      <-> {s : GroupHomomorphism B E & hext_p $o s == idmap}.
+Proof.
+  refine (iff_compose (iff_equiv (equiv_path_hext _ _)) _); split.
+  - intros [phi [g h]].
+    exists (grp_homo_compose (grp_iso_inverse phi) ab_biprod_inr).
+    intro x.
+    refine (equiv_path_grouphomomorphism^-1 h (ab_biprod_inr x) @ _); cbn.
+    apply left_identity.
+  - intros [s h].
+    exists (hext_p_split_iso E h).
+    split; apply equiv_path_grouphomomorphism.
+    + apply hext_p_split_beta.
+    + intros [a b]; simpl.
+      rewrite (left_identity b), (right_identity a).
+      refine (grp_homo_op hext_p  _ _ @ _).
+      refine (ap011 (+) _ (h _) @ _).
+      1: rapply cx_isexact.
+      apply ab_unit_l.
+Defined.
+
+
+(** * The set [Ext B A] of abelian group extensions *)
+
+Definition Ext (B A : AbGroup) := Tr 0 (hExt B A).
+
+Global Instance ispointed_ext {B A : AbGroup} : IsPointed (Ext B A) := tr (point _).
+      
+(** An extension [E : hext B A] is trivial in [Ext B A] if and only if [E] merely splits. *)
+Proposition iff_ab_ext_trivial_split `{Univalence} {B A : AbGroup} (E : hExt B A)
+  : (tr E = point (Ext B A))
+      <~> merely { s : GroupHomomorphism B E & hext_p $o s == idmap }.
+Proof.
+  refine (_ oE (equiv_path_Tr _ _)^-1).
+  srapply equiv_iff_hprop;
+    apply Trunc_functor;
+    apply iff_hext_trivial_split.
+Defined.

--- a/theories/Algebra/AbGroups/AbExt.v
+++ b/theories/Algebra/AbGroups/AbExt.v
@@ -9,49 +9,49 @@ Local Open Scope mc_add_scope.
 (** * Extensions of abelian groups *)
 
 (** The type of abelian group extensions [A -> E -> B]. *)
-Record Exts (B A : AbGroup) : Type := {
-  exts_E : AbGroup;
-  exts_i : A $-> exts_E;
-  exts_p : exts_E $-> B;
-  exts_isembedding_i : IsEmbedding exts_i;
-  exts_issurjection_p : IsSurjection exts_p;
-  exts_isexact : IsExact (Tr (-1)) exts_i exts_p;
+Record AbExt (B A : AbGroup) : Type := {
+  abext_E : AbGroup;
+  abext_i : A $-> abext_E;
+  abext_p : abext_E $-> B;
+  abext_isembedding_i : IsEmbedding abext_i;
+  abext_issurjection_p : IsSurjection abext_p;
+  abext_isexact : IsExact (Tr (-1)) abext_i abext_p;
 }.
 
-(** Given an extension [A -> E -> B : Exts B A], we coerce it to [E]. *)
-Coercion exts_E : Exts >-> AbGroup.
+(** Given an extension [A -> E -> B : AbExt B A], we coerce it to [E]. *)
+Coercion abext_E : AbExt >-> AbGroup.
 
-Global Existing Instances exts_isembedding_i exts_issurjection_p exts_isexact.
+Global Existing Instances abext_isembedding_i abext_issurjection_p abext_isexact.
 
-Arguments exts_E {B A E} : rename.
-Arguments exts_i {B A E} : rename.
-Arguments exts_p {B A E} : rename.
+Arguments abext_E {B A E} : rename.
+Arguments abext_i {B A E} : rename.
+Arguments abext_p {B A E} : rename.
 
-Arguments Build_Exts {B A} _ _ _ _ _ _.
+Arguments Build_AbExt {B A} _ _ _ _ _ _.
 
 (** TODO Figure out why printing this term eats memory and seems to never finish. *)
-Local Definition issig_exts_do_not_print {B A : AbGroup} : _ <~> Exts B A := ltac:(issig).
+Local Definition issig_abext_do_not_print {B A : AbGroup} : _ <~> AbExt B A := ltac:(issig).
 
 (** [make_equiv] is slow if used in the context of the next result, so we give the abstract form of the goal here. *)
-Local Definition issig_exts_helper {AG : Type} {P : AG -> Type} {Q : AG -> Type}
+Local Definition issig_abext_helper {AG : Type} {P : AG -> Type} {Q : AG -> Type}
            {R : forall E, P E -> Type} {S : forall E, Q E -> Type} {T : forall E, P E -> Q E -> Type}
   : {X : {E : AG & P E * Q E} & R _ (fst X.2) * S _ (snd X.2) * T _ (fst X.2) (snd X.2)}
   <~> {E : AG & {H0 : P E & {H1 : Q E & {_ : R _ H0 & {_ : S _ H1 & T _ H0 H1}}}}}
   := ltac:(make_equiv).
 
-(** A more useful organization of [Exts] as a sigma-type. *)
-Definition issig_exts {B A : AbGroup}
+(** A more useful organization of [AbExt] as a sigma-type. *)
+Definition issig_abext {B A : AbGroup}
   : {X : {E : AbGroup & (A $-> E) * (E $-> B)} &
           (IsEmbedding (fst X.2)
            * IsSurjection (snd X.2)
            * IsExact (Tr (-1)) (fst X.2) (snd X.2))}
-      <~> Exts B A
-  := issig_exts_do_not_print oE issig_exts_helper.
+      <~> AbExt B A
+  := issig_abext_do_not_print oE issig_abext_helper.
 
-(** [Exts B A] is pointed by the split sequence [A -> A+B -> B]. *)
-Global Instance ispointed_exts {B A : AbGroup} : IsPointed (Exts B A).
+(** [AbExt B A] is pointed by the split sequence [A -> A+B -> B]. *)
+Global Instance ispointed_abext {B A : AbGroup} : IsPointed (AbExt B A).
 Proof.
-  rapply (Build_Exts (ab_biprod A B) ab_biprod_inl ab_biprod_pr2).
+  rapply (Build_AbExt (ab_biprod A B) ab_biprod_inl ab_biprod_pr2).
   snrapply Build_IsExact.
   - srapply Build_pHomotopy.
     + reflexivity.
@@ -64,21 +64,21 @@ Proof.
     exact (path_prod' idpath p^).
 Defined.
 
-(** Paths in [Exts] corespond to isomorphisms between the [exts_E]s respecting [exts_i] and [exts_p]. *)
-Proposition equiv_path_exts `{Univalence} {B A : AbGroup} (E F : Exts B A)
+(** Paths in [AbExt] corespond to isomorphisms between the [abext_E]s respecting [abext_i] and [abext_p]. *)
+Proposition equiv_path_abext `{Univalence} {B A : AbGroup} (E F : AbExt B A)
   : (E = F) <~> {phi : GroupIsomorphism E F &
-                       (phi $o exts_i = exts_i)
-                       * (exts_p $o grp_iso_inverse phi = exts_p)}.
+                       (phi $o abext_i = abext_i)
+                       * (abext_p $o grp_iso_inverse phi = abext_p)}.
 Proof.
-  refine (_ oE equiv_ap issig_exts^-1 _ _).
+  refine (_ oE equiv_ap issig_abext^-1 _ _).
   refine (_ oE (equiv_path_sigma_hprop _ _)^-1).
   refine (_ oE (equiv_path_sigma _ _ _)^-1).
   srapply equiv_functor_sigma'.
   1: exact equiv_path_abgroup^-1%equiv.
   intro q; lazy beta.
   snrefine (_ oE equiv_concat_l _ _); only 3: symmetry.
-  2: exact (grp_homo_compose (equiv_path_abgroup^-1 q) exts_i,
-            (grp_homo_compose exts_p (grp_iso_inverse (equiv_path_abgroup^-1 q)))).
+  2: exact (grp_homo_compose (equiv_path_abgroup^-1 q) abext_i,
+            (grp_homo_compose abext_p (grp_iso_inverse (equiv_path_abgroup^-1 q)))).
   1: exact (equiv_path_prod _ _)^-1%equiv.
   refine (transport_prod _ _ @ _).
   apply path_prod'.
@@ -89,26 +89,26 @@ Defined.
 
 (** * Characterization of trivial extensions
 
-    We characterize trivial extensions in [Exts] as those for which [exts_p] splits. *)
+    We characterize trivial extensions in [AbExt] as those for which [abext_p] splits. *)
 
-(** If [exts_p : E -> B] splits, we get an induced map [fun e => e - s (exts_p e)] from [E] to [ab_kernel exts_p]. *)
-Definition exts_p_split_to_kernel {B A : AbGroup} (E : Exts B A)
-      {s : GroupHomomorphism B E} (h : exts_p $o s == idmap)
-  : GroupHomomorphism E (@ab_kernel E B exts_p).
+(** If [abext_p : E -> B] splits, we get an induced map [fun e => e - s (abext_p e)] from [E] to [ab_kernel abext_p]. *)
+Definition abext_p_split_to_kernel {B A : AbGroup} (E : AbExt B A)
+      {s : GroupHomomorphism B E} (h : abext_p $o s == idmap)
+  : GroupHomomorphism E (@ab_kernel E B abext_p).
 Proof.
   snrapply (grp_kernel_corec (G:=E) (A:=E)).
-  - exact (ab_homo_add grp_homo_id (ab_homo_negation $o s $o exts_p)).
+  - exact (ab_homo_add grp_homo_id (ab_homo_negation $o s $o abext_p)).
   - intro x; simpl.
-    refine (grp_homo_op exts_p x _ @ _).
-    refine (ap (fun y => exts_p x + y) _ @ right_inverse (exts_p x)).
+    refine (grp_homo_op abext_p x _ @ _).
+    refine (ap (fun y => abext_p x + y) _ @ right_inverse (abext_p x)).
     refine (grp_homo_inv _ _ @ ap (-) _ ).
     apply h.
 Defined.
 
-(** The composite [A -> E -> ab_kernel exts_p] is [grp_cxfib]. *)
-Lemma exts_p_split_to_kernel_beta {B A : AbGroup} (E : Exts B A)
-      {s : GroupHomomorphism B E} (h : exts_p $o s == idmap)
-  : exts_p_split_to_kernel E h $o exts_i == grp_cxfib cx_isexact.
+(** The composite [A -> E -> ab_kernel abext_p] is [grp_cxfib]. *)
+Lemma abext_p_split_to_kernel_beta {B A : AbGroup} (E : AbExt B A)
+      {s : GroupHomomorphism B E} (h : abext_p $o s == idmap)
+  : abext_p_split_to_kernel E h $o abext_i == grp_cxfib cx_isexact.
 Proof.
   intro a.
   apply path_sigma_hprop; cbn.
@@ -118,14 +118,14 @@ Proof.
   exact (ap _ (grp_homo_unit _) @ negate_mon_unit).
 Defined.
 
-(** The induced map [E -> ab_kernel exts_p + B] is an isomorphism. We suffix it with 1 since it is the first composite in the desired isomorphism [E -> A + B]. *)
-Definition exts_p_split_iso1 {B A : AbGroup} (E : Exts B A)
-      {s : GroupHomomorphism B E} (h : exts_p $o s == idmap)
-  : GroupIsomorphism E (ab_biprod (@ab_kernel E B exts_p) B).
+(** The induced map [E -> ab_kernel abext_p + B] is an isomorphism. We suffix it with 1 since it is the first composite in the desired isomorphism [E -> A + B]. *)
+Definition abext_p_split_iso1 {B A : AbGroup} (E : AbExt B A)
+      {s : GroupHomomorphism B E} (h : abext_p $o s == idmap)
+  : GroupIsomorphism E (ab_biprod (@ab_kernel E B abext_p) B).
 Proof.
   srapply Build_GroupIsomorphism.
-  - refine (ab_biprod_corec _ exts_p).
-    exact (exts_p_split_to_kernel E h).
+  - refine (ab_biprod_corec _ abext_p).
+    exact (abext_p_split_to_kernel E h).
   - srapply isequiv_adjointify.
     + refine (ab_biprod_rec _ s).
       rapply subgroup_incl.
@@ -137,54 +137,54 @@ Proof.
         refine (ap _ _ @ right_inverse _).
         apply (ap (-)).
         apply (ap s).
-        refine (grp_homo_op exts_p a.1 (s b) @ _).
+        refine (grp_homo_op abext_p a.1 (s b) @ _).
         exact (ap (fun y => y + _) a.2 @ left_identity _ @ h b).
-      * refine (grp_homo_op exts_p a.1 (s b) @ _).
+      * refine (grp_homo_op abext_p a.1 (s b) @ _).
         exact (ap (fun y => y + _) a.2 @ left_identity _ @ h b).
     + intro e; simpl.
       by apply grp_moveR_gM.
 Defined.
 
 (** The full isomorphism [E -> A+B]. *)
-Definition exts_p_split_iso {B A : AbGroup} (E : Exts B A)
-      {s : GroupHomomorphism B E} (h : exts_p $o s == idmap)
+Definition abext_p_split_iso {B A : AbGroup} (E : AbExt B A)
+      {s : GroupHomomorphism B E} (h : abext_p $o s == idmap)
   : GroupIsomorphism E (ab_biprod A B).
 Proof.
   etransitivity (ab_biprod (ab_kernel _) B).
-  - exact (exts_p_split_iso1 E h).
+  - exact (abext_p_split_iso1 E h).
   - srapply (equiv_functor_ab_biprod (grp_iso_inverse _) grp_iso_id).
     rapply grp_iso_cxfib.
 Defined.
 
-Proposition exts_p_split_beta {B A : AbGroup} (E : Exts B A)
-      {s : GroupHomomorphism B E} (h : exts_p $o s == idmap)
-  : exts_p_split_iso E h $o exts_i == ab_biprod_inl.
+Proposition abext_p_split_beta {B A : AbGroup} (E : AbExt B A)
+      {s : GroupHomomorphism B E} (h : abext_p $o s == idmap)
+  : abext_p_split_iso E h $o abext_i == ab_biprod_inl.
 Proof.
   intro a.
   refine (ap _ (ab_corec_beta _ _ _ _) @ _).
   refine (ab_biprod_functor_beta _ _ _ _ _ @ _).
   nrapply path_prod'.
   2: rapply cx_isexact.
-  refine (ap _ (exts_p_split_to_kernel_beta E h a) @ _).
+  refine (ap _ (abext_p_split_to_kernel_beta E h a) @ _).
   apply eissect.
 Defined.
 
-(** An extension [E] in [Exts B A] is trivial if and only if it splits. *)
-Proposition iff_exts_trivial_split `{Univalence} {B A : AbGroup} (E : Exts B A)
-  : (E = point (Exts B A))
-      <-> {s : GroupHomomorphism B E & exts_p $o s == idmap}.
+(** An extension [E] in [AbExt B A] is trivial if and only if it splits. *)
+Proposition iff_abext_trivial_split `{Univalence} {B A : AbGroup} (E : AbExt B A)
+  : (E = point (AbExt B A))
+      <-> {s : GroupHomomorphism B E & abext_p $o s == idmap}.
 Proof.
-  refine (iff_compose (iff_equiv (equiv_path_exts _ _)) _); split.
+  refine (iff_compose (iff_equiv (equiv_path_abext _ _)) _); split.
   - intros [phi [g h]].
     exists (grp_homo_compose (grp_iso_inverse phi) ab_biprod_inr).
     intro x.
     exact (equiv_path_grouphomomorphism^-1 h (ab_biprod_inr x)).
   - intros [s h].
-    exists (exts_p_split_iso E h).
+    exists (abext_p_split_iso E h).
     split; apply equiv_path_grouphomomorphism.
-    + apply exts_p_split_beta.
+    + apply abext_p_split_beta.
     + intros [a b]; simpl.
-      refine (grp_homo_op exts_p  _ _ @ _).
+      refine (grp_homo_op abext_p  _ _ @ _).
       refine (ap011 (+) _ (h _) @ _).
       1: rapply cx_isexact.
       apply left_identity.
@@ -193,17 +193,17 @@ Defined.
 
 (** * The set [Ext B A] of abelian group extensions *)
 
-Definition Ext (B A : AbGroup) := Tr 0 (Exts B A).
+Definition Ext (B A : AbGroup) := Tr 0 (AbExt B A).
 
 Global Instance ispointed_ext {B A : AbGroup} : IsPointed (Ext B A) := tr (point _).
       
-(** An extension [E : Exts B A] is trivial in [Ext B A] if and only if [E] merely splits. *)
-Proposition iff_ab_ext_trivial_split `{Univalence} {B A : AbGroup} (E : Exts B A)
+(** An extension [E : AbExt B A] is trivial in [Ext B A] if and only if [E] merely splits. *)
+Proposition iff_ab_ext_trivial_split `{Univalence} {B A : AbGroup} (E : AbExt B A)
   : (tr E = point (Ext B A))
-      <~> merely { s : GroupHomomorphism B E & exts_p $o s == idmap }.
+      <~> merely { s : GroupHomomorphism B E & abext_p $o s == idmap }.
 Proof.
   refine (_ oE (equiv_path_Tr _ _)^-1).
   srapply equiv_iff_hprop;
     apply Trunc_functor;
-    apply iff_exts_trivial_split.
+    apply iff_abext_trivial_split.
 Defined.

--- a/theories/Algebra/AbGroups/AbExt.v
+++ b/theories/Algebra/AbGroups/AbExt.v
@@ -61,10 +61,7 @@ Proof.
     apply tr.
     exists a.
     rapply path_sigma_hprop; cbn.
-    + intro x.
-      apply istrunc_paths.
-      exact _.
-    + exact (path_prod' idpath p^).
+    exact (path_prod' idpath p^).
 Defined.
 
 (** Paths in [Exts] corespond to isomorphisms between the [exts_E]s respecting [exts_i] and [exts_p]. *)

--- a/theories/Algebra/AbGroups/AbExt.v
+++ b/theories/Algebra/AbGroups/AbExt.v
@@ -9,49 +9,49 @@ Local Open Scope mc_add_scope.
 (** * Extensions of abelian groups *)
 
 (** The type of abelian group extensions [A -> E -> B]. *)
-Record hExt (B A : AbGroup) : Type := {
-  hext_E : AbGroup;
-  hext_i : A $-> hext_E;
-  hext_p : hext_E $-> B;
-  hext_isembedding_i : IsEmbedding hext_i;
-  hext_issurjection_p : IsSurjection hext_p;
-  hext_isexact : IsExact (Tr (-1)) hext_i hext_p;
+Record Exts (B A : AbGroup) : Type := {
+  exts_E : AbGroup;
+  exts_i : A $-> exts_E;
+  exts_p : exts_E $-> B;
+  exts_isembedding_i : IsEmbedding exts_i;
+  exts_issurjection_p : IsSurjection exts_p;
+  exts_isexact : IsExact (Tr (-1)) exts_i exts_p;
 }.
 
-(** Given an extension [A -> E -> B : hExt B A], we coerce it to [E]. *)
-Coercion hext_E : hExt >-> AbGroup.
+(** Given an extension [A -> E -> B : Exts B A], we coerce it to [E]. *)
+Coercion exts_E : Exts >-> AbGroup.
 
-Global Existing Instances hext_isembedding_i hext_issurjection_p hext_isexact.
+Global Existing Instances exts_isembedding_i exts_issurjection_p exts_isexact.
 
-Arguments hext_E {B A E} : rename.
-Arguments hext_i {B A E} : rename.
-Arguments hext_p {B A E} : rename.
+Arguments exts_E {B A E} : rename.
+Arguments exts_i {B A E} : rename.
+Arguments exts_p {B A E} : rename.
 
-Arguments Build_hExt {B A} _ _ _ _ _ _.
+Arguments Build_Exts {B A} _ _ _ _ _ _.
 
 (** TODO Figure out why printing this term eats memory and seems to never finish. *)
-Local Definition issig_hext_do_not_print {B A : AbGroup} : _ <~> hExt B A := ltac:(issig).
+Local Definition issig_exts_do_not_print {B A : AbGroup} : _ <~> Exts B A := ltac:(issig).
 
 (** [make_equiv] is slow if used in the context of the next result, so we give the abstract form of the goal here. *)
-Local Definition issig_hext_helper {AG : Type} {P : AG -> Type} {Q : AG -> Type}
+Local Definition issig_exts_helper {AG : Type} {P : AG -> Type} {Q : AG -> Type}
            {R : forall E, P E -> Type} {S : forall E, Q E -> Type} {T : forall E, P E -> Q E -> Type}
   : {X : {E : AG & P E * Q E} & R _ (fst X.2) * S _ (snd X.2) * T _ (fst X.2) (snd X.2)}
   <~> {E : AG & {H0 : P E & {H1 : Q E & {_ : R _ H0 & {_ : S _ H1 & T _ H0 H1}}}}}
   := ltac:(make_equiv).
 
-(** A more useful organization of [hExt] as a sigma-type. *)
-Definition issig_hext {B A : AbGroup}
+(** A more useful organization of [Exts] as a sigma-type. *)
+Definition issig_exts {B A : AbGroup}
   : {X : {E : AbGroup & (A $-> E) * (E $-> B)} &
           (IsEmbedding (fst X.2)
            * IsSurjection (snd X.2)
            * IsExact (Tr (-1)) (fst X.2) (snd X.2))}
-      <~> hExt B A
-  := issig_hext_do_not_print oE issig_hext_helper.
+      <~> Exts B A
+  := issig_exts_do_not_print oE issig_exts_helper.
 
-(** [hExt B A] is pointed by the split sequence [A -> A+B -> B]. *)
-Global Instance ispointed_hext {B A : AbGroup} : IsPointed (hExt B A).
+(** [Exts B A] is pointed by the split sequence [A -> A+B -> B]. *)
+Global Instance ispointed_exts {B A : AbGroup} : IsPointed (Exts B A).
 Proof.
-  rapply (Build_hExt (ab_biprod A B) ab_biprod_inl ab_biprod_pr2).
+  rapply (Build_Exts (ab_biprod A B) ab_biprod_inl ab_biprod_pr2).
   snrapply Build_IsExact.
   - srapply Build_pHomotopy.
     + reflexivity.
@@ -67,22 +67,21 @@ Proof.
     + exact (path_prod' idpath p^).
 Defined.
 
-(** Paths in [hExt] corespond to isomorphisms between the [hext_E]s respecting [hext_i] and [hext_i]. *)
-Proposition equiv_path_hext `{Univalence} {B A : AbGroup} (E F : hExt B A)
-  : (E = F :> hExt B A)
-      <~> {phi : GroupIsomorphism E F &
-                 (phi $o hext_i = hext_i)
-                 * (hext_p $o grp_iso_inverse phi = hext_p)}.
+(** Paths in [Exts] corespond to isomorphisms between the [exts_E]s respecting [exts_i] and [exts_p]. *)
+Proposition equiv_path_exts `{Univalence} {B A : AbGroup} (E F : Exts B A)
+  : (E = F) <~> {phi : GroupIsomorphism E F &
+                       (phi $o exts_i = exts_i)
+                       * (exts_p $o grp_iso_inverse phi = exts_p)}.
 Proof.
-  refine (_ oE equiv_ap issig_hext^-1 _ _).
+  refine (_ oE equiv_ap issig_exts^-1 _ _).
   refine (_ oE (equiv_path_sigma_hprop _ _)^-1).
   refine (_ oE (equiv_path_sigma _ _ _)^-1).
   srapply equiv_functor_sigma'.
   1: exact equiv_path_abgroup^-1%equiv.
   intro q; lazy beta.
   snrefine (_ oE equiv_concat_l _ _); only 3: symmetry.
-  2: exact (grp_homo_compose (equiv_path_abgroup^-1 q) hext_i,
-            (grp_homo_compose hext_p (grp_iso_inverse (equiv_path_abgroup^-1 q)))).
+  2: exact (grp_homo_compose (equiv_path_abgroup^-1 q) exts_i,
+            (grp_homo_compose exts_p (grp_iso_inverse (equiv_path_abgroup^-1 q)))).
   1: exact (equiv_path_prod _ _)^-1%equiv.
   refine (transport_prod _ _ @ _).
   apply path_prod'.
@@ -93,48 +92,48 @@ Defined.
 
 (** * Characterization of trivial extensions
 
-    We characterize trivial extensions in [hExt] as those for which [hext_p] splits. *)
+    We characterize trivial extensions in [Exts] as those for which [exts_p] splits. *)
 
-(** If [hext_p : E -> B] splits, we get an induced map [fun e => e - s(hext_p s)] from [E] to [ab_kernel hext_p]. *)
-Definition hext_p_split_to_kernel {B A : AbGroup} (E : hExt B A)
-      {s : GroupHomomorphism B E} (h : hext_p $o s == idmap)
-  : GroupHomomorphism E (@ab_kernel E B hext_p).
+(** If [exts_p : E -> B] splits, we get an induced map [fun e => e - s (exts_p e)] from [E] to [ab_kernel exts_p]. *)
+Definition exts_p_split_to_kernel {B A : AbGroup} (E : Exts B A)
+      {s : GroupHomomorphism B E} (h : exts_p $o s == idmap)
+  : GroupHomomorphism E (@ab_kernel E B exts_p).
 Proof.
   snrapply (grp_kernel_corec (G:=E) (A:=E)).
-  - (** We construct the map [fun e => e - s(hext_p e)] by going via [E + E]. *)
+  - (** We construct the map [fun e => e - s(exts_p e)] by going via [E + E]. *)
     rapply grp_homo_compose.
-    (** [fun e => (e,-e)] *)
+    (** [fun (e0,e1) => e0-e1] *)
     1: exact (ab_biprod_rec grp_homo_id ab_homo_negation).
-    (** [fun (e,f) => e + s(hext_p s)] **)
-    refine (ab_biprod_corec grp_homo_id (s $o hext_p)).
+    (** [fun e => (e, s (exts_p e))] **)
+    refine (ab_biprod_corec grp_homo_id (s $o exts_p)).
   - intro x; simpl.
-    refine (grp_homo_op hext_p x _ @ _).
-    refine (ap (fun y => hext_p x + y) _ @ right_inverse (hext_p x)).
+    refine (grp_homo_op exts_p x _ @ _).
+    refine (ap (fun y => exts_p x + y) _ @ right_inverse (exts_p x)).
     refine (grp_homo_inv _ _ @ ap (-) _ ).
     apply h.
 Defined.
 
-(** The composite [A -> E -> (ab_kernel hext_p) + B] is [grp_cxfib]. *)
-Lemma hext_p_split_to_kernel_beta {B A : AbGroup} (E : hExt B A)
-      {s : GroupHomomorphism B E} (h : hext_p $o s == idmap)
-  : hext_p_split_to_kernel E h $o hext_i == grp_cxfib cx_isexact.
+(** The composite [A -> E -> ab_kernel exts_p] is [grp_cxfib]. *)
+Lemma exts_p_split_to_kernel_beta {B A : AbGroup} (E : Exts B A)
+      {s : GroupHomomorphism B E} (h : exts_p $o s == idmap)
+  : exts_p_split_to_kernel E h $o exts_i == grp_cxfib cx_isexact.
 Proof.
   intro a.
   apply path_sigma_hprop; cbn.
-  refine (ap _ _ @ right_identity (hext_i a)).
+  apply grp_cancelL1.
   refine (ap (fun x => - s x) _ @ _).
   1: rapply cx_isexact.
   exact (ap _ (grp_homo_unit _) @ negate_mon_unit).
 Defined.
 
-(** The induced map [E -> ab_kernel hext_p + B] is an isomorphism. We suffix it with 1 since it is the first composite in the desired isomorphism [E -> A + B]. *)
-Definition hext_p_split_iso1 {B A : AbGroup} (E : hExt B A)
-      {s : GroupHomomorphism B E} (h : hext_p $o s == idmap)
-  : GroupIsomorphism E (ab_biprod (@ab_kernel E B hext_p) B).
+(** The induced map [E -> ab_kernel exts_p + B] is an isomorphism. We suffix it with 1 since it is the first composite in the desired isomorphism [E -> A + B]. *)
+Definition exts_p_split_iso1 {B A : AbGroup} (E : Exts B A)
+      {s : GroupHomomorphism B E} (h : exts_p $o s == idmap)
+  : GroupIsomorphism E (ab_biprod (@ab_kernel E B exts_p) B).
 Proof.
   srapply Build_GroupIsomorphism.
-  - refine (ab_biprod_corec _ hext_p).
-    exact (hext_p_split_to_kernel E h).
+  - refine (ab_biprod_corec _ exts_p).
+    exact (exts_p_split_to_kernel E h).
   - srapply isequiv_adjointify.
     + refine (ab_biprod_rec _ s).
       rapply subgroup_incl.
@@ -145,29 +144,29 @@ Proof.
         apply grp_cancelL1.
         refine (ap _ _ @ right_inverse _).
         apply (ap (-)).
-        refine (grp_homo_op (s $o hext_p) _ _ @ _).
+        refine (grp_homo_op (s $o exts_p) _ _ @ _).
         refine (ap (fun x => x + _) (ap s a.2 @ grp_homo_unit s) @ _).
         exact (left_identity _ @ ap s (h b)).
-      * refine (grp_homo_op hext_p a.1 (s b) @ _).
+      * refine (grp_homo_op exts_p a.1 (s b) @ _).
         exact (ap (fun y => y + _) a.2 @ left_identity _ @ h b).
     + intro e; simpl.
       by apply grp_moveR_gM.
 Defined.
 
-(** The full isomorphism [E -> A + B]. *)
-Definition hext_p_split_iso {B A : AbGroup} (E : hExt B A)
-      {s : GroupHomomorphism B E} (h : hext_p $o s == idmap)
+(** The full isomorphism [E -> A+B]. *)
+Definition exts_p_split_iso {B A : AbGroup} (E : Exts B A)
+      {s : GroupHomomorphism B E} (h : exts_p $o s == idmap)
   : GroupIsomorphism E (ab_biprod A B).
 Proof.
   etransitivity (ab_biprod (ab_kernel _) B).
-  - exact (hext_p_split_iso1 E h).
+  - exact (exts_p_split_iso1 E h).
   - srapply (equiv_functor_ab_biprod (grp_iso_inverse _) grp_iso_id).
     rapply grp_iso_cxfib.
 Defined.
 
-Proposition hext_p_split_beta `{Funext} {B A : AbGroup} (E : hExt B A)
-      {s : GroupHomomorphism B E} (h : hext_p $o s == idmap)
-  : hext_p_split_iso E h $o hext_i == ab_biprod_inl.
+Proposition exts_p_split_beta `{Funext} {B A : AbGroup} (E : Exts B A)
+      {s : GroupHomomorphism B E} (h : exts_p $o s == idmap)
+  : exts_p_split_iso E h $o exts_i == ab_biprod_inl.
 Proof.
   intro a.
   refine (ap _ (ab_corec_beta _ _ _ _) @ _).
@@ -176,28 +175,28 @@ Proof.
   1: exact grp_homo_id.
   - refine (ap (fun g => _ $o g) _ @ _);
       apply equiv_path_grouphomomorphism; intro.
-    1: apply hext_p_split_to_kernel_beta.
+    1: apply exts_p_split_to_kernel_beta.
     apply eissect.
   - refine (path_prod' idpath _); cbn.
     rapply cx_isexact.
 Defined.
 
-(** An extension [E] in [hExt B A] is trivial if and only if it splits. *)
-Proposition iff_hext_trivial_split `{Univalence} {B A : AbGroup} (E : hExt B A)
-  : (E = point _ :> hExt B A)
-      <-> {s : GroupHomomorphism B E & hext_p $o s == idmap}.
+(** An extension [E] in [Exts B A] is trivial if and only if it splits. *)
+Proposition iff_exts_trivial_split `{Univalence} {B A : AbGroup} (E : Exts B A)
+  : (E = point (Exts B A))
+      <-> {s : GroupHomomorphism B E & exts_p $o s == idmap}.
 Proof.
-  refine (iff_compose (iff_equiv (equiv_path_hext _ _)) _); split.
+  refine (iff_compose (iff_equiv (equiv_path_exts _ _)) _); split.
   - intros [phi [g h]].
     exists (grp_homo_compose (grp_iso_inverse phi) ab_biprod_inr).
     intro x.
     exact (equiv_path_grouphomomorphism^-1 h (ab_biprod_inr x)).
   - intros [s h].
-    exists (hext_p_split_iso E h).
+    exists (exts_p_split_iso E h).
     split; apply equiv_path_grouphomomorphism.
-    + apply hext_p_split_beta.
+    + apply exts_p_split_beta.
     + intros [a b]; simpl.
-      refine (grp_homo_op hext_p  _ _ @ _).
+      refine (grp_homo_op exts_p  _ _ @ _).
       refine (ap011 (+) _ (h _) @ _).
       1: rapply cx_isexact.
       apply left_identity.
@@ -206,17 +205,17 @@ Defined.
 
 (** * The set [Ext B A] of abelian group extensions *)
 
-Definition Ext (B A : AbGroup) := Tr 0 (hExt B A).
+Definition Ext (B A : AbGroup) := Tr 0 (Exts B A).
 
 Global Instance ispointed_ext {B A : AbGroup} : IsPointed (Ext B A) := tr (point _).
       
-(** An extension [E : hext B A] is trivial in [Ext B A] if and only if [E] merely splits. *)
-Proposition iff_ab_ext_trivial_split `{Univalence} {B A : AbGroup} (E : hExt B A)
+(** An extension [E : Exts B A] is trivial in [Ext B A] if and only if [E] merely splits. *)
+Proposition iff_ab_ext_trivial_split `{Univalence} {B A : AbGroup} (E : Exts B A)
   : (tr E = point (Ext B A))
-      <~> merely { s : GroupHomomorphism B E & hext_p $o s == idmap }.
+      <~> merely { s : GroupHomomorphism B E & exts_p $o s == idmap }.
 Proof.
   refine (_ oE (equiv_path_Tr _ _)^-1).
   srapply equiv_iff_hprop;
     apply Trunc_functor;
-    apply iff_hext_trivial_split.
+    apply iff_exts_trivial_split.
 Defined.

--- a/theories/Algebra/AbGroups/AbExt.v
+++ b/theories/Algebra/AbGroups/AbExt.v
@@ -28,27 +28,25 @@ Arguments hext_i {B A E} : rename.
 Arguments hext_p {B A E} : rename.
 
 Arguments Build_hExt {B A} _ _ _ _ _ _.
-  
-Definition issig_hext {B A : AbGroup} : _ <~> hExt B A := ltac:(issig).
+
+(** TODO Figure out why printing this term eats memory and seems to never finish. *)
+Local Definition issig_hext_do_not_print {B A : AbGroup} : _ <~> hExt B A := ltac:(issig).
+
+(** [make_equiv] is slow if used in the context of the next result, so we give the abstract form of the goal here. *)
+Local Definition issig_hext_helper {AG : Type} {P : AG -> Type} {Q : AG -> Type}
+           {R : forall E, P E -> Type} {S : forall E, Q E -> Type} {T : forall E, P E -> Q E -> Type}
+  : {X : {E : AG & P E * Q E} & R _ (fst X.2) * S _ (snd X.2) * T _ (fst X.2) (snd X.2)}
+  <~> {E : AG & {H0 : P E & {H1 : Q E & {_ : R _ H0 & {_ : S _ H1 & T _ H0 H1}}}}}
+  := ltac:(make_equiv).
 
 (** A more useful organization of [hExt] as a sigma-type. *)
-Definition issig_hext' {B A : AbGroup}
+Definition issig_hext {B A : AbGroup}
   : {X : {E : AbGroup & (A $-> E) * (E $-> B)} &
           (IsEmbedding (fst X.2)
            * IsSurjection (snd X.2)
            * IsExact (Tr (-1)) (fst X.2) (snd X.2))}
-      <~> hExt B A.
-Proof. (** [make_equiv] is slow to solve this, so we prove it by hand. *)
-  refine (issig_hext oE _).
-  equiv_via {X : {E : AbGroup & (A $-> E) * (E $-> B)} &
-                  {_ : IsEmbedding (fst X.2) &
-                       {_ : IsConnMap (Tr (-1)) (snd X.2) & IsExact (Tr (-1)) (fst X.2) (snd X.2)}}}.
-  - apply equiv_functor_sigma_id; intro X.
-    exact (equiv_sigma_prod1 _ _ _)^-1%equiv.
-  - refine (_ oE (equiv_sigma_assoc _ _)^-1%equiv).
-    apply equiv_functor_sigma_id; intro E.
-    exact (equiv_sigma_prod _)^-1%equiv.
-Defined.
+      <~> hExt B A
+  := issig_hext_do_not_print oE issig_hext_helper.
 
 (** [hExt B A] is pointed by the split sequence [A -> A+B -> B]. *)
 Global Instance ispointed_hext {B A : AbGroup} : IsPointed (hExt B A).
@@ -56,16 +54,17 @@ Proof.
   rapply (Build_hExt (ab_biprod A B) ab_biprod_inl ab_biprod_pr2).
   snrapply Build_IsExact.
   - srapply Build_pHomotopy.
-    + intro x; cbn.
-      apply ab_unit_l.
+    + reflexivity.
     + apply path_ishprop.
   - intros [[a b] p]; cbn; cbn in p.
     rapply contr_inhabited_hprop.
     apply tr.
     exists a.
-    srapply path_sigma_hprop; cbn.
-    apply (path_prod' idpath).
-    exact (p^ @ left_identity _).
+    rapply path_sigma_hprop; cbn.
+    + intro x.
+      apply istrunc_paths.
+      exact _.
+    + exact (path_prod' idpath p^).
 Defined.
 
 (** Paths in [hExt] corespond to isomorphisms between the [hext_E]s respecting [hext_i] and [hext_i]. *)
@@ -75,7 +74,7 @@ Proposition equiv_path_hext `{Univalence} {B A : AbGroup} (E F : hExt B A)
                  (phi $o hext_i = hext_i)
                  * (hext_p $o grp_iso_inverse phi = hext_p)}.
 Proof.
-  refine (_ oE equiv_ap issig_hext'^-1 _ _).
+  refine (_ oE equiv_ap issig_hext^-1 _ _).
   refine (_ oE (equiv_path_sigma_hprop _ _)^-1).
   refine (_ oE (equiv_path_sigma _ _ _)^-1).
   srapply equiv_functor_sigma'.
@@ -142,17 +141,17 @@ Proof.
     + intros [a b]; simpl.
       apply path_prod'.
       * srapply path_sigma_hprop; cbn.
-        refine ((ab_assoc _ _ _)^ @ _).
-        apply ab_cancelL1.
-        refine (ap _ _ @ ab_inv_r _).
+        refine ((associativity _ _ _)^ @ _).
+        apply grp_cancelL1.
+        refine (ap _ _ @ right_inverse _).
         apply (ap (-)).
         refine (grp_homo_op (s $o hext_p) _ _ @ _).
         refine (ap (fun x => x + _) (ap s a.2 @ grp_homo_unit s) @ _).
-        exact (ab_unit_l _ @ ap s (h b)).
+        exact (left_identity _ @ ap s (h b)).
       * refine (grp_homo_op hext_p a.1 (s b) @ _).
         exact (ap (fun y => y + _) a.2 @ left_identity _ @ h b).
     + intro e; simpl.
-      by apply ab_moveR_gM.
+      by apply grp_moveR_gM.
 Defined.
 
 (** The full isomorphism [E -> A + B]. *)
@@ -192,18 +191,16 @@ Proof.
   - intros [phi [g h]].
     exists (grp_homo_compose (grp_iso_inverse phi) ab_biprod_inr).
     intro x.
-    refine (equiv_path_grouphomomorphism^-1 h (ab_biprod_inr x) @ _); cbn.
-    apply left_identity.
+    exact (equiv_path_grouphomomorphism^-1 h (ab_biprod_inr x)).
   - intros [s h].
     exists (hext_p_split_iso E h).
     split; apply equiv_path_grouphomomorphism.
     + apply hext_p_split_beta.
     + intros [a b]; simpl.
-      rewrite (left_identity b), (right_identity a).
       refine (grp_homo_op hext_p  _ _ @ _).
       refine (ap011 (+) _ (h _) @ _).
       1: rapply cx_isexact.
-      apply ab_unit_l.
+      apply left_identity.
 Defined.
 
 

--- a/theories/Algebra/AbGroups/AbExt.v
+++ b/theories/Algebra/AbGroups/AbExt.v
@@ -97,12 +97,7 @@ Definition exts_p_split_to_kernel {B A : AbGroup} (E : Exts B A)
   : GroupHomomorphism E (@ab_kernel E B exts_p).
 Proof.
   snrapply (grp_kernel_corec (G:=E) (A:=E)).
-  - (** We construct the map [fun e => e - s(exts_p e)] by going via [E + E]. *)
-    rapply grp_homo_compose.
-    (** [fun (e0,e1) => e0-e1] *)
-    1: exact (ab_biprod_rec grp_homo_id ab_homo_negation).
-    (** [fun e => (e, s (exts_p e))] **)
-    refine (ab_biprod_corec grp_homo_id (s $o exts_p)).
+  - exact (ab_homo_add grp_homo_id (ab_homo_negation $o s $o exts_p)).
   - intro x; simpl.
     refine (grp_homo_op exts_p x _ @ _).
     refine (ap (fun y => exts_p x + y) _ @ right_inverse (exts_p x)).
@@ -141,9 +136,9 @@ Proof.
         apply grp_cancelL1.
         refine (ap _ _ @ right_inverse _).
         apply (ap (-)).
-        refine (grp_homo_op (s $o exts_p) _ _ @ _).
-        refine (ap (fun x => x + _) (ap s a.2 @ grp_homo_unit s) @ _).
-        exact (left_identity _ @ ap s (h b)).
+        apply (ap s).
+        refine (grp_homo_op exts_p a.1 (s b) @ _).
+        exact (ap (fun y => y + _) a.2 @ left_identity _ @ h b).
       * refine (grp_homo_op exts_p a.1 (s b) @ _).
         exact (ap (fun y => y + _) a.2 @ left_identity _ @ h b).
     + intro e; simpl.
@@ -161,21 +156,17 @@ Proof.
     rapply grp_iso_cxfib.
 Defined.
 
-Proposition exts_p_split_beta `{Funext} {B A : AbGroup} (E : Exts B A)
+Proposition exts_p_split_beta {B A : AbGroup} (E : Exts B A)
       {s : GroupHomomorphism B E} (h : exts_p $o s == idmap)
   : exts_p_split_iso E h $o exts_i == ab_biprod_inl.
 Proof.
   intro a.
   refine (ap _ (ab_corec_beta _ _ _ _) @ _).
   refine (ab_biprod_functor_beta _ _ _ _ _ @ _).
-  srefine (ap (fun p => ab_biprod_corec p _ a) _ @ _).
-  1: exact grp_homo_id.
-  - refine (ap (fun g => _ $o g) _ @ _);
-      apply equiv_path_grouphomomorphism; intro.
-    1: apply exts_p_split_to_kernel_beta.
-    apply eissect.
-  - refine (path_prod' idpath _); cbn.
-    rapply cx_isexact.
+  nrapply path_prod'.
+  2: rapply cx_isexact.
+  refine (ap _ (exts_p_split_to_kernel_beta E h a) @ _).
+  apply eissect.
 Defined.
 
 (** An extension [E] in [Exts B A] is trivial if and only if it splits. *)

--- a/theories/Algebra/AbGroups/AbelianGroup.v
+++ b/theories/Algebra/AbGroups/AbelianGroup.v
@@ -335,6 +335,16 @@ Proof.
     1-2: exact negate_involutive.
 Defined.
 
+(** Addition [+] is a group homomorphism [A+A -> A]. *)
 Definition ab_add_homo {A : AbGroup}
   : ab_biprod A A $-> A
   := ab_biprod_rec grp_homo_id grp_homo_id.
+
+(** We can add group homomorphisms. *)
+Definition ab_homo_add {A : Group} {B : AbGroup} (f g : A $-> B)
+  : A $-> B.
+Proof.
+  refine (grp_homo_compose ab_add_homo _).
+  (** [fun a => f(a) + g(a)] **)
+  exact (grp_prod_corec f g).
+Defined.

--- a/theories/Algebra/AbGroups/AbelianGroup.v
+++ b/theories/Algebra/AbGroups/AbelianGroup.v
@@ -5,8 +5,6 @@ Require Export Algebra.Groups.
 Require Import Cubical.
 Require Import WildCat.
 
-Set Printing Universes.
-
 Local Open Scope mc_add_scope.
 
 (** * Abelian groups *)

--- a/theories/Algebra/AbGroups/AbelianGroup.v
+++ b/theories/Algebra/AbGroups/AbelianGroup.v
@@ -5,6 +5,8 @@ Require Export Algebra.Groups.
 Require Import Cubical.
 Require Import WildCat.
 
+Set Printing Universes.
+
 Local Open Scope mc_add_scope.
 
 (** * Abelian groups *)
@@ -24,6 +26,23 @@ Global Instance isabgroup_abgroup {A : AbGroup} : IsAbGroup A.
 Proof.
   split; exact _.
 Defined.
+
+Definition issig_abgroup : _ <~> AbGroup := ltac:(issig).
+
+(** ** Paths between abelian groups *)
+
+Definition equiv_path_abgroup `{Univalence} {A B : AbGroup@{u}}
+  : GroupIsomorphism A B <~> (A = B).
+Proof.
+  refine (equiv_ap_inv issig_abgroup _ _ oE _).
+  About equiv_path_sigma_hprop.
+  refine (equiv_path_sigma_hprop _ _ oE _).
+  exact equiv_path_group@{v w u u u u u u u u u}.
+Defined.
+
+Definition equiv_path_abgroup_group `{Univalence} {A B : AbGroup}
+  : (A = B :> AbGroup) <~> (A = B :> Group)
+  := equiv_path_group@{v w u u u u u u u u u} oE equiv_path_abgroup^-1.
 
 (** ** Subgroups of abelian groups *)
 
@@ -151,6 +170,7 @@ Proof.
   apply path_prod; simpl; apply commutativity.
 Defined.
 
+(** These are known to be embeddings, since their versions for [grp_prod] are. *)
 Definition ab_biprod_inl {A B : AbGroup} : A $-> ab_biprod A B := grp_prod_inl.
 Definition ab_biprod_inr {A B : AbGroup} : B $-> ab_biprod A B := grp_prod_inr.
 
@@ -176,6 +196,26 @@ Definition ab_biprod_pr1 {A B : AbGroup} : ab_biprod A B $-> A
 
 Definition ab_biprod_pr2 {A B : AbGroup} : ab_biprod A B $-> B
   := ab_biprod_rec grp_homo_const grp_homo_id.
+
+Global Instance issurjection_ab_biprod_pr1 {A B : AbGroup}
+  : IsSurjection (@ab_biprod_pr1 A B).
+Proof.
+  intro a.
+  rapply contr_inhabited_hprop.
+  apply tr.
+  exists (a, mon_unit); cbn.
+  apply right_identity.
+Defined.
+
+Global Instance issurjection_ab_biprod_pr2 {A B : AbGroup}
+  : IsSurjection (@ab_biprod_pr2 A B).
+Proof.
+  intro b.
+  rapply contr_inhabited_hprop.
+  apply tr.
+  exists (mon_unit, b); cbn.
+  apply left_identity.
+Defined.
 
 Corollary ab_biprod_rec_uncurried {A B Y : AbGroup}
   : (A $-> Y) * (B $-> Y)
@@ -243,6 +283,78 @@ Definition ab_biprod_corec {A B X : AbGroup}
            (f : X $-> A) (g : X $-> B)
   : X $-> ab_biprod A B := grp_prod_corec f g.
 
+Definition ab_corec_beta {X Y A B : AbGroup} (f : X $-> Y) (g0 : Y $-> A) (g1 : Y $-> B)
+  : ab_biprod_corec g0 g1 $o f == ab_biprod_corec (g0 $o f) (g1 $o f)
+  := fun x => idpath.
+
+(** *** Functoriality of [ab_biprod] *)
+
+Definition functor_ab_biprod {A A' B B' : AbGroup} (f : A $-> A') (g: B $-> B')
+  : ab_biprod A B $-> ab_biprod A' B'
+  := (ab_biprod_corec (f $o ab_biprod_pr1) (g $o ab_biprod_pr2)).
+
+Definition ab_biprod_functor_beta {Z X Y A B : AbGroup} (f0 : Z $-> X) (f1 : Z $-> Y)
+           (g0 : X $-> A) (g1 : Y $-> B)
+  : functor_ab_biprod g0 g1 $o ab_biprod_corec f0 f1
+    == ab_biprod_corec (g0 $o f0) (g1 $o f1).
+Proof.
+  intro x; cbn.
+  apply path_prod'.
+  - exact (ap _ (right_identity _)).
+  - exact (ap _ (left_identity _)).
+Defined.
+
+Definition isequiv_functor_ab_biprod {A A' B B' : AbGroup}
+           (f : A $-> A') (g : B $-> B') `{IsEquiv _ _ f} `{IsEquiv _ _ g}
+  : IsEquiv (functor_ab_biprod f g).
+Proof.
+  srapply isequiv_adjointify.
+  1: { rapply functor_ab_biprod;
+       apply grp_iso_inverse.
+       + exact (Build_GroupIsomorphism _ _ f _).
+       + exact (Build_GroupIsomorphism _ _ g _). }
+  all: intros [a b]; simpl.
+  all: apply path_prod'.
+  1,3: refine (ap _ (right_identity _) @ _).
+  3,4: refine (ap _ (left_identity _) @ _).
+  1,3: refine (eisretr _ _ @ _).
+  3,4: refine (eissect _ _ @ _).
+  1,3: apply right_identity.
+  all: apply left_identity.
+Defined.
+
+Definition equiv_functor_ab_biprod {A A' B B' : AbGroup}
+           (f : A $-> A') (g : B $-> B') `{IsEquiv _ _ f} `{IsEquiv _ _ g}
+  : GroupIsomorphism (ab_biprod A B) (ab_biprod A' B')
+  := Build_GroupIsomorphism _ _ _ (isequiv_functor_ab_biprod f g).
+
+(** ** Kernels of abelian groups *)
+
+Definition ab_kernel {A B : AbGroup} (f : A $-> B) : AbGroup
+  := Build_AbGroup (grp_kernel f) _.
+
+(** ** Transporting in families related to abelian groups *)
+
+Lemma transport_abgrouphomomorphism_from_const `{Univalence} {A B B' : AbGroup}
+      (p : B = B') (f : GroupHomomorphism A B)
+  : transport (Hom A) p f
+    = grp_homo_compose (equiv_path_abgroup^-1 p) f.
+Proof.
+  induction p.
+  by apply equiv_path_grouphomomorphism.
+Defined.
+
+Lemma transport_abgrouphomomorphism_to_const `{Univalence} {A A' B : AbGroup}
+      (p : A = A') (f : GroupHomomorphism A B)
+  : transport (fun G => Hom G B) p f
+    = grp_homo_compose f (grp_iso_inverse (equiv_path_abgroup^-1 p)).
+Proof.
+  induction p; cbn.
+  by apply equiv_path_grouphomomorphism.
+Defined.
+
+(** ** Operations on abelian groups *)
+
 (** The negation automorphism of an abelian group *)
 Definition ab_homo_negation {A : AbGroup} : GroupIsomorphism A A.
 Proof.
@@ -256,3 +368,7 @@ Proof.
     1: exact (fun a => -a).
     1-2: exact negate_involutive.
 Defined.
+
+Definition ab_add_homo {A : AbGroup}
+  : ab_biprod A A $-> A
+  := ab_biprod_rec grp_homo_id grp_homo_id.

--- a/theories/Algebra/AbGroups/AbelianGroup.v
+++ b/theories/Algebra/AbGroups/AbelianGroup.v
@@ -170,7 +170,7 @@ Proof.
   apply path_prod; simpl; apply commutativity.
 Defined.
 
-(** These are known to be embeddings, since their versions for [grp_prod] are. *)
+(** These inherit [IsEmbedding] instances from their [grp_prod] versions. *)
 Definition ab_biprod_inl {A B : AbGroup} : A $-> ab_biprod A B := grp_prod_inl.
 Definition ab_biprod_inr {A B : AbGroup} : B $-> ab_biprod A B := grp_prod_inr.
 
@@ -191,31 +191,9 @@ Proof.
     exact (associativity _ (f a') _)^.
 Defined.
 
-Definition ab_biprod_pr1 {A B : AbGroup} : ab_biprod A B $-> A
-  := ab_biprod_rec grp_homo_id grp_homo_const.
-
-Definition ab_biprod_pr2 {A B : AbGroup} : ab_biprod A B $-> B
-  := ab_biprod_rec grp_homo_const grp_homo_id.
-
-Global Instance issurjection_ab_biprod_pr1 {A B : AbGroup}
-  : IsSurjection (@ab_biprod_pr1 A B).
-Proof.
-  intro a.
-  rapply contr_inhabited_hprop.
-  apply tr.
-  exists (a, mon_unit); cbn.
-  apply right_identity.
-Defined.
-
-Global Instance issurjection_ab_biprod_pr2 {A B : AbGroup}
-  : IsSurjection (@ab_biprod_pr2 A B).
-Proof.
-  intro b.
-  rapply contr_inhabited_hprop.
-  apply tr.
-  exists (mon_unit, b); cbn.
-  apply left_identity.
-Defined.
+(** These inherit [IsSurjection] instances from their [grp_prod] versions. *)
+Definition ab_biprod_pr1 {A B : AbGroup} : ab_biprod A B $-> A := grp_prod_pr1.
+Definition ab_biprod_pr2 {A B : AbGroup} : ab_biprod A B $-> B := grp_prod_pr2.
 
 Corollary ab_biprod_rec_uncurried {A B Y : AbGroup}
   : (A $-> Y) * (B $-> Y)
@@ -229,8 +207,7 @@ Proposition ab_biprod_rec_beta' {A B Y : AbGroup}
   : ab_biprod_rec (u $o ab_biprod_inl) (u $o ab_biprod_inr) == u.
 Proof.
   intros [a b]; simpl.
-  refine ((grp_homo_op u _ _)^ @ _).
-  apply (ap u).
+  refine ((grp_homo_op u _ _)^ @ ap u _).
   apply path_prod.
   - exact (right_identity a).
   - exact (left_identity b).
@@ -284,8 +261,8 @@ Definition ab_biprod_corec {A B X : AbGroup}
   : X $-> ab_biprod A B := grp_prod_corec f g.
 
 Definition ab_corec_beta {X Y A B : AbGroup} (f : X $-> Y) (g0 : Y $-> A) (g1 : Y $-> B)
-  : ab_biprod_corec g0 g1 $o f == ab_biprod_corec (g0 $o f) (g1 $o f)
-  := fun x => idpath.
+  : ab_biprod_corec g0 g1 $o f $== ab_biprod_corec (g0 $o f) (g1 $o f)
+  := fun _ => idpath.
 
 (** *** Functoriality of [ab_biprod] *)
 
@@ -296,13 +273,8 @@ Definition functor_ab_biprod {A A' B B' : AbGroup} (f : A $-> A') (g: B $-> B')
 Definition ab_biprod_functor_beta {Z X Y A B : AbGroup} (f0 : Z $-> X) (f1 : Z $-> Y)
            (g0 : X $-> A) (g1 : Y $-> B)
   : functor_ab_biprod g0 g1 $o ab_biprod_corec f0 f1
-    == ab_biprod_corec (g0 $o f0) (g1 $o f1).
-Proof.
-  intro x; cbn.
-  apply path_prod'.
-  - exact (ap _ (right_identity _)).
-  - exact (ap _ (left_identity _)).
-Defined.
+                      $== ab_biprod_corec (g0 $o f0) (g1 $o f1)
+  := fun _ => idpath.
 
 Definition isequiv_functor_ab_biprod {A A' B B' : AbGroup}
            (f : A $-> A') (g : B $-> B') `{IsEquiv _ _ f} `{IsEquiv _ _ g}
@@ -315,12 +287,8 @@ Proof.
        + exact (Build_GroupIsomorphism _ _ g _). }
   all: intros [a b]; simpl.
   all: apply path_prod'.
-  1,3: refine (ap _ (right_identity _) @ _).
-  3,4: refine (ap _ (left_identity _) @ _).
-  1,3: refine (eisretr _ _ @ _).
-  3,4: refine (eissect _ _ @ _).
-  1,3: apply right_identity.
-  all: apply left_identity.
+  1,2: apply eisretr.
+  all: apply eissect.
 Defined.
 
 Definition equiv_functor_ab_biprod {A A' B B' : AbGroup}

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -635,6 +635,30 @@ Proof.
   exact (snd ((equiv_path_prod _ _)^-1 q)).
 Defined.
 
+Definition grp_prod_pr1 {G H : Group}
+  : GroupHomomorphism (grp_prod G H) G.
+Proof.
+  snrapply Build_GroupHomomorphism.
+  1: exact fst.
+  intros ? ?; reflexivity.
+Defined.
+
+Definition grp_prod_pr2 {G H : Group}
+  : GroupHomomorphism (grp_prod G H) H.
+Proof.
+  snrapply Build_GroupHomomorphism.
+  1: exact snd.
+  intros ? ?; reflexivity.
+Defined.
+
+Global Instance issurj_grp_prod_pr1 {G H : Group}
+  : IsSurjection (@grp_prod_pr1 G H)
+  := issurj_retr grp_prod_inl (fun _ => idpath).
+
+Global Instance issurj_grp_prod_pr2 {G H : Group}
+  : IsSurjection (@grp_prod_pr2 G H)
+  := issurj_retr grp_prod_inr (fun _ => idpath).
+
 (** *** Properties of maps to and from the trivial group *)
 
 Global Instance isinitial_grp_trivial : IsInitial grp_trivial.

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -1,5 +1,5 @@
 Require Import Basics Types.
-Require Import HProp HFiber.
+Require Import HProp HFiber HSet.
 Require Import PathAny.
 Require Export Classes.interfaces.abstract_algebra.
 Require Export Classes.theory.groups.
@@ -277,6 +277,9 @@ Proof.
   srapply (Build_GroupHomomorphism idmap).
 Defined.
 
+Definition grp_iso_id {G : Group} : GroupIsomorphism G G
+  := Build_GroupIsomorphism _ _ grp_homo_id _.
+
 Definition grp_homo_const {G H : Group} : GroupHomomorphism G H.
 Proof.
   snrapply Build_GroupHomomorphism.
@@ -448,6 +451,14 @@ Section GroupMovement.
   Definition grp_moveR_M1 : mon_unit = -x * y <~> x = y
     := (equiv_concat_l (grp_unit_r _) _)^-1%equiv oE grp_moveR_Mg.
 
+  (** *** Cancelling elements equal to unit. *)
+
+  Definition grp_cancelL1 : x = mon_unit <~> z * x = z
+    := (equiv_concat_r (grp_unit_r _) _ oE grp_cancelL z).
+
+  Definition grp_cancelR1 : x = mon_unit <~> x * z = z
+    := (equiv_concat_r (grp_unit_l _) _) oE grp_cancelR z.
+
 End GroupMovement.
 
 (** The wild cat of Groups *)
@@ -606,6 +617,22 @@ Proof.
   intros x y.
   apply path_prod.
   1,2: apply grp_homo_op.
+Defined.
+
+Global Instance isembedding_grp_prod_inl {H K : Group}
+  : IsEmbedding (@grp_prod_inl H K).
+Proof.
+  apply isembedding_isinj_hset.
+  intros h0 h1 p; cbn in p.
+  exact (fst ((equiv_path_prod _ _)^-1 p)).
+Defined.
+
+Global Instance isembedding_grp_prod_inr {H K : Group}
+  : IsEmbedding (@grp_prod_inr H K).
+Proof.
+  apply isembedding_isinj_hset.
+  intros k0 k1 q; cbn in q.
+  exact (snd ((equiv_path_prod _ _)^-1 q)).
 Defined.
 
 (** *** Properties of maps to and from the trivial group *)

--- a/theories/Algebra/Groups/ShortExactSequence.v
+++ b/theories/Algebra/Groups/ShortExactSequence.v
@@ -8,11 +8,32 @@ Local Open Scope path_scope.
 
 (** * Complexes of groups *)
 
-Proposition grp_homo_cxfib {A B C : Group} {i : A $-> B} {f : B $-> C} (cx : IsComplex i f)
-  : GroupHomomorphism A (grp_kernel f).
+Definition grp_cxfib {A B C : Group} {i : A $-> B} {f : B $-> C} (cx : IsComplex i f)
+  : GroupHomomorphism A (grp_kernel f)
+  := grp_kernel_corec cx.
+
+Definition grp_cxfib_homotopic {A B C : Group} {i : A $-> B} {f : B $-> C} (cx : IsComplex i f)
+  : cxfib cx == grp_cxfib cx := fun _ => idpath.
+
+Global Instance isequiv_grp_cxfib {A B C : Group} {i : A $-> B} {f : B $-> C}
+           `{IsEmbedding i} (ex : IsExact (Tr (-1)) i f)
+  : IsEquiv (grp_cxfib cx_isexact)
+  := isequiv_homotopic (cxfib cx_isexact) (grp_cxfib_homotopic _).
+
+Definition grp_iso_cxfib {A B C : Group} {i : A $-> B} {f : B $-> C}
+           `{IsEmbedding i} (ex : IsExact (Tr (-1)) i f)
+  : GroupIsomorphism A (grp_kernel f)
+  := Build_GroupIsomorphism _ _ (grp_cxfib cx_isexact) _.
+
+(** This is the same proof as for [equiv_cxfib_beta], but giving the proof is easier than specializing the general result. *)
+Proposition grp_iso_cxfib_beta {A B C : Group} {i : A $-> B} {f : B $-> C}
+            `{IsEmbedding i} (ex : IsExact (Tr (-1)) i f)
+  : i $o (grp_iso_inverse (grp_iso_cxfib ex)) == subgroup_incl (grp_kernel f).
 Proof.
-  destruct cx as [phi eq]; simpl in phi, eq.
-  exact (@grp_kernel_corec _ _ _ f i phi).
+  rapply equiv_ind.
+  1: exact (isequiv_cxfib ex).
+  intro x.
+  exact (ap (fun y => i y) (eissect _ x)).
 Defined.
 
 Definition grp_iscomplex_trivial {X Y : Group} (f : X $-> Y)

--- a/theories/Algebra/Groups/ShortExactSequence.v
+++ b/theories/Algebra/Groups/ShortExactSequence.v
@@ -12,23 +12,15 @@ Definition grp_cxfib {A B C : Group} {i : A $-> B} {f : B $-> C} (cx : IsComplex
   : GroupHomomorphism A (grp_kernel f)
   := grp_kernel_corec cx.
 
-Definition grp_cxfib_homotopic {A B C : Group} {i : A $-> B} {f : B $-> C} (cx : IsComplex i f)
-  : cxfib cx == grp_cxfib cx := fun _ => idpath.
-
-Global Instance isequiv_grp_cxfib {A B C : Group} {i : A $-> B} {f : B $-> C}
-           `{IsEmbedding i} (ex : IsExact (Tr (-1)) i f)
-  : IsEquiv (grp_cxfib cx_isexact)
-  := isequiv_homotopic (cxfib cx_isexact) (grp_cxfib_homotopic _).
-
 Definition grp_iso_cxfib {A B C : Group} {i : A $-> B} {f : B $-> C}
            `{IsEmbedding i} (ex : IsExact (Tr (-1)) i f)
   : GroupIsomorphism A (grp_kernel f)
-  := Build_GroupIsomorphism _ _ (grp_cxfib cx_isexact) _.
+  := Build_GroupIsomorphism _ _ (grp_cxfib cx_isexact) (isequiv_cxfib ex).
 
 (** This is the same proof as for [equiv_cxfib_beta], but giving the proof is easier than specializing the general result. *)
 Proposition grp_iso_cxfib_beta {A B C : Group} {i : A $-> B} {f : B $-> C}
             `{IsEmbedding i} (ex : IsExact (Tr (-1)) i f)
-  : i $o (grp_iso_inverse (grp_iso_cxfib ex)) == subgroup_incl (grp_kernel f).
+  : i $o (grp_iso_inverse (grp_iso_cxfib ex)) $== subgroup_incl (grp_kernel f).
 Proof.
   rapply equiv_ind.
   1: exact (isequiv_cxfib ex).

--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -65,6 +65,9 @@ Definition equiv_compose' {A B C : Type} (g : B <~> C) (f : A <~> B)
   : A <~> C
   := equiv_compose g f.
 
+Definition iff_equiv {A B : Type} (f : A <~> B)
+  : A <-> B := (equiv_fun f, f^-1).
+
 (** We put [g] and [f] in [equiv_scope] explcitly.  This is a partial work-around for https://coq.inria.fr/bugs/show_bug.cgi?id=3990, which is that implicitly bound scopes don't nest well. *)
 Notation "g 'oE' f" := (equiv_compose' g%equiv f%equiv) : equiv_scope.
 

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -762,6 +762,8 @@ Register tt as core.True.I.
 (** A space is pointed if that space has a point. *)
 Class IsPointed (A : Type) := point : A.
 
+Typeclasses Transparent IsPointed.
+
 Arguments point A {_}.
 
 Cumulative Record pType :=

--- a/theories/Classes/interfaces/canonical_names.v
+++ b/theories/Classes/interfaces/canonical_names.v
@@ -241,6 +241,15 @@ Class RightInverse {A} {B} {C} (op : A -> B -> C) (inv : A -> B) (unit : C)
 Class Commutative {B A} (f : A -> A -> B) : Type
   := commutativity: forall x y, f x y = f y x.
 
+Global Instance ishprop_commutative `{Funext} {G : Type}
+       `{IsTrunc 0 G} (m : SgOp G) : IsHProp (Commutative m).
+Proof.
+  apply hprop_allpath.
+  intros x y.
+  funext k l.
+  apply path_ishprop.
+Defined.
+
 Class HeteroAssociative {A B C AB BC ABC}
   (fA_BC: A -> BC -> ABC) (fBC: B -> C -> BC)
   (fAB_C: AB -> C -> ABC) (fAB : A -> B -> AB): Type

--- a/theories/Classes/interfaces/canonical_names.v
+++ b/theories/Classes/interfaces/canonical_names.v
@@ -241,14 +241,7 @@ Class RightInverse {A} {B} {C} (op : A -> B -> C) (inv : A -> B) (unit : C)
 Class Commutative {B A} (f : A -> A -> B) : Type
   := commutativity: forall x y, f x y = f y x.
 
-Global Instance ishprop_commutative `{Funext} {G : Type}
-       `{IsTrunc 0 G} (m : SgOp G) : IsHProp (Commutative m).
-Proof.
-  apply hprop_allpath.
-  intros x y.
-  funext k l.
-  apply path_ishprop.
-Defined.
+Global Hint Unfold Commutative : typeclass_instances.
 
 Class HeteroAssociative {A B C AB BC ABC}
   (fA_BC: A -> BC -> ABC) (fBC: B -> C -> BC)

--- a/theories/Homotopy/ExactSequence.v
+++ b/theories/Homotopy/ExactSequence.v
@@ -238,7 +238,7 @@ Definition equiv_cxfib {O : Modality} {F X Y : pType} {i : F ->* X} {f : X ->* Y
 
 Proposition equiv_cxfib_beta {F X Y : pType} {i : F ->* X} {f : X ->* Y}
             `{forall y y' : Y, In O (y = y')} `{MapIn O _ _ i} (ex : IsExact O i f)
-  : i o* pequiv_inverse (equiv_cxfib ex) == pr1. (** poitned pr1? *)
+  : i o pequiv_inverse (equiv_cxfib ex) == pfib _.
 Proof.
   rapply equiv_ind.
   1: exact (isequiv_cxfib ex).

--- a/theories/Homotopy/ExactSequence.v
+++ b/theories/Homotopy/ExactSequence.v
@@ -222,6 +222,30 @@ Proof.
   rewrite (concat_A1p (eisretr k)), concat_V_pp. reflexivity.
 Defined.
 
+(** If a complex [F -> E -> B] is [O]-exact, the map [F -> B] is [O]-local, and path types in [Y] are [O]-local, then the induced map [cxfib] is an equivalence. *)
+Global Instance isequiv_cxfib {O : Modality} {F X Y : pType} {i : F ->* X} {f : X ->* Y}
+       `{forall y y' : Y, In O (y = y')} `{MapIn O _ _ i} (ex : IsExact O i f)
+  : IsEquiv (cxfib cx_isexact).
+Proof.
+  rapply isequiv_conn_ino_map.
+  1: apply ex.
+  rapply (cancelL_mapinO _ _ pr1).
+Defined.
+
+Definition equiv_cxfib {O : Modality} {F X Y : pType} {i : F ->* X} {f : X ->* Y}
+           `{forall y y' : Y, In O (y = y')} `{MapIn O _ _ i} (ex : IsExact O i f)
+  : F <~>* pfiber f := Build_pEquiv _ _ _ (isequiv_cxfib ex).
+
+Proposition equiv_cxfib_beta {F X Y : pType} {i : F ->* X} {f : X ->* Y}
+            `{forall y y' : Y, In O (y = y')} `{MapIn O _ _ i} (ex : IsExact O i f)
+  : i o* pequiv_inverse (equiv_cxfib ex) == pr1. (** poitned pr1? *)
+Proof.
+  rapply equiv_ind.
+  1: exact (isequiv_cxfib ex).
+  intro x.
+  exact (ap (fun g => i g) (eissect _ x)).
+Defined.
+
 (** When [n] is the identity modality [purely], so that [cxfib] is an equivalence, we get simply a fiber sequence.  In particular, the fiber of a given map yields an purely-exact sequence. *)
 
 Definition iscomplex_pfib {X Y} (f : X ->* Y)
@@ -265,12 +289,7 @@ Defined.
 
 Definition pequiv_cxfib {F X Y : pType} {i : F ->* X} {f : X ->* Y}
            `{IsExact purely F X Y i f}
-  : F <~>* pfiber f.
-Proof.
-  refine (Build_pEquiv _ _ (cxfib cx_isexact) _).
-  apply isequiv_contr_map; intros u. 
-  rapply conn_map_isexact.
-Defined.
+  : F <~>* pfiber f := Build_pEquiv _ _ (cxfib cx_isexact) _.
 
 Definition fiberseq_isexact_purely {F X Y : pType} (i : F ->* X) (f : X ->* Y)
            `{IsExact purely F X Y i f}

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -288,3 +288,14 @@ Proof.
   destruct fs as [f_a0 [f_b0 f_a0b0]].
   refine (wedge_incl_elim _ _ _ _ _ f_a0b0).
 Defined.
+
+(** ** Connectivity of maps *)
+
+(** Retractions are surjective. *)
+Definition issurj_retr {X Y : Type} {r : X -> Y} (s : Y -> X) (h : forall y:Y, r (s y) = y)
+  : IsSurjection r.
+Proof.
+  intro y.
+  rapply contr_inhabited_hprop.
+  exact (tr (s y; h y)).
+Defined.

--- a/theories/Types/Sigma.v
+++ b/theories/Types/Sigma.v
@@ -516,6 +516,10 @@ Proof.
   make_equiv.
 Defined.
 
+Definition equiv_sigma_prod1 (A B C : Type)
+  : {a : A & {b : B & C}} <~> A * B * C
+  := ltac:(make_equiv).
+
 (** ** Symmetry *)
 
 Definition equiv_sigma_symm `(P : A -> B -> Type)


### PR DESCRIPTION
The first commit adds facts about functoriality of `ab_biprod` and lemmas for working with equations in abelian groups, basically ported from groups. While this may seem redundant, I did not easily find a way to specialize the results for groups without breaking things (specifically `CRing`), and this solution was discussed with @Alizter.

The main content is the thrid commit, which defines a type `hExt` of abelian group extensions, characterises paths in `hExt` and proves that the trivial extensions are the split ones. Some of these results (e.g. characterisation of paths) could be done for all group extensions and then specialised for a type of abelian group extensions, however in general I don't think there's much commonality so it makes sense to define these types separately. A more modular approach made inference troublesome when I tried.

This is part of joint work with my advisor, @jdchristensen.