### PR TITLE
Speed up natpair_integers.v

### DIFF
--- a/theories/Classes/implementations/natpair_integers.v
+++ b/theories/Classes/implementations/natpair_integers.v
@@ -434,9 +434,10 @@ Definition Z_negate_compute q : - (' q) = ' (PairT.opp _ q)
 
 Lemma Z_ring@{} : IsRing Z.
 Proof.
-repeat split;try apply _;
-first [change sg_op with mult; change mon_unit with 1|
-       change sg_op with plus; change mon_unit with 0];hnf.
+  repeat split.
+  1,8: exact _.
+  all: first [change sg_op with mult; change mon_unit with 1 |
+       change sg_op with plus; change mon_unit with 0]; hnf.
 - apply (Z_ind3 _).
   intros a b c;apply Z_path;red;simpl.
   rewrite !plus_assoc. reflexivity.

--- a/theories/Classes/tactics/ring_tac.v
+++ b/theories/Classes/tactics/ring_tac.v
@@ -113,7 +113,7 @@ Ltac ring_with_nat :=
   |- @paths ?R _ _ =>
     ((pose proof (_ : IsSemiRing R)) || fail "target equality not on a semiring");
     apply (by_quoting (naturals_to_semiring nat R));
-    compute;reflexivity
+    reflexivity
   end.
 
 Ltac ring_with_integers Z :=
@@ -121,7 +121,7 @@ Ltac ring_with_integers Z :=
   |- @paths ?R _ _ =>
     ((pose proof (_ : IsRing R)) || fail "target equality not on a ring");
     apply (by_quoting (integers_to_ring Z R));
-    compute;reflexivity
+    reflexivity
   end.
 
 Ltac ring_with_self :=
@@ -129,7 +129,7 @@ Ltac ring_with_self :=
   |- @paths ?R _ _ =>
     ((pose proof (_ : IsSemiRing R)) || fail "target equality not on a ring");
     apply (by_quoting (@id R));
-    compute;reflexivity
+    reflexivity
   end.
 
 Ltac ring_repl a b :=


### PR DESCRIPTION
The change from using `try apply _` on all goals in Z_ring to using `exact _` on just the two goals that are solved speeds up building natpair_integers.v by around 5%.  The removal of `compute` in the tactics saves another 10%.  Overall, the build time of the part of the library that depends on these files is reduced by 7%.
