### PR TITLE
Make Contr_internal and some algebra Classes Cumulative

### DIFF
--- a/theories/Algebra/AbGroups/AbelianGroup.v
+++ b/theories/Algebra/AbGroups/AbelianGroup.v
@@ -5,6 +5,8 @@ Require Export Algebra.Groups.
 Require Import Cubical.
 Require Import WildCat.
 
+Local Set Polymorphic Inductive Cumulativity.
+
 Local Open Scope mc_add_scope.
 
 (** * Abelian groups *)

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -7,6 +7,8 @@ Require Import Pointed.Core.
 Require Import WildCat.
 Require Basics.Utf8.
 
+Local Set Polymorphic Inductive Cumulativity.
+
 Generalizable Variables G H A B C f g.
 
 Declare Scope group_scope.

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -539,7 +539,7 @@ In order to achieve moderate coverage and speedy resolution, we currently follow
 (** A space [A] is contractible if there is a point [x : A] and a (pointwise) homotopy connecting the identity on [A] to the constant map at [x].  Thus an element of [contr A] is a pair whose first component is a point [x] and the second component is a pointwise retraction of [A] to [x]. *)
 
 (** We use the [Contr_internal] record so as not to pollute typeclass search; we only do truncation typeclass search on the [IsTrunc] datatype, usually.  We will define a notation [Contr] which is equivalent to [Contr_internal], but picked up by typeclass search.  However, we must make [Contr_internal] a class so that we pick up typeclasses on [center] and [contr].  However, the only typeclass rule we register is the one that turns it into a [Contr]/[IsTrunc].  Unfortunately, this means that declaring an instance like [Instance contr_foo : Contr foo := { center := bar }.] will fail with mismatched instances/contexts.  Instead, we must iota expand such definitions to get around Coq's deficiencies, and write [Instance contr_foo : Contr foo := let x := {| center := bar |} in x.] *)
-Class Contr_internal (A : Type) := Build_Contr {
+Cumulative Class Contr_internal (A : Type) := Build_Contr {
   center : A ;
   contr : (forall y : A, center = y)
 }.

--- a/theories/Classes/interfaces/abstract_algebra.v
+++ b/theories/Classes/interfaces/abstract_algebra.v
@@ -2,6 +2,8 @@ Require Import Spaces.Nat.
 Require Export HoTT.Classes.interfaces.canonical_names.
 Require Import HProp.
 
+Local Set Polymorphic Inductive Cumulativity.
+
 Generalizable Variables A B f g x y.
 
 (* 


### PR DESCRIPTION
The main change here is to specify that `Contr_internal` is a `Cumulative Record`.  With this done, the following things work:

```
Definition test@{u v | u < v} (A : Type@{u}) (C : Contr_internal@{u} A)
  : Contr_internal@{v} A := C.

Definition test2@{u v | u < v} (A : Type@{u}) (C : IsHSet A)
  : IsHSet A := C.

Cumulative Record Test@{+u} := { T : Type@{u}; H : IsHSet T }.
```

However, for general `n`, you don't get definitional cumulativity of `IsTrunc_internal n A`:

```
Fail Definition test3@{u v | u < v} (n : trunc_index) (A : Type@{u}) (C : IsTrunc_internal@{u u} n A)
  : IsTrunc_internal@{v v} n A := C.
```

(Is it possible to make that work?  It would be nice to have.)

The reason Jarl and I are interested in making this change is that it allows `Group` to be cumulative as well.  (The `IsHSet` condition was an issue before this.)  When dealing with things like `BAut` and the type of all short exact sequences, the groups you get can lie in different universes, which means one has to fiddle with a lot of explicit universe variables.  This PR includes changes to `Group` and a few other needed things to allow us to avoid this.

Question:  should I also make this change to everything else in `Classes/interfaces/abstract_algebra.v`?  Or should we just make this change as needed?

(Note that I couldn't find a way to tell Coq to make Records and Classes cumulative by default.)

I timed builds before and after this change, and they were within the noise.  No file increased by more than 0.1s.  I see no logical issues with having `Contr_internal` cumulative, but I'm not an expert on this.
