### PR TITLE
Various wildcat usability changes and changes to transformations

### DIFF
--- a/theories/WildCat/NatTrans.v
+++ b/theories/WildCat/NatTrans.v
@@ -9,7 +9,7 @@ Definition Transformation {A : Type} {B : A -> Type} `{forall x, IsGraph (B x)}
   (F G : forall (x : A), B x)
   := forall (a : A), F a $-> G a.
 
-(** This let's us apply transformations to things. *)
+(** This lets us apply transformations to things. Identity Coercion tells coq that this coercion is in fact definitionally the identity map so it doesn't need to insert it, but merely rewrite definitionally when typechecking. *)
 Identity Coercion fun_trans : Transformation >-> Funclass.
 
 Notation "F $=> G" := (Transformation F G).

--- a/theories/WildCat/NatTrans.v
+++ b/theories/WildCat/NatTrans.v
@@ -191,7 +191,6 @@ Defined.
 (** Throws a warning, but can probably be ignored. *)
 Global Set Warnings "-ambiguous-paths".
 Coercion nattrans_natequiv : NatEquiv >-> NatTrans.
-(* Set Warnings "+ambiguous-paths". *)
 
 Definition natequiv_compose {A B} {F G H : A -> B} `{IsGraph A} `{HasEquivs B}
   `{!Is0Functor F, !Is0Functor G, !Is0Functor H}

--- a/theories/WildCat/Yoneda.v
+++ b/theories/WildCat/Yoneda.v
@@ -119,7 +119,7 @@ Definition opyon_cancel {A : Type} `{Is01Cat A} (a b : A)
 
 Definition opyon1 {A : Type} `{Is01Cat A} (a : A) : Fun01 A Type.
 Proof.
-  rapply (Build_Fun01 _ _ _ _ (opyon a)).
+  rapply (Build_Fun01 _ _ (opyon a)).
 Defined.
 
 (** We can also deduce "full-faithfulness" on equivalences. *)


### PR DESCRIPTION
There are various usability changes such as naming/order of arguments in this patch. Importantly the definition of `Transformation` was changed to be a dependent function, which would allow it to be used in a future definition of modification etc. Unfortunately this comes with a diamond in the coercion tree which isn't a problem on paper, but coq is not permissive enough. We disable to warning anyway to avoid spam every time the module is imported. It might be worth moving the disabling of the warning earlier in the library. 