### PR TITLE
Remove uses of instantiate (to fix some warnings)

### DIFF
--- a/theories/Categories/Adjoint/Composition/Core.v
+++ b/theories/Categories/Adjoint/Composition/Core.v
@@ -63,10 +63,10 @@ Section compose.
             | _ => rewrite <- ?composition_of, unit_counit_equation_2
             | [ A : _ -| _ |- _ = 1%morphism ]
               => (etransitivity; [ | apply (unit_counit_equation_1 A) ];
-                  instantiate; try_associativity_quick f_ap)
+                  try_associativity_quick f_ap)
             | [ A : _ -| _ |- _ = 1%morphism ]
               => (etransitivity; [ | apply (unit_counit_equation_2 A) ];
-                  instantiate; try_associativity_quick f_ap)
+                  try_associativity_quick f_ap)
             | _ => repeat (try_associativity_quick rewrite <- !composition_of);
                   progress repeat apply ap;
                   rewrite ?composition_of

--- a/theories/Categories/Category/Morphisms.v
+++ b/theories/Categories/Category/Morphisms.v
@@ -180,7 +180,6 @@ Section iso_equiv_relation.
 
   Local Ltac iso_comp_t inv_lemma :=
     etransitivity; [ | apply inv_lemma ];
-    instantiate;
     first [ rewrite -> ?associativity; apply ap
           | rewrite <- ?associativity; apply ap ];
     first [ rewrite -> ?associativity; rewrite inv_lemma


### PR DESCRIPTION
It has been deprecated in 8.16 (alpha) and has the behaviour of idtac. Therefore it can be safely removed.