### PR TITLE
Weaken 'Decidable' to 'Stable' in hypotheses.

### DIFF
--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -194,15 +194,14 @@ Proof.
   refine (contr_inhabited_hprop _ ma).
 Defined.
 
-(** A decidable type is logically equivalent to its (-1)-truncation. *)
-Definition merely_inhabited_iff_inhabited_decidable {A} {A_dec : Decidable A}
+(** A stable type is logically equivalent to its (-1)-truncation. *)
+Definition merely_inhabited_iff_inhabited_stable {A} {A_stable : Stable A}
   : Tr (-1) A <-> A.
 Proof.
   refine (_, tr).
   intro ma.
-  destruct A_dec as [a | na].
-  - exact a.
-  - exact (Empty_rec (Trunc_rec na ma)).
+  apply stable; intro na.
+  revert ma; apply Trunc_ind; [exact _ | done].
 Defined.
 
 (** Surjections are the (-1)-connected maps, but they can be characterized more simply since an inhabited hprop is automatically contractible. *)


### PR DESCRIPTION
We could still leave the original theorem, named "merely_inhabited_iff_inhabited_decidable", or we could leave it up to typeclass inference to patch that gap, as there is a Decidable -> Stable hint. Not clear which is better.

New version of the theorem lets us conclude, for example,  merely (~A) -> ~A for any A, even if A is not decidable.