### PR TITLE
HoTT doesn't depend on Stdlib

### DIFF
--- a/coq-hott.opam
+++ b/coq-hott.opam
@@ -17,7 +17,7 @@ homepage: "http://homotopytypetheory.org/"
 bug-reports: "https://github.com/HoTT/HoTT/issues"
 depends: [
   "dune" {>= "3.13"}
-  "coq" {>= "8.19.0"}
+  ("coq" {>= "8.19.0" & < "9~"} | "coq-core" {>= "9.0"})
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
HoTT doesn't depend on Stdlib