### PR TITLE
Cubical/PathSquare.v: edit diagram in comment + formulate interchange lemma

### DIFF
--- a/theories/Cubical/PathSquare.v
+++ b/theories/Cubical/PathSquare.v
@@ -614,6 +614,26 @@ Defined.
 
 (* Interchange playground *)
 
+Definition experimental {A}
+(a : A)
+(P : A -> Type)
+(f : forall (x : A), (a = x) -> P(x))
+(g : forall (x : A), P(x) -> (a = x))
+(fxgxid: forall (x : A) (p : P x), (p = f x (g x p)))
+:
+forall (x : A)(p : P x), p = transport P (g x p) (f a 1).
+
+Proof.
+  intros.
+  remember (g x p) as gxp eqn:H.
+  destruct gxp. (* Syntax error: destruct (g x p) as gxp eqn:H.  *)
+  simpl. (* Here you see that p = f a 1 if g a p = 1 *)
+  destruct H.
+  apply fxgxid.
+Defined.
+
+
+
 Definition interchange {A}
 {a00 a10 a20 a01 a11 a21 a02 a12 a22 :A} (** 9 points in big square of 2x2 squares *)
 (** sq00, top left, 4 paths *)
@@ -642,7 +662,12 @@ sq_concat_h (sq_concat_v sq00 sq10) (sq_concat_v sq01 sq11)
 sq_concat_v (sq_concat_h sq00 sq01) (sq_concat_h sq10 sq11).
 
 Proof.
-  destruct sq00, sq11, vj0, h0j.
+  destruct sq00, sq11.
+  destruct vi2, h2i.
+  simpl.
+  rewrite (sq_concat_h_1s (p0y:=1) (p1y:=1) sq01).
+  simpl.
+  (* We're missing the analogous [sq_concat_v_1s].  Even with it, it's not clear to me how to proceed. *)
 Admitted.
 
   


### PR DESCRIPTION
1. Please take a look at the edited diagram at the beginning of PathSquare.v, fixing #2324.
2. I added a formulation of an interchange lemma at the end.
2a. (minor) I didn't get the infix operators `@@h, @@v` to work.
2b. Just before `Admitted`, the proof state is:
```
1 goal
A : Type
x : A
h2i, vi2 : x = x
sq10 : PathSquare 1 1 1 h2i
sq01 : PathSquare 1 vi2 1 1
______________________________________(1/1)
sq_concat_h (sq_concat_v 1%square sq10) (sq_concat_v sq01 1%square) =
sq_concat_v (sq_concat_h 1%square sq01) (sq_concat_h sq10 1%square)
```
 My plan would be the following. Through `equiv_sq_path` and some easy path algebra, the `sq`-variables correspond to 2-paths between `1 : x=x` and `h2i, vi2`, respectively. The latter are also variables, so we can do path induction on the 2-paths and assume they are reflexivity paths. In that case the `sq`-variables correspond  both to a `1%square` and the goal can be solved by reflexivity.

I'm new to this library, so I have difficulties getting this idea to work. Any help will be appreciated, both regarding the formulation of the interchange lemma and the feasibility of my idea to prove it. 