### PR TITLE
propositional truncation via join construction

### DIFF
--- a/theories/Colimits/Sequential.v
+++ b/theories/Colimits/Sequential.v
@@ -16,7 +16,7 @@ Local Open Scope path_scope.
 Notation coe := (transport idmap).
 Notation "a ^+" := (@arr sequence_graph _ _ _ 1 a).
 
-(** Mapping spaces from colimits of sequences can be characterized. *)
+(** Mapping spaces into hprops from colimits of sequences can be characterized. *)
 Lemma equiv_colim_seq_rec `{Funext} (A : Sequence) (P : Type) `{IsHProp P}
   : (Colimit A -> P) <~> (forall n, A n -> P).
 Proof.

--- a/theories/Colimits/Sequential.v
+++ b/theories/Colimits/Sequential.v
@@ -16,6 +16,55 @@ Local Open Scope path_scope.
 Notation coe := (transport idmap).
 Notation "a ^+" := (@arr sequence_graph _ _ _ 1 a).
 
+(** Mapping spaces from colimits of sequences can be characterized. *)
+Lemma equiv_colim_seq_rec `{Funext} (A : Sequence) (P : Type) `{IsHProp P}
+  : (Colimit A -> P) <~> (forall n, A n -> P).
+Proof.
+  symmetry.
+  refine (equiv_colimit_rec P oE _).
+  refine (issig_Cocone _ _ oE _).
+  symmetry.
+  srapply Build_Equiv.
+  1: exact pr1.
+  exact _.
+Defined.
+
+(** If a sequential colimit has maps homotopic to a constant map then the colimit is contractible. *)
+Global Instance contr_colim_seq_into_prop {funext : Funext} (A : Sequence)
+  (a : forall n, A n) (H : forall n, const (a n.+1) == A _f idpath)
+  : Contr (Colimit A).
+Proof.
+  transparent assert (B : Sequence).
+  { srapply Build_Sequence.
+    1: exact A.
+    intros n.
+    exact (const (a n.+1)). }
+  rapply contr_equiv'.
+  1: rapply equiv_functor_colimit.
+  1: rapply (equiv_sequence B A).
+  1: reflexivity.
+  { intros n e.
+    exists equiv_idmap.
+    intros x.
+    symmetry.
+    exact (H _ (e x)). }
+  srapply Build_Contr.
+  1: exact (colim (D:=B) 1%nat (a 1%nat)).
+  srapply Colimit_ind.
+  { intros i x.
+    induction i.
+    1: exact (colimp (D:=B) _ _ idpath x).
+    refine (IHi (a i) @ _).
+    refine ((colimp (D:=B) _ _ idpath (a i))^ @ _).
+    refine ((colimp (D:=B) _ _ idpath (a i.+1))^ @ _).
+    exact (colimp (D:=B) _ _ idpath x). }
+  intros n m [] x.
+  rewrite transport_paths_FlFr.
+  rewrite ap_const.
+  rewrite ap_idmap.
+  destruct n; simpl; hott_simpl.
+Qed.
+
 Definition seq_shift_from_zero_by {A : Sequence} (a : A 0) k : A k.
 Proof.
   induction k as [ | k q].

--- a/theories/Diagrams/Cocone.v
+++ b/theories/Diagrams/Cocone.v
@@ -21,6 +21,9 @@ Arguments legs_comm {G D X} C i j g x : rename.
 
 Coercion legs : Cocone >-> Funclass.
 
+Definition issig_Cocone {G : Graph} (D : Diagram G) (X : Type)
+  : _ <~> Cocone D X := ltac:(issig).
+
 Section Cocone.
   Context `{Funext} {G : Graph} {D : Diagram G} {X : Type}.
 

--- a/theories/Homotopy/Join.v
+++ b/theories/Homotopy/Join.v
@@ -1,9 +1,5 @@
-(* -*- mode: coq; mode: visual-line -*- *)
-Require Import Basics.
-Require Import Types.
-Require Import Cubical.
-Require Import HProp.
-Require Import HSet.
+Require Import Basics Types Cubical.
+Require Import HProp HSet.
 Require Import NullHomotopy.
 Require Import Extensions.
 Require Import Colimits.Pushout.
@@ -173,6 +169,18 @@ Section Join.
       exact (contr_inhabited_hprop B b).
   Defined.
 
+  Lemma equiv_into_hprop `{Funext} {A B P : Type} `{IsHProp P} (f : A -> P)
+    : (Join A B -> P) <~> (B -> P).
+  Proof.
+    srapply equiv_iff_hprop.
+    1: exact (fun f => f o joinr).
+    intros g.
+    srapply Join_rec.
+    1,2: assumption.
+    intros a b.
+    apply path_ishprop.
+  Defined.
+
   (** And coincides with their disjunction *)
   Definition equiv_join_hor `{Funext} A B `{IsHProp A} `{IsHProp B} 
     : Join A B <~> hor A B.
@@ -258,4 +266,13 @@ Proof.
   destruct p.
   apply diamond_symm.
 Defined.
+
+
+(** The joint of n.+1 copies of a type. *)
+Fixpoint Join_power (A : Type) (n : nat) : Type :=
+  match n with
+  | 0%nat => A
+  | m.+1%nat => Join A (Join_power A m)
+  end.
+
 

--- a/theories/Metatheory/PropTrunc.v
+++ b/theories/Metatheory/PropTrunc.v
@@ -1,0 +1,61 @@
+Require Import Basics Types.
+Require Import Diagrams.Sequence.
+Require Import Homotopy.Join.
+Require Import Colimits.Colimit Colimits.Sequential.
+
+Local Open Scope nat_scope.
+
+(** * Propositonal truncation as a colimit. *)
+
+(** In this file we give an alternative construction of the propositional truncation using colimits. This can serve as a metatheoretic justification that propositional truncations exist. *)
+
+(** The sequence of increasing joins. *)
+Definition Join_seq (A : Type) : Sequence.
+Proof.
+  srapply Build_Sequence.
+  1: exact (Join_power A).
+  intros n.
+  exact joinr.
+Defined.
+
+(** Propositional truncation can be defined as the colimit of this sequence. *)
+Definition PropTrunc A : Type := Colimit (Join_seq A).
+
+(** The constructor is given by the colimit constructor. *)
+Definition ptr_in {A} : A -> PropTrunc A := colim (D:=Join_seq A) 0.
+
+(** The sequential colimit of this sequence is the propositional truncation. *)
+
+(** Universal property of propositional truncation. *)
+Lemma equiv_PropTrunc_rec `{Funext} (A P : Type) `{IsHProp P}
+  : (PropTrunc A -> P) <~> (A -> P).
+Proof.
+  refine (_ oE equiv_colim_seq_rec _ P).
+  srapply equiv_iff_hprop.
+  { intros h.
+    exact (h 0). }
+  intros f.
+  induction n.
+  - exact f.
+  - cbn.
+    srapply Join_rec.
+    1,2: assumption.
+    intros a b.
+    rapply path_ishprop.
+Defined.
+
+(** The propositional truncation is a hprop. *)
+Global Instance ishprop_proptrunc `{Funext} (A : Type)
+  : IsHProp (PropTrunc A).
+Proof.
+  rapply hprop_inhabited_contr.
+  rapply (equiv_PropTrunc_rec _ _)^-1.
+  intros x.
+  srapply contr_colim_seq_into_prop.
+  - intros n.
+    destruct n.
+    1: exact x.
+    exact (joinl x).
+  - intros n.
+    rapply jglue.
+Defined.


### PR DESCRIPTION
While working on the full join construction, I thought that this would be a good addition to our metatheory folder. We define truncations as a private inductive type at the moment, but this shows that having coequalizers is enough.

