### PR TITLE
Changing various functors to use fmap + misc wildcat additions

### DIFF
--- a/theories/Algebra/AbGroups/AbelianGroup.v
+++ b/theories/Algebra/AbGroups/AbelianGroup.v
@@ -138,7 +138,7 @@ Proof.
       symmetry.
       apply left_identity. }
     intros g []; cbn.
-    exact (grp_homo_unit g). }
+    exact (grp_homo_unit g)^. }
   intro A.
   snrefine (Build_GroupHomomorphism (fun _ => mon_unit); _).
   1: exact _.

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -681,7 +681,7 @@ Proof.
   intro G.
   exists (grp_trivial_rec _).
   intros g [].
-  apply (grp_homo_unit g).
+  apply (grp_homo_unit g)^.
 Defined.
 
 Global Instance contr_grp_homo_trivial_source `{Funext} G

--- a/theories/Algebra/Rings/Z.v
+++ b/theories/Algebra/Rings/Z.v
@@ -226,7 +226,7 @@ Proof.
   intros g x.
   destruct x as [n| |p].
   + induction n using pos_peano_ind.
-    { cbn. rapply rng_homo_minus_one. }
+    { cbn. symmetry; rapply rng_homo_minus_one. }
     simpl.
     rewrite pos_peano_rec_beta_pos_succ.
     rewrite int_neg_pos_succ.
@@ -238,7 +238,7 @@ Proof.
     exact IHn.
   + by rewrite 2 rng_homo_zero.
   + induction p using pos_peano_ind.
-    { cbn. rapply rng_homo_one. }
+    { cbn. symmetry; rapply rng_homo_one. }
     simpl.
     rewrite pos_peano_rec_beta_pos_succ.
     rewrite int_pos_pos_succ.

--- a/theories/Algebra/ooGroup.v
+++ b/theories/Algebra/ooGroup.v
@@ -149,15 +149,11 @@ Definition group_loops_functor_idmap {X : pType}
   == group_loops_functor (Id (A:=pType) _).
 Proof.
   intros g.
-  unfold grouphom_fun, grouphom_idmap.
-  assert (p := eisretr (loops_group X) g).
   refine (fmap_id loops _ g @ _).
-  rewrite <- p.
+  rewrite <- (eisretr (loops_group X) g).
+  unfold grouphom_fun, grouphom_idmap.
   rewrite !loops_functor_group.
-  pose (q := pointed_htpy
-    (fmap_id loops X : _ ==* _) ((loops_group X)^-1 g)).
-  rewrite q.
-  reflexivity.
+  exact (ap (loops_group X) (fmap_id loops _ _)^).
 Qed.
 
 (** *** Homomorphic properties *)

--- a/theories/Algebra/ooGroup.v
+++ b/theories/Algebra/ooGroup.v
@@ -74,7 +74,7 @@ Definition ooGroupHom (G H : ooGroup)
   := B G ->* B H.
 
 Definition grouphom_fun {G H} (phi : ooGroupHom G H) : G -> H
-  := loops_functor phi.
+  := fmap loops phi.
 
 Coercion grouphom_fun : ooGroupHom >-> Funclass.
 
@@ -95,8 +95,8 @@ Defined.
 (** And this functor "is" the same as the ordinary loop space functor. *)
 Definition loops_functor_group
            {X Y : pType} (f : X ->* Y)
-: loops_functor (group_loops_functor f) o loops_group X
-  == loops_group Y o loops_functor f.
+: fmap loops (group_loops_functor f) o loops_group X
+  == loops_group Y o fmap loops f.
 Proof.
   intros x.
   apply (equiv_inj (equiv_path_sigma_hprop _ _)^-1).
@@ -129,16 +129,16 @@ Definition group_loops_functor_compose
 Proof.
   intros g.
   unfold grouphom_fun, grouphom_compose.
-  refine (pointed_htpy (loops_functor_compose _ _) g @ _).
+  refine (pointed_htpy (fmap_comp loops _ _) g @ _).
   pose (p := eisretr (loops_group X) g).
-  change (loops_functor (group_loops_functor psi)
-            (loops_functor (group_loops_functor phi) g)
-          = loops_functor (group_loops_functor
+  change (fmap loops (group_loops_functor psi)
+            (fmap loops (group_loops_functor phi) g)
+          = fmap loops (group_loops_functor
                                  (pmap_compose psi phi)) g).
   rewrite <- p.
   rewrite !loops_functor_group.
   apply ap.
-  symmetry; apply loops_functor_compose.
+  symmetry; rapply (fmap_comp loops).
 Qed.
 
 Definition grouphom_idmap (G : ooGroup) : ooGroupHom G G
@@ -146,32 +146,19 @@ Definition grouphom_idmap (G : ooGroup) : ooGroupHom G G
 
 Definition group_loops_functor_idmap {X : pType}
 : grouphom_idmap (group_loops X)
-  == group_loops_functor pmap_idmap.
+  == group_loops_functor (Id (A:=pType) _).
 Proof.
   intros g.
   unfold grouphom_fun, grouphom_idmap.
   assert (p := eisretr (loops_group X) g).
+  refine (fmap_id loops _ g @ _).
   rewrite <- p.
   rewrite !loops_functor_group.
-  rewrite (pointed_htpy (loops_functor_idmap _)).
-  simpl. apply ap.
-  rewrite concat_p1, concat_1p, ap_idmap.
+  pose (q := pointed_htpy
+    (fmap_id loops X : _ ==* _) ((loops_group X)^-1 g)).
+  rewrite q.
   reflexivity.
 Qed.
-
-Definition group_loops_2functor
-           {X Y : pType} {phi psi : X ->* Y}
-           (theta : pHomotopy phi psi)
-: (group_loops_functor phi) == (group_loops_functor psi).
-Proof.
-  intros g.
-  assert (p := eisretr (loops_group X) g).
-  rewrite <- p.
-  unfold grouphom_fun.
-  rewrite !loops_functor_group.
-  apply ap.
-  apply loops_2functor; assumption.
-Defined.
 
 (** *** Homomorphic properties *)
 
@@ -307,13 +294,13 @@ Global Instance is0functor_group_to_oogroup : Is0Functor group_to_oogroup.
 Proof.
   snrapply Build_Is0Functor.
   intros G H f.
-  by rapply functor_pclassifyingspace.
+  by rapply (fmap pClassifyingSpace).
 Defined.
 
 Global Instance is1functor_group_to_oogroup : Is1Functor group_to_oogroup.
 Proof.
-  snrapply Build_Is1Functor.
-  1: exact @functor2_pclassifyingspace.
-  1: exact functor_pclassifyingspace_idmap.
-  exact functor_pclassifyingspace_compose.
+  snrapply Build_Is1Functor; hnf; intros.
+  1: by rapply (fmap2 pClassifyingSpace).
+  1: by rapply (fmap_id pClassifyingSpace).
+  by rapply (fmap_comp pClassifyingSpace).
 Defined.

--- a/theories/Homotopy/ExactSequence.v
+++ b/theories/Homotopy/ExactSequence.v
@@ -308,7 +308,7 @@ Proof.
   exact ((pfiber_fmap_loops fs.1)^-1* ).
 Defined.
 
-(** Now we can deduce that they preserve purely-exact sequences.  The hardest part is modifying the first map back to [fmap_loops i]. *)
+(** Now we can deduce that they preserve purely-exact sequences.  The hardest part is modifying the first map back to [fmap loops i]. *)
 Global Instance isexact_loops {F X Y} (i : F ->* X) (f : X ->* Y)
            `{IsExact purely F X Y i f}
   : IsExact purely (fmap loops i) (fmap loops f).

--- a/theories/Homotopy/HomotopyGroup.v
+++ b/theories/Homotopy/HomotopyGroup.v
@@ -46,7 +46,7 @@ Global Instance is0functor_homotopygroup_type_ptype (n : nat)
   definitionally equal to [Pi 1 (iterated_loops n X)] *)
 Definition Pi1 (X : pType) : Group.
 Proof.
-  srapply (Build_Group (pTr 0 (loops X)));
+  srapply (Build_Group (Tr 0 (loops X)));
   repeat split.
   (** Operation *)
   + intros x y.
@@ -132,7 +132,7 @@ Definition pi_functor_type_pmap {n X Y}
      end.
 Coercion pi_functor_type_pmap : pi_functor_type >-> pForall.
 
-(** For the same reason as for [Pi1] we first define [pi1_functor]. *)
+(** For the same reason as for [Pi1] we make [Pi1] a functor before making [Pi] a functor. *)
 Global Instance is0functor_pi1 : Is0Functor Pi1.
 Proof.
   apply Build_Is0Functor.
@@ -166,14 +166,16 @@ Defined.
 
 Global Instance is1functor_pi1 : Is1Functor Pi1.
 Proof.
-  apply Build_Is1Functor.
-  - intros a b f g p.
-    exact (fmap2 (Tr 0 o loops) p).
-  - intros X.
-    exact (fmap_id (Tr 0 o loops) X).
-  - intros a b c f g.
-    exact (fmap_comp (Tr 0 o loops) f g).
+  (** The conditions for [Pi1] to be a 1-functor only involve equalities of maps between groups, which reduce to equalities of maps between types.  Type inference shows that [Tr 0 o loops] is a 1-functor, and so it follows that [Pi1] is a 1-functor. *)
+  assert (is1f : Is1Functor (Tr 0 o loops)) by exact _.
+  apply Build_Is1Functor; intros;
+    [ by rapply (fmap2 _ (is1functor_F := is1f))
+    | by rapply (fmap_id _ (is1functor_F := is1f))
+    | by rapply (fmap_comp _ (is1functor_F := is1f)) ].
 Defined.
+
+Global Instance is1functor_pi (n : nat) : Is1Functor (Pi n)
+  := ltac:(destruct n; exact _).
 
 (* The homotopy groups of a loop space are those of the space shifted.  *)
 Definition pi_loops n X : Pi n.+1 X <~> Pi n (loops X).
@@ -253,4 +255,3 @@ Proof.
   apply path_Tr, tr.
   exact (ap_pp tr x y).
 Defined.
-

--- a/theories/Homotopy/HomotopyGroup.v
+++ b/theories/Homotopy/HomotopyGroup.v
@@ -28,12 +28,25 @@ Definition HomotopyGroup_type_ptype (n : nat) : HomotopyGroup_type n -> pType
 
 Coercion HomotopyGroup_type_ptype : HomotopyGroup_type >-> pType.
 
+(** We construct the wildcat structure on HomotopyGroup_type in the obvious way. *)
+Global Instance isgraph_homotopygroup_type (n : nat)
+  : IsGraph (HomotopyGroup_type n) := ltac:(destruct n; exact _).
+Global Instance is2graph_homotopygroup_type (n : nat)
+  : Is2Graph (HomotopyGroup_type n) := ltac:(destruct n; exact _).
+Global Instance is01cat_homotopygroup_type (n : nat)
+  : Is01Cat (HomotopyGroup_type n) := ltac:(destruct n; exact _).
+Global Instance is1cat_homotopygroup_type (n : nat)
+  : Is1Cat (HomotopyGroup_type n) := ltac:(destruct n; exact _).
+Global Instance is0functor_homotopygroup_type_ptype (n : nat)
+  : Is0Functor (HomotopyGroup_type_ptype n)
+  := ltac:(destruct n; exact _).
+
 (** We first define [Pi 1 X], and use this to define [Pi n X].
   The reason is to make it easier for Coq to see that [Pi (n.+1) X] is
   definitionally equal to [Pi 1 (iterated_loops n X)] *)
 Definition Pi1 (X : pType) : Group.
 Proof.
-  srapply (Build_Group (Tr 0 (loops X)));
+  srapply (Build_Group (pTr 0 (loops X)));
   repeat split.
   (** Operation *)
   + intros x y.
@@ -120,13 +133,13 @@ Definition pi_functor_type_pmap {n X Y}
 Coercion pi_functor_type_pmap : pi_functor_type >-> pForall.
 
 (** For the same reason as for [Pi1] we first define [pi1_functor]. *)
-Definition pi1_functor {X Y : pType}
-  : (X ->* Y) -> Pi1 X $-> Pi1 Y.
+Global Instance is0functor_pi1 : Is0Functor Pi1.
 Proof.
-  intro f.
+  apply Build_Is0Functor.
+  intros X Y f.
   snrapply Build_GroupHomomorphism.
-  { apply Trunc_functor.
-    apply loops_functor.
+  { rapply (fmap (Tr 0)).
+    rapply (fmap loops).
     assumption. }
   (** Note: we don't have to be careful about which paths we choose here since we are trying to inhabit a proposition. *)
   intros x y.
@@ -142,49 +155,24 @@ Proof.
   apply ap_pp.
 Defined.
 
-Definition pi_functor (n : nat) {X Y : pType}
-  : (X ->* Y) -> pi_functor_type n X Y.
-Proof.
-  destruct n.
-  + exact (ptr_functor 0).
-  + intro f. exact (pi1_functor (iterated_loops_functor n f)).
-Defined.
+Global Instance is0functor_pi (n : nat) : Is0Functor (Pi n)
+  := ltac:(destruct n; exact _).
 
-Definition pi_functor_succ {X Y : pType} (f : X $-> Y) (n : nat)
-  : pi_functor n.+1 f $== pi_functor 1 (iterated_loops_functor n f).
+Definition fmap_pi_succ {X Y : pType} (f : X $-> Y) (n : nat)
+  : fmap (Pi n.+1) f $== fmap (Pi 1) (fmap (iterated_loops n) f).
 Proof.
   reflexivity.
 Defined.
 
-Definition pi_functor_idmap n {X : pType}
-  : pi_functor n (@pmap_idmap X) == pmap_idmap.
+Global Instance is1functor_pi1 : Is1Functor Pi1.
 Proof.
-  destruct n; intros x.
-  - apply Trunc_functor_idmap.
-  - etransitivity.
-    + apply O_functor_homotopy.
-      exact (iterated_loops_functor_idmap _ n.+1).
-    + apply O_functor_idmap.
-Defined.
-
-Definition pi_functor_compose n {X Y Z : pType}
-  (f : X ->* Y) (g : Y ->* Z)
-  : pi_functor n (g o* f) == pi_functor n g o pi_functor n f.
-Proof.
-  destruct n; intro x.
-  - cbn; apply Trunc_functor_compose.
-  - etransitivity.
-    + apply O_functor_homotopy. rapply (iterated_loops_functor_compose (n.+1)).
-    + refine (O_functor_compose (Tr 0) _ _ x).
-Defined.
-
-Definition pi_2functor (n : nat)
-  {X Y : pType} (f g : X ->* Y) (p : f ==* g)
-  : pi_functor n f == pi_functor n g.
-Proof.
-  destruct n; intros x.
-  - apply O_functor_homotopy; exact p.
-  - apply O_functor_homotopy. refine (iterated_loops_2functor (n.+1) _); exact p.
+  apply Build_Is1Functor.
+  - intros a b f g p.
+    exact (fmap2 (Tr 0 o loops) p).
+  - intros X.
+    exact (fmap_id (Tr 0 o loops) X).
+  - intros a b c f g.
+    exact (fmap_comp (Tr 0 o loops) f g).
 Defined.
 
 (* The homotopy groups of a loop space are those of the space shifted.  *)
@@ -196,26 +184,22 @@ Proof.
   all:apply unfold_iterated_loops'.
 Defined.
 
-Definition pi_functor_loops (n : nat) {X Y : pType} (f : X ->* Y)
-  : (pi_loops n Y) o (pi_functor n.+1 f)
-    == (pi_functor n (loops_functor f)) o (pi_loops n X).
+Definition fmap_pi_loops (n : nat) {X Y : pType} (f : X ->* Y)
+  : (pi_loops n Y) o (fmap (Pi n.+1) f)
+    == (fmap (HomotopyGroup_type_ptype n o Pi n o loops) f)
+        o (pi_loops n X).
 Proof.
   destruct n; intros x.
   all:refine ((O_functor_compose 0 _ _ _)^ @ _ @ (O_functor_compose 0 _ _ _)).
   all:apply O_functor_homotopy.
   - reflexivity.
-  - exact (pointed_htpy (unfold_iterated_loops_functor n.+1 f)).
+  - exact (pointed_htpy (unfold_iterated_fmap_loops n.+1 f)).
 Defined.
 
 Definition groupiso_pi_functor (n : nat)
   {X Y : pType} (e : X <~>* Y)
-  : Pi n.+1 X $<~> Pi n.+1 Y.
-Proof.
-  snrapply Build_GroupIsomorphism.
-  1: apply (pi_functor n.+1 e).
-  nrefine (Trunc_functor_isequiv _ _).
-  refine (isequiv_homotopic _ (pequiv_iterated_loops_functor_is_iterated_loops_functor n.+1 e)).
-Defined.
+  : Pi n.+1 X $<~> Pi n.+1 Y
+  := emap (Pi n.+1) e.
 
 (** Homotopy groups preserve products *)
 Lemma pi_prod (X Y : pType) {n : nat}
@@ -243,24 +227,10 @@ Proof.
   1,2: reflexivity.
 Defined.
 
-(** WildCat instances for [Pi] *)
-Global Instance is0functor_pi (n : nat) : Is0Functor (Pi n.+1).
-Proof.
-  constructor. intros X Y f. exact (pi_functor (n.+1) f).
-Defined.
-
-Global Instance is1functor_pi (n : nat) : Is1Functor (Pi n.+1).
-Proof.
-  constructor. 
-  + intros X Y f g h. exact (pi_2functor (n.+1) _ _ h).
-  + intros X. exact (pi_functor_idmap (n.+1)).
-  + intros X Y Z f g h. exact (pi_functor_compose (n.+1) f g h).
-Defined.
-
 (** Can we make this reflexivity? *)
 Lemma pmap_pi_functor {X Y : pType} (f : X ->* Y) (n : nat) 
-  : pi_functor_type_pmap (pi_functor (S n) f) ==* 
-  ptr_functor 0 (iterated_loops_functor (S n) f).
+  : fmap (Pi n.+1) f
+    ==* fmap (pTr 0) (fmap (iterated_loops n.+1) f).
 Proof.
   srapply Build_pHomotopy. 1: reflexivity. apply path_ishprop.
 Defined.

--- a/theories/Homotopy/WhiteheadsPrinciple.v
+++ b/theories/Homotopy/WhiteheadsPrinciple.v
@@ -101,7 +101,8 @@ Proof.
                IsEquiv (fmap (Pi k.+1) (pmap_from_point (@ap _ _ f x y) q))).
     2:exact (h3 x).
     intros y q. destruct q.
-    refine (isequiv_homotopic (fmap (Pi k.+1) (fmap loops (pmap_from_point f x))) _).
+    snrefine (isequiv_homotopic _ _).
+    1: exact (fmap (Pi k.+1) (fmap loops (pmap_from_point f x))).
     2:{ rapply (fmap2 (Pi k.+1)); srefine (Build_pHomotopy _ _).
         - intros p; cbn.
           refine (concat_1p _ @ concat_p1 _).

--- a/theories/Homotopy/WhiteheadsPrinciple.v
+++ b/theories/Homotopy/WhiteheadsPrinciple.v
@@ -1,5 +1,5 @@
 Require Import Basics Types Pointed.
-Require Import HFiber.
+Require Import WildCat HFiber.
 Require Import Algebra.Groups.
 Require Import Homotopy.HomotopyGroup.
 Require Import Truncations.
@@ -34,7 +34,7 @@ Defined.
 Definition isequiv_isbij_tr0_isequiv_loops
            `{Univalence} {A B : Type} (f : A -> B)
            {i  : IsEquiv (Trunc_functor 0 f)}
-           {ii : forall x, IsEquiv (loops_functor (pmap_from_point f x)) }
+           {ii : forall x, IsEquiv (fmap loops (pmap_from_point f x)) }
   : IsEquiv f.
 Proof.
   srapply (isequiv_issurj_tr0_isequiv_ap f).
@@ -55,7 +55,7 @@ Defined.
 Definition isequiv_is0connected_isequiv_loops
            `{Univalence} {A B : pType} `{IsConnected 0 A} `{IsConnected 0 B}
            (f : A ->* B)
-           (e : IsEquiv (loops_functor f))
+           (e : IsEquiv (fmap loops f))
   : IsEquiv f.
 Proof.
   apply isequiv_isbij_tr0_isequiv_loops.
@@ -76,7 +76,7 @@ Definition whiteheads_principle
            {ua : Univalence} {A B : Type} {f : A -> B}
            (n : trunc_index) {H0 : IsTrunc n A} {H1 : IsTrunc n B}
            {i  : IsEquiv (Trunc_functor 0 f)}
-           {ii : forall (x : A) (k : nat), IsEquiv (pi_functor k.+1 (pmap_from_point f x)) }
+           {ii : forall (x : A) (k : nat), IsEquiv (fmap (Pi k.+1) (pmap_from_point f x)) }
   : IsEquiv f.
 Proof.
   revert A B H0 H1 f i ii.
@@ -92,21 +92,21 @@ Proof.
   pose proof (@istrunc_paths _ _ H1 (f x) (f x)) as h1.
   nrefine (IHn (x=x) (f x=f x) h0 h1 (@ap _ _ f x x) _ _).
   - pose proof (ii x 0) as h2.
-    unfold pi_functor in h2; cbn in h2.
+    unfold is0functor_pi in h2; cbn in h2.
     refine (@isequiv_homotopic _ _ _ _ h2 _).
     apply (O_functor_homotopy (Tr 0)); intros p.
     exact (concat_1p _ @ concat_p1 _).
   - intros p k; revert p.
     assert (h3 : forall (y:A) (q:x=y),
-               IsEquiv (pi_functor k.+1 (pmap_from_point (@ap _ _ f x y) q))).
+               IsEquiv (fmap (Pi k.+1) (pmap_from_point (@ap _ _ f x y) q))).
     2:exact (h3 x).
     intros y q. destruct q.
-    nrefine (isequiv_homotopic (pi_functor k.+1 (loops_functor (pmap_from_point f x))) _).
-    2:{ apply pi_2functor; srefine (Build_pHomotopy _ _).
+    refine (isequiv_homotopic (fmap (Pi k.+1) (fmap loops (pmap_from_point f x))) _).
+    2:{ rapply (fmap2 (Pi k.+1)); srefine (Build_pHomotopy _ _).
         - intros p; cbn.
           refine (concat_1p _ @ concat_p1 _).
         - reflexivity. }
-    nrefine (isequiv_commsq _ _ _ _ (pi_functor_loops k.+1 (pmap_from_point f x))).
+    nrefine (isequiv_commsq _ _ _ _ (fmap_pi_loops k.+1 (pmap_from_point f x))).
     2-3:refine (equiv_isequiv (pi_loops _ _)).
     exact (ii x k.+1).
 Defined.

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -655,7 +655,6 @@ Proof.
     + intros x; exact (s x).
 Defined.
 
-(** TODO: finish *)
 (** pType is a univalent 1-coherent 1-category *)
 Global Instance isunivalent_ptype `{Univalence} : IsUnivalent1Cat pType.
 Proof.

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -565,18 +565,18 @@ Defined.
 Definition pconst {A B : pType} : A ->* B
   := point_pforall (fun _ => B).
 
-Lemma pmap_punit_pconst {A : pType} (f : A ->* pUnit) : f ==* pconst.
+Lemma pmap_punit_pconst {A : pType} (f : A ->* pUnit) : pconst ==* f.
 Proof.
   srapply Build_pHomotopy.
   1: intro; apply path_unit.
   apply path_contr.
 Defined.
 
-Lemma punit_pmap_pconst {A : pType} (f : pUnit ->* A) : f ==* pconst.
+Lemma punit_pmap_pconst {A : pType} (f : pUnit ->* A) : pconst ==* f.
 Proof.
   srapply Build_pHomotopy.
-  1: intros []; exact (point_eq f).
-  exact (concat_p1 _)^.
+  1: intros []; exact (point_eq f)^.
+  exact (concat_1p _)^.
 Defined.
 
 (** * pType as a wild category *)
@@ -664,8 +664,16 @@ Proof.
   intros []; apply path_pequiv.
   srefine (Build_pHomotopy _ _).
   - intros x; reflexivity.
-  - (* Some messy path algebra here. *)
-Abort.
+  - simpl.
+    refine (_^ @ (concat_p1 _)^).
+    rapply (equiv_moveL_Mp _ _ _)^-1.
+    refine (_ @ (concat_p1 _)^).
+    rewrite transport_paths_FlFr.
+    hott_simpl.
+    rewrite transport_path_universe_equiv_path.
+    rewrite ap_V.
+    apply inv_V.
+Defined.
 
 (** pType is a pointed category *)
 Global Instance ispointedcat_ptype : IsPointedCat pType.

--- a/theories/Pointed/pFiber.v
+++ b/theories/Pointed/pFiber.v
@@ -1,5 +1,4 @@
-Require Import Basics.
-Require Import Types.
+Require Import Basics Types WildCat.
 Require Import HFiber.
 Require Import Pointed.Core.
 Require Import Pointed.pEquiv.
@@ -31,8 +30,8 @@ Proof.
   cbn; apply concat_Vp.
 Defined.
 
-Definition pfiber_loops_functor {A B : pType} (f : A ->* B)
-  : pfiber (loops_functor f) <~>* loops (pfiber f).
+Definition pfiber_fmap_loops {A B : pType} (f : A ->* B)
+  : pfiber (fmap loops f) <~>* loops (pfiber f).
 Proof.
   srapply Build_pEquiv'.
   { etransitivity.
@@ -49,9 +48,9 @@ Proof.
   by pointed_reduce.
 Defined.
 
-Definition pr1_pfiber_loops_functor {A B} (f : A ->* B)
-  : loops_functor (pfib f) o* pfiber_loops_functor f
-    ==* pfib (loops_functor f).
+Definition pr1_pfiber_fmap_loops {A B} (f : A ->* B)
+  : fmap loops (pfib f) o* pfiber_fmap_loops f
+    ==* pfib (fmap loops f).
 Proof.
   srapply Build_pHomotopy.
   - intros [u v].
@@ -60,14 +59,14 @@ Proof.
   - abstract (pointed_reduce_rewrite; reflexivity).
 Defined.
 
-Definition pfiber_iterated_loops_functor {A B : pType} (n : nat) (f : A ->* B)
-  : pfiber (iterated_loops_functor n f) <~>* iterated_loops n (pfiber f).
+Definition pfiber_fmap_iterated_loops {A B : pType} (n : nat) (f : A ->* B)
+  : pfiber (fmap (iterated_loops n) f) <~>* iterated_loops n (pfiber f).
 Proof.
   induction n.
   1: reflexivity.
-  refine (_ o*E pfiber_loops_functor _ ).
-  apply pequiv_loops_functor.
-  apply IHn.
+  refine (_ o*E pfiber_fmap_loops _ ).
+  rapply (emap loops).
+  exact IHn.
 Defined.
 
 Definition functor_pfiber {A B C D}
@@ -106,9 +105,9 @@ Definition square_pequiv_pfiber {A B C D}
   := square_functor_pfiber p.
 
 (** The triple-fiber functor is equal to the negative of the loopspace functor. *)
-Definition pfiber2_loops_functor {A B : pType} (f : A ->* B)
+Definition pfiber2_fmap_loops {A B : pType} (f : A ->* B)
 : pfiber2_loops f o* pfib (pfib (pfib f))
-  ==* loops_functor f o* (loops_inv _ o* pfiber2_loops (pfib f)).
+  ==* fmap loops f o* (loops_inv _ o* pfiber2_loops (pfib f)).
 Proof.
   pointed_reduce.
   simple refine (Build_pHomotopy _ _).

--- a/theories/Pointed/pMap.v
+++ b/theories/Pointed/pMap.v
@@ -45,6 +45,7 @@ Lemma pconst_factor {A B : pType} {f : pUnit ->* B} {g : A ->* pUnit}
 Proof.
   refine (_ @* precompose_pconst f).
   apply pmap_postwhisker.
+  symmetry.
   apply pmap_punit_pconst.
 Defined.
 

--- a/theories/Spaces/Torus/TorusHomotopy.v
+++ b/theories/Spaces/Torus/TorusHomotopy.v
@@ -1,4 +1,4 @@
-Require Import Basics Types Pointed.
+Require Import Basics Types Pointed WildCat.
 Require Import Algebra.AbGroups.
 Require Import Homotopy.HomotopyGroup.
 Require Import Homotopy.Pi1S1.
@@ -37,7 +37,7 @@ Theorem loops_torus `{Univalence} : loops T <~>* Int * Int.
 Proof.
   srefine (_ o*E _).
   1: exact (loops (S1 * S1)).
-  1: apply pequiv_loops_functor.
+  1: rapply (emap loops).
   { srapply Build_pEquiv.
     1: srapply Build_pMap.
     1: exact equiv_torus_prod_Circle.

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 
-Require Import Basics Types.
+Require Import Basics Types WildCat.
 Require Import TruncType HProp.
 Require Import Modalities.Modality Modalities.Descent.
 
@@ -93,6 +93,9 @@ Section TruncationModality.
     : Tr@{i} n X -> Tr@{j} n Y
     := O_functor@{k k k} (Tr n) f.
 
+  Global Instance is0functor_Tr : Is0Functor (Tr n)
+    := Build_Is0Functor _ _ _ _ (Tr n) (@Trunc_functor).
+
   Global Instance Trunc_functor_isequiv {X Y : Type}
     (f : X -> Y) `{IsEquiv _ _ f}
     : IsEquiv (Trunc_functor f)
@@ -117,6 +120,14 @@ Section TruncationModality.
   Definition equiv_Trunc_prod_cmp `{Funext} {X Y}
     : Tr n (X * Y) <~> Tr n X * Tr n Y
     := equiv_O_prod_cmp (Tr n) X Y.
+
+  Global Instance is1functor_Tr : Is1Functor (Tr n).
+  Proof.
+    apply Build_Is1Functor.
+    - apply @O_functor_homotopy.
+    - apply @Trunc_functor_idmap.
+    - apply @Trunc_functor_compose.
+  Defined.
 
 End TruncationModality.
 

--- a/theories/WildCat/Core.v
+++ b/theories/WildCat/Core.v
@@ -165,13 +165,31 @@ Defined.
 
 (** Initial objects *)
 Definition IsInitial {A : Type} `{Is1Cat A} (x : A)
-  := forall (y : A), {f : x $-> y & forall g, g $== f}.
+  := forall (y : A), {f : x $-> y & forall g, f $== g}.
 Existing Class IsInitial.
+
+Definition mor_initial {A : Type} `{Is1Cat A} (x y : A) {h : IsInitial x}
+  : x $-> y
+  := (h y).1.
+
+Definition mor_initial_unique {A : Type} `{Is1Cat A} (x y : A) {h : IsInitial x}
+  (f : x $-> y)
+  : mor_initial x y $== f
+  := (h y).2 f.
 
 (** Terminal objects *)
 Definition IsTerminal {A : Type} `{Is1Cat A} (y : A)
-  := forall (x : A), {f : x $-> y & forall g, g $== f}.
+  := forall (x : A), {f : x $-> y & forall g, f $== g}.
 Existing Class IsTerminal.
+
+Definition mor_terminal {A : Type} `{Is1Cat A} (x y : A) {h : IsTerminal y}
+  : x $-> y
+  := (h x).1.
+
+Definition mor_terminal_unique {A : Type} `{Is1Cat A} (x y : A) {h : IsTerminal y}
+  (f : x $-> y)
+  : mor_terminal x y $== f
+  := (h x).2 f.
 
 (** Generalizing function extensionality, "Morphism extensionality" states that homwise [GpdHom_path] is an equivalence. *)
 Class HasMorExt (A : Type) `{Is1Cat A} := {
@@ -359,4 +377,34 @@ Class Is3Graph (A : Type) `{Is2Graph A}
   := isgraph_hom_hom : forall (a b : A), Is2Graph (a $-> b).
 Global Existing Instance isgraph_hom_hom | 30.
 Typeclasses Transparent Is3Graph.
+
+(** *** Preservation of initial and terminal objects *)
+
+Class PreservesInitial {A B : Type} (F : A -> B)
+  `{Is1Functor A B F} : Type
+  := isinitial_preservesinitial
+    : forall (x : A), IsInitial x -> IsInitial (F x).
+Global Existing Instance isinitial_preservesinitial.
+
+(** The initial morphism is preserved by such a functor. *)
+Lemma fmap_initial {A B : Type} (F : A -> B)
+  `{PreservesInitial A B F} (x y : A) (h : IsInitial x)
+  : fmap F (mor_initial x y) $== mor_initial (F x) (F y).
+Proof.
+  exact (mor_initial_unique _ _ _)^$.
+Defined.
+
+Class PreservesTerminal {A B : Type} (F : A -> B)
+  `{Is1Functor A B F} : Type
+  := isterminal_preservesterminal
+    : forall (x : A), IsTerminal x -> IsTerminal (F x).
+Global Existing Instance isterminal_preservesterminal.
+
+(** The terminal morphism is preserved by such a functor. *)
+Lemma fmap_terminal {A B : Type} (F : A -> B)
+  `{PreservesTerminal A B F} (x y : A) (h : IsTerminal y)
+  : fmap F (mor_terminal x y) $== mor_terminal (F x) (F y).
+Proof.
+  exact (mor_terminal_unique _ _ _)^$.
+Defined.
 

--- a/theories/WildCat/Core.v
+++ b/theories/WildCat/Core.v
@@ -69,7 +69,7 @@ Defined.
 Class Is0Functor {A B : Type} `{IsGraph A} `{IsGraph B} (F : A -> B)
   := { fmap : forall (a b : A) (f : a $-> b), F a $-> F b }.
 
-Arguments fmap {_ _ _ _} F {_ _ _} f.
+Arguments fmap {A B isgraph_A isgraph_B} F {is0functor_F a b} f : rename.
 
 Class Is2Graph (A : Type) `{IsGraph A}
   := isgraph_hom : forall (a b : A), IsGraph (a $-> b).
@@ -223,9 +223,18 @@ Class Is1Functor {A B : Type} `{Is1Cat A} `{Is1Cat B}
     fmap F (g $o f) $== fmap F g $o fmap F f;
 }.
 
-Arguments fmap2 {A B _ _ _ _ _ _ _ _} F {_ _ _ _ _ _} p.
-Arguments fmap_id {A B _ _ _ _ _ _ _ _} F {_ _} a.
-Arguments fmap_comp {A B _ _ _ _ _ _ _ _} F {_ _ _ _ _} f g.
+Arguments fmap2 {A B
+  isgraph_A is2graph_A is01cat_A is1cat_A
+  isgraph_B is2graph_B is01cat_B is1cat_B}
+  F {is0functor_F is1functor_F a b f g} p : rename.
+Arguments fmap_id {A B
+  isgraph_A is2graph_A is01cat_A is1cat_A
+  isgraph_B is2graph_B is01cat_B is1cat_B}
+  F {is0functor_F is1functor_F} a : rename.
+Arguments fmap_comp {A B
+  isgraph_A is2graph_A is01cat_A is1cat_A
+  isgraph_B is2graph_B is01cat_B is1cat_B}
+  F {is0functor_F is1functor_F a b c} f g : rename.
 
 (** Identity functor *)
 

--- a/theories/WildCat/Equiv.v
+++ b/theories/WildCat/Equiv.v
@@ -401,3 +401,25 @@ Proof.
   1: exact (((tex _).2 _)^$ $@ (tex _).2 _).
 Defined.
 
+Lemma isinitial_cate A `{HasEquivs A} (x y : A)
+  : x $<~> y -> IsInitial x -> IsInitial y.
+Proof.
+  intros f inx z.
+  exists ((inx z).1 $o f^-1$).
+  intros g.
+  refine (_ $@ compose_hh_V _ f).
+  refine (_ $@R _).
+  exact ((inx z).2 _).
+Defined.
+
+Lemma isterminal_cate A `{HasEquivs A} (x y : A)
+  : x $<~> y -> IsTerminal x -> IsTerminal y.
+Proof.
+  intros f tex z.
+  exists (f $o (tex z).1).
+  intros g.
+  refine (_ $@ compose_h_Vh f _).
+  refine (_ $@L _).
+  exact ((tex z).2 _).
+Defined.
+

--- a/theories/WildCat/Equiv.v
+++ b/theories/WildCat/Equiv.v
@@ -381,3 +381,23 @@ Proof.
   apply cat_idl.
 Defined.
 
+(** * Initial objects and terminal objects are all respectively equivalent. *)
+
+Lemma cate_isinitial A `{HasEquivs A} (x y : A)
+  : IsInitial x -> IsInitial y -> x $<~> y.
+Proof.
+  intros inx iny.
+  srapply (cate_adjointify (inx y).1 (iny x).1).
+  1: exact (((iny _).2 _)^$ $@ (iny _).2 _).
+  1: exact (((inx _).2 _)^$ $@ (inx _).2 _).
+Defined.
+
+Lemma cate_isterminal A `{HasEquivs A} (x y : A)
+  : IsTerminal x -> IsTerminal y -> x $<~> y.
+Proof.
+  intros tex tey.
+  srapply (cate_adjointify (tey x).1 (tex y).1).
+  1: exact (((tey _).2 _)^$ $@ (tey _).2 _).
+  1: exact (((tex _).2 _)^$ $@ (tex _).2 _).
+Defined.
+

--- a/theories/WildCat/PointedCat.v
+++ b/theories/WildCat/PointedCat.v
@@ -54,7 +54,7 @@ Section ZeroLaws.
 
 End ZeroLaws.
 
-(** We show the last two arguments so that end pointes can easily be specified. We had to do this again, since the section encapsulated the previous attempt. *)
+(** We make the last two arguments explicit so that end points can easily be specified. We had to do this again, since the section encapsulated the previous attempt. *)
 Local Arguments zero_morphism {_ _ _ _ _ _} _ _.
 
 (** A functor is pointed if it preserves the zero object. *)

--- a/theories/WildCat/PointedCat.v
+++ b/theories/WildCat/PointedCat.v
@@ -1,6 +1,6 @@
 Require Import Basics.
 Require Import WildCat.Core.
-
+Require Import WildCat.Equiv.
 
 (** A wild category is pointed if the initial and terminal object are the same. *)
 Class IsPointedCat (A : Type) `{Is1Cat A} := {
@@ -14,7 +14,7 @@ Global Existing Instance isterminal_zero_object.
 
 (** The zero morphism between objects [a] and [b] of a pointed category [A] is the unique morphism that factors throguh the zero object. *)
 Definition zero_morphism {A : Type} `{IsPointedCat A} {a b : A} : a $-> b
-  := (isinitial_zero_object b).1 $o (isterminal_zero_object a).1.
+  := (mor_initial _ b) $o (mor_terminal a _).
 
 Section ZeroLaws.
 
@@ -22,26 +22,91 @@ Section ZeroLaws.
     (f : a $-> b) (g : b $-> c).
 
   Definition cat_zero_source (h : zero_object $-> a) : h $== zero_morphism
-    := (isinitial_zero_object a).2 h
-      $@ ((isinitial_zero_object a).2 zero_morphism)^$.
+    := (mor_initial_unique _ _ _)^$ $@ (mor_initial_unique _ _ _).
 
   Definition cat_zero_target (h : a $-> zero_object) : h $== zero_morphism
-    := (isterminal_zero_object a).2 h
-      $@ ((isterminal_zero_object a).2 zero_morphism)^$.
+    := (mor_terminal_unique _ _ _)^$ $@ (mor_terminal_unique _ _ _).
 
-  Local Arguments zero_morphism {_ _ _ _ _ _} _ _.
+  (** We show the last two arguments so that end pointes can easily be specified. *)
+  Arguments zero_morphism {_ _ _ _ _ _} _ _.
 
   Definition cat_zero_l : zero_morphism b c $o f $== zero_morphism a c.
   Proof.
-    refine (cat_assoc _ _ _ $@ _).
-    apply cat_postwhisker, (isterminal_zero_object a).2.
+    refine (cat_assoc _ _ _ $@ (_ $@L _^$)).
+    apply mor_terminal_unique.
   Defined.
 
   Definition cat_zero_r : g $o zero_morphism a b $== zero_morphism a c.
   Proof.
-    refine ((cat_assoc _ _ _)^$ $@ _).
-    apply cat_prewhisker, (isinitial_zero_object c).2.
+    refine ((_ $@R _) $@ cat_assoc _ _ _)^$.
+    apply mor_initial_unique.
+  Defined.
+
+  (** Any morphism which factors through an object equivalent to the zero object is homotopic to the zero morphism. *)
+  Definition cat_zero_m `{!HasEquivs A} (be : b $<~> zero_object)
+    : g $o f $== zero_morphism a c.
+  Proof.
+    refine (_ $@L (compose_V_hh be f)^$ $@ _).
+    refine (cat_assoc_opp _ _ _ $@ _).
+    refine (_ $@L (mor_terminal_unique a _ _)^$ $@ _).
+    exact ((mor_initial_unique _ _ _)^$ $@R _).
   Defined.
 
 End ZeroLaws.
 
+(** We show the last two arguments so that end pointes can easily be specified. We had to do this again, since the section encapsulated the previous attempt. *)
+Local Arguments zero_morphism {_ _ _ _ _ _} _ _.
+
+(** A functor is pointed if it preserves the zero object. *)
+Class IsPointedFunctor {A B : Type} (F : A -> B) `{Is1Functor A B F} :=
+{
+  preservesinitial_pfunctor : PreservesInitial F ;
+  preservesterminal_pfunctor : PreservesTerminal F ;
+}.
+Global Existing Instances preservesinitial_pfunctor preservesterminal_pfunctor.
+
+(** Here is an alternative construct using preservation of the zero object. This requires more structure on the categories however. *)
+Definition Build_IsPointedFunctor' {A B : Type} (F : A -> B)
+  `{Is1Cat A, Is1Cat B, !Is0Functor F, !Is1Functor F}
+  `{!IsPointedCat A, !IsPointedCat B, !HasEquivs A, !HasEquivs B}
+  (p : F zero_object $<~> zero_object)
+  : IsPointedFunctor F.
+Proof.
+  apply Build_IsPointedFunctor.
+  + intros x inx.
+    rapply isinitial_cate.
+    symmetry.
+    refine (p $oE _).
+    rapply (emap F _).
+    rapply cate_isinitial.
+  + intros x tex.
+    rapply isterminal_cate.
+    symmetry.
+    refine (p $oE _).
+    rapply (emap F _).
+    rapply cate_isterminal.
+Defined.
+
+(** Pointed functors preserve the zero object upto isomorphism. *)
+Lemma pfunctor_zero {A B : Type} (F : A -> B)
+  `{IsPointedCat A, IsPointedCat B, !HasEquivs B,
+    !Is0Functor F, !Is1Functor F, !IsPointedFunctor F}
+  : F zero_object $<~> zero_object.
+Proof.
+  rapply cate_isinitial.
+Defined.
+
+(** Pointed functors preserve the zero morphism upto homotopy *)
+Lemma fmap_zero_morphism {A B : Type} (F : A -> B)
+  `{IsPointedCat A, IsPointedCat B, !HasEquivs B,
+    !Is0Functor F, !Is1Functor F, !IsPointedFunctor F} {a b : A}
+  : fmap F (zero_morphism a b) $== zero_morphism (F a) (F b).
+Proof.
+  refine (fmap_comp F _ _ $@ _).
+  refine (_ $@R _ $@ _).
+  1: nrapply fmap_initial; [exact _].
+  refine (_ $@L _ $@ _).
+  1: nrapply fmap_terminal; [exact _].
+  rapply cat_zero_m.
+  rapply pfunctor_zero.
+Defined.


### PR DESCRIPTION
Summary of changes:
 * Changed many definitions/lemmas about `X_functor` to use the wildcat `fmap` instead. This is by no means comprehensive, but a good look at what can be done.
 * Added various lemmas about initial and terminal objects.
 * Added some theory of pointed functors (functors between pointed categories)
 * Cleaned up a few proofs along the way.
 * Finished proof that pType is univalent.
 * Probably some others that I missed.

This work is culminating from another project I am working on.