### PR TITLE
Pull HasEquivFuns out of HasEquivs

### DIFF
--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -508,12 +508,17 @@ Proof.
   intros []; reflexivity. 
 Defined.
 
-Global Instance hasequivs_group : HasEquivs Group.
+Global Instance hasequivfuns_group : HasEquivFuns Group.
 Proof.
-  unshelve econstructor.
+  srapply Build_HasEquivFuns.
   + exact GroupIsomorphism.
   + exact (fun G H f => IsEquiv f).
   + intros G H f; exact f.
+Defined.
+
+Global Instance hasequivs_group : HasEquivs Group.
+Proof.
+  unshelve econstructor.
   + exact Build_GroupIsomorphism.
   + intros G H; exact grp_iso_inverse.
   + cbn; exact _.

--- a/theories/Algebra/Rings/CRing.v
+++ b/theories/Algebra/Rings/CRing.v
@@ -275,12 +275,17 @@ Proof.
   intros []; reflexivity. 
 Defined.
 
-Global Instance hasequivs_cring : HasEquivs CRing.
+Global Instance hasequivfuns_cring : HasEquivFuns CRing.
 Proof.
-  unshelve econstructor.
+  srapply Build_HasEquivFuns.
   + exact CRingIsomorphism.
   + exact (fun G H f => IsEquiv f).
   + intros G H f; exact f.
+Defined.
+
+Global Instance hasequivs_cring : HasEquivs CRing.
+Proof.
+  unshelve econstructor.
   + exact Build_CRingIsomorphism.
   + intros G H; exact rng_iso_inverse.
   + cbn; exact _.

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -630,12 +630,18 @@ Proof.
   intros []; reflexivity.
 Defined.
 
+Global Instance hasequivfuns_ptype : HasEquivFuns pType.
+Proof.
+  srapply Build_HasEquivFuns.
+  - exact pEquiv.
+  - intros A B. exact IsEquiv.
+  - intros a b f. apply f.
+Defined.
+
 (** pType has equivalences *)
 Global Instance hasequivs_ptype : HasEquivs pType.
 Proof.
-  srapply (Build_HasEquivs _ _ _ _ pEquiv (fun A B f => IsEquiv f));
-    intros A B f; cbn; intros.
-  - exact f.
+  srapply Build_HasEquivs; intros A B f; cbn; intros.
   - exact _.
   - exact (Build_pEquiv _ _ f _).
   - reflexivity.

--- a/theories/WildCat/FunctorCat.v
+++ b/theories/WildCat/FunctorCat.v
@@ -70,15 +70,23 @@ Defined.
 
 (** It also inherits a notion of equivalence, namely a natural transformation that is a pointwise equivalence.  Note that this is not a "fully coherent" notion of equivalence, since the functors and transformations are not themselves fully coherent. *)
 
+Global Instance hasequivfuns_fun01 (A B : Type) `{Is01Cat A} `{HasEquivs B}
+  : HasEquivFuns (Fun01 A B).
+Proof.
+  srapply Build_HasEquivFuns.
+  - intros [F ?] [G ?].
+    exact (NatEquiv F G).
+  - intros [F ?] [G ?] [alpha ?].
+    exact (forall a, CatIsEquiv (alpha a)).
+  - intros [F ?] [G ?] [alpha ?].
+    exists (fun a => alpha a); assumption.
+Defined.
+
 Global Instance hasequivs_fun01 (A B : Type) `{Is01Cat A} `{HasEquivs B}
   : HasEquivs (Fun01 A B).
 Proof.
   srapply Build_HasEquivs.
-  1:{ intros [F ?] [G ?]. exact (NatEquiv F G). }
-  1:{ intros [F ?] [G ?] [alpha ?]; cbn in *.
-      exact (forall a, CatIsEquiv (alpha a)). }
   all:intros [F ?] [G ?] [alpha alnat]; cbn in *.
-  - exists (fun a => alpha a); assumption.
   - intros a; exact _.
   - intros ?.
     snrapply Build_NatEquiv.

--- a/theories/WildCat/Induced.v
+++ b/theories/WildCat/Induced.v
@@ -72,14 +72,18 @@ Section Induced_category.
     constructor. intros. apply X.
   Defined.
 
+  Definition induced_hasequivfuns `{HasEquivFuns B} : HasEquivFuns A.
+  Proof.
+    srapply Build_HasEquivFuns.
+    + intros a b. exact (f a $<~> f b).
+    + intros a b h. apply (CatIsEquiv' (f a) (f b)). exact (fmap f h).
+    + intros a b. intros g. exact(cate_fun g).
+  Defined.
+
   Definition induced_hasequivs `{HasEquivs B} : HasEquivs A.
   Proof.
     srapply Build_HasEquivs.
-    + intros a b. exact (f a $<~> f b).
-    + intros a b h. apply (CatIsEquiv' (f a) (f b)).
-      exact (fmap f h).
-    + intros a b; cbn in *. 
-      intros g. exact( cate_fun g).
+    + apply induced_hasequivfuns.
     + intros a b h; cbn in *. 
       exact (cate_isequiv' _ _ h ).
     + intros a b h; cbn in *. 

--- a/theories/WildCat/Opposite.v
+++ b/theories/WildCat/Opposite.v
@@ -170,13 +170,20 @@ Proof.
   srapply isnat_tr.
 Defined.
 
-(** Opposite categories preserve having equivalences. *)
-Global Instance hasequivs_op {A} `{HasEquivs A} : HasEquivs A^op.
+
+Global Instance hasequivfuns_op {A} `{HasEquivFuns A} : HasEquivFuns A^op.
 Proof.
-  srapply Build_HasEquivs; intros a b; unfold op in *; cbn.
+  srapply (Build_HasEquivFuns A); intros a b; cbn.
   - exact (b $<~> a).
   - apply CatIsEquiv.
   - apply cate_fun'.
+Defined.
+
+(** Opposite categories preserve having equivalences. *)
+Global Instance hasequivs_op {A} `{HasEquivs A} : HasEquivs A^op.
+Proof.
+  srapply Build_HasEquivs.
+  all: intros a b; unfold op in *; cbn.
   - apply cate_isequiv'.
   - apply cate_buildequiv'.
   - apply cate_buildequiv_fun'.

--- a/theories/WildCat/Prod.v
+++ b/theories/WildCat/Prod.v
@@ -72,15 +72,20 @@ Defined.
 
 (** Product categories inherit equivalences *)
 
+Global Instance hasequivfuns_prod A B `{HasEquivFuns A} `{HasEquivFuns B}
+  : HasEquivFuns (A * B).
+Proof.
+  srapply Build_HasEquivFuns.
+  - intros a b. exact ((fst a $<~> fst b) * (snd a $<~> snd b)).
+  - intros a b f; exact (CatIsEquiv (fst f) * CatIsEquiv (snd f)).
+  - intros a b f. split; [ exact (fst f) | exact (snd f) ].
+Defined.
+
 Global Instance hasequivs_prod A B `{HasEquivs A} `{HasEquivs B}
   : HasEquivs (A * B).
 Proof.
-  srefine (Build_HasEquivs (A * B) _ _ _
-             (fun a b => (fst a $<~> fst b) * (snd a $<~> snd b))
-             _ _ _ _ _ _ _ _ _).
-  1:intros a b f; exact (CatIsEquiv (fst f) * CatIsEquiv (snd f)).
+  srefine (Build_HasEquivs (A * B) _ _ _ _ _ _ _ _ _ _ _).
   all:cbn; intros a b f.
-  - split; [ exact (fst f) | exact (snd f) ].
   - split; exact _.
   - intros [fe1 fe2]; split.
     + exact (Build_CatEquiv (fst f)).

--- a/theories/WildCat/Type.v
+++ b/theories/WildCat/Type.v
@@ -58,12 +58,19 @@ Proof.
   destruct p; reflexivity.
 Defined.
 
+Global Instance hasequivfuns_type : HasEquivFuns Type.
+Proof.
+  srapply Build_HasEquivFuns.
+  - exact Equiv.
+  - intros A B. exact IsEquiv.
+  - intros A B. exact equiv_fun.
+Defined.
+
 Global Instance hasequivs_type : HasEquivs Type.
 Proof.
-  srefine (Build_HasEquivs Type _ _ _ Equiv (@IsEquiv) _ _ _ _ _ _ _ _); intros A B.
-  all:intros f.
-  - exact f.
-  - exact _.
+  srefine (Build_HasEquivs Type _ _ _ _ _ _ _ _ _ _ _).
+  all:intros A B f.
+  - apply f.
   - apply Build_Equiv.
   - intros; reflexivity.
   - intros; exact (f^-1).

--- a/theories/WildCat/Yoneda.v
+++ b/theories/WildCat/Yoneda.v
@@ -136,7 +136,8 @@ Proof.
     refine (_ @ cate_issect (f a) (Id a)); cbn.
     apply ap.
     srapply cat_idr_strong.
-  - refine ((isnat (cat_equiv_natequiv _ _ f) (f^-1$ b (Id b)) (Id a))^ @ _); cbn.
+  - pose (g := @cate_inv _ _ _ _ _ (opyon1 a) (opyon1 b) f).
+    refine ((isnat (cat_equiv_natequiv _ _ f) (g b (Id b)) (Id a))^ @ _); cbn.
     refine (_ @ cate_isretr (f b) (Id b)); cbn.
     apply ap.
     srapply cat_idr_strong.


### PR DESCRIPTION
A have made a new class `HasEquivFuns` for the equivalence notation `a $<~> b`, since the laws in `HasEquivs` may require `Funext` or `Univalence`. With this new class we can use the `a $<~> b`, even if an axiom is required for `HasEquivs`.

My first attempt was to only take `CatEquiv'` out of `HasEquivs`, but then the useful coercion `Coercion cate_fun : CatEquiv >-> Hom` got invalid.