### PR TITLE
New CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,24 +1,116 @@
-## This is the name of the CI
 name: CI
 
-## These are the triggers for the CI to run
 on: [ push , pull_request ]
+
+# We set the supported coq-version from here. In order to use this environment variable correctly, look at how they are used in the following jobs.
+env:
+  coq-version-supported: '8.13'
+  ocaml-version: '4.11-flambda'
+  deployment-branch: 'gh-pages'
+
+# Our jobs come in 3 stages, the latter stages depending on the former:
+# - Stage 1: Build jobs
+# - Stage 2: Documentation and validation jobs
+# - Stage 3: Deployment job
+# - Stage 4: Clean-up job
 
 jobs:
 
+#
+#  Stage 1:
+#
+
+# Here we define the build jobs:
+# - opam-build: Building the library using opam
+# - quick-build: Building the library quickly using make
+# - build: Building with timeing information for use in doc jobs
+
+  # Building the library using opam
+  opam-build:
+    strategy:
+      fail-fast: false
+      matrix:
+        coq-version-dummy:
+        - 'supported'
+        - 'latest'
+        - 'dev'
+        os:
+          - ubuntu-latest
+    env:
+      coq-version: ${{ matrix.coq-version-dummy }}    
+    runs-on: ${{ matrix.os }}
+    steps:
+    # Github actions doesn't let us set workflow level enviornment variables inside the stategy of a job. Therefore we use the dummy variable coq-version in the matrix to set an environment varible env.coq-version, which uses the globablly set coq-version-supported when running the 'supported' case. 
+    - name: Set supported coq-version
+      if: matrix.coq-version-dummy == 'supported'
+      run: echo "coq-version=${{ env.coq-version-supported }}" >> $GITHUB_ENV
+        
+    - name: Checkout repo
+      uses: actions/checkout@v2
+    - name: Build HoTT
+      uses: coq-community/docker-coq-action@v1
+      with:
+        opam_file: 'hott.opam'
+        coq_version: ${{ env.coq-version }}
+        ocaml_version: ${{ env.ocaml-version }}
+        
+  # Quick build
+  quick-build:
+    strategy:
+      fail-fast: false
+      matrix:
+        coq-version-dummy:
+        - 'supported'
+        - 'latest'
+        - 'dev'
+        os:
+        - ubuntu-latest
+    env:
+      coq-version: ${{ matrix.coq-version-dummy }}    
+    runs-on: ${{ matrix.os }}
+    steps:
+    # Github actions doesn't let us set workflow level enviornment variables inside the stategy of a job. Therefore we use the dummy variable coq-version in the matrix to set an environment varible env.coq-version, which uses the globablly set coq-version-supported when running the 'supported' case. 
+    - name: Set supported coq-version
+      if: matrix.coq-version-dummy == 'supported'
+      run: echo "coq-version=${{ env.coq-version-supported }}" >> $GITHUB_ENV
+    - name: Checkout repo
+      uses: actions/checkout@v2
+    - name: Build HoTT
+      uses: coq-community/docker-coq-action@v1
+      with:
+        coq_version: ${{ env.coq-version }}
+        ocaml_version: ${{ env.ocaml-version }}
+        custom_script: |
+          startGroup "Workaround permission issue" # https://github.com/coq-community/docker-coq-action#permissions
+          sudo chown -R coq:coq .
+          endGroup
+          make -j2
+    - name: Revert permissions
+      # to avoid a warning at cleanup time - https://github.com/coq-community/docker-coq-action#permissions
+      if: ${{ always() }}
+      run: sudo chown -R 1001:116 .
+          
+  # Main build which docs will run off
   build:
     strategy:
       fail-fast: false
       matrix:
         # We build on our supported version of coq and the master version
-        coq_version: [ '8.13' , 'latest' , 'dev' ]
-        ocaml_version: [ '4.11-flambda' ]
+        coq-version-dummy:
+        - 'supported'
+        - 'latest'
+        - 'dev'
         include:
-        - coq_version: 'dev'
+        - coq-version-dummy: 'dev'
           extra_gh_reportify: '--warnings'
-        
+    env:
+      coq-version: ${{ matrix.coq-version-dummy }}    
     runs-on: ubuntu-latest
     steps:
+    # Github actions doesn't let us set workflow level enviornment variables inside the stategy of a job. Therefore we use the dummy variable coq-version in the matrix to set an environment varible env.coq-version, which uses the globablly set coq-version-supported when running the 'supported' case. 
+    - name: Set supported coq-version
+      if: matrix.coq-version-dummy == 'supported'
+      run: echo "coq-version=${{ env.coq-version-supported }}" >> $GITHUB_ENV
     # Checkout branch
     - uses: actions/checkout@v2
     # Checkout submodules
@@ -26,127 +118,58 @@ jobs:
     # We use the coq docker so we don't have to build coq
     - uses: coq-community/docker-coq-action@v1
       with:
-        coq_version: ${{ matrix.coq_version }}
-        ocaml_version: ${{ matrix.ocaml_version }}
+        coq_version: ${{ env.coq-version }}
+        ocaml_version: ${{ env.ocaml-version }}
         custom_script: |
           startGroup "Workaround permission issue" # https://github.com/coq-community/docker-coq-action#permissions
             sudo chown -R coq:coq .
           endGroup
           sudo apt-get -o Acquire::Retries=30 update -q
           sudo apt-get -o Acquire::Retries=30 install python -y --allow-unauthenticated
-          etc/coq-scripts/github/reportify-coq.sh --stdout --errors ${{ matrix.extra_gh_reportify }} etc/coq-scripts/timing/make-pretty-timed.sh -j2 TIMING=1
-          make
+          etc/coq-scripts/github/reportify-coq.sh --errors make TIMED=1 -j2 --output-sync GH_REPORT_ERRORS=1
+
     - name: Revert permissions
       # to avoid a warning at cleanup time - https://github.com/coq-community/docker-coq-action#permissions
       if: ${{ always() }}
       run: sudo chown -R 1001:116 .
+    # Tar workspace files
+    - name: 'Tar .vo files'
+      run: tar -cf workspace.tar .
+    # We upload build artifacts for use by documentation
+    - name: 'Upload Artifact'
+      uses: actions/upload-artifact@v2
+      with:
+        name: workspace-${{ env.coq-version }}
+        path: workspace.tar   
 
+#
+#  Stage 2:
+#
 
-  doc:
+# Here we define the documentation and validation jobs:
+# - doc-alectryon: Builds the alectryon documentation
+# - doc-dep-graph: Builds dependency graphs
+# - doc-coqdoc: Builds the coqdoc documentation
+# - doc-proviola: Builds the proviola documentation
+# - doc-timing: Builds the timing documentation
+# - coqchk: Runs coqchk
+# - install: Tests install target
+
+   # alectryon job
+  doc-alectryon:
+    needs: build
     strategy:
       fail-fast: false
-      matrix:
-        include:
-        - label: update dep graphs
-          env: { UPDATE_DEP_GRAPHS: "yes", BUILD_COQ: "yes", UPDATE_QUICK_DOC: "" }
-        - label: update quick doc
-          env: { UPDATE_QUICK_DOC: "yes" }
-        - label: update html
-          env: { UPDATE_HTML: "yes", UPDATE_QUICK_DOC: "" }
-        - label: validate
-          env: { VALIDATE: "yes"   , UPDATE_QUICK_DOC: "" }
-    env: ${{ matrix.env }}
-
-    # The operating system
-    runs-on: ubuntu-latest
-
-    # Here is the main script
-    steps:
-    # First we set up Python 2.7
-    - name: Set up Python 2.7
-      run: |
-        sudo apt-get install -y python curl
-        sudo curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
-        sudo python ./get-pip.py
-
-    - uses: actions/checkout@v2
-
-    # We update the submodules
-    - name: submodules-init
-      uses: snickerbockers/submodules-init@v4
-
-    - name: Add repositories to apt
-      ## TODO: Cache dependencies?
-      run: |
-        # echo Adding repositories...
-        # sudo add-apt-repository avsm
-        # sudo add-apt-repository -y 'ppa:jgross-h/graphviz'
-        sudo add-apt-repository -y 'ppa:jgross-h/coq-master-daily'
-
-    - name: Update apt
-      run: sudo apt-get update
-
-    - name: Installing dependencies
-      run: |
-        # Work around issue with npm as per https://bugs.launchpad.net/ubuntu/+source/npm/+bug/1809828 and https://askubuntu.com/a/1092849/223605
-        sudo apt-get install -y --allow-unauthenticated libnode-dev node-gyp libssl-dev
-        sudo apt-get install -y --allow-unauthenticated npm aspcud ghc cabal-install graphviz xsltproc python-lxml python-pexpect libxml2-dev libxslt1-dev time lua5.1 unzip ocaml
-        sudo sh -c "yes | $(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)"
-        opam init --disable-sandboxing -y
-        opam update
-        sudo apt-get install -y libipc-system-simple-perl libstring-shellquote-perl
-        opam install -y camlp5 ocamlfind ocamlgraph zarith
-
-    - name: Upgrade and autoremove packages
-      run: |
-        # This will take a very long time
-        # sudo apt-get -y upgrade
-        sudo apt-get autoremove
-
-    - name: Before script information
-      run: |
-        eval $(opam env)
-        lscpu
-        uname -a
-        lsb_release -a
-        etc/ci/before_script.sh
-        coqc --version
-        echo | coqtop
-        export COMMITISH="$(git rev-list HEAD -1)"
-
-    # we display errors in the changes tab from all jobs
-    # we only display warnings from the master job, so we don't get duplicate warnings
-    - name: add warning problem matchers
-      run: |
-        #echo "::add-matcher::etc/coq-scripts/github/coqdoc.json" # disabled for now, since they don't have file names
-      if: ${{ matrix.display-warnings }}
-
-    - name: make strict-test
-      run: make strict-test
-      if: env.UPDATE_QUICK_DOC == ''
-
-    # we display errors in the changes tab from all jobs
-    # we only display warnings from the master job, so we don't get duplicate warnings
-    - name: Build with timing
-      run: |
-        etc/coq-scripts/github/reportify-coq.sh --stdout --errors ${EXTRA_GH_REPORTIFY} etc/coq-scripts/timing/make-pretty-timed.sh -j2 TIMING=1
-        make
-      if: env.UPDATE_QUICK_DOC == ''
-
-    - name: Test install target
-      run: etc/ci/test-install-target.sh
-      if: env.UPDATE_QUICK_DOC == ''
-
-    - name: After success script
-      run: etc/ci/after_success.sh
-      env:
-        ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-  
-  alectryon:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: snickerbockers/submodules-init@v4
+    # Download artifact
+    - uses: actions/download-artifact@v2
+      with:
+        name: workspace-${{ env.coq-version-supported }}
+    # Unpack Tar
+    - run: tar -xf workspace.tar
     - name: add problem matchers
       run: |
         #echo "::add-matcher::etc/coq-scripts/github/coq-oneline-error.json" # now via a script
@@ -155,7 +178,7 @@ jobs:
         #echo "::add-matcher::etc/coq-scripts/github/alectryon-warning.json" # too noisy right now, cf https://github.com/cpitclaudel/alectryon/issues/34 and https://github.com/cpitclaudel/alectryon/issues/33
     - uses: coq-community/docker-coq-action@v1
       with:
-        coq_version: 8.13
+        coq_version: ${{ env.coq-version-supported }}
         ocaml_version: 4.11-flambda
         custom_script: |
           opam install -y coq-serapi
@@ -165,22 +188,448 @@ jobs:
           startGroup "Workaround permission issue" # https://github.com/coq-community/docker-coq-action#permissions
             sudo chown -R coq:coq .
           endGroup
-          etc/coq-scripts/github/reportify-coq.sh --errors make TIMED=1 -j2 --output-sync GH_REPORT_ERRORS=1
           make alectryon ALECTRYON_EXTRAFLAGS=--traceback
     - name: Revert permissions
       # to avoid a warning at cleanup time - https://github.com/coq-community/docker-coq-action#permissions
       if: ${{ always() }}
       run: sudo chown -R 1001:116 .
+    - name: tar alectryon artifact
+      run: tar -cf alectryon-html.tar alectryon-html
     - name: upload alectryon artifact
       uses: actions/upload-artifact@v1
       with:
         name: alectryon-html
-        path: alectryon-html
-    - name: Deploy html files
-      uses: JamesIves/github-pages-deploy-action@releases/v4
+        path: alectryon-html.tar
+
+
+  # dependency graph doc job
+  doc-dep-graphs:
+    needs: build
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+    # Checkout branch
+    - uses: actions/checkout@v2
+    # Checkout submodules
+    - uses: snickerbockers/submodules-init@v4
+    # Download artifact
+    - uses: actions/download-artifact@v2
       with:
-        dry-run: ${{ github.ref != 'refs/heads/master' || github.event_name != 'push' }}
-        branch: gh-pages
-        folder: alectryon-html
-        target-folder: alectryon-html
-        single-commit: false
+        name: workspace-${{ env.coq-version-supported }}
+    # Unpack Tar
+    - run: tar -xf workspace.tar
+    # We use the coq docker so we don't have to build coq
+    - uses: coq-community/docker-coq-action@v1
+      with:
+        coq_version: ${{ env.coq-version-supported }}
+        ocaml_version: ${{ env.ocaml-version }}
+        custom_script: |
+          sudo apt-get update
+          sudo apt-get install -y ghc cabal-install
+          sudo apt-get install -y --allow-unauthenticated \
+          libnode-dev node-gyp libssl-dev npm aspcud      \
+          graphviz xsltproc python-lxml python-pexpect    \
+          libxml2-dev libxslt1-dev time lua5.1 unzip
+
+          cabal update
+          cabal install graphviz text
+          sudo -E npm config set strict-ssl false
+          sudo -E npm i -g npm
+          sudo -E npm install -g doctoc
+          
+          startGroup "Workaround permission issue" # https://github.com/coq-community/docker-coq-action#permissions
+            sudo chown -R coq:coq .
+          endGroup
+          ## Make dependency graph
+          make HoTT.deps HoTTCore.deps
+          runhaskell etc/DepsToDot.hs --coqdocbase="http://hott.github.io/HoTT/proviola-html/" --title="HoTT Library Dependency Graph" < HoTT.deps > HoTT.dot
+          runhaskell etc/DepsToDot.hs --coqdocbase="http://hott.github.io/HoTT/proviola-html/" --title="HoTT Core Library Dependency Graph" < HoTTCore.deps > HoTTCore.dot
+          dot -Tsvg HoTT.dot -o HoTT.svg
+          dot -Tsvg HoTTCore.dot -o HoTTCore.svg
+          rm -rf dep-graphs
+          mkdir -p dep-graphs
+          mv HoTT.svg HoTTCore.svg dep-graphs/
+
+          
+          ## Make file dependency graphs
+          opam install ocamlgraph -y
+          ./etc/ci/make_dpd_graphs.sh
+
+          make dpdgraph || exit $?
+          make svg-file-dep-graphs -k || exit $?
+          # `dot` hates file-dep-graphs/hott-all.dot, because it's too big, and
+          # makes `dot` spin for over a dozen minutes.  So disable it for now.
+          #make svg-aggregate-dep-graphs -k || exit $?
+          make file-dep-graphs/index.html -k || exit $?
+
+          
+        
+    - name: Revert permissions
+      # to avoid a warning at cleanup time - https://github.com/coq-community/docker-coq-action#permissions
+      if: ${{ always() }}
+      run: sudo chown -R 1001:116 .
+    # Tar dependency graph files
+    - name: 'Tar .svg files'
+      run: |
+        tar -cf dep-graphs.tar dep-graphs
+        tar -cf file-dep-graphs.tar file-dep-graphs.tar
+    # We upload the artifacts
+    - name: 'Upload Artifact dep-graphs.tar'
+      uses: actions/upload-artifact@v2
+      with:
+        name: dep-graphs
+        path: dep-graphs.tar
+    - name: 'Upload Artifact file-dep-graphs.tar'
+      uses: actions/upload-artifact@v2
+      with:
+        name: file-dep-graphs
+        path: file-dep-graphs.tar
+
+  # doc-coqdoc job
+  # This builds coqdoc, proviola and timing docs and uploads their artifacts
+  doc-coqdoc:
+    needs: build
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+    # Checkout branch
+    - uses: actions/checkout@v2
+    # Checkout submodules
+    - uses: snickerbockers/submodules-init@v4
+    # Download artifact
+    - uses: actions/download-artifact@v2
+      with:
+        name: workspace-${{ env.coq-version-supported }}
+    # Unpack Tar
+    - run: tar -xf workspace.tar
+    # We use the coq docker so we don't have to build coq
+    - uses: coq-community/docker-coq-action@v1
+      with:
+        coq_version: ${{ env.coq-version-supported }}
+        ocaml_version: ${{ env.ocaml-version }}
+        custom_script: |
+          startGroup "Workaround permission issue" # https://github.com/coq-community/docker-coq-action#permissions
+            sudo chown -R coq:coq .
+          endGroup
+          ## Make HTML doc
+          make -j2 html
+          mv html coqdoc-html
+    - name: Revert permissions
+      # to avoid a warning at cleanup time - https://github.com/coq-community/docker-coq-action#permissions
+      if: ${{ always() }}
+      run: sudo chown -R 1001:116 .
+    # Tar html files
+    - name: 'Tar doc files'
+      run: tar -cf coqdoc-html.tar coqdoc-html
+    # Upload coqdoc-html artifact
+    - name: 'Upload coqdoc-html Artifact'
+      uses: actions/upload-artifact@v2
+      with:
+        name: coqdoc-html
+        path: coqdoc-html.tar      
+          
+  # doc-proviola job
+  # This builds coqdoc, proviola and timing docs and uploads their artifacts
+  doc-proviola:
+    needs: build
+    strategy:
+      fail-fast: false 
+    runs-on: ubuntu-latest
+    steps:
+    # Checkout branch
+    - uses: actions/checkout@v2
+    # Checkout submodules
+    - uses: snickerbockers/submodules-init@v4
+    # Download artifact
+    - uses: actions/download-artifact@v2
+      with:
+        name: workspace-${{ env.coq-version-supported }}
+    # Unpack Tar
+    - run: tar -xf workspace.tar
+    # We use the coq docker so we don't have to build coq
+    - uses: coq-community/docker-coq-action@v1
+      with:
+        coq_version: ${{ env.coq-version-supported }}
+        ocaml_version: ${{ env.ocaml-version }}
+        custom_script: |
+          sudo apt-get update
+          sudo apt-get install -y ghc cabal-install
+          sudo apt-get install -y --allow-unauthenticated \
+          libnode-dev node-gyp libssl-dev npm aspcud curl \
+          graphviz xsltproc python-lxml python-pexpect    \
+          libxml2-dev libxslt1-dev time lua5.1 unzip python
+
+          sudo curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
+          sudo python ./get-pip.py
+
+          startGroup "Workaround permission issue" # https://github.com/coq-community/docker-coq-action#permissions
+            sudo chown -R coq:coq .
+          endGroup
+          ./etc/ci/install_proviola.sh
+          ## Make proviola doc
+          make -j2 proviola TIMED=1 -k; make proviola TIMED=1 || exit $?
+    - name: Revert permissions
+      # to avoid a warning at cleanup time - https://github.com/coq-community/docker-coq-action#permissions
+      if: ${{ always() }}
+      run: sudo chown -R 1001:116 .
+    # Tar html files
+    - name: 'Tar doc files'
+      run: tar -cf proviola-html.tar proviola-html
+    # Upload proviola-html artifact
+    - name: 'Upload proviola-html Artifact'
+      uses: actions/upload-artifact@v2
+      with:
+        name: proviola-html
+        path: proviola-html.tar
+          
+  # doc-timing job
+  # This builds coqdoc, proviola and timing docs and uploads their artifacts
+  doc-timing:
+    needs: build
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+    # Checkout branch
+    - uses: actions/checkout@v2
+    # Checkout submodules
+    - uses: snickerbockers/submodules-init@v4
+    # Download artifact
+    - uses: actions/download-artifact@v2
+      with:
+        name: workspace-${{ env.coq-version-supported }}
+    # Unpack Tar
+    - run: tar -xf workspace.tar
+    # We use the coq docker so we don't have to build coq
+    - uses: coq-community/docker-coq-action@v1
+      with:
+        coq_version: ${{ env.coq-version-supported }}
+        ocaml_version: ${{ env.ocaml-version }}
+        custom_script: |
+          sudo apt-get update
+          sudo apt-get install -y time python lua5.1 
+          startGroup "Workaround permission issue" # https://github.com/coq-community/docker-coq-action#permissions
+            sudo chown -R coq:coq .
+          endGroup
+          ## Make timing doc
+          make -j2 timing-html         
+    - name: Revert permissions
+      # to avoid a warning at cleanup time - https://github.com/coq-community/docker-coq-action#permissions
+      if: ${{ always() }}
+      run: sudo chown -R 1001:116 .
+    # Tar html files
+    - name: 'Tar doc files'
+      run: tar -cf timing-html.tar timing-html
+    # Upload timing-html artifact
+    - name: 'Upload timing-html Artifact'
+      uses: actions/upload-artifact@v2
+      with:
+        name: timing-html
+        path: timing-html.tar   
+
+  # The coqchk job
+  coqchk:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        # We build on our supported version of coq and the master version
+        coq-version-dummy:
+        - 'supported'
+        - 'latest'
+        - 'dev'
+        include:
+        - coq-version: 'dev'
+          extra_gh_reportify: '--warnings'
+    env:
+      coq-version: ${{ matrix.coq-version-dummy }}    
+    runs-on: ubuntu-latest
+    steps:
+    # Github actions doesn't let us set workflow level enviornment variables inside the stategy of a job. Therefore we use the dummy variable coq-version in the matrix to set an environment varible env.coq-version, which uses the globablly set coq-version-supported when running the 'supported' case. 
+    - name: Set supported coq-version
+      if: matrix.coq-version-dummy == 'supported'
+      run: echo "coq-version=${{ env.coq-version-supported }}" >> $GITHUB_ENV
+    # Checkout branch
+    - uses: actions/checkout@v2
+    # Checkout submodules
+    - uses: snickerbockers/submodules-init@v4
+    # Download artifact
+    - uses: actions/download-artifact@v2
+      with:
+        name: workspace-${{ env.coq-version }}
+    # Unpack Tar
+    - run: tar -xf workspace.tar
+    # We use the coq docker so we don't have to build coq
+    - uses: coq-community/docker-coq-action@v1
+      with:
+        coq_version: ${{ env.coq-version }}
+        ocaml_version: ${{ env.ocaml-version }}
+        custom_script: |
+          startGroup "Workaround permission issue" # https://github.com/coq-community/docker-coq-action#permissions
+            sudo chown -R coq:coq .
+          endGroup
+          make validate
+    - name: Revert permissions
+      # to avoid a warning at cleanup time - https://github.com/coq-community/docker-coq-action#permissions
+      if: ${{ always() }}
+      run: sudo chown -R 1001:116 .
+
+  # Test install target
+  install:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        # We build on our supported version of coq and the master version
+        coq-version-dummy:
+        - 'supported'
+        - 'latest'
+        - 'dev'
+        include:
+        - coq-version: 'dev'
+          extra_gh_reportify: '--warnings'
+    env:
+      coq-version: ${{ matrix.coq-version-dummy }}    
+    runs-on: ubuntu-latest
+    steps:
+    # Github actions doesn't let us set workflow level enviornment variables inside the stategy of a job. Therefore we use the dummy variable coq-version in the matrix to set an environment varible env.coq-version, which uses the globablly set coq-version-supported when running the 'supported' case. 
+    - name: Set supported coq-version
+      if: matrix.coq-version-dummy == 'supported'
+      run: echo "coq-version=${{ env.coq-version-supported }}" >> $GITHUB_ENV
+    # Checkout branch
+    - uses: actions/checkout@v2
+    # Checkout submodules
+    - uses: snickerbockers/submodules-init@v4
+    # Download artifact
+    - uses: actions/download-artifact@v2
+      with:
+        name: workspace-${{ env.coq-version }}
+    # Unpack Tar
+    - run: tar -xf workspace.tar
+    # We use the coq docker so we don't have to build coq
+    - uses: coq-community/docker-coq-action@v1
+      with:
+        coq_version: ${{ env.coq-version }}
+        ocaml_version: ${{ env.ocaml-version }}
+        custom_script: |
+          startGroup "Workaround permission issue" # https://github.com/coq-community/docker-coq-action#permissions
+            sudo chown -R coq:coq .
+          endGroup
+          ## Test install target
+          make install
+          (echo 'Require Import HoTT.HoTT.' | coqtop -q)
+
+    - name: Revert permissions
+      # to avoid a warning at cleanup time - https://github.com/coq-community/docker-coq-action#permissions
+      if: ${{ always() }}
+      run: sudo chown -R 1001:116 .
+        
+#
+#  Stage 3
+#
+
+  deploy-doc:
+    # We only deploy when the reference is the master branch
+    if: ${{ github.ref == 'refs/heads/master' }}
+    # This job relies on the documentation jobs having finished. Technically we don't need to rely on coqchk and install, but it is simpler this way.
+    needs:
+    - coqchk
+    - install
+    - doc-alectryon
+    - doc-dep-graphs
+    - doc-coqdoc
+    - doc-proviola
+    - doc-timing 
+    runs-on: ubuntu-latest
+    steps:
+    # Checkout branch
+    - uses: actions/checkout@v2
+    # Download alectryon artifact
+    - uses: actions/download-artifact@v2
+      with:
+        name: alectryon-html
+    # Download dependency graph artifacts
+    - uses: actions/download-artifact@v2
+      with:
+        name: dep-graphs 
+    # Download file dependency graph artifacts
+    - uses: actions/download-artifact@v2
+      with:
+        name: file-dep-graphs
+    # Download coqdoc artifact
+    - uses: actions/download-artifact@v2
+      with:
+        name: coqdoc-html
+    # Download proviola artifact
+    - uses: actions/download-artifact@v2
+      with:
+        name: proviola-html
+    # Download timing artifact
+    - uses: actions/download-artifact@v2
+      with:
+        name: timing-html
+    # Unpack Tar files
+    - run: |
+        mkdir doc
+        tar -xf alectryon-html.tar  -C doc  
+        tar -xf dep-graphs.tar      -C doc
+        tar -xf file-dep-graphs.tar -C doc
+        tar -xf coqdoc-html.tar     -C doc
+        tar -xf proviola-html.tar   -C doc
+        tar -xf timing-html.tar     -C doc
+            
+    - name: Deploy 🚀
+      uses: JamesIves/github-pages-deploy-action@4.1.4
+      with:
+        branch: ${{ env.deployment-branch }}
+        folder: doc
+        single-commit: true
+      
+    
+#
+#  Stage 4
+#
+
+# Here we define the cleanup job:
+# - delete-artifacts: We delete the artifacts from the previous jobs
+
+  delete-artifacts:
+    # We always want to run this job even if we cancel
+    if: ${{ always() }}
+    # We depend on the stage 3 jobs
+    needs:
+    - deploy-doc
+    runs-on: ubuntu-latest
+    steps:
+    # Delete workspace artifacts
+    - uses: geekyeggo/delete-artifact@v1
+      with:
+        name: workspace-${{ env.coq-version-supported }}
+    - uses: geekyeggo/delete-artifact@v1
+      with:
+        name: workspace-latest
+    - uses: geekyeggo/delete-artifact@v1
+      with:
+        name: workspace-dev
+    # Delete documentation artifacts
+    - uses: geekyeggo/delete-artifact@v1
+      with:
+        name: dep-graphs
+    - uses: geekyeggo/delete-artifact@v1
+      with:
+        name: file-dep-graphs
+    - uses: geekyeggo/delete-artifact@v1
+      with:
+        name: alectryon-html
+    - uses: geekyeggo/delete-artifact@v1
+      with:
+        name: coqdoc-html
+    - uses: geekyeggo/delete-artifact@v1
+      with:
+        name: proviola-html
+    - uses: geekyeggo/delete-artifact@v1
+      with:
+        name: timing-html
+    


### PR DESCRIPTION
Here is a project that I have been working on for a few months now. I have completely rewritten the CI.

The CI is now stratified into 4 stages:
 1. **Build Stage** - Here we build the library in 3 different ways:
    - `opam-build`: Build the library using the `hott.opam` file.
    - `build`: The main build job generating timing data.
    - `quick-build`: A faster build than the others, allowing you to see compilation errors quickly.

Each of these jobs runs on our current supported version of coq, the latest stable version and the dev version. The dev versions of the builds have the possibility of breaking due to the live development of coq. The stable version of coq is slightly behind, allowing us to distinguish between coq errors and the library breaking on the latest version of coq.

We don't actually build and install coq but run everything in the coq-docker containers. This makes things much faster.

The compiled files from the `build` job are uploaded as artifacts for use in the documentation and validation stage.

 2. **Documentation and Validation Stage** - Here we carry out the following jobs:
     - `doc-alectryon`: Build the alectryon html documentation and upload the artifacts.
     - `doc-dep-graph`: Build the dependency graphs and upload the artifacts.
     - `doc-coqdoc`: Build the coqdoc html documentation and upload the artifacts.
     - `doc-proviola`: Build the proviola html documentation and upload the artifacts.
     - `doc-timing`: Build the timing html documentation and upload the artifacts.
     - `coqchk`: Validate the compiled coq files. This step wasn't actually being carried out in the previous CI and has some interesting information. It lists all the axioms used in the library.
     - `install`: Test the installation process

The `doc` jobs will only build on the supported version of coq wheras the `coqchk` and `install` jobs use artifacts from all 3 versions.

  3. **Deployment Stage** - Here we deploy the html documentation and dependency graphs. This is done as a single-commit to the branch gh-pages, squashing the history and keeping the size of the repo down as a result. 

 4. **Clean up Stage** - Here we delete the workspace and documentation artifacts generated.

The CI should also be easier to maintain. For example, the current supported coq version is at the top of `ci.yml` and can be changed easily. The jobs are more modular than the previous bash scripts which means we can add and remove parts as we please in the future. 

---

There are a few things left we can do that I haven't included in this PR.
 * Since we don't rely on the coq submodule any more we can finally remove it. #1456
 * Many of the scripts in `etc/ci` are no longer being used, and may be worth removing.

Closes #1516 
