### PR TITLE
Allow O_rec to unfold when passed (tr x)

### DIFF
--- a/theories/Algebra/Groups/FreeProduct.v
+++ b/theories/Algebra/Groups/FreeProduct.v
@@ -322,7 +322,7 @@ Section FreeProduct.
         1,3: apply word_concat_w_ww.
         apply amal_omega_K. } }
     { intros r y h1 h2; revert r.
-      rapply amal_type_ind_hprop; cbn.
+      rapply amal_type_ind_hprop.
       intros z;
       change (amal_eta ((x ++ ((inl h1 :: [inl h2]) ++ y)) ++ z)
         = amal_eta ((x ++ [inl (h1 * h2)] ++ y) ++ z)).
@@ -332,7 +332,7 @@ Section FreeProduct.
       1,3: apply word_concat_w_ww.
       apply amal_mu_H. }
     { intros r y k1 k2; revert r.
-      rapply amal_type_ind_hprop; cbn.
+      rapply amal_type_ind_hprop.
       intros z;
       change (amal_eta ((x ++ ((inr k1 :: [inr k2]) ++ y)) ++ z)
         = amal_eta ((x ++ [inr (k1 * k2)] ++ y) ++ z)).
@@ -342,7 +342,7 @@ Section FreeProduct.
       1,3: apply word_concat_w_ww.
       apply amal_mu_K. }
     { intros r y z; revert r.
-      rapply amal_type_ind_hprop; cbn.
+      rapply amal_type_ind_hprop.
       intros w;
       change (amal_eta ((x ++ [inl (f z)] ++ y) ++ w)
         = amal_eta ((x ++ [inr (g z)] ++ y) ++ w)).
@@ -352,7 +352,7 @@ Section FreeProduct.
       1,3: apply word_concat_w_ww.
       apply amal_tau. }
     { intros r z; revert r.
-      rapply amal_type_ind_hprop; cbn.
+      rapply amal_type_ind_hprop.
       intros w;
       change (amal_eta ((x ++ [inl mon_unit] ++ z) ++ w) = amal_eta ((x ++ z) ++ w)).
       refine (ap amal_eta _^ @ _ @ ap amal_eta _).
@@ -361,7 +361,7 @@ Section FreeProduct.
       1: apply word_concat_w_ww.
       apply amal_omega_H. }
     { intros r z; revert r.
-      rapply amal_type_ind_hprop; cbn.
+      rapply amal_type_ind_hprop.
       intros w;
       change (amal_eta ((x ++ [inr mon_unit] ++ z) ++ w) = amal_eta ((x ++ z) ++ w)).
       refine (ap amal_eta _^ @ _ @ ap amal_eta _).

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -243,13 +243,13 @@ Section ORecursion.
 
 End ORecursion.
 
-(* We never want to see [extendable_to_O].  The [!x] allows [cbn] to unfold [O_rec] when passed a constructor, such as [tr x].  This, for example, means that [O_rec (O:=Tr n) f (tr x)] will compute to [f x] and [Trunc_functor n f (tr x)] will compute to [tr (f x)]. *)
+(* We never want to see [extendable_to_O].  The [!x] allows [cbn] to unfold these when passed a constructor, such as [tr x].  This, for example, means that [O_rec (O:=Tr n) f (tr x)] will compute to [f x] and [Trunc_functor n f (tr x)] will compute to [tr (f x)]. *)
 Arguments O_rec {O} {P Q}%type_scope {Q_inO H H0} f%function_scope !x.
-Arguments O_rec_beta : simpl never.
-Arguments O_indpaths : simpl never.
-Arguments O_indpaths_beta : simpl never.
-Arguments O_ind2paths : simpl never.
-Arguments O_ind2paths_beta : simpl never.
+Arguments O_rec_beta {O} {P Q}%type_scope {Q_inO H H0} f%function_scope !x.
+Arguments O_indpaths {O} {P Q}%type_scope {Q_inO H H0} (g h)%function_scope p !x.
+Arguments O_indpaths_beta {O} {P Q}%type_scope {Q_inO H H0} (g h)%function_scope p !x.
+Arguments O_ind2paths {O} {P Q}%type_scope {Q_inO H H0} {g h}%function_scope p q r !x.
+Arguments O_ind2paths_beta {O} {P Q}%type_scope {Q_inO H H0} {g h}%function_scope p q r !x.
 
 (** A tactic that generalizes [strip_truncations] to reflective subuniverses. [strip_truncations] introduces fewer universe variables, so tends to work better when removing truncations. [strip_modalities] in Modality.v also applies dependent elimination when [O] is a modality. *)
 Ltac strip_reflections :=

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -243,8 +243,8 @@ Section ORecursion.
 
 End ORecursion.
 
-(* We never want to see [extendable_to_O]. *)
-Arguments O_rec : simpl never.
+(* We never want to see [extendable_to_O].  The [!x] allows [cbn] to unfold [O_rec] when passed a constructor, such as [tr x].  This, for example, means that [O_rec (O:=Tr n) f (tr x)] will compute to [f x] and [Trunc_functor n f (tr x)] will compute to [tr (f x)]. *)
+Arguments O_rec {O} {P Q}%type_scope {Q_inO H H0} f%function_scope !x.
 Arguments O_rec_beta : simpl never.
 Arguments O_indpaths : simpl never.
 Arguments O_indpaths_beta : simpl never.


### PR DESCRIPTION
We currently have `O_rec` marked as `simpl never` to avoid having it unfold with `cbn`.  This PR changes it to

```
Arguments O_rec {O} {P Q}%type_scope {Q_inO H H0} f%function_scope !x.
```

which means that `cbn` will unfold it if `x` appears with a constructor.  This means that `cbn` changes `O_rec (O:=Tr n) f (tr x)` to `f x` and `Trunc_functor n f (tr x)` to `tr (f x)`, both of which are convenient.  If the argument is `x` instead of `tr x`, then these are left alone.

No other changes were required in the library.

Five `cbn`s in FreeProduct.v got about 0.1s slower each, but both before and after they produced an unwieldy term, and it worked to just remove them.  After this, the overall build time is about 0.1s faster than before, and no file increased by more than 0.06s.

In #1475, `Arguments O_rec / .` was mentioned, but this breaks the build and unfolds too much in some situations.  Similarly, 

```
Arguments O_rec {O} {P Q}%type_scope {Q_inO H H0} f%function_scope / x.
```

unfolds `O_rec` too eagerly.

This simplifies some WIP.
