### PR TITLE
Use git ls-files in a worktree as well

### DIFF
--- a/etc/generate_coqproject.sh
+++ b/etc/generate_coqproject.sh
@@ -1,5 +1,5 @@
 ## List tracked .v files
-if [ -d .git ]; then
+if [ -e .git ]; then
   TRACKED_V_FILES="$(git ls-files "*.v")"
 else
   echo "Warning: Not a git clone, using find instead" >&2


### PR DESCRIPTION
In a git worktree, .git is a file, not a directory, so use -e instead of -d to test for it.