### PR TITLE
Relation coequalizer

### DIFF
--- a/theories/Algebra/AbGroups/AbelianGroup.v
+++ b/theories/Algebra/AbGroups/AbelianGroup.v
@@ -1,6 +1,6 @@
 Require Import HoTT.Basics HoTT.Types.
 Require Import Truncations.
-Require Import HIT.Coeq.
+Require Import Colimits.Coeq.
 Require Export Algebra.Groups.
 Require Import Cubical.
 Require Import WildCat.
@@ -76,7 +76,7 @@ Proof.
   intro y; revert x.
   srapply Quotient_ind_hprop.
   intro x.
-  apply (ap (tr o coeq)).
+  apply (ap (class_of _)).
   apply commutativity.
 Defined.
 

--- a/theories/Algebra/AbGroups/Abelianization.v
+++ b/theories/Algebra/AbGroups/Abelianization.v
@@ -1,6 +1,6 @@
 Require Import Basics Types Cubical WildCat.
 Require Import Truncations.
-Require Import HIT.Coeq.
+Require Import Colimits.Coeq.
 Require Import Algebra.Groups.
 Require Import Algebra.AbGroups.AbelianGroup.
 
@@ -97,9 +97,8 @@ Section Abel.
     (x y z : G) : dp_apD (Abel_ind P a c) (ab_comm x y z) = c x y z.
   Proof.
     apply dp_apD_path_transport.
-    refine (apD_compose' tr _ _ @ _).
-    refine (ap _ (Coeq_ind_beta_cglue _ _ _ (x, y, z)) @ _).
-    apply concat_V_pp.
+    refine (apD_compose' tr _ _ @ ap _ _ @ concat_V_pp _ _).
+    rapply Coeq_ind_beta_cglue.
   Defined.
 
   (** We also have a recursion princple. *)
@@ -166,7 +165,7 @@ Section AbelGroup.
       refine (ap _ (associativity _ _ _)). }
     intros b c d.
     revert a.
-    Abel_ind_hprop a; cbn.
+    Abel_ind_hprop a; simpl.
     refine (ap _ (associativity _ _ _) @ _).
     refine (ab_comm _ _ _ @ _).
     refine (ap _ (associativity _ _ _)^).
@@ -178,7 +177,7 @@ Section AbelGroup.
     intros x y.
     Abel_ind_hprop z; revert y.
     Abel_ind_hprop y; revert x.
-    Abel_ind_hprop x; cbn.
+    Abel_ind_hprop x; simpl.
     apply ap, associativity.
   Defined.
 
@@ -192,13 +191,13 @@ Section AbelGroup.
   Global Instance abel_leftidentity : LeftIdentity abel_sgop abel_mon_unit.
   Proof.
     Abel_ind_hprop x.
-    cbn; apply ap, left_identity.
+    simpl; apply ap, left_identity.
   Defined.
 
   Global Instance abel_rightidentity : RightIdentity abel_sgop abel_mon_unit.
   Proof.
     Abel_ind_hprop x.
-    cbn; apply ap, right_identity.
+    simpl; apply ap, right_identity.
   Defined.
 
   (** Hence Abel G is a monoid *)
@@ -211,7 +210,6 @@ Section AbelGroup.
     Abel_ind_hprop y.
     revert x.
     Abel_ind_hprop x.
-    cbn.
     refine ((ap ab (left_identity _))^ @ _).
     refine (_ @ (ap ab (left_identity _))).
     apply ab_comm.
@@ -236,14 +234,14 @@ Section AbelGroup.
   (** Again by Abel_ind_hprop and the corresponding laws for G we can prove the left and right inverse laws. *)
   Global Instance abel_leftinverse : LeftInverse abel_sgop abel_negate abel_mon_unit.
   Proof.
-    Abel_ind_hprop x.
-    cbn; apply ap; apply left_inverse.
+    Abel_ind_hprop x; simpl.
+    apply ap; apply left_inverse.
   Defined.
 
   Instance abel_rightinverse : RightInverse abel_sgop abel_negate abel_mon_unit.
   Proof.
-    Abel_ind_hprop x.
-    cbn; apply ap; apply right_inverse.
+    Abel_ind_hprop x; simpl.
+    apply ap; apply right_inverse.
   Defined.
 
   (** Thus Abel G is a group *)

--- a/theories/Algebra/Groups/FreeGroup.v
+++ b/theories/Algebra/Groups/FreeGroup.v
@@ -1,7 +1,7 @@
 Require Import Basics Types.
 Require Import Groups.Group.
 Require Import Truncations.
-Require Import HIT.Coeq.
+Require Import Colimits.Coeq.
 Require Import WildCat.
 
 Local Open Scope mc_scope.
@@ -237,7 +237,7 @@ Section Reduction.
     revert x; snrapply Coeq_ind; intro x; [ | apply path_ishprop].
     revert y; snrapply Coeq_ind; intro y; [ | apply path_ishprop].
     revert z; snrapply Coeq_ind; intro z; [ | apply path_ishprop].
-    cbn; apply ap.
+    rapply (ap (tr o coeq)).
     apply word_concat_w_ww.
   Defined.
 

--- a/theories/Algebra/Groups/FreeProduct.v
+++ b/theories/Algebra/Groups/FreeProduct.v
@@ -1,6 +1,6 @@
 Require Import Basics Types.
 Require Import Cubical.
-Require Import HIT.Coeq.
+Require Import Colimits.Coeq.
 Require Import Spaces.List.
 Require Import Colimits.Pushout.
 Require Import Algebra.Groups.Group.
@@ -448,7 +448,7 @@ Section FreeProduct.
     rapply amal_type_ind_hprop; intro z; revert y.
     rapply amal_type_ind_hprop; intro y; revert x.
     rapply amal_type_ind_hprop; intro x.
-    cbn; nrapply (ap amal_eta).
+    nrapply (ap amal_eta).
     rapply word_concat_w_ww.
   Defined.
 
@@ -461,7 +461,7 @@ Section FreeProduct.
   Global Instance rightidentity_sgop_amal_type : RightIdentity sg_op mon_unit.
   Proof.
     rapply amal_type_ind_hprop; intro x.
-    cbn; nrapply (ap amal_eta).
+    nrapply (ap amal_eta).
     apply word_concat_w_nil.
   Defined.
 
@@ -496,7 +496,6 @@ Section FreeProduct.
       change (amal_eta ([inl h]) * amal_eta ((xs ++ word_inverse xs)) * amal_eta ([inl (- h)]) = mon_unit).
       rewrite IHxs.
       rewrite rightidentity_sgop_amal_type.
-      cbn.
       rewrite <- (word_concat_w_nil (cons _ _)).
       change (amal_eta (([inl h] ++ [inl (- h)]) ++ nil) = mon_unit).
       rewrite <- word_concat_w_ww.
@@ -514,7 +513,6 @@ Section FreeProduct.
       change (amal_eta ([inr k]) * amal_eta ((xs ++ word_inverse xs)) * amal_eta ([inr (-k)]) = mon_unit).
       rewrite IHxs.
       rewrite rightidentity_sgop_amal_type.
-      cbn.
       rewrite <- (word_concat_w_nil (cons _ _)).
       change (amal_eta (([inr k] ++ [inr (- k)]) ++ nil) = mon_unit).
       rewrite <- word_concat_w_ww.
@@ -676,7 +674,7 @@ Section FreeProduct.
     destruct hkp as [h [k p]].
     apply path_prod; cbn;
     apply equiv_path_grouphomomorphism;
-    intro; cbn; apply right_identity.
+    intro; simpl; rapply right_identity.
   Defined.
 
 End FreeProduct.

--- a/theories/Algebra/Groups/GroupCoeq.v
+++ b/theories/Algebra/Groups/GroupCoeq.v
@@ -1,6 +1,6 @@
 Require Import Basics Types WildCat.
 Require Import Algebra.Groups.Group.
-Require Import HIT.Coeq.
+Require Import Colimits.Coeq.
 Require Import Algebra.Groups.FreeProduct.
 
 Local Open Scope mc_scope.

--- a/theories/Algebra/Groups/Presentation.v
+++ b/theories/Algebra/Groups/Presentation.v
@@ -93,7 +93,7 @@ Proof.
   { intros p.
     hnf.
     rapply Trunc_ind.
-    srapply Coeq.Coeq.Coeq_ind.
+    srapply Coeq.Coeq_ind.
     2: intros; apply path_ishprop.
     intros w; hnf.
     induction w.

--- a/theories/Colimits/Colimit.v
+++ b/theories/Colimits/Colimit.v
@@ -3,7 +3,7 @@ Require Import Diagrams.Diagram.
 Require Import Diagrams.Graph.
 Require Import Diagrams.Cocone.
 Require Import Diagrams.ConstantDiagram.
-Require Import HIT.Coeq.
+Require Import Colimits.Coeq.
 
 Local Open Scope path_scope.
 Generalizable All Variables.

--- a/theories/Colimits/Colimit_Coequalizer.v
+++ b/theories/Colimits/Colimit_Coequalizer.v
@@ -5,7 +5,7 @@ Require Import Diagrams.Diagram.
 Require Import Diagrams.ParallelPair.
 Require Import Diagrams.Cocone.
 Require Import Colimits.Colimit.
-Require Import HIT.Coeq.
+Require Import Colimits.Coeq.
 
 Generalizable All Variables.
 

--- a/theories/Colimits/GraphQuotient.v
+++ b/theories/Colimits/GraphQuotient.v
@@ -1,0 +1,60 @@
+Require Import Basics.
+
+(** * Quotient of a graph *)
+
+Local Unset Elimination Schemes.
+
+Module Export GraphQuotient.
+
+  Private Inductive GraphQuotient@{i j u}
+    {A : Type@{i}} (R : A -> A -> Type@{j}) : Type@{u} :=
+  | gq : A -> GraphQuotient R.
+
+  Arguments gq {A R} a.
+
+  Axiom gqglue@{i j u}
+    : forall {A : Type@{i}} {R : A -> A -> Type@{j}} {a b : A},
+    R a b -> paths@{u} (@gq A R a) (gq b).
+
+  Definition GraphQuotient_ind@{i j u k} {A : Type@{i}} {R : A -> A -> Type@{j}}
+    (P : GraphQuotient@{i j u} R -> Type@{k})
+    (gq' : forall a, P (gq@{i j u} a))
+    (gqglue' : forall a b (s : R a b), gqglue@{i j u} s # gq' a = gq' b)
+    : forall x, P x := fun x =>
+    match x with
+    | gq a => gq' a
+    end.
+
+  Axiom GraphQuotient_ind_beta_gqglue@{i j u k}
+  : forall  {A : Type@{i}} {R : A -> A -> Type@{j}}
+    (P : GraphQuotient@{i j u} R -> Type@{k})
+    (gq' : forall a, P (gq a))
+    (gqglue' : forall a b (s : R a b), gqglue s # gq' a = gq' b)
+    (a b: A) (s : R a b),
+    apD (GraphQuotient_ind P gq' gqglue') (gqglue s) = gqglue' a b s.
+
+End GraphQuotient.
+
+Arguments gq {A R} a.
+
+
+Definition GraphQuotient_rec {A R P} (c : A -> P) (g : forall a b, R a b -> c a = c b)
+  : GraphQuotient R -> P.
+Proof.
+  srapply GraphQuotient_ind.
+  1: exact c.
+  intros a b s.
+  refine (transport_const _ _ @ g a b s).
+Defined.
+
+Definition GraphQuotient_rec_beta_gqglue {A R P}
+  (c : A -> P) (g : forall a b, R a b -> c a = c b)
+  (a b : A) (s : R a b)
+  : ap (GraphQuotient_rec c g) (gqglue s) = g a b s.
+Proof.
+  unfold GraphQuotient_rec.
+  Search ap apD.
+  refine (cancelL _ _ _ _ ).
+  refine ((apD_const _ _)^ @ _).
+  rapply GraphQuotient_ind_beta_gqglue.
+Defined.

--- a/theories/Colimits/MappingCylinder.v
+++ b/theories/Colimits/MappingCylinder.v
@@ -3,7 +3,7 @@
 (** * Mapping Cylinders *)
 
 Require Import HoTT.Basics HoTT.Types Cubical.DPath Cubical.PathSquare.
-Require Import HIT.Coeq Colimits.Pushout.
+Require Import Colimits.Coeq Colimits.Pushout.
 Local Open Scope path_scope.
 
 (** As in topology, the mapping cylinder of a function [f : A -> B] is a way to replace it with an equivalent cofibration (dually to how [hfiber] replaces it with an equivalent fibration).  We can't talk *internally* in type theory about cofibrations, but we can say metatheoretically what they are: functions with the isomorphism extension property.  So while we can't literally say "let [f] be a cofibration" we can do a mostly equivalent thing and say "let [f] be a map and consider its mapping cylinder".  Replacing a map by a cofibration can be useful because it allows us to make more equalities true definitionally. *)

--- a/theories/Colimits/Pushout.v
+++ b/theories/Colimits/Pushout.v
@@ -1,7 +1,7 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 Require Import Basics Types WildCat.
 Require Import HSet TruncType.
-Require Export HIT.Coeq.
+Require Export Colimits.Coeq.
 Local Open Scope path_scope.
 
 (** * Homotopy Pushouts *)
@@ -10,7 +10,7 @@ Local Open Scope path_scope.
 
 Definition Pushout@{i j k l} {A : Type@{i}} {B : Type@{j}} {C : Type@{k}}
   (f : A -> B) (g : A -> C) : Type@{l}
-  := Coeq@{l l} (inl o f) (inr o g).
+  := Coeq@{l l _} (inl o f) (inr o g).
 
 Definition push {A B C : Type} {f : A -> B} {g : A -> C}
  : B+C -> Pushout f g

--- a/theories/Extensions.v
+++ b/theories/Extensions.v
@@ -5,7 +5,7 @@
 Require Import HoTT.Basics HoTT.Types.
 Require Import HProp Equiv.PathSplit PathAny.
 Require Import Cubical.DPath Cubical.PathSquare Cubical.DPathSquare.
-Require Import HIT.Coeq Colimits.MappingCylinder.
+Require Import Colimits.Coeq Colimits.MappingCylinder.
 
 Local Open Scope nat_scope.
 Local Open Scope path_scope.
@@ -737,7 +737,7 @@ Proof.
     2:change (fun y => pr_cylcoeq p q (coeq (functor_cyl q y)))
       with (fun y => coeq (f := f') (g := g') (pr_cyl (functor_cyl q y))).
     all:refine ((ap_V _ (eissect pr_cyl x))^ @ _).
-    all:rapply ap_compose. }
+    all: exact (ap_compose (fun x => pr_cyl (functor_cyl _ x)) coeq _). }
   pose (eb1 := fun u v w => (fst (cyl_extendable _ _ _ (eb'' u v)) w).1).
   (** Now we construct an extension using Coeq-induction, and prove that it *is* an extension also using Coeq-induction. *)
   srefine (_;_); srapply Coeq_ind_dp.

--- a/theories/HIT/Flattening.v
+++ b/theories/HIT/Flattening.v
@@ -5,7 +5,7 @@
 Require Import HoTT.Basics.
 Require Import Types.Paths Types.Forall Types.Sigma Types.Arrow Types.Universe.
 Local Open Scope path_scope.
-Require Import HoTT.HIT.Coeq.
+Require Import HoTT.Colimits.Coeq.
 
 (** The base HIT [W] is just a homotopy coequalizer [Coeq]. *)
 

--- a/theories/HIT/FreeIntQuotient.v
+++ b/theories/HIT/FreeIntQuotient.v
@@ -2,7 +2,7 @@
 Require Import HoTT.Basics HoTT.Types.
 Require Import TruncType HProp HSet.
 Require Import Spaces.Int Spaces.Circle.
-Require Import HIT.Coeq HIT.Flattening Truncations.
+Require Import Colimits.Coeq HIT.Flattening Truncations.
 
 Local Open Scope path_scope.
 

--- a/theories/HoTT.v
+++ b/theories/HoTT.v
@@ -40,7 +40,6 @@ Require Export HoTT.PropResizing.PropResizing.
 (* Don't export the rest of [PropResizing] *)
 
 Require Export HoTT.HIT.Interval.
-Require Export HoTT.HIT.Coeq.
 Require Export HoTT.HIT.Flattening.
 Require Export HoTT.HIT.FreeIntQuotient.
 Require Export HoTT.HIT.SetCone.
@@ -66,6 +65,8 @@ Require Export HoTT.Limits.Pullback.
 Require Export HoTT.Limits.Equalizer.
 Require Export HoTT.Limits.Limit.
 
+Require Export HoTT.Colimits.GraphQuotient.
+Require Export HoTT.Colimits.Coeq.
 Require Export HoTT.Colimits.Pushout.
 Require Export HoTT.Colimits.SpanPushout.
 Require Export HoTT.Colimits.Quotient.

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -2,7 +2,7 @@
 Require Import HoTT.Basics HoTT.Types.
 Require Import Equiv.BiInv Extensions HProp HFiber NullHomotopy Pullback.
 Require Import PathAny.
-Require Import HIT.Coeq Colimits.Pushout.
+Require Import Colimits.Coeq Colimits.Pushout.
 
 Local Open Scope nat_scope.
 Local Open Scope path_scope.

--- a/theories/Spaces/Circle.v
+++ b/theories/Spaces/Circle.v
@@ -2,7 +2,7 @@
 Require Import Basics Types.
 Require Import HProp HSet.
 Require Import Spaces.Pos Spaces.Int.
-Require Import HIT.Coeq.
+Require Import Colimits.Coeq.
 Require Import Modalities.Modality Truncations.
 Require Import Cubical.DPath.
 


### PR DESCRIPTION
Here is a simpler definition of a coequalizer as a HIT. We then redefine Quotient and Coeq in terms of this. Working with the "untypetheoretic coequalizer" can be a bit awkward sometimes since you might have to pass a sigma type here and there. This mostly removes this requirement.

This is a step towards cleaning up the HIT folder. 