### PR TITLE
Adapt to Coq PR #15537: schemes paths_rec & paths_ind have different automatically generated names

### DIFF
--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -242,9 +242,9 @@ Cumulative Inductive paths {A : Type} (a : A) : A -> Type :=
 Arguments idpath {A a} , [A] a.
 
 Scheme paths_ind := Induction for paths Sort Type.
-Arguments paths_ind [A] a P f y p.
+Arguments paths_ind [A] a P f y p : rename.
 Scheme paths_rec := Minimality for paths Sort Type.
-Arguments paths_rec [A] a P f y p.
+Arguments paths_rec [A] a P f y p : rename.
 
 Register idpath as core.identity.refl.
 


### PR DESCRIPTION
This is a consequence of fixing a naming bug in coq/coq#15537. It now requires an explicit `rename` flag in the subsequent calls to `Arguments` for `paths` induction schemes.

A priori, I don't see other consequences of the naming fix (except on printing, where sometimes, especially in `return` clauses, `y` will be displayed `a`).

If ok with the change, this is backward-compatible and can be merged as soon as now.
