### PR TITLE
Added a hint MapIn (Tr (-1)) f -> IsInjective f as an Instance in the…

### DIFF
--- a/theories/Classes/interfaces/abstract_algebra.v
+++ b/theories/Classes/interfaces/abstract_algebra.v
@@ -349,10 +349,10 @@ Global Instance isinj_idmap A : @IsInjective A A idmap
 
 #[export]
 Hint Unfold IsInjective : typeclass_instances.
-Print mapinO_tr_istruncmap.
+
 #[export]
-  Instance IsInjective_mapinO_tr {A B : Type} (f : A -> B)
-  {p : MapIn (Tr (-1)) f} : IsInjective f :=
+Instance isinjective_mapinO_tr {A B : Type} (f : A -> B)
+{p : MapIn (Tr (-1)) f} : IsInjective f :=
   fun x y pfeq => ap pr1 (@center _ (p (f y) (x; pfeq) (y; idpath))).
   
 Section strong_injective.

--- a/theories/Classes/interfaces/abstract_algebra.v
+++ b/theories/Classes/interfaces/abstract_algebra.v
@@ -349,7 +349,12 @@ Global Instance isinj_idmap A : @IsInjective A A idmap
 
 #[export]
 Hint Unfold IsInjective : typeclass_instances.
-
+Print mapinO_tr_istruncmap.
+#[export]
+  Instance IsInjective_mapinO_tr {A B : Type} (f : A -> B)
+  {p : MapIn (Tr (-1)) f} : IsInjective f :=
+  fun x y pfeq => ap pr1 (@center _ (p (f y) (x; pfeq) (y; idpath))).
+  
 Section strong_injective.
   Context {A B} {Aap : Apart A} {Bap : Apart B} (f : A -> B) .
   Class IsStrongInjective :=

--- a/theories/Classes/interfaces/abstract_algebra.v
+++ b/theories/Classes/interfaces/abstract_algebra.v
@@ -352,8 +352,8 @@ Hint Unfold IsInjective : typeclass_instances.
 
 #[export]
 Instance isinjective_mapinO_tr {A B : Type} (f : A -> B)
-{p : MapIn (Tr (-1)) f} : IsInjective f :=
-  fun x y pfeq => ap pr1 (@center _ (p (f y) (x; pfeq) (y; idpath))).
+  {p : MapIn (Tr (-1)) f} : IsInjective f
+  := fun x y pfeq => ap pr1 (@center _ (p (f y) (x; pfeq) (y; idpath))).
   
 Section strong_injective.
   Context {A B} {Aap : Apart A} {Bap : Apart B} (f : A -> B) .

--- a/theories/Sets/Hartogs.v
+++ b/theories/Sets/Hartogs.v
@@ -37,7 +37,6 @@ Section Hartogs_Number.
     exists carrier relation. srapply (isordinal_simulation pr1).
     - exact _.
     - exact _.
-    - intros B C. apply path_sigma_hprop.
     - constructor.
       + intros a a' a_a'. exact a_a'.
       + intros [B small_B] C C_B; cbn in *. apply tr.
@@ -146,13 +145,7 @@ Section Hartogs_Number.
                    apply irreflexivity in b'_b1; try exact _. assumption.
         }
       }
-      assert (IsOrdinal X (ϕ X)). {
-        srefine (isordinal_simulation iso.1); try exact _.
-        intros x1 x2 p.
-        rewrite <- (eissect iso.1 x1).
-        rewrite <- (eissect iso.1 x2).
-        f_ap.
-      }
+      assert (IsOrdinal X (ϕ X)) by exact (isordinal_simulation iso.1). 
       apply apD10 in H0. specialize (H0 X). cbn in H0.
       refine (transitive_Isomorphism _ (X : Type; ϕ X) _ _ _). {
         apply isomorphism_inverse. assumption.
@@ -244,8 +237,6 @@ Section Hartogs_Number.
     exists C (fun c1 c2 : C => resize_hprop (g c1 < g c2)).
     srapply (isordinal_simulation g); try exact _.
     - apply (istrunc_equiv_istrunc B (equiv_inverse g)).
-    - intros c1 c2. intros p.
-      rewrite <- (eissect g c1).  rewrite <- (eissect g c2). f_ap.
     - constructor.
       + intros a a' a_a'. apply (equiv_resize_hprop _)^-1. exact a_a'.
       + intros a b b_fa. apply tr. exists (g^-1 b). split.

--- a/theories/Sets/Ordinals.v
+++ b/theories/Sets/Ordinals.v
@@ -480,7 +480,6 @@ Proof.
   - unfold lt. exact _.
   - exact _.
   - exact _.
-  - intros x y p. apply path_sigma_hprop. exact p.
   - constructor.
     + intros x y x_y. exact x_y.
     + intros b a' a'_b; cbn in *. apply tr.


### PR DESCRIPTION
… typeclasses resolution hint database for IsInjective.

This broke proofs in Sets/Ordinals.v and Sets/Hartogs.v where the automation solved more cases than before; I deleted the extra cases that no longer needed a manual solution.

Total compilation time increased by 6 seconds from 8:42 to 8:48, a 1% increase. Total memory usage unchanged.
Largest time increase in Classes/theory/int_abs.vo, compilation took 2 seconds longer.