### PR TITLE
Weaken "Decidable" to "Stable" in hypotheses

### DIFF
--- a/theories/Basics/Decidable.v
+++ b/theories/Basics/Decidable.v
@@ -46,6 +46,11 @@ Proof.
   - apply Empty_rect,dn,n.
 Qed.
 
+Global Instance stable_negation P : Stable (~ P).
+Proof.
+  intros nnnp p; contradiction nnnp; intro np; contradiction np; exact p.
+Defined.
+
 (**
   Because [vm_compute] evaluates terms in [PROP] eagerly
   and does not remove dead code we

--- a/theories/Basics/Decidable.v
+++ b/theories/Basics/Decidable.v
@@ -48,7 +48,8 @@ Qed.
 
 Global Instance stable_negation P : Stable (~ P).
 Proof.
-  intros nnnp p; contradiction nnnp; intro np; contradiction np; exact p.
+  intros nnnp p.
+  exact (nnnp (fun np => np p)).
 Defined.
 
 (**

--- a/theories/BoundedSearch.v
+++ b/theories/BoundedSearch.v
@@ -90,7 +90,7 @@ Section bounded_search.
   Definition minimal_n : { n : nat & P n }.
   Proof.
     destruct prop_n_to_min_n as [n pl]. destruct pl as [p _].
-    exact (n; fst merely_inhabited_iff_inhabited_decidable p).
+    exact (n; fst merely_inhabited_iff_inhabited_stable p).
   Defined.
 
 End bounded_search.

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -194,7 +194,7 @@ Proof.
   refine (contr_inhabited_hprop _ ma).
 Defined.
 
-(** A stable type is logically equivalent to its (-1)-truncation. *)
+(** A stable type is logically equivalent to its (-1)-truncation. (It follows that this is true for decidable types as well.) *)
 Definition merely_inhabited_iff_inhabited_stable {A} {A_stable : Stable A}
   : Tr (-1) A <-> A.
 Proof.

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -194,15 +194,14 @@ Proof.
   refine (contr_inhabited_hprop _ ma).
 Defined.
 
-(** A decidable type is logically equivalent to its (-1)-truncation. *)
-Definition merely_inhabited_iff_inhabited_decidable {A} {A_dec : Decidable A}
+(** A stable type is logically equivalent to its (-1)-truncation. *)
+Definition merely_inhabited_iff_inhabited_stable {A} {A_stable : Stable A}
   : Tr (-1) A <-> A.
 Proof.
   refine (_, tr).
   intro ma.
-  destruct A_dec as [a | na].
-  - exact a.
-  - exact (Empty_rec (Trunc_rec na ma)).
+  apply stable; intro na.
+  revert ma; apply Trunc_ind; [exact _ | done].
 Defined.
 
 (** Surjections are the (-1)-connected maps, but they can be characterized more simply since an inhabited hprop is automatically contractible. *)

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -201,7 +201,7 @@ Proof.
   refine (_, tr).
   intro ma.
   apply stable; intro na.
-  revert ma; apply Trunc_ind; [exact _ | done].
+  revert ma; rapply Trunc_ind; exact na.
 Defined.
 
 (** Surjections are the (-1)-connected maps, but they can be characterized more simply since an inhabited hprop is automatically contractible. *)


### PR DESCRIPTION
If P is double-negation stable (as, for example, any negated proposition ~P is), then merely P -> P.
We could retain the original theorem under its name, or we could leave it up to typeclass resolution to fill the gap. Not clear which is better.