### PR TITLE
Adapt w.r.t. coq/coq#15171.

### DIFF
--- a/theories/Algebra/Rings/Z.v
+++ b/theories/Algebra/Rings/Z.v
@@ -158,7 +158,7 @@ Lemma cring_catamorphism_fun_negate {R} x
   : cring_catamorphism_fun R (- x) = - cring_catamorphism_fun R x.
 Proof.
   snrapply (groups.preserves_negate _).
-  1-6: exact _.
+  1-6: typeclasses eauto.
   snrapply Build_IsMonoidPreserving.
   1: exact _.
   split.


### PR DESCRIPTION
HoTT was exploiting a weird multigoal behaviour of the exact tactic that was interleaving global evar resolution with goal filling. It is not clear that this can be qualified as a bug, but the net result is quite surprising and it's better for HoTT not to depend on it, especially if we merge coq/coq#15171.

This should be backwards compatible.