### PR TITLE
chore: bump minimal rocq version

### DIFF
--- a/coq-hott.opam
+++ b/coq-hott.opam
@@ -2,7 +2,7 @@
 opam-version: "2.0"
 synopsis: "The Homotopy Type Theory library"
 description: """
-To use the HoTT library, the following flags must be passed to coqc:
+To use the HoTT library, the following flags must be passed to rocq:
   -noinit -indices-matter
 To use the HoTT library in a project, add the following to _CoqProject:
   -arg -noinit

--- a/dune-project
+++ b/dune-project
@@ -23,5 +23,6 @@
  (name coq-hott)
  (synopsis "The Homotopy Type Theory library")
  (description
-  "To use the HoTT library, the following flags must be passed to coqc:\n  -noinit -indices-matter\nTo use the HoTT library in a project, add the following to _CoqProject:\n  -arg -noinit\n  -arg -indices-matter\n")
- (depends))
+  "To use the HoTT library, the following flags must be passed to rocq:\n  -noinit -indices-matter\nTo use the HoTT library in a project, add the following to _CoqProject:\n  -arg -noinit\n  -arg -indices-matter\n")
+ (depends
+  (rocq (>= 9.0.0))))


### PR DESCRIPTION
We bump the minimal rocq version needed in the dune-project file.