### PR TITLE
Avoid Funext in BoundedSearch.v

### DIFF
--- a/theories/Analysis/Locator.v
+++ b/theories/Analysis/Locator.v
@@ -535,7 +535,6 @@ Section locator.
       {
         apply minimal_n_alt_type.
         - apply QQpos_eq.
-        - apply P_isHProp.
         - apply P_dec.
         - apply P_inhab.
       }

--- a/theories/BoundedSearch.v
+++ b/theories/BoundedSearch.v
@@ -17,7 +17,7 @@ Section bounded_search.
   Local Definition minimal (n : nat) : Type := forall m : nat, P m -> n <= m.
 
   (** If we assume [Funext], then [minimal n] is a proposition.  But to avoid needing [Funext], we propositionally truncate it. *)
-  Local Definition min_n_Type : Type := { n : nat & ((P n) * merely (minimal n))%type}.
+  Local Definition min_n_Type : Type := { n : nat & (P n) * merely (minimal n) }.
 
   Local Definition ishpropmin_n : IsHProp min_n_Type.
   Proof.
@@ -27,25 +27,24 @@ Section bounded_search.
     apply leq_antisym.
     - exact (m n' p').
     - exact (m' n p).
-  Qed.
+  Defined.
 
-  (* Local Definition min_n : hProp := hProppair min_n_UU isapropmin_n. *)
-
-  Local Definition smaller (n : nat) := { l : nat & (P l * minimal l * (l <= n))%type}.
+  Local Definition smaller (n : nat) := { l : nat & P l * minimal l * (l <= n) }.
 
   Local Definition smaller_S (n : nat) (k : smaller n) : smaller (S n).
   Proof.
-    induction k as [l [[p m] z]].
+    destruct k as [l [[p m] z]].
     exists l.
-    repeat split; try assumption.
+    repeat split.
+    1,2: assumption.
     exact _.
-  Qed.
+  Defined.
 
   Local Definition bounded_search (n : nat) : smaller n + forall l : nat, (l <= n) -> not (P l).
   Proof.
     induction n as [|n IHn].
     - assert (P 0 + not (P 0)) as X; [apply P_dec |].
-      induction X as [h|].
+      destruct X as [h|].
       + left.
         refine (0;(h,_,_)).
         * intros ? ?. exact _.
@@ -53,14 +52,14 @@ Section bounded_search.
         intros l lleq0.
         assert (l0 : l = 0) by rapply leq_antisym.
         rewrite l0; assumption.
-    - induction IHn as [|n0].
+    - destruct IHn as [|n0].
       + left. apply smaller_S. assumption.
       + assert (P (n.+1) + not (P (n.+1))) as X by apply P_dec.
-        induction X as [h|].
+        destruct X as [h|].
         * left.
           refine (n.+1;(h,_,_)).
           -- intros m pm.
-             assert ((n.+1 <= m)+(n.+1>m))%type as X by apply leq_dichot.
+             assert ((n.+1 <= m)+(n.+1>m)) as X by apply leq_dichot.
              destruct X as [leqSnm|ltmSn].
              ++ assumption.
              ++ unfold gt, lt in ltmSn.
@@ -68,17 +67,17 @@ Section bounded_search.
                 destruct (n0 m X pm).
         * right. intros l q.
           assert ((l <= n) + (l > n)) as X by apply leq_dichot.
-          induction X as [h|h].
+          destruct X as [h|h].
           -- exact (n0 l h).
           -- unfold lt in h.
              assert (eqlSn : l = n.+1) by (apply leq_antisym; assumption).
              rewrite eqlSn; assumption.
-  Qed.
+  Defined.
 
   Local Definition n_to_min_n (n : nat) (Pn : P n) : min_n_Type.
   Proof.
     assert (smaller n + forall l, (l <= n) -> not (P l)) as X by apply bounded_search.
-    induction X as [[l [[Pl ml] leqln]]|none].
+    destruct X as [[l [[Pl ml] leqln]]|none].
     - exact (l;(Pl,tr ml)).
     - destruct (none n (leq_refl n) Pn).
   Defined.
@@ -87,19 +86,19 @@ Section bounded_search.
   Proof.
     refine (Trunc_rec _ P_inhab).
     - exact ishpropmin_n.
-    - induction 1 as [n Pn]. exact (n_to_min_n n Pn).
+    - destruct 1 as [n Pn]. exact (n_to_min_n n Pn).
   Defined.
 
   Definition minimal_n : { n : nat & P n }.
   Proof.
-    induction prop_n_to_min_n as [n pl]. induction pl as [p _].
+    destruct prop_n_to_min_n as [n pl]. destruct pl as [p _].
     exact (n;p).
   Defined.
 
 End bounded_search.
 
 Section bounded_search_alt_type.
-  Context `{Funext}.
+
   Context (X : Type)
           (e : nat <~> X)
           (P : X -> Type)

--- a/theories/BoundedSearch.v
+++ b/theories/BoundedSearch.v
@@ -6,7 +6,6 @@ Require Import HoTT.Spaces.Nat.
 Section bounded_search.
 
   Context (P : nat -> Type)
-          {P_hprop : forall n, IsHProp (P n)}
           (P_dec : forall n, Decidable (P n))
           (P_inhab : hexists (fun n => P n)).
   
@@ -17,9 +16,9 @@ Section bounded_search.
   Local Definition minimal (n : nat) : Type := forall m : nat, P m -> n <= m.
 
   (** If we assume [Funext], then [minimal n] is a proposition.  But to avoid needing [Funext], we propositionally truncate it. *)
-  Local Definition min_n_Type : Type := { n : nat & (P n) * merely (minimal n) }.
+  Local Definition min_n_Type : Type := { n : nat & merely (P n) * merely (minimal n) }.
 
-  Local Definition ishpropmin_n : IsHProp min_n_Type.
+  Local Instance ishpropmin_n : IsHProp min_n_Type.
   Proof.
     apply ishprop_sigma_disjoint.
     intros n n' [p m] [p' m'].
@@ -78,21 +77,20 @@ Section bounded_search.
   Proof.
     assert (smaller n + forall l, (l <= n) -> not (P l)) as X by apply bounded_search.
     destruct X as [[l [[Pl ml] leqln]]|none].
-    - exact (l;(Pl,tr ml)).
+    - exact (l;(tr Pl,tr ml)).
     - destruct (none n (leq_refl n) Pn).
   Defined.
 
   Local Definition prop_n_to_min_n : min_n_Type.
   Proof.
     refine (Trunc_rec _ P_inhab).
-    - exact ishpropmin_n.
-    - destruct 1 as [n Pn]. exact (n_to_min_n n Pn).
+    intros [n Pn]. exact (n_to_min_n n Pn).
   Defined.
 
   Definition minimal_n : { n : nat & P n }.
   Proof.
     destruct prop_n_to_min_n as [n pl]. destruct pl as [p _].
-    exact (n;p).
+    exact (n; fst merely_inhabited_iff_inhabited_decidable p).
   Defined.
 
 End bounded_search.
@@ -102,7 +100,6 @@ Section bounded_search_alt_type.
   Context (X : Type)
           (e : nat <~> X)
           (P : X -> Type)
-          {P_hprop : forall x, IsHProp (P x)}
           (P_dec : forall x, Decidable (P x))
           (P_inhab : hexists (fun x => P x)).
 
@@ -110,7 +107,6 @@ Section bounded_search_alt_type.
   Definition minimal_n_alt_type : {x : X & P x}.
   Proof.
     set (P' n := P (e n)).
-    assert (P'_hprop : forall n, IsHProp (P' n)) by apply _.
     assert (P'_dec : forall n, Decidable (P' n)) by apply _.
     assert (P'_inhab : hexists (fun n => P' n)).
     {

--- a/theories/BoundedSearch.v
+++ b/theories/BoundedSearch.v
@@ -5,7 +5,6 @@ Require Import HoTT.Spaces.Nat.
 
 Section bounded_search.
 
-  Context `{Funext}.
   Context (P : nat -> Type)
           {P_hprop : forall n, IsHProp (P n)}
           (P_dec : forall n, Decidable (P n))
@@ -16,16 +15,13 @@ Section bounded_search.
   Local Open Scope type_scope.
   
   Local Definition minimal (n : nat) : Type := forall m : nat, P m -> n <= m.
-  Local Definition ishprop_minimal (n : nat) : IsHProp (minimal n).
-  Proof.
-    apply _.
-  Qed.
-  Local Definition min_n_Type : Type := { n : nat & ((P n) * (minimal n))%type}.
+  Local Definition min_n_Type : Type := { n : nat & ((P n) * merely (minimal n))%type}.
 
   Local Definition ishpropmin_n : IsHProp min_n_Type.
   Proof.
     apply ishprop_sigma_disjoint.
     intros n n' [p m] [p' m'].
+    strip_truncations.
     apply leq_antisym.
     - exact (m n' p').
     - exact (m' n p).
@@ -81,7 +77,7 @@ Section bounded_search.
   Proof.
     assert (smaller n + forall l, (l <= n) -> not (P l)) as X by apply bounded_search.
     induction X as [[l [[Pl ml] leqln]]|none].
-    - exact (l;(Pl,ml)).
+    - exact (l;(Pl,tr ml)).
     - destruct (none n (leq_refl n) Pn).
   Defined.
 

--- a/theories/BoundedSearch.v
+++ b/theories/BoundedSearch.v
@@ -15,6 +15,8 @@ Section bounded_search.
   Local Open Scope type_scope.
   
   Local Definition minimal (n : nat) : Type := forall m : nat, P m -> n <= m.
+
+  (** If we assume [Funext], then [minimal n] is a proposition.  But to avoid needing [Funext], we propositionally truncate it. *)
   Local Definition min_n_Type : Type := { n : nat & ((P n) * merely (minimal n))%type}.
 
   Local Definition ishpropmin_n : IsHProp min_n_Type.

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -194,6 +194,17 @@ Proof.
   refine (contr_inhabited_hprop _ ma).
 Defined.
 
+(** A decidable type is logically equivalent to its (-1)-truncation. *)
+Definition merely_inhabited_iff_inhabited_decidable {A} {A_dec : Decidable A}
+  : Tr (-1) A <-> A.
+Proof.
+  refine (_, tr).
+  intro ma.
+  destruct A_dec as [a | na].
+  - exact a.
+  - exact (Empty_rec (Trunc_rec na ma)).
+Defined.
+
 (** Surjections are the (-1)-connected maps, but they can be characterized more simply since an inhabited hprop is automatically contractible. *)
 Notation IsSurjection := (IsConnMap (Tr (-1))).
 


### PR DESCRIPTION
By inserting a propositional truncation, can avoid needing Funext.
