### PR TITLE
Syllepsis: use Ltac2 for slight speed up; reverts #1628

### DIFF
--- a/theories/Homotopy/Syllepsis.v
+++ b/theories/Homotopy/Syllepsis.v
@@ -924,32 +924,53 @@ Defined.
 
 (** Next we prove a coherence law relating [eh_V p (q @ r)] to [eh_V p q] and [eh_V p q]. *)
 
-(* The following tactics will be used to make the proof faster, but with only minor modifications, the proof goes through without these tactics. The final tactic [generalize_goal] takes a goal of the form [forall a b c ..., expression] and asserts a new goal [forall P, _ -> forall a b c ..., P a b c ...] which can be used to prove the original goal. Because [expression] has been replaced with a generic function, the proof of the new goal can be more efficient than the proof of the special case, especially when there are around 84 variables. *)
+(* The following tactics will be used to make the proof faster, but with only minor modifications, the proof goes through without these tactics. The final tactic [generalize_goal] takes a goal of the form [forall a b c ..., expression] and asserts a new goal [forall P, _ -> forall a b c ..., P a b c ...] which can be used to prove the original goal. During the proof, the underscore gets replaced by a special case of [P].  Because [expression] has been replaced with a generic function, the proof of the new goal can be more efficient than the proof of the special case, especially when there are around 84 variables. *)
 
-Ltac apply_P ty P :=
-  lazymatch ty with
-  | forall a : ?A, ?ty
-    => let ty' := fresh in
-       let P' := fresh in
-       constr:(forall a : A,
-                  (* Bind [ty] in [match] so that we avoid issues such as https://github.com/coq/coq/issues/7299 and similar ones.  Without [return _], [match] tries two ways to elaborate the branches, which results in exponential blowup on failure. *)
-                  match ty, P a return _ with
-                  | ty', P'
-                    => ltac:(let ty := (eval cbv delta [ty'] in ty') in
-                             let P := (eval cbv delta [P'] in P') in
-                             clear ty' P';
-                             let res := apply_P ty P in
-                             exact res)
-                  end)
-  | _ => P
+(* This can be done with Ltac1, but is a bit faster with Ltac2.  See the git history for the Ltac1 version. *)
+Require Import Ltac2.Ltac2.
+
+Ltac2 rec replace_under_prod (ty : constr) (final : constr) :=
+  match Constr.Unsafe.kind ty with
+  | Constr.Unsafe.Prod a ty
+    => Constr.Unsafe.make (Constr.Unsafe.Prod a (replace_under_prod ty final))
+  | _ => final
   end.
 
-Ltac make_P_and_evar ty :=
-  let P := fresh "P" in
-  open_constr:(forall P : _, _ -> ltac:(let res := apply_P ty P in exact res)).
+Ltac2 make_P (ty : constr) := replace_under_prod ty 'Type.
+
+Ltac2 rec count_prod (ty : constr) :=
+  match Constr.Unsafe.kind ty with
+  | Constr.Unsafe.Prod _ ty => Int.add 1 (count_prod ty)
+  | _ => 0
+  end.
+
+Ltac2 apply_P_on (p : constr) (n : int) :=
+  Constr.Unsafe.make
+    (Constr.Unsafe.App
+       p
+       (Array.init
+          n
+          (fun i => Constr.Unsafe.make (Constr.Unsafe.Rel (Int.sub n i))))).
+
+Ltac2 apply_P (ty : constr) (p : int -> constr) :=
+  let n := count_prod ty in
+  replace_under_prod ty (apply_P_on (p n) n).
+
+Ltac2 make_P_and_evars (ty : constr) :=
+  let p_ty := make_P ty in
+  let res := apply_P ty (fun n => Constr.Unsafe.make (Constr.Unsafe.Rel (Int.add n 1))) in
+  '(forall P : $p_ty, _ -> $res).
+
+Ltac make_P_and_evars :=
+  ltac2:(ty |- Control.refine (fun _ => make_P_and_evars (Option.get (Ltac1.to_constr ty)))).
 
 Ltac generalize_goal X :=
-  match goal with |- ?G => let T := make_P_and_evar G in assert (X : T) end.
+  match goal with |- ?G =>
+                    let T := open_constr:(ltac:(make_P_and_evars G)) in
+                    assert (X : T) end.
+
+(* Make Ltac1 the default again. *)
+Set Default Proof Mode "Classic".
 
 (* We need this equivalence twice below. *)
 Local Lemma equiv_helper {X} {a b : X} {p q r : a = b} (t : q @ 1 = r) (u : p @ 1 = r) (s : p = q)


### PR DESCRIPTION
It was easy to go back to the Ltac2 version, since I just had to revert #1628.  (I also made a couple of minor style fixes, and improved the comment slightly.)

On a slow-ish machine, this reduces the build time for Syllepsis.v from 5.25s to 4.55s.  Not a huge gain, but not nothing.