### PR TITLE
Remove polymorphism from def of ordinals.

### DIFF
--- a/theories/Spaces/Finite/FinNat.v
+++ b/theories/Spaces/Finite/FinNat.v
@@ -8,7 +8,7 @@ Require Import
 
 Local Open Scope nat_scope.
 
-Definition FinNat (n : nat) : Type := {x : nat | x < n}.
+Definition FinNat (n : nat) : Type0 := {x : nat | x < n}.
 
 Definition zero_finnat (n : nat) : FinNat n.+1
   := (0; leq_1_Sn).


### PR DESCRIPTION
I think that the finite ordinals should be defined in the ground universe to avoid excessive proliferation of universes.