### PR TITLE
bump supported Coq version to 8.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,8 @@ on: [ push , pull_request ]
 
 # We set the supported coq-version from here. In order to use this environment variable correctly, look at how they are used in the following jobs.
 env:
-  coq-version-supported: '8.15'
-  ocaml-version: '4.13-flambda'
+  coq-version-supported: '8.16'
+  ocaml-version: '4.14-flambda'
   deployment-branch: 'gh-pages'
 
 # Our jobs come in 3 stages, the latter stages depending on the former:
@@ -257,7 +257,7 @@ jobs:
           mv HoTT.svg HoTTCore.svg dep-graphs/
 
           ## Install coq-dpdgraph
-          opam install coq-dpdgraph.1.0+8.15 -y
+          opam install coq-dpdgraph.1.0+8.16 -y
 
           # For some reason, we get a stackoverflow. So we are lax
           # with making these.

--- a/hott.opam
+++ b/hott.opam
@@ -8,7 +8,7 @@ build: [
 ]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.15~"}
+  "coq" {>= "8.16~"}
 ]
 authors: ["The HoTT Library Development Team"]
 dev-repo: "git+https://github.com/HoTT/HoTT.git"


### PR DESCRIPTION
The HoTT release for 8.16 was already done. If we merge this then we can start using the new 8.16 features such as:
- Reversible coercions, see #1641
- Better cumulative universes
- `Print Notation` command detailing parsing information about a particular notation.
- Generalized rewriting (formerly setoid_rewrite) now supports relations polymorphic in Type.

See the full Coq changelog: https://coq.inria.fr/refman/changes.html