### PR TITLE
get the library working with Coq.Init.Tactics loaded

### DIFF
--- a/theories/Basics/PathGroupoids.v
+++ b/theories/Basics/PathGroupoids.v
@@ -808,6 +808,8 @@ Proof.
   exact q.
 Defined.
 
+Register ap011 as core.eq.congr2.
+
 Definition ap011_V {A B C} (f : A -> B -> C) {x x' y y'} (p : x = x') (q : y = y')
   : ap011 f p^ q^ = (ap011 f p q)^.
 Proof.


### PR DESCRIPTION
Branch for trying to get the library working with `Coq.Init.Tactics` loaded. Dan reported an error where `inversion` uses `Logic.eq` instead of `paths`, so we try to fix it by registering appropriate terms for `core.eq.*`, but this causes breakages in the `rewrite` tactic, how can we fix this?