### PR TITLE
chore: add .*.aux to makefile clean targets

### DIFF
--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -254,4 +254,4 @@ clean::
 	$(SHOW)"RM *.DOT"
 	$(HIDE)rm -f $(ALL_DOTFILES)
 	rm -f $(EXTRA_CLEANFILES)
-	find theories contrib test \( -name \*.vo -o -name \*.glob -o -name \*.timing \) -delete
+	find theories contrib test \( -name \*.vo -o -name \*.glob -o -name \*.timing -o -name \*.aux \) -delete


### PR DESCRIPTION
These were always getting left behind after using the makefile