### PR TITLE
Reduce universe levels in hfiber_functor_sigma

### DIFF
--- a/theories/Algebra/AbGroups/AbelianGroup.v
+++ b/theories/Algebra/AbGroups/AbelianGroup.v
@@ -34,12 +34,12 @@ Proof.
   refine (equiv_ap_inv issig_abgroup _ _ oE _).
   About equiv_path_sigma_hprop.
   refine (equiv_path_sigma_hprop _ _ oE _).
-  exact equiv_path_group@{v w u u u u u u u u u}.
+  exact equiv_path_group@{v u u u u u u u u u}.
 Defined.
 
 Definition equiv_path_abgroup_group `{Univalence} {A B : AbGroup}
   : (A = B :> AbGroup) <~> (A = B :> Group)
-  := equiv_path_group@{v w u u u u u u u u u} oE equiv_path_abgroup^-1.
+  := equiv_path_group@{v u u u u u u u u u} oE equiv_path_abgroup^-1.
 
 (** ** Subgroups of abelian groups *)
 

--- a/theories/Idempotents.v
+++ b/theories/Idempotents.v
@@ -807,10 +807,10 @@ Section CoherentIdempotents.
 
   (** For instance, here is the standard coherent idempotent structure on the identity map. *)
   Global Instance isidem_idmap (X : Type@{i})
-  : @IsIdempotent@{i i j k} X idmap
+  : @IsIdempotent@{i i j} X idmap
     := Build_IsIdempotent idmap (splitting_idmap X).
 
-  Definition idem_idmap (X : Type@{i}) : Idempotent@{i i j k} X
+  Definition idem_idmap (X : Type@{i}) : Idempotent@{i i j} X
   := (idmap ; isidem_idmap X).
 
   (** Note that [Idempotent X], unlike [RetractOf X], lives in the same universe as [X], even if we demand that it contain the identity. *)

--- a/theories/Types/Sigma.v
+++ b/theories/Types/Sigma.v
@@ -728,8 +728,8 @@ Definition hfiber_functor_sigma {A B} (P : A -> Type) (Q : B -> Type)
 Proof.
   unfold hfiber, functor_sigma.
   refine (_ oE equiv_functor_sigma_id _).
-  2:intros; symmetry; apply equiv_path_sigma.
-  transitivity {w : {x : A & f x = b} & {x : P w.1 & (w.2) # (g w.1 x) = v}}.
+  2:intros; apply equiv_inverse; apply equiv_path_sigma.
+  equiv_via {w : {x : A & f x = b} & {x : P w.1 & (w.2) # (g w.1 x) = v}}.
   1:make_equiv.
   apply equiv_functor_sigma_id; intros [a p]; simpl.
   apply equiv_functor_sigma_id; intros u; simpl.


### PR DESCRIPTION
By avoiding `symmetry` and `transitivity`, we get rid of two larger universes in `hfiber_functor_sigma`.  Only a couple of other places are affected by this.  This is useful for WIP where I'm tracking universe usage.