### PR TITLE
Basics/Settings: globally set "-notation-for-abbreviation" for now

### DIFF
--- a/theories/Basics/Settings.v
+++ b/theories/Basics/Settings.v
@@ -79,3 +79,8 @@ Register reverse_coercion as core.coercion.reverse_coercion.
 
 (** Keywords for blacklisting from search function *)
 Add Search Blacklist "_admitted" "_subproof" "Private_".
+
+(** ** Warnings *)
+
+(** Rocq 9.2 complains if you use "Notation" when you could use "Abbreviation".  However, Rocq 9.1 doesn't support the Abbreviation command, so unless Rocq 9.2 is our minimum, we will continue to use "Notation".  This suppresses the resulting warnings. *)
+Global Set Warnings "-notation-for-abbreviation".


### PR DESCRIPTION
Rocq 9.2 complains if you use "Notation" when you could use "Abbreviation".  However, Rocq 9.1 doesn't support the Abbreviation command, so unless Rocq 9.2 is our minimum, we will continue to use "Notation".  This suppresses the resulting warnings.

(Rocq 9.2 generates lots of other warnings too, but I haven't looked into how to fix them.)