### PR TITLE
Pointed/Core: slightly speed up pelim tactic

### DIFF
--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -204,7 +204,7 @@ Ltac pointed_reduce_pmap f
 (** A general tactic to replace pointedness paths in a pForall with reflexivity.  Because it generalizes [f pt], it can usually only be applied once the function itself is not longer needed.  Compared to [pointed_reduce], an advantage is that the pointed types do not need to be destructed. *)
 Ltac pelim f :=
   try match type of f with
-    | pEquiv ?X ?Y => destruct f as [f ?iseq]
+    | pEquiv ?X ?Y => destruct f as [f ?iseq]; unfold pointed_fun in *
   end;
   destruct f as [f ?ptd];
   cbn in f, ptd |- *;


### PR DESCRIPTION
This slightly improves the speed of the `pelim` tactic, but building Pointed/Core is still very slow.  If we can't speed up `pelim`, we should consider not using it as much.  Note that it's partially that the tactic is slow, but also that the `Defined` lines are slow with terms it produces.  With this commit applied, it still produces terms like this:

```coq
pmap_precompose_idmap@{u u0} =
fun (A B : pType) (f : A ->* B) =>
Build_pHomotopy (fun x0 : A => 1)
  ((fun (f0 : forall x : A, pfam_const B x) (ptd : f0 pt = dpoint (pfam_const B)) =>
    paths_ind_r pt (fun (y : B) (p : y = pt) => 1 = (1 @ p) @ p^) 1 (f0 pt) ptd
    :
    1 =
    dpoint_eq ({| pointed_fun := f0; dpoint_eq := ptd |} o* pmap_idmap) @
    (dpoint_eq {| pointed_fun := f0; dpoint_eq := ptd |})^) f 
     (dpoint_eq f))
     : forall (A B : pType) (f : A ->* B), f o* pmap_idmap ==* f
```
when a simpler term like the following would work instead:
```coq
pmap_precompose_idmap'@{u u0} =
fun (A B : pType) (f : A ->* B) =>
Build_pHomotopy (fun x0 : A => 1)
  (paths_ind_r pt (fun (y : B) (p : y = pt) => 1 = (1 @ p) @ p^) 1 (f pt) (dpoint_eq f))
     : forall (A B : pType) (f : A ->* B), f o* pmap_idmap ==* f
```
The big term has `f` destructed, and also needs to be beta-reduced.  I figured out how to make `pelim` work without destructing `f`, but unfortunately it made things slower.

The thing we need to do is to figure out how to write the goal as a type family to pass into `paths_ind_r`, and then we should be able to avoid all of the surrounding boilerplate.

The proof term for `is21cat_ptype` was 5600 lines long (printed with default settings in a window 90 characters wide) before the commit below, and is now 4918 lines long.