### PR TITLE
Change Hint Unfold Commutative to Typeclasses Transparent.

### DIFF
--- a/theories/Classes/interfaces/canonical_names.v
+++ b/theories/Classes/interfaces/canonical_names.v
@@ -241,7 +241,7 @@ Class RightInverse {A} {B} {C} (op : A -> B -> C) (inv : A -> B) (unit : C)
 Class Commutative {B A} (f : A -> A -> B) : Type
   := commutativity: forall x y, f x y = f y x.
 
-Global Hint Unfold Commutative : typeclass_instances.
+Typeclasses Transparent Commutative.
 
 Class HeteroAssociative {A B C AB BC ABC}
   (fA_BC: A -> BC -> ABC) (fBC: B -> C -> BC)


### PR DESCRIPTION
The issue in #1555 would have been prevented if I'd made `Commutative` a transparent instance, instead of adding the more intrusive `Hint Unfold`. This is how I should have done it from the start, and should prevent similar issues in the future.

Edit: This saves ~4s, as can be seen here: https://gist.github.com/jarlg/5e75f9195ee9379f84fbb38f55d47653 