### PR TITLE
fix typo in ci causing file-dep-graphs to not be deployed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,7 @@ jobs:
     - name: 'Tar .svg files'
       run: |
         tar -cf dep-graphs.tar dep-graphs
-        tar -cf file-dep-graphs.tar file-dep-graphs.tar
+        tar -cf file-dep-graphs.tar file-dep-graphs
     # We upload the artifacts
     - name: 'Upload Artifact dep-graphs.tar'
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
We have dependency graphs for each file. A typo in the CI file caused these not to be uploaded to the ghpages website.