### PR TITLE
Updated BiInv.v and related files

### DIFF
--- a/contrib/HoTTBook.v
+++ b/contrib/HoTTBook.v
@@ -597,17 +597,17 @@ Definition Book_4_2_13 := @HoTT.Types.Equiv.hprop_isequiv.
 (* ================================================== defn:biinv *)
 (** Definition 4.3.1 *)
 
-Definition Book_4_3_1  := @HoTT.Equiv.BiInv.BiInv.
+Definition Book_4_3_1  := @HoTT.Equiv.BiInv.IsBiInv.
 
 (* ================================================== thm:isprop-biinv *)
 (** Theorem 4.3.2 *)
 
-Definition Book_4_3_2  := @HoTT.Equiv.BiInv.ishprop_biinv.
+Definition Book_4_3_2  := @HoTT.Equiv.BiInv.ishprop_isbiinv.
 
 (* ================================================== thm:equiv-biinv-isequiv *)
 (** Corollary 4.3.3 *)
 
-Definition Book_4_3_3  := @HoTT.Equiv.BiInv.equiv_biinv_isequiv.
+Definition Book_4_3_3  := @HoTT.Equiv.BiInv.equiv_isbiinv_isequiv.
 
 (* ================================================== defn:equivalence *)
 (** Definition 4.4.1 *)

--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -1452,12 +1452,10 @@ Section Book_4_5.
 
     Local Instance Book_4_5_g : IsEquiv g.
     Proof.
-      apply isequiv_biinv.
-      split.
-      - exists ((h o g)^-1 o h).
-        exact (eissect (h o g)).
-      - exists (f o (g o f)^-1).
-        exact (eisretr (g o f)).
+      apply isequiv_isbiinv.
+      apply (Build_IsBiInv _ _ _ (f o (g o f)^-1) ((h o g)^-1 o h)).
+      - exact (eisretr (g o f)).
+      - exact (eissect (h o g)).
     Defined.
 
     Local Instance Book_4_5_f : IsEquiv f.

--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -310,6 +310,14 @@ Definition equiv_inj `(f : A -> B) `{IsEquiv A B f} {x y : A}
   : (f x = f y) -> (x = y)
   := (ap f)^-1.
 
+Definition equiv_inj_comp `(f : A -> B) `{IsEquiv A B f} {x y : A}
+  (p : f x = f y)
+  : ap f (equiv_inj f p) = p.
+Proof.
+  unfold equiv_inj.
+  apply eisretr.
+Defined.
+
 (** Assuming function extensionality, composing with an equivalence is itself an equivalence *)
 
 Instance isequiv_precompose `{Funext} {A B C : Type}

--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -310,7 +310,7 @@ Definition equiv_inj `(f : A -> B) `{IsEquiv A B f} {x y : A}
   : (f x = f y) -> (x = y)
   := (ap f)^-1.
 
-Definition equiv_inj_comp `(f : A -> B) `{IsEquiv A B f} {x y : A}
+Definition ap_equiv_inj `(f : A -> B) `{IsEquiv A B f} {x y : A}
   (p : f x = f y)
   : ap f (equiv_inj f p) = p.
 Proof.

--- a/theories/Equiv/BiInv.v
+++ b/theories/Equiv/BiInv.v
@@ -1,4 +1,4 @@
-From HoTT Require Import Basics Types.Prod Types.Equiv.
+Require Import HoTT.Basics Types.Prod Types.Equiv Types.Sigma Types.Universe.
 
 Local Open Scope path_scope.
 Generalizable Variables A B f.
@@ -7,47 +7,205 @@ Generalizable Variables A B f.
 
 (** A map is "bi-invertible" if it has both a section and a retraction, not necessarily the same.  This definition of equivalence was proposed by Andre Joyal. *)
 
-Definition BiInv `(f : A -> B) : Type
-  := {g : B -> A & g o f == idmap} * {h : B -> A & f o h == idmap}.
+Class IsBiInv {A B : Type} (e : A -> B) := {
+  sect_biinv : B -> A ;
+  retr_biinv : B -> A ;
+  eisretr_biinv : e o sect_biinv == idmap ;
+  eissect_biinv : retr_biinv o e == idmap ;
+}.
 
-(** It seems that the easiest way to show that bi-invertibility is equivalent to being an equivalence is also to show that both are h-props and that they are logically equivalent. *)
+Arguments sect_biinv {A B}%_type_scope e%_function_scope {_} _.
+Arguments retr_biinv {A B}%_type_scope e%_function_scope {_} _.
+Arguments eisretr_biinv {A B}%_type_scope e%_function_scope {_} _.
+Arguments eissect_biinv {A B}%_type_scope e%_function_scope {_} _.
 
-Definition isequiv_biinv `(f : A -> B)
-  : BiInv f -> IsEquiv f.
+Record BiInv A B := {
+  biinv_fun : A -> B ;
+  biinv_isbiinv :: IsBiInv biinv_fun
+}.
+
+Coercion biinv_fun : BiInv >-> Funclass.
+
+Arguments biinv_fun {A B} _ _.
+Arguments biinv_isbiinv {A B} _.
+
+(** If [e] is bi-invertible, then the retraction and the section of [e] are equal. *)
+Definition sect_retr_homotopic_isbiinv {A B : Type} (f : A -> B) `{bi : !IsBiInv f}
+  : sect_biinv f == retr_biinv f.
 Proof.
-  intros [[g s] [h r]].
+  revert bi.
+  intros [h g r s].
+  exact (fun y => (s (h y))^ @ ap g (r y)).
+Defined.
+
+Definition retr_is_sect_isbiinv {A B : Type} (f : A -> B) `{bi : !IsBiInv f}
+  : f o retr_biinv f == idmap.
+Proof.
+  intro z.
+  lhs_V napply (ap f (sect_retr_homotopic_isbiinv f z)).
+  apply eisretr_biinv.
+Defined.
+
+Definition sect_is_retr_isbiinv {A B : Type} (f : A -> B) `{bi : !IsBiInv f}
+  : sect_biinv f o f == idmap.
+Proof.
+  intro z.
+  lhs napply sect_retr_homotopic_isbiinv.
+  apply eissect_biinv.
+Defined.
+
+(** The record is equivalent to a product type.  This is used below in a 'product of contractible types is contractible' argument. *)
+Definition prod_isbiinv (A B : Type) `{f : A -> B}
+  : {g : B -> A & g o f == idmap} * {h : B -> A & f o h == idmap} <~> IsBiInv f.
+Proof.
+  make_equiv.
+Defined.
+
+Definition issig_biinv (A B : Type) : {f : A -> B & IsBiInv f} <~> BiInv A B
+  := ltac:(issig).
+
+(** From a bi-invertible map, we can construct a half-adjoint equivalence in two ways.  Here we take the inverse to be the retraction. *)
+#[export] Instance isequiv_isbiinv {A B : Type} (f : A -> B) `{bi : !IsBiInv f}
+  : IsEquiv f.
+Proof.
+  destruct bi as [h g r s].
   exact (isequiv_adjointify f g
     (fun x => ap f (ap g (r x)^ @ s (h x)) @ r x)
     s).
 Defined.
 
-Definition biinv_isequiv `(f : A -> B)
-  : IsEquiv f -> BiInv f.
+#[export] Instance isequiv_isbiinv_retr {A B : Type} (f : A -> B) `{bi : !IsBiInv f}
+  : IsEquiv (retr_biinv f)
+  := isequiv_inverse f.
+
+(** Here we take the inverse to be the section. *)
+Definition isequiv_isbiinv' {A B : Type} (f : A -> B) `{bi : !IsBiInv f}
+  : IsEquiv f.
+Proof.
+  snapply isequiv_adjointify.
+  - apply (sect_biinv f).
+  - apply eisretr_biinv.  (* We provide proof of eissect, but it gets modified. *)
+  - intro a.
+    lhs napply sect_retr_homotopic_isbiinv.
+    apply eissect_biinv.
+Defined.
+
+#[export] Instance isequiv_isbiinv_sect {A B : Type} (f : A -> B) `{bi : !IsBiInv f}
+  : IsEquiv (sect_biinv f)
+  := isequiv_inverse f (feq:=isequiv_isbiinv' f).
+
+Definition isbiinv_isequiv {A B : Type} (f : A -> B)
+  : IsEquiv f -> IsBiInv f.
 Proof.
   intros [g s r adj].
-  exact ((g; r), (g; s)).
+  exact (Build_IsBiInv _ _ f g g s r).
 Defined.
 
-Definition iff_biinv_isequiv `(f : A -> B)
-  : BiInv f <-> IsEquiv f.
+Definition iff_isbiinv_isequiv {A B : Type} (f : A -> B)
+  : IsBiInv f <-> IsEquiv f.
 Proof.
   split.
-  - apply isequiv_biinv.
-  - apply biinv_isequiv.
+  - apply isequiv_isbiinv.
+  - apply isbiinv_isequiv.
 Defined.
 
-Instance ishprop_biinv `{Funext} `(f : A -> B) : IsHProp (BiInv f) | 0.
+#[export] Instance ishprop_isbiinv `{Funext} {A B : Type} (f : A -> B)
+  : IsHProp (IsBiInv f) | 0.
 Proof.
   apply hprop_inhabited_contr.
-  intros bif; pose (fe := isequiv_biinv f bif).
-  apply @contr_prod.
-  (* For this, we've done all the work already. *)
-  - by apply contr_retr_equiv.
-  - by apply contr_sect_equiv.
+  intros bif.
+  (* This uses implicitly that the product of contractible types is contractible: *)
+  srapply (contr_equiv' _ (prod_isbiinv A B)).
 Defined.
 
-Definition equiv_biinv_isequiv `{Funext} `(f : A -> B)
-  : BiInv f <~> IsEquiv f.
+Definition equiv_isbiinv_isequiv `{Funext} {A B : Type} (f : A -> B)
+  : IsBiInv f <~> IsEquiv f.
 Proof.
-  apply equiv_iff_hprop_uncurried, iff_biinv_isequiv.
+  apply equiv_iff_hprop_uncurried, iff_isbiinv_isequiv.
 Defined.
+
+(** Some lemmas to send equivalences and biinvertible maps back and forth. *)
+
+Definition equiv_biinv A B (f : BiInv A B) : A <~> B
+  := Build_Equiv A B f _.
+
+Definition biinv_equiv A B (e : A <~> B) : BiInv A B
+  := Build_BiInv A B e (isbiinv_isequiv e (equiv_isequiv e)).
+
+Definition equiv_biinv_equiv `{Funext} A B
+  : BiInv A B <~> (A <~> B).
+Proof.
+  nrefine ((issig_equiv A B) oE _ oE (issig_biinv A B)^-1).
+  napply (equiv_functor_sigma_id equiv_isbiinv_isequiv).
+Defined.
+
+Definition idmap_biinv (A : Type) : BiInv A A.
+Proof.
+  by nrefine (Build_BiInv A A idmap (Build_IsBiInv A A idmap idmap idmap _ _)).
+Defined.
+
+(** Assume we have a commutative square [e' o f == g o e] in which [e] and [e'] are bi-invertible.  Then [f] and [g] also commute with the retractions and sections, and the homotopies in these new squares each satisfy a coherence condition. *)
+
+Section EquivalenceCompatibility.
+
+  Context {A B C D : Type}.
+  Context (e : BiInv A B) (e' : BiInv C D) (f : A -> C) (g : B -> D).
+
+  Let s := sect_biinv e.
+  Let r := retr_biinv e.
+  Let re := eissect_biinv e : r o e == idmap.
+  Let es := eisretr_biinv e : e o s == idmap.
+  Let s' := sect_biinv e'.
+  Let r' := retr_biinv e'.
+  Let re' := eissect_biinv e' : r' o e' == idmap.
+  Let es' := eisretr_biinv e' : e' o s' == idmap.
+
+  Definition helper_r (pe : e' o f == g o e) : r' o g o e == f o r o e.
+  Proof.
+    intro x.
+    exact ((ap r' (pe x))^ @ (re' (f x) @ (ap f (re x))^)).
+  Defined.
+
+  Definition helper_s (pe : e' o f == g o e) : e' o s' o g == e' o f o s.
+  Proof.
+    intro y.
+    exact (es' (g y) @ (ap g (es y))^ @ (pe (s y))^).
+  Defined.
+
+  (** The following lemmas express the coherence conditions mentioned above. *)
+
+  Definition biinv_compat_pr (pe : forall (x : A), e' (f x) = g (e x))
+    : r' o g == f o r.
+  Proof.
+    rapply (equiv_ind e).
+    apply (helper_r pe).
+  Defined.
+
+  Definition biinv_compat_ps (pe : forall (x : A), e' (f x) = g (e x))
+    : s' o g == f o s.
+  Proof.
+    intro y.
+    apply (equiv_inj e').
+    apply (helper_s pe).
+  Defined.
+
+  Definition biinv_compat_pre (pe : forall (x : A), e' (f x) = g (e x)) (x : A)
+    : re' (f x) = ap r' (pe x) @ (biinv_compat_pr pe) (e x) @ ap f (re x).
+  Proof.
+    unfold biinv_compat_pr.
+    rewrite equiv_ind_comp.
+    apply moveL_pM.
+    apply moveL_Mp.
+    reflexivity.
+  Defined.
+
+  Definition biinv_compat_pes (pe : forall (x : A), e' (f x) = g (e x)) (y : B)
+    : es' (g y) = ap e' ((biinv_compat_ps pe) y) @ pe (s y) @ ap g (es y).
+  Proof.
+    rewrite equiv_inj_comp.
+    apply moveL_pM.
+    apply moveL_pM.
+    reflexivity.
+  Defined.
+
+End EquivalenceCompatibility.

--- a/theories/Equiv/BiInv.v
+++ b/theories/Equiv/BiInv.v
@@ -139,7 +139,7 @@ Proof.
   napply (equiv_functor_sigma_id equiv_isbiinv_isequiv).
 Defined.
 
-Definition idmap_biinv (A : Type) : BiInv A A.
+Definition biinv_idmap (A : Type) : BiInv A A.
 Proof.
   by nrefine (Build_BiInv A A idmap (Build_IsBiInv A A idmap idmap idmap _ _)).
 Defined.
@@ -202,7 +202,7 @@ Section EquivalenceCompatibility.
   Definition biinv_compat_pes (pe : forall (x : A), e' (f x) = g (e x)) (y : B)
     : es' (g y) = ap e' ((biinv_compat_ps pe) y) @ pe (s y) @ ap g (es y).
   Proof.
-    rewrite equiv_inj_comp.
+    rewrite ap_equiv_inj.
     apply moveL_pM.
     apply moveL_pM.
     reflexivity.

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -996,24 +996,24 @@ Section Reflective_Subuniverse.
     Proof.
       refine (inO_equiv_inO _ (issig_equiv@{i j k} A B)).
       refine (inO_equiv_inO _ (equiv_functor_sigma equiv_idmap@{k}
-                                 (fun f => equiv_biinv_isequiv@{i j k} f))).
+                                 (fun f => equiv_isbiinv_isequiv@{i j k} f))).
       transparent assert (c : (prod@{k k} (A->B) (prod@{k k} (B->A) (B->A)) -> prod@{k k} (A -> A) (B -> B))).
       { intros [f [g h]]; exact (h o f, f o g). }
       pose (U := hfiber@{k k} c (idmap, idmap)).
       refine (inO_equiv_inO'@{k k k} U _). (** Introduces some extra copies of [k] by typeclass inference. *)
-      unfold hfiber, BiInv; cbn in *.
+      unfold hfiber; cbn in *.
       srefine (equiv_adjointify _ _ _ _).
       - intros [[f [g h]] p].
         apply (equiv_inverse (equiv_path_prod _ _)) in p.
         destruct p as [p q]; cbn in *.
-        exists f; split; [ exists h | exists g ].
+        exists f; nrefine (Build_IsBiInv _ _ f g h _ _).
         all:apply ap10; assumption.
-      - intros [f [[g p] [h q]]].
-        exists (f,(h,g)); cbn.
+      - intros [f [g h p q]].
+        exists (f,(g,h)); cbn.
         apply path_prod; apply path_arrow; assumption.
-      - intros [f [[g p] [h q]]]; cbn.
-        apply (path_sigma' _ 1); apply path_prod; apply (path_sigma' _ 1);
-          cbn; rewrite transport_1.
+      - intros [f [g h p q]]; cbn.
+        apply (path_sigma' _ 1); cbn.
+        apply (ap011 (fun r s => Build_IsBiInv _ _ f g h s r)).
         1:rewrite ap_fst_path_prod.
         2:rewrite ap_snd_path_prod.
         all:apply path_forall; intros x; rewrite ap10_path_arrow; reflexivity.

--- a/theories/Spaces/BAut/Bool/IncoherentIdempotent.v
+++ b/theories/Spaces/BAut/Bool/IncoherentIdempotent.v
@@ -39,10 +39,10 @@ Section IncoherentQuasiIdempotent.
   Proof.
     intros oops.
     assert (IsEquiv s).
-    { apply isequiv_biinv; split.
-      - exists r; exact issect.
-      - exists (fun q => (oops q).1).
-        exact (fun q => (oops q).2). }
+    { apply isequiv_isbiinv.
+      apply (Build_IsBiInv _ _ s (fun q => (oops q).1) r).
+      2: exact issect.
+      exact (fun q => (oops q).2). }
     apply splitting_preidem_notequiv_qidem_baut_baut_bool; intros q.
     refine (ap s (ap r (eisretr s q)^) @ _).
     refine (ap s (issect (s^-1 q)) @ _).


### PR DESCRIPTION
We update BiInv.v and all related files to make the types BiInv and IsBiInv follow the same pattern as Equiv and IsEquiv, the former being a record and the latter being a typeclass. This is an improvement of the current version where BiInv is a product type which should be according to the naming conventions of the library in fact be called 'IsBiInv'. We also added some useful lemmas to the file that can be used in future projects within the library in which bi-invertible maps are used.

This is jww @jdchristensen.