### PR TITLE
Add transport lemmas for morphisms to Category/Core

### DIFF
--- a/theories/Categories/Category/Core.v
+++ b/theories/Categories/Category/Core.v
@@ -164,8 +164,8 @@ Definition transport_compose_morphism {C : PreCategory} {X Y Z W : object C}
     (g o transport (fun U => morphism C U Y) p f)%morphism
   := match p with idpath => idpath end.
 
-(** Composing transported morphisms along inverse paths. *)
-Definition transport_compose_both_inverse {C : PreCategory} {W X Y Z : object C}
+(** Transporting the middle object in a composition. *)
+Definition transport_compose_middle {C : PreCategory} {W X Y Z : object C}
   (p : W = X) (f : morphism C W Z) (g : morphism C Y W)
   : (transport (fun U : object C => morphism C U Z) p f o 
      transport (fun U : object C => morphism C Y U) p g)%morphism =


### PR DESCRIPTION
Move transport lemmas from separate file to Core.v per PR #2298 review - @jdchristensen 

Changes:
- Add transport_compose_morphism and transport_compose_both_inverse to Category/Core.v
- Remove TransportMorphisms.v from Additive folder
- Use Definition with pattern matching instead of Lemma with destruct
- Drop redundant lemmas (moveL_transport_V already exists)

Extracted from stable categories formalization (PR #2288). Tested with: make -f Makefile.coq