### PR TITLE
strip_reflections, strip_modalities tactics

### DIFF
--- a/theories/Modalities/Modality.v
+++ b/theories/Modalities/Modality.v
@@ -215,8 +215,8 @@ Ltac strip_modalities :=
     match goal with
     | [ T : _ |- _ ]
       => revert_opaque T;
-        (** The dependent case requires that [O] be a modality. *)
-        refine (@O_ind@{_ _ _} _ _ _ _ _ _ _);
+        (** Handle the non-dependent and dependent cases.  The last case requires that [O] be a modality. *)
+        refine (@O_rec _ _ _ _ _ _ _) || refine (@O_indpaths _ _ _ _ _ _ _ _ _) || refine (@O_ind _ _ _ _ _ _ _);
         (** Ensure that we didn't generate more than one subgoal, i.e. that the goal was appropriately local. *)
         [];
         intro T

--- a/theories/Modalities/Modality.v
+++ b/theories/Modalities/Modality.v
@@ -208,6 +208,19 @@ Proof.
   srapply (isequiv_oD_to_O O O).
 Defined.
 
+(** A tactic that generalizes [strip_reflections] to modalities. *)
+Ltac strip_modalities :=
+  (** Search for hypotheses of type [O X] for some [O] such that the goal is [O]-local. *)
+  progress repeat
+    match goal with
+    | [ T : _ |- _ ]
+      => revert_opaque T;
+        (** The dependent case requires that [O] be a modality. *)
+        refine (@O_ind@{_ _ _} _ _ _ _ _ _ _);
+        (** Ensure that we didn't generate more than one subgoal, i.e. that the goal was appropriately local. *)
+        [];
+        intro T
+  end.
 
 (** ** Dependent sums *)
 

--- a/theories/Modalities/Modality.v
+++ b/theories/Modalities/Modality.v
@@ -208,7 +208,7 @@ Proof.
   srapply (isequiv_oD_to_O O O).
 Defined.
 
-(** A tactic that generalizes [strip_reflections] to modalities. *)
+(** A tactic that extends [strip_reflections] to modalities. It handles non-dependent elimination for reflective subuniverses and dependent elimination for modalities. [strip_truncations] does the same for truncations, but introduces fewer universe variables, so tends to work better when removing truncations. *)
 Ltac strip_modalities :=
   (** Search for hypotheses of type [O X] for some [O] such that the goal is [O]-local. *)
   progress repeat

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -239,14 +239,13 @@ Arguments O_indpaths_beta : simpl never.
 Arguments O_ind2paths : simpl never.
 Arguments O_ind2paths_beta : simpl never.
 
-(** A tactic that generalizes [strip_truncations] to reflective subuniverses. *)
+(** A tactic that generalizes [strip_truncations] to reflective subuniverses. [strip_truncations] introduces fewer universe variables, so tends to work better when removing truncations. [strip_modalities] in Modality.v also applies dependent elimination when [O] is a modality. *)
 Ltac strip_reflections :=
   (** Search for hypotheses of type [O X] for some [O] such that the goal is [O]-local. *)
   progress repeat
     match goal with
     | [ T : _ |- _ ]
       => revert_opaque T;
-        (** We don't treat the dependent case since it requires that [O] is a modality. We define [strip_modalities] in Modality.v that does this. *)
         refine (@O_rec _ _ _ _ _ _ _) || refine (@O_indpaths _ _ _ _ _ _ _ _ _);
         (** Ensure that we didn't generate more than one subgoal, i.e. that the goal was appropriately local. *)
         [];

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -246,8 +246,8 @@ Ltac strip_reflections :=
     match goal with
     | [ T : _ |- _ ]
       => revert_opaque T;
-        (** We don't treat the dependent case since it requires that [O] is a modality. We therefore define [strip_modalities] in Modality.v that does this. *)
-        refine (@O_rec _ _ _ _ _ _ _); (* || refine (@O_ind _ _ _ _ _ _ _); *)
+        (** We don't treat the dependent case since it requires that [O] is a modality. We define [strip_modalities] in Modality.v that does this. *)
+        refine (@O_rec _ _ _ _ _ _ _) || refine (@O_indpaths _ _ _ _ _ _ _ _ _);
         (** Ensure that we didn't generate more than one subgoal, i.e. that the goal was appropriately local. *)
         [];
         intro T

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -1224,9 +1224,8 @@ Section Reflective_Subuniverse.
     : O_functor (functor_prod f g) o O_monad_strength A B ==
       O_monad_strength A' B' o functor_prod f (O_functor g).
     Proof.
-      intros [a ob]. revert a. apply ap10.
-      revert ob; apply O_indpaths.
-      intros b; simpl.
+      intros [a b]. revert a. apply ap10.
+      strip_reflections.
       apply path_arrow; intros a.
       unfold O_monad_strength, O_functor; simpl.
       repeat rewrite O_rec_beta.
@@ -1237,10 +1236,10 @@ Section Reflective_Subuniverse.
     Definition O_monad_strength_unitlaw1 (A : Type)
     : O_functor (@snd Unit A) o O_monad_strength Unit A == @snd Unit (O A).
     Proof.
-      intros [[] oa]; revert oa.
-      apply O_indpaths; intros x; unfold O_monad_strength, O_functor. simpl.
-      repeat rewrite O_rec_beta.
-      reflexivity.
+      intros [[] a]. strip_reflections.
+      unfold O_monad_strength, O_functor. simpl.
+      rewrite O_rec_beta.
+      nrapply O_rec_beta.
     Qed.
 
     Definition O_monad_strength_unitlaw2 (A B : Type)
@@ -1248,18 +1247,17 @@ Section Reflective_Subuniverse.
     Proof.
       intros [a b].
       unfold O_monad_strength, functor_prod. simpl.
-      repeat rewrite O_rec_beta.
-      reflexivity.
+      revert a; apply ap10.
+      nrapply O_rec_beta.
     Qed.
 
     Definition O_monad_strength_assoc1 (A B C : Type)
     : O_functor (equiv_prod_assoc A B C)^-1 o O_monad_strength (A*B) C ==
       O_monad_strength A (B*C) o functor_prod idmap (O_monad_strength B C) o (equiv_prod_assoc A B (O C))^-1.
     Proof.
-      intros [[a b] oc].
+      intros [[a b] c].
       revert a; apply ap10. revert b; apply ap10.
-      revert oc; apply O_indpaths.
-      intros c; simpl.
+      strip_reflections.
       apply path_arrow; intros b. apply path_arrow; intros a.
       unfold O_monad_strength, O_functor, functor_prod. simpl.
       repeat rewrite O_rec_beta.
@@ -1270,9 +1268,9 @@ Section Reflective_Subuniverse.
     : O_monad_mult (A*B) o O_functor (O_monad_strength A B) o O_monad_strength A (O B) ==
       O_monad_strength A B o functor_prod idmap (O_monad_mult B).
     Proof.
-      intros [a oob]. revert a; apply ap10.
-      revert oob; apply O_indpaths. apply O_indpaths.
-      intros b; simpl. apply path_arrow; intros a.
+      intros [a b]. revert a; apply ap10.
+      strip_reflections.
+      apply path_arrow; intros a.
       unfold O_monad_strength, O_functor, O_monad_mult, functor_prod. simpl.
       repeat (rewrite O_rec_beta; simpl).
       reflexivity.

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -239,6 +239,20 @@ Arguments O_indpaths_beta : simpl never.
 Arguments O_ind2paths : simpl never.
 Arguments O_ind2paths_beta : simpl never.
 
+(** A tactic that generalizes [strip_truncations] to reflective subuniverses. *)
+Ltac strip_reflections :=
+  (** Search for hypotheses of type [O X] for some [O] such that the goal is [O]-local. *)
+  progress repeat
+    match goal with
+    | [ T : _ |- _ ]
+      => revert_opaque T;
+        (** We don't treat the dependent case since it requires that [O] is a modality. We therefore define [strip_modalities] in Modality.v that does this. *)
+        refine (@O_rec _ _ _ _ _ _ _); (* || refine (@O_ind _ _ _ _ _ _ _); *)
+        (** Ensure that we didn't generate more than one subgoal, i.e. that the goal was appropriately local. *)
+        [];
+        intro T
+  end.
+
 (** Given [Funext], we prove the definition of reflective subuniverse in the book. *)
 Global Instance isequiv_o_to_O `{Funext}
        (O : ReflectiveSubuniverse) (P Q : Type) `{In O Q}
@@ -973,6 +987,14 @@ Section Reflective_Subuniverse.
         rewrite O_indpaths_beta; reflexivity.
     Qed.
     Global Existing Instance inO_paths.
+
+    Lemma O_concat {A : Type} {a0 a1 a2 : A}
+      : O (a0 = a1) -> O (a1 = a2) -> O (a0 = a2).
+    Proof.
+      intros p q.
+      strip_reflections.
+      exact (to O _ (p @ q)).
+    Defined.
 
     (** ** Truncations  *)
 

--- a/theories/Projective.v
+++ b/theories/Projective.v
@@ -154,7 +154,7 @@ Section AC_oo_neg1.
     pose (X := Build_HSet (Tr 0 A)).
     pose proof ((equiv_isoprojective_hasochoice _ X)^-1 (AC X)) as P.
     pose proof (P A _ X _ idmap tr _) as F; clear P.
-    revert F; refine (Trunc_ind@{_ _} _ _); intros F.
+    strip_truncations.
     destruct F as [f p].
     refine (tr (X; (f; BuildIsSurjection f _))).
     intro a; unfold hfiber.

--- a/theories/Projective.v
+++ b/theories/Projective.v
@@ -154,7 +154,7 @@ Section AC_oo_neg1.
     pose (X := Build_HSet (Tr 0 A)).
     pose proof ((equiv_isoprojective_hasochoice _ X)^-1 (AC X)) as P.
     pose proof (P A _ X _ idmap tr _) as F; clear P.
-    strip_truncations.
+    revert F; refine (Trunc_ind@{_ _} _ _); intros F.
     destruct F as [f p].
     refine (tr (X; (f; BuildIsSurjection f _))).
     intro a; unfold hfiber.

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -218,14 +218,17 @@ Defined.
 (** ** Tactic to remove truncations in hypotheses if possible. *)
 Ltac strip_truncations :=
   (** search for truncated hypotheses *)
-  progress repeat match goal with
-                    | [ T : _ |- _ ]
-                      => revert_opaque T;
-                        refine (@Trunc_ind _ _ _ _ _);
-                        (** ensure that we didn't generate more than one subgoal, i.e. that the goal was appropriately truncated *)
-                        [];
-                        intro T
-                  end.
+  progress repeat
+    match goal with
+    | [ T : _ |- _ ]
+      => revert_opaque T;
+        refine (@Trunc_ind _ _ _ _ _);
+        (** ensure that we didn't generate more than one subgoal, i.e. that the goal was appropriately truncated *)
+        [];
+        intro T
+  end.
+(** We would like to define this in terms of the [strip_modalities] tactic, however [O_ind] uses more universes than [Trunc_ind] which causes some problems down the line. *)
+(* Ltac strip_truncations := strip_modalities. *)
 
 (** ** Iterated truncations *)
 

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -215,7 +215,7 @@ Proof.
   apply (@isequiv_conn_ino_map (Tr (-1))); assumption.
 Defined.
 
-(** ** Tactic to remove truncations in hypotheses if possible. *)
+(** ** Tactic to remove truncations in hypotheses if possible. See [strip_reflections] and [strip_modalities] for generalizations to other reflective subuniverses and modalities. *)
 Ltac strip_truncations :=
   (** search for truncated hypotheses *)
   progress repeat


### PR DESCRIPTION
As discussed in #1481

Perhaps it would be better to have a `strip_using` tactic where we provide an induction principle, than all three become special cases of that.

I also wonder why `strip_truncations` is so good at what it does. Replacing it in `Classes/implementations/HProp_lattice.v` for example breaks things. Projective.v also breaks.