### PR TITLE
Redefine AbGroup to be commutative groups.

### DIFF
--- a/theories/Algebra/AbGroups/AbPullback.v
+++ b/theories/Algebra/AbGroups/AbPullback.v
@@ -23,7 +23,7 @@ Section AbPullback.
     : IsAbGroup (grp_pullback f g) := {}.
 
   Definition ab_pullback
-    : AbGroup := Build_AbGroup (grp_pullback f g) _ _ _ _.
+    : AbGroup := Build_AbGroup (grp_pullback f g) _.
 
   (** The corecursion principle is inherited from Groups; use grp_pullback_corec and friends from Groups/GrpPullback.v. *)
 

--- a/theories/Algebra/AbGroups/AbelianGroup.v
+++ b/theories/Algebra/AbGroups/AbelianGroup.v
@@ -18,7 +18,7 @@ Record AbGroup := {
 
 Coercion abgroup_group : AbGroup >-> Group.
 
-Existing Instance abgroup_commutative.
+Global Existing Instance abgroup_commutative.
 
 Global Instance isabgroup_abgroup {A : AbGroup} : IsAbGroup A.
 Proof.

--- a/theories/Algebra/AbGroups/Abelianization.v
+++ b/theories/Algebra/AbGroups/Abelianization.v
@@ -277,7 +277,9 @@ Defined.
 Definition abel : Group -> AbGroup.
 Proof.
   intro G.
-  srapply (Build_AbGroup (Abel G)).
+  snrapply Build_AbGroup.
+  - srapply (Build_Group (Abel G)).
+  - exact _.
 Defined.
 
 (** The unit of this map is the map ab which typeclasses can pick up to be a homomorphism. We write it out explicitly here. *)

--- a/theories/Algebra/AbGroups/Z.v
+++ b/theories/Algebra/AbGroups/Z.v
@@ -8,25 +8,12 @@ Local Open Scope int_scope.
 
 Definition abgroup_Z : AbGroup.
 Proof.
-  srapply (Build_AbGroup Int); repeat split.
-  + (** Operation *)
-    exact int_add.
-  + (** Unit *)
-    exact 0.
-  + (** Negation *)
-    exact int_negation.
-  + (** IsHSet *)
-    exact _.
-  + (** Associativity *)
-    exact int_add_assoc.
-  + (** Left identity *)
-    exact int_add_0_l.
-  + (** Right identity *)
-    exact int_add_0_r.
-  + (** Left inverse *)
-    exact int_add_negation_l.
-  + (** Right inverse *)
-    exact int_add_negation_r.
-  + (** Commutativity *)
-    exact int_add_comm.
+  snrapply Build_AbGroup.
+  - refine (Build_Group Int int_add 0 int_negation _); repeat split.
+    + exact _.
+    + exact int_add_assoc.
+    + exact int_add_0_r.
+    + exact int_add_negation_l.
+    + exact int_add_negation_r.
+  - exact int_add_comm.
 Defined.

--- a/theories/Algebra/Rings/CRing.v
+++ b/theories/Algebra/Rings/CRing.v
@@ -161,8 +161,13 @@ Global Instance transitive_cringisomorphism : Transitive CRingIsomorphism
   := fun x y z f g => Build_CRingIsomorphism _ _ (rng_homo_compose g f) _.
 
 (** Underlying abelian groups of rings *)
-Definition abgroup_cring : CRing -> AbGroup
-  := fun A => Build_AbGroup A _ _ _ _.
+Definition abgroup_cring : CRing -> AbGroup.
+Proof.
+  intro A.
+  snrapply Build_AbGroup.
+  - srapply (Build_Group (cring_type A)).
+  - exact _.
+Defined.
 
 Coercion abgroup_cring : CRing >-> AbGroup.
 
@@ -189,11 +194,11 @@ Definition Build_CRingIsomorphism'' (A B : CRing) (e : GroupIsomorphism A B)
 
 (** Here is an alternative way to build a commutative ring using the underlying abelian group. *)
 Definition Build_CRing' (R : AbGroup)
-  `(Mult R, One R, LeftDistribute R mult (abgroup_sgop R))
+  `(Mult R, One R, LeftDistribute R mult (@group_sgop R))
   (iscomm : @IsCommutativeMonoid R mult one)
   : CRing
-  := Build_CRing R (abgroup_sgop R) _ (abgroup_unit R) _
-       (abgroup_inverse R) (Build_IsRing _ _ _ _).
+  := Build_CRing R (@group_sgop R) _ (@group_unit R) _
+       (@group_inverse R) (Build_IsRing _ _ _ _).
 
 (** ** Ring movement lemmas *)
 

--- a/theories/Algebra/Rings/QuotientRing.v
+++ b/theories/Algebra/Rings/QuotientRing.v
@@ -104,11 +104,11 @@ End QuotientRing.
 
 (** Here is an alternative way to build a commutative ring using the underlying abelian group. *)
 Definition Build_CRing' (R : AbGroup)
-  `(Mult R, One R, LeftDistribute R mult (abgroup_sgop R))
+  `(Mult R, One R, LeftDistribute R mult (@group_sgop R))
   (iscomm : @IsCommutativeMonoid R mult one)
   : CRing
-  := Build_CRing R (abgroup_sgop R) _ (abgroup_unit R) _
-       (abgroup_inverse R) (Build_IsRing _ _ _ _).
+  := Build_CRing R (@group_sgop R) _ (@group_unit R) _
+       (@group_inverse R) (Build_IsRing _ _ _ _).
 
 (** The image of a ring homomorphism *)
 Definition rng_image {R S : CRing} (f : R $-> S) : CRing.

--- a/theories/Algebra/Rings/Z.v
+++ b/theories/Algebra/Rings/Z.v
@@ -10,24 +10,12 @@ Require Import WildCat.
 (** The ring of integers *)
 Definition cring_Z : CRing.
 Proof.
-  snrapply (Build_CRing abgroup_Z).
-  6: split; [exact _ | repeat split | ].
-  + (** Multiplication *)
-    exact int_mul.
-  + (** Multiplicative unit *)
-    exact 1%int.
-  + (** IsHSet *)
-    exact _.
-  + (** Associativity of multiplication *)
-    exact int_mul_assoc.
-  + (** Left identity *)
-    exact int_mul_1_l.
-  + (** Right identity *)
-    exact int_mul_1_r.
-  + (** Commutativity of integer multiplication *)
-    exact int_mul_comm.
-  + (** Left distributivity *)
-    exact int_mul_add_distr_l.
+  snrapply (Build_CRing abgroup_Z int_add int_mul 0%int 1%int); only 2: repeat split; try exact _.
+  + exact int_mul_assoc.
+  + exact int_mul_1_l.
+  + exact int_mul_1_r.
+  + exact int_mul_comm.
+  + exact int_mul_add_distr_l.
 Defined.
 
 Local Open Scope mc_scope.


### PR DESCRIPTION
To prove things in #1534, we had to port lemmas from `Group` for working with equations in `AbGroup`. This can be resolved by coercing elements in `AbGroup` via the underlying `Group` instead of a direct coercion `AbGroup >-> Sortclass` (to the underlying type). However then it seems cleanest to simply define `AbGroup` as commutative groups, and we do this here.

(I definitely recommend split view for the diff!)