### PR TITLE
Reduce universe variables in V.v

### DIFF
--- a/theories/HIT/V.v
+++ b/theories/HIT/V.v
@@ -29,6 +29,7 @@ set (h o (spushl R)) = set (h o (spushr R)).
 Axiom ishset_V : IsHSet V.
 Global Existing Instance ishset_V.
 
+(** The induction principle.  Annotating the universes here greatly reduces the number of universe variables later in the file.  For example, [function] below went from 279 to 3.  If [V_ind] needs to be generalized in the future, check [function] to make sure things haven't exploded again. *)
 Fixpoint V_ind@{U' U u | U < U'} (P : V@{U' U} -> Type@{u})
   (H_0trunc : forall v : V@{U' U}, IsTrunc 0 (P v))
   (H_set : forall (A : Type@{U}) (f : A -> V) (H_f : forall a : A, P (f a)), P (set f))

--- a/theories/HIT/V.v
+++ b/theories/HIT/V.v
@@ -19,7 +19,7 @@ Definition bitotal {A B : Type} (R : A -> B -> HProp) :=
 
 Module Export CumulativeHierarchy.
 
-Private Inductive V : Type@{U'} :=
+Private Inductive V@{U' U | U < U'} : Type@{U'} :=
 | set {A : Type@{U}} (f : A -> V) : V.
 
 Axiom setext : forall {A B : Type} (R : A -> B -> HProp)
@@ -29,12 +29,12 @@ set (h o (spushl R)) = set (h o (spushr R)).
 Axiom ishset_V : IsHSet V.
 Global Existing Instance ishset_V.
 
-Fixpoint V_ind (P : V -> Type)
-  (H_0trunc : forall v : V, IsTrunc 0 (P v))
-  (H_set : forall (A : Type) (f : A -> V) (H_f : forall a : A, P (f a)), P (set f))
-  (H_setext : forall (A B : Type) (R : A -> B -> HProp) (bitot_R : bitotal R)
+Fixpoint V_ind@{U' U u | U < U'} (P : V@{U' U} -> Type@{u})
+  (H_0trunc : forall v : V@{U' U}, IsTrunc 0 (P v))
+  (H_set : forall (A : Type@{U}) (f : A -> V) (H_f : forall a : A, P (f a)), P (set f))
+  (H_setext : forall (A B : Type@{U}) (R : A -> B -> HProp@{U}) (bitot_R : bitotal R)
     (h : SPushout R -> V) (H_h : forall x : SPushout R, P (h x)),
-    (setext R bitot_R h) # (H_set A (h o spushl R) (H_h oD spushl R))
+    transport@{U' u} _ (setext R bitot_R h) (H_set A (h o spushl R) (H_h oD spushl R))
       = H_set B (h o spushr R) (H_h oD spushr R) )
   (v : V)
 : P v


### PR DESCRIPTION
Closes: #620 

See issue #620 for a discussion of this.  In the past, some definitions in the file HIT/V.v used tens of thousands of universe variables.  It seems like Coq has to a large degree fixed this:  with Coq 8.16, I randomly checked a number of definitions, and the worst I found were:  `V_func` (219 universe variables), `V_union` (219 universe variables) and `infinity` (64).  (Did I miss any that are worse?)

I found that annotating the definition of just one function, `V_ind`, greatly improved things.  Now those three definitions use 3, 3 and 6 universe variables, respectively.  Also, the build time goes from 1.35s to 0.96s on my system.

I also annotated the definition of `V` a bit more, but there is no change to the meaning.  This just documents and enforces the existing universe variables.

One note:  it's possible to get rid of the universe variable `U'` in the definition of `V`, which would make it land in the successor universe `Type@{U+1}`.  But since we can't use successor universes in other situations, we still need `U'` for most or all of the remaining definitions in the file.  So I left it in `V` as well, for consistency.  