### PR TITLE
fix generate_coqproject.sh

### DIFF
--- a/etc/generate_coqproject.sh
+++ b/etc/generate_coqproject.sh
@@ -3,7 +3,7 @@ if [ -e .git ]; then
   TRACKED_V_FILES="$(git ls-files "*.v")"
 else
   echo "Warning: Not a git clone, using find instead" >&2
-  TRACKED_V_FILES="$(find theories/ contrib/ -type f -name "*.v")"
+  TRACKED_V_FILES="$(find theories contrib -type f -name "*.v")"
 fi
 
 ## List untracked .v files


### PR DESCRIPTION
This was causing macos users of the opam file to have "theories//..." in the _CoqProject file. This should fix that. Otherwise the build doesn't work for them.