### PR TITLE
Remove coq submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "coq-HoTT"]
-	path = coq-HoTT
-	url = https://github.com/coq/coq.git
-	branch = master
 [submodule "etc/coq-scripts"]
 	path = etc/coq-scripts
 	url = https://github.com/JasonGross/coq-scripts.git


### PR DESCRIPTION
The library has worked with Coq out-of-the-box for a while now. We can finally get rid of this.

If anybody is still using the submodule, please consult INSTALL.md on using opam for Coq.