### PR TITLE
Presentation notation

### DIFF
--- a/theories/Algebra/Groups/FreeGroup.v
+++ b/theories/Algebra/Groups/FreeGroup.v
@@ -110,7 +110,6 @@ Section Reduction.
   Proof.
     intros x y.
     strip_truncations.
-(*      apply tr. *)
     revert x; snrapply Coeq_rec.
     { intros x; revert y.
       snrapply Coeq_rec.
@@ -366,8 +365,15 @@ Section Reduction.
   (** Typeclass search can already find this but we leave it here as a definition for reference. *)
   Definition isfreegroup_freegrup `{Funext} : IsFreeGroup FreeGroup := _.
 
+  Definition freegroup_in : A -> FreeGroup
+    := freegroup_eta o word_sing o inl.
+
+  Coercion freegroup_in : A >-> group_type.
+
 End Reduction.
 
+Arguments freegroup_eta {A}.
+Arguments freegroup_in {A}.
 
 (** Properties of free groups *)
 

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -461,6 +461,14 @@ Section GroupMovement.
 
 End GroupMovement.
 
+(** Power operation *)
+
+Fixpoint grp_pow {G : Group} (g : G) (n : nat) : G :=
+  match n with
+  | 0%nat => mon_unit
+  | m.+1%nat => g * grp_pow g m
+  end.
+
 (** The wild cat of Groups *)
 Global Instance isgraph_group : IsGraph Group
   := Build_IsGraph Group GroupHomomorphism.

--- a/theories/Algebra/Groups/Presentation.v
+++ b/theories/Algebra/Groups/Presentation.v
@@ -5,6 +5,10 @@ Require Import Algebra.Groups.GroupCoeq.
 Require Import Spaces.Finite.
 Require Import WildCat.
 
+
+Local Open Scope mc_scope.
+Local Open Scope mc_mult_scope.
+
 (** In this file we develop presentations of groups. *)
 
 (** The data of a group presentation *)
@@ -104,7 +108,7 @@ Proof.
     refine (p _ @ (grp_homo_unit _)^). }
   intros p r.
   hnf in p.
-  pose (p' := p o freegroup_eta _).
+  pose (p' := p o freegroup_eta).
   clearbody p'; clear p.
   specialize (p' (FreeGroup.word_sing _ (inl r))).
   refine (_ @ p').
@@ -114,3 +118,76 @@ Proof.
   refine (_ @ right_identity _).
   f_ap.
 Defined.
+
+(** ** Constructors for finite presentations *)
+
+Definition Build_Finite_GroupPresentation n m
+  (f : FinSeq m (FreeGroup (Fin n)))
+  : GroupPresentation.
+Proof.
+  snrapply Build_GroupPresentation.
+  - exact (Fin n).
+  - exact (Fin m).
+  - exact f.
+Defined.
+
+Global Instance FinitelyGeneratedPresentation_Build_Finite_GroupPresentation
+  {n m f}
+  : FinitelyGeneratedPresentation (Build_Finite_GroupPresentation n m f).
+Proof.
+  unshelve econstructor.
+  2: simpl; apply tr; reflexivity.
+Defined.
+
+Global Instance FinitelyRelatedPresentation_Build_Finite_GroupPresentation
+  {n m f}
+  : FinitelyRelatedPresentation (Build_Finite_GroupPresentation n m f).
+Proof.
+  unshelve econstructor.
+  2: simpl; apply tr; reflexivity.
+Defined.
+
+(** ** Notations for presentations *)
+
+(** Convenient abbreviation when defining notations. *)
+Local Notation ff := (freegroup_in o fin_nat).
+
+(** TODO: I haven't worked out how to generalize to any number of binders, so we explicitly list the first few levels. *)
+
+Local Open Scope nat_scope.
+
+(** One generator *)
+Notation "⟨ x | F , .. , G ⟩" :=
+  (Build_Finite_GroupPresentation 1 _
+    (fscons ((fun (x : FreeGroup (Fin 1))
+      => F : FreeGroup (Fin _)) (ff 0%nat))
+    .. (fscons ((fun (x : FreeGroup (Fin 1))
+      => G : FreeGroup (Fin _)) (ff 0)) fsnil) ..))
+  (at level 200, x binder).
+
+(** Two generators *)
+Notation "⟨ x , y | F , .. , G ⟩" :=
+  (Build_Finite_GroupPresentation 2 _
+    (fscons ((fun (x y : FreeGroup (Fin 2))
+      => F : FreeGroup (Fin _)) (ff 0) (ff 1))
+    .. (fscons ((fun (x y : FreeGroup (Fin 2))
+      => G : FreeGroup (Fin _)) (ff 0) (ff 1)) fsnil) ..))
+  (at level 200, x binder, y binder).
+
+(** Three generators *)
+Notation "⟨ x , y , z | F , .. , G ⟩" :=
+  (Build_Finite_GroupPresentation 3 _
+    (fscons ((fun (x y z : FreeGroup (Fin 3))
+      => F : FreeGroup (Fin _)) (ff 0) (ff 1) (ff 2))
+    .. (fscons ((fun (x y z : FreeGroup (Fin 3))
+      => G : FreeGroup (Fin _)) (ff 0) (ff 1) (ff 2)) fsnil) ..))
+  (at level 200, x binder, y binder, z binder).
+
+(** Tests: *)
+
+(*
+Check ⟨ x , y | x * y ,  x * y * x , x * (-y)*x*x*x⟩.
+Check ⟨ x | x * x * x , -x ⟩.
+Check ⟨ x , y , z | x * y * z , x * -z , x * y⟩.
+*)
+ 


### PR DESCRIPTION
Here is something fun that I have been working on. I've created a notation for group presentations allowing us to quickly write one down without having to do a lot of leg work. The new notation allows us to do things like:
```coq
Definition presentation_q16 : GroupPresentation :=
  ⟨ a , b | grp_pow a 8 , (grp_pow a 4) * -(grp_pow b 2) , a * b * a * -b ⟩.
```

Currently there is only support up to 3 generators, we can add more as needed. I haven't worked out how to get an arbitrary number of binders just yet.